### PR TITLE
fix: show banner when using --help or -h flags

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -11,7 +11,7 @@ import type {
 	AuthData,
 	GlobalOptions,
 } from './types';
-import { showBanner } from './banner';
+import { showBanner, generateBanner } from './banner';
 import { requireAuth, optionalAuth, requireOrg, optionalOrg as selectOptionalOrg } from './auth';
 import { listRegions, type RegionList } from '@agentuity/server';
 import enquirer from 'enquirer';
@@ -262,7 +262,6 @@ export async function createCLI(version: string): Promise<Command> {
 	program.addOption(skipVersionCheckOption);
 
 	program.action(() => {
-		showBanner(version);
 		program.help();
 	});
 
@@ -366,8 +365,15 @@ export async function createCLI(version: string): Promise<Command> {
 				return term;
 			}
 
-			// Format each section (don't show banner for subcommands)
+			// Format each section (show banner for root command)
 			let output = '';
+
+			// Show banner if this is the root command (no parent)
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const isRootCommand = !(cmd as any).parent;
+			if (isRootCommand) {
+				output += `${generateBanner(version)}\n\n`;
+			}
 
 			// Description
 			const description = helper.commandDescription(cmd);


### PR DESCRIPTION
## Summary
Fixes the CLI banner not displaying when using `--help` or `-h` flags.

## Changes
- Modified `formatHelp()` in `cli.ts` to include banner for root command
- Removed duplicate banner call from root action handler to prevent double-display
- Imported `generateBanner()` function to get banner text

## Testing
- ✅ Banner shows with `--help`
- ✅ Banner shows with `-h`
- ✅ Banner shows with no arguments
- ✅ Banner doesn't show for subcommands (e.g., `auth --help`)
- ✅ Typecheck passes
- ✅ Lint passes

Fixes #113

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Root command banner now displays when rendering help output rather than at startup.
  * Subcommand banner behavior unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->