### PR TITLE
Resolves #30 trying to use GITHUB_TOKEN and it shouldnt

### DIFF
--- a/packages/cli/src/download.ts
+++ b/packages/cli/src/download.ts
@@ -18,13 +18,7 @@ export async function downloadWithProgress(
 ): Promise<NodeJS.ReadableStream> {
 	const { url, headers = {}, onProgress } = options;
 
-	// Add GITHUB_TOKEN if available and not already set
-	const requestHeaders = { ...headers };
-	if (process.env.GITHUB_TOKEN && !requestHeaders['Authorization']) {
-		requestHeaders['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
-	}
-
-	const response = await fetch(url, { headers: requestHeaders });
+	const response = await fetch(url, { headers });
 	if (!response.ok) {
 		throw new APIError({
 			url,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Modified authentication handling in download operations to require explicit authorization headers instead of automatic credential propagation from the environment.

**Note:** Users providing authorization headers manually will not be affected; existing explicit headers continue to work as expected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->