### PR TITLE
Remove AgentContext from public exports

### DIFF
--- a/apps/testing/legacy/auth-app/src/agent/simple/agent.ts
+++ b/apps/testing/legacy/auth-app/src/agent/simple/agent.ts
@@ -1,4 +1,4 @@
-import { type AgentContext, createAgent } from '@agentuity/runtime';
+import { createAgent } from '@agentuity/runtime';
 import { z } from 'zod';
 
 const agent = createAgent('simple', {

--- a/examples/evals/src/agent/eval/agent.ts
+++ b/examples/evals/src/agent/eval/agent.ts
@@ -1,4 +1,4 @@
-import { createAgent, type AgentContext } from '@agentuity/runtime';
+import { createAgent } from '@agentuity/runtime';
 import { s } from '@agentuity/schema';
 
 const agent = createAgent('eval', {

--- a/examples/evals/src/agent/eval/input-only/agent.ts
+++ b/examples/evals/src/agent/eval/input-only/agent.ts
@@ -1,4 +1,4 @@
-import { createAgent, type AgentContext } from '@agentuity/runtime';
+import { createAgent } from '@agentuity/runtime';
 import { s } from '@agentuity/schema';
 
 const agent = createAgent('eval/input-only', {

--- a/examples/evals/src/agent/eval/no-schema/agent.ts
+++ b/examples/evals/src/agent/eval/no-schema/agent.ts
@@ -1,4 +1,4 @@
-import { createAgent, type AgentContext } from '@agentuity/runtime';
+import { createAgent } from '@agentuity/runtime';
 
 const agent = createAgent('eval/no-schema', {
 	handler: async (_c) => {

--- a/examples/evals/src/agent/eval/output-only/agent.ts
+++ b/examples/evals/src/agent/eval/output-only/agent.ts
@@ -1,4 +1,4 @@
-import { createAgent, type AgentContext } from '@agentuity/runtime';
+import { createAgent } from '@agentuity/runtime';
 import { s } from '@agentuity/schema';
 
 const agent = createAgent('eval/output-only', {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -3,7 +3,6 @@ export {
 	type AgentEventName,
 	type AgentEventCallback,
 	type AgentRuntimeState,
-	type AgentContext,
 	type CreateEvalConfig,
 	type AgentValidator,
 	type Agent,


### PR DESCRIPTION
## Summary

Removes `AgentContext` type from the public API exports of `@agentuity/runtime`.

## Problem

When users explicitly type the context parameter as `AgentContext`, it defeats TypeScript's automatic type narrowing based on the agent's schema:

```typescript
// ❌ BAD: Defeats type inference
handler: async (ctx: AgentContext, input) => { ... }

// ✅ GOOD: Let TypeScript infer the narrowed type
handler: async (ctx, input) => { ... }
```

## Changes

- Removed `type AgentContext` export from `packages/runtime/src/index.ts`
- Removed unused `AgentContext` imports from 5 example/test files
- Type remains available internally for runtime implementation and test utilities

## Testing

- ✅ All typechecks pass
- ✅ All lints pass  
- ✅ All 931 tests pass

Fixes #44