### PR TITLE
Remove JSON comments and JSONC file associations from agentuity.json

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,19 @@
       "name": "testing",
       "version": "0.0.86",
     },
+    "apps/testing/cloud-deployment": {
+      "name": "cloud-deployment-tests",
+      "version": "0.0.1",
+      "dependencies": {
+        "@agentuity/cli": "workspace:*",
+        "@agentuity/core": "workspace:*",
+        "@agentuity/runtime": "workspace:*",
+        "@agentuity/schema": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+    },
     "apps/testing/integration-suite": {
       "name": "integration-suite",
       "version": "0.0.1",
@@ -1306,6 +1319,8 @@
     "cli-table3": ["cli-table3@0.6.5", "", { "dependencies": { "string-width": "^4.2.0" }, "optionalDependencies": { "@colors/colors": "1.5.0" } }, "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ=="],
 
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "cloud-deployment-tests": ["cloud-deployment-tests@workspace:apps/testing/cloud-deployment"],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
@@ -2963,6 +2978,8 @@
 
     "cheerio/whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
 
+    "cloud-deployment-tests/@types/bun": ["@types/bun@1.3.4", "", { "dependencies": { "bun-types": "1.3.4" } }, "sha512-EEPTKXHP+zKGPkhRLv+HI0UEX8/o+65hqARxLy8Ov5rIxMBPNTjeZww00CIihrIQGEQBYg+0roO5qOnS/7boGA=="],
+
     "create-agentuity/@agentuity/cli": ["@agentuity/cli@0.0.62", "", { "dependencies": { "@agentuity/core": "0.0.62", "@agentuity/server": "0.0.62", "@datasert/cronjs-parser": "^1.4.0", "@terascope/fetch-github-release": "^2.2.1", "acorn-loose": "^8.5.2", "adm-zip": "^0.5.16", "astring": "^1.9.0", "cli-table3": "^0.6.5", "commander": "^14.0.2", "enquirer": "^2.4.1", "git-url-parse": "^16.1.0", "json-colorizer": "^3.0.1", "json5": "^2.2.3", "tar": "^7.5.2", "tar-fs": "^3.1.1", "typescript": "^5.9.0", "zod": "^4.1.12" }, "bin": { "agentuity": "bin/cli.ts" } }, "sha512-/6vbxsS2hmlRb0kqfmSpcRwpP/ALCrf0tiYCEQNwid4lzprEFMl1wB62tzvn+VEOt8zig+T5PJIlGfodhg93pg=="],
 
     "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
@@ -3238,6 +3255,8 @@
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "cheerio/htmlparser2/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "cloud-deployment-tests/@types/bun/bun-types": ["bun-types@1.3.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-5ua817+BZPZOlNaRgGBpZJOSAQ9RQ17pkwPD0yR7CfJg+r8DgIILByFifDTa+IPDDxzf5VNhtNlcKqFzDgJvlQ=="],
 
     "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
 


### PR DESCRIPTION
## Summary

This PR removes JSON comments from the generated `agentuity.json` file and cleans up the JSONC file association in VS Code settings to reduce editor friction.

## Changes

- Replace `generateJSON5WithComments()` with plain `JSON.stringify()` for cleaner JSON output
- Remove `'agentuity.json': 'jsonc'` file association from `.vscode/settings.json`
- Clean up unused helper functions:
  - `generateJSON5WithComments()`
  - `extractDefaultValue()`
  - `getValueWithDefaults()`

## Benefits

- Standard JSON format works seamlessly with all editors
- No more editor-specific file associations needed
- Simpler, more maintainable code (-93 lines)
- All tests pass ✓

Closes #85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified project configuration file format from JSON5 to standard JSON with schema validation support.
  * Removed automatic VSCode file association settings previously generated for configuration files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->