### PR TITLE
fix(cli): exclude .git folder from dev server file watcher

### DIFF
--- a/packages/cli/src/cmd/dev/index.ts
+++ b/packages/cli/src/cmd/dev/index.ts
@@ -938,6 +938,17 @@ export const command = createCommand({
 						return;
 					}
 
+					// Ignore .git folder
+					if (changedFile && (changedFile === '.git' || changedFile.startsWith('.git/'))) {
+						logger.trace(
+							'File change ignored (.git folder): %s (event: %s, file: %s)',
+							watchDir,
+							eventType,
+							changedFile
+						);
+						return;
+					}
+
 					// Ignore changes in .agentuity directory (build output)
 					// Check both relative path and normalized absolute path
 					const isInAgentuityDir =


### PR DESCRIPTION
Prevents hot reloading when performing git operations (commit, checkout, etc) while dev server is running.

## Changes
- Added `.git` folder exclusion to the file watcher in dev command
- Placed check right after `node_modules` exclusion for consistency

## Testing
Run `bun run dev` and perform git operations - no longer triggers hot reload.
