### PR TITLE
Fix @agentuity/runtime documentation inconsistencies

### DIFF
--- a/packages/runtime/AGENTS.md
+++ b/packages/runtime/AGENTS.md
@@ -98,15 +98,8 @@ The validator supports three overload signatures:
 import { createAgent } from '@agentuity/runtime';
 import { s } from '@agentuity/schema';
 
-export default createAgent({
-	metadata: {
-		id: 'unique-id',
-		identifier: 'folder-name',
-		name: 'Human Name',
-		description: 'What it does',
-		filename: __filename,
-		version: 'hash-or-version',
-	},
+export default createAgent('my-agent', {
+	description: 'What this agent does',
 	schema: {
 		input: s.object({
 			/* ... */
@@ -116,11 +109,13 @@ export default createAgent({
 		}),
 	},
 	handler: async (ctx, input) => {
-		// ctx.logger, ctx.tracer, ctx.kv, etc.
+		// ctx.logger, ctx.tracer, ctx.kv, ctx.app, etc.
 		return output;
 	},
 });
 ```
+
+**Note:** Internal metadata (id, agentId, filename, version) is automatically injected by the build system.
 
 ## Router Extensions
 
@@ -143,6 +138,11 @@ interface AgentContext {
 	kv: KeyValueStorage; // Key-value storage
 	stream: StreamStorage; // Stream storage
 	vector: VectorStorage; // Vector storage
+	state: Map<string, unknown>; // Request-scoped state
+	thread: Thread; // Thread information
+	session: Session; // Session information
+	config: TConfig; // Agent-specific config from setup
+	app: TAppState; // Application state from createApp
 	waitUntil: (promise) => void; // Background tasks
 }
 ```


### PR DESCRIPTION
## Changes

Fixed documentation in `@agentuity/runtime` package to match actual implementation and template examples:

### README.md
- Fixed `createApp()` to show correct usage: `const { server, logger } = await createApp()`
- Fixed `createAgent()` signature: takes name as first parameter, description as config field
- Replaced all `z.object()` (zod) with `s.object()` (@agentuity/schema)
- Added route validation example using `agent.validator()` pattern
- Updated `AgentContext` interface to include all current properties: `state`, `thread`, `session`, `config`, `app`

### AGENTS.md
- Fixed `createAgent()` example to match current API
- Removed user-provided metadata object (build system injects this)
- Updated `AgentContext` interface with complete property list
- Added note explaining internal vs external metadata

## Validation
- ✅ All typecheck passed
- ✅ All lint passed
- ✅ Examples verified against template in `sdk/templates/default`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * `createApp()` now returns a Promise; use `await` syntax
  * `createAgent()` API changed to named parameter format: `createAgent(name, options)`
  * `AgentContext` interface expanded with new public fields: state, thread, session, config, app

* **Documentation**
  * Updated all examples and usage patterns across AGENTS.md and README.md

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->