### PR TITLE
Fix profile create to preserve name instead of defaulting to 'production'

### DIFF
--- a/packages/cli/src/cmd/profile/create.ts
+++ b/packages/cli/src/cmd/profile/create.ts
@@ -73,6 +73,7 @@ export const createCommand = createSubcommand({
 			if (name === 'local') {
 				// if we're creating a local profile, go ahead and fill it out for the dev to make it easier to get started
 				const localConfig = (await loadConfig(filename)) as Config;
+				localConfig.name = name;
 				localConfig.overrides = {
 					api_url: 'https://api.agentuity.io',
 					app_url: 'https://app.agentuity.io',


### PR DESCRIPTION
Fixes #90

When creating a local profile with `agentuity profile create local`, the profile was being created with `name: production` instead of `name: local`.

## Root Cause
The bug was in the profile creation code. When the 'local' profile is created, the code loads the newly created config file and adds local development overrides. However, after loading the config, the name field wasn't being explicitly preserved before calling `saveConfig()`, causing it to default back to 'production'.

## Fix
Added `localConfig.name = name;` to explicitly preserve the profile name before saving the config with overrides.

## Testing
- Verified typecheck passes
- Verified lint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed local profile initialization to properly include an explicit name field during profile creation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->