### PR TITLE
fix: prevent catch-all route from intercepting API routes

### DIFF
--- a/packages/runtime/src/_server.ts
+++ b/packages/runtime/src/_server.ts
@@ -52,7 +52,7 @@ let globalLogger: Logger | null = null;
 /**
  * List of AgentContext properties that should trigger helpful error messages
  * when accessed directly on HonoContext in route handlers.
- * 
+ *
  * Users should access these via c.var.propertyName instead of c.propertyName.
  */
 export const AGENT_CONTEXT_PROPERTIES = [


### PR DESCRIPTION
## Problem
In v0.87, the catch-all route was returning HTML for all non-matched paths, including API routes like `/api/agents`. This caused API endpoints to return the SPA HTML instead of proper 404 responses.

## Solution
Updated the catch-all handler in `plugin.ts` to check if the path is `/api` or starts with `/api/` and return 404 instead of HTML for these paths.

## Changes
- Modified catch-all route handler to skip API paths
- Added comprehensive test suite with 11 test cases covering:
  - API routes returning JSON
  - Non-existent API routes returning 404 (not HTML)
  - Edge cases: `/api`, `/api/`, `/apiSomething`
  - SPA fallback behavior
  - Directory traversal protection

## Testing
```bash
cd packages/cli
bun test test/build/catchall-routing.test.ts
```

All tests pass ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed routing to ensure API requests under `/api` properly return 404 instead of being served by static asset middleware, improving API route handling.

* **Tests**
  * Added comprehensive test coverage for catch-all routing including API paths, SPA patterns, and directory traversal protection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->