### PR TITLE
Fix Anthropic SDK authentication patching

### DIFF
--- a/packages/cli/src/cmd/build/patch/_util.ts
+++ b/packages/cli/src/cmd/build/patch/_util.ts
@@ -44,13 +44,13 @@ export function generateGatewayEnvGuard(
 	provider: string
 ): string {
 	return `{
-    const apikey = process.env.AGENTUITY_SDK_KEY;
-    const url = process.env.AGENTUITY_AIGATEWAY_URL || process.env.AGENTUITY_TRANSPORT_URL || (apikey ? 'https://agentuity.ai' : '');
-    if (url && apikey) {
-        process.env.${apikey} = ${apikeyval};
-        process.env.${apibase} = url + '/gateway/${provider}';
+    const _agentuity_sdk_key = process.env.AGENTUITY_SDK_KEY;
+    const _agentuity_url = process.env.AGENTUITY_AIGATEWAY_URL || process.env.AGENTUITY_TRANSPORT_URL || (_agentuity_sdk_key ? 'https://agentuity.ai' : '');
+    if (_agentuity_url && _agentuity_sdk_key) {
+        process.env.${apikey} = _agentuity_sdk_key;
+        process.env.${apibase} = _agentuity_url + '/gateway/${provider}';
         console.debug('Enabled Agentuity AI Gateway for ${provider}');
-    } else {
+    } else if (!process.env.${apikey}) {
      ${generateEnvWarning(apikey)}
     }
 }

--- a/packages/cli/src/cmd/build/patch/llm.ts
+++ b/packages/cli/src/cmd/build/patch/llm.ts
@@ -24,7 +24,7 @@ export function generatePatches(): Map<string, PatchModule> {
 	const patches = new Map<string, PatchModule>();
 	registerLLMPatch(
 		patches,
-		'@anthropic-ai',
+		'@anthropic-ai/sdk',
 		'index',
 		'ANTHROPIC_API_KEY',
 		'ANTHROPIC_BASE_URL',


### PR DESCRIPTION
## Problem

Users reported this error when using the Anthropic JS SDK with Agentuity:

```
Error: Could not resolve authentication method. Expected either apiKey or authToken to be set. 
Or for one of the "X-Api-Key" or "Authorization" headers to be explicitly omitted
```

## Root Cause

1. **Module name mismatch**: The SDK build patching system registered the module as `@anthropic-ai` but the actual npm package is `@anthropic-ai/sdk`
2. **Suboptimal warning logic**: The environment variable injection would show warnings even when users had their own API keys configured

## Solution

### Fixed module name in `llm.ts`
- Changed module registration from `'@anthropic-ai'` → `'@anthropic-ai/sdk'` to match the actual package name
- This ensures the build system correctly patches the Anthropic SDK's index file

### Improved patching logic in `_util.ts`
- Better variable naming (`_agentuity_sdk_key`, `_agentuity_url`) to avoid conflicts
- Only show warning if user doesn't have `ANTHROPIC_API_KEY` already set: `else if (!process.env.${apikey})`
- This prevents false warnings when developers use their own API keys

## Testing

Created a test agent with Anthropic SDK and verified:
- Environment variables are correctly injected before SDK initialization
- No authentication errors when using Agentuity AI Gateway
- Existing user API keys are respected

## Related Issues

Fixes the authentication error reported by users when integrating Anthropic SDK with Agentuity AI Gateway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed environment variable handling in gateway configuration to prevent unintended overrides
  * Added warning notification when required API key is not configured
  * Corrected module resolution for Anthropic LLM integration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->