### PR TITLE
fix: skip Hono middleware methods in router parsing

### DIFF
--- a/packages/cli/src/cmd/build/ast.ts
+++ b/packages/cli/src/cmd/build/ast.ts
@@ -1270,6 +1270,13 @@ export async function parseRoute(
 						let suffix = '';
 						let config: Record<string, unknown> | undefined;
 						switch (method) {
+							case 'use':
+							case 'on':
+							case 'all':
+							case 'route': {
+								// Skip Hono middleware/routing methods - they don't represent API routes
+								continue;
+							}
 							case 'get':
 							case 'put':
 							case 'post':


### PR DESCRIPTION
Fixes the 'unsupported router method' error when using Hono middleware methods like `use()`, `on()`, `all()`, and `route()`.

These methods are for middleware and routing composition, not API endpoints, so they should be skipped during route parsing.

**Changes:**
- Updated router parser to skip `use`, `on`, `all`, and `route` methods
- Added comprehensive test cases
- All 335 tests passing ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route detection in the CLI to properly exclude middleware and routing configuration methods from being identified as API routes, ensuring more accurate route extraction.

* **Tests**
  * Added test coverage validating correct handling of middleware and routing methods during route parsing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->