### PR TITLE
fix(cli): Change --help=[json] to --help [json] to fix exit code

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -229,7 +229,7 @@ export async function createCLI(version: string): Promise<Command> {
 	program
 		.name('agentuity')
 		.version(version, '-v, --version', 'Display version')
-		.helpOption('-h, --help=[json]', 'Display help (with optional JSON output)')
+		.helpOption('-h, --help [json]', 'Display help (with optional JSON output)')
 		.allowUnknownOption(false)
 		.allowExcessArguments(false)
 		.showHelpAfterError(true);
@@ -553,7 +553,7 @@ async function registerSubcommand(
 ): Promise<void> {
 	const cmd = parent.command(subcommand.name, { hidden }).description(subcommand.description);
 
-	cmd.helpOption('-h, --help=[json]', 'Display help (with optional JSON output)');
+	cmd.helpOption('-h, --help [json]', 'Display help (with optional JSON output)');
 
 	if (subcommand.aliases) {
 		cmd.aliases(subcommand.aliases);
@@ -1210,7 +1210,7 @@ export async function registerCommands(
 				.command(cmdDef.name, { hidden: cmdDef.hidden })
 				.description(cmdDef.description);
 
-			cmd.helpOption('-h, --help=[json]', 'Display help (with optional JSON output)');
+			cmd.helpOption('-h, --help [json]', 'Display help (with optional JSON output)');
 
 			if (cmdDef.aliases) {
 				cmd.aliases(cmdDef.aliases);


### PR DESCRIPTION
## Problem

The SDK upgrade tests were failing because the `--help=[json]` syntax caused commander.js to exit with code 1 when using `--help` without a value. The test expects exit code 0.

Test failure:
- Running `agentuity upgrade --help` displayed help correctly but exited with code 1
- Running `agentuity upgrade -h` worked fine and exited with code 0

## Solution

Changed the help option syntax from `--help=[json]` to `--help [json]` (space instead of equals sign with brackets) in all 3 locations in cli.ts.

This makes commander.js properly handle the optional parameter and exit with code 0.

## Verification

Both syntaxes still work for JSON output:
- `--help json` (space-separated) ✅
- `--help=json` (equals sign) ✅
- `--help` (no parameter) ✅ now exits with code 0

Tested with compiled executable:
```bash
/tmp/agentuity-fixed upgrade --help     # Exit code: 0 ✅
/tmp/agentuity-fixed upgrade --help json # Exit code: 0 ✅ (JSON output)
/tmp/agentuity-fixed upgrade --help=json # Exit code: 0 ✅ (JSON output)
```

## Fixes

Fixes https://github.com/agentuity/sdk/actions/runs/20120327618/job/57738881100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized help option syntax across the CLI. Updated the help flag format in all commands and subcommands to use uniform formatting for optional JSON output parameters. This ensures consistent and predictable behavior when users request help with JSON output, improving the overall usability and reliability of the command-line interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->