### PR TITLE
fix: Correct MIME type for CSS files in CDN uploads

### DIFF
--- a/packages/cli/test/build/mime-type.test.ts
+++ b/packages/cli/test/build/mime-type.test.ts
@@ -1,0 +1,84 @@
+import { describe, test, expect } from 'bun:test';
+import { getCorrectMimeType } from '../../src/cmd/build/bundler';
+
+describe('getCorrectMimeType', () => {
+	test('should return correct MIME type for CSS files', () => {
+		expect(getCorrectMimeType('styles.css', 'text/javascript;charset=utf-8')).toBe(
+			'text/css;charset=utf-8'
+		);
+		expect(getCorrectMimeType('chunk/index-abc123.css', 'text/javascript;charset=utf-8')).toBe(
+			'text/css;charset=utf-8'
+		);
+	});
+
+	test('should return correct MIME type for JavaScript files', () => {
+		expect(getCorrectMimeType('main.js', 'text/javascript;charset=utf-8')).toBe(
+			'text/javascript;charset=utf-8'
+		);
+		expect(getCorrectMimeType('module.mjs', 'text/javascript;charset=utf-8')).toBe(
+			'text/javascript;charset=utf-8'
+		);
+	});
+
+	test('should return correct MIME type for JSON files', () => {
+		expect(getCorrectMimeType('data.json', 'text/javascript;charset=utf-8')).toBe(
+			'application/json;charset=utf-8'
+		);
+		expect(getCorrectMimeType('index.js.map', 'text/javascript;charset=utf-8')).toBe(
+			'application/json;charset=utf-8'
+		);
+	});
+
+	test('should return correct MIME type for image files', () => {
+		expect(getCorrectMimeType('logo.svg', 'text/javascript;charset=utf-8')).toBe('image/svg+xml');
+		expect(getCorrectMimeType('photo.png', 'text/javascript;charset=utf-8')).toBe('image/png');
+		expect(getCorrectMimeType('banner.jpg', 'text/javascript;charset=utf-8')).toBe('image/jpeg');
+		expect(getCorrectMimeType('image.jpeg', 'text/javascript;charset=utf-8')).toBe('image/jpeg');
+		expect(getCorrectMimeType('animation.gif', 'text/javascript;charset=utf-8')).toBe('image/gif');
+		expect(getCorrectMimeType('modern.webp', 'text/javascript;charset=utf-8')).toBe('image/webp');
+	});
+
+	test('should return correct MIME type for font files', () => {
+		expect(getCorrectMimeType('font.woff', 'text/javascript;charset=utf-8')).toBe('font/woff');
+		expect(getCorrectMimeType('font.woff2', 'text/javascript;charset=utf-8')).toBe('font/woff2');
+		expect(getCorrectMimeType('font.ttf', 'text/javascript;charset=utf-8')).toBe('font/ttf');
+		expect(getCorrectMimeType('font.otf', 'text/javascript;charset=utf-8')).toBe('font/otf');
+	});
+
+	test('should handle case-insensitive extensions', () => {
+		expect(getCorrectMimeType('STYLES.CSS', 'text/javascript;charset=utf-8')).toBe(
+			'text/css;charset=utf-8'
+		);
+		expect(getCorrectMimeType('Image.PNG', 'text/javascript;charset=utf-8')).toBe('image/png');
+	});
+
+	test('should fall back to Bun type for unknown extensions', () => {
+		expect(getCorrectMimeType('file.xyz', 'application/octet-stream')).toBe(
+			'application/octet-stream'
+		);
+		expect(getCorrectMimeType('noextension', 'text/plain')).toBe('text/plain');
+	});
+
+	test('should handle files with multiple dots in path', () => {
+		expect(getCorrectMimeType('path/to/file.min.css', 'text/javascript;charset=utf-8')).toBe(
+			'text/css;charset=utf-8'
+		);
+		expect(getCorrectMimeType('bundle.es2020.js', 'text/javascript;charset=utf-8')).toBe(
+			'text/javascript;charset=utf-8'
+		);
+	});
+
+	test('should use extension-based mapping when Bun type is incorrect', () => {
+		// This is the actual bug case - CSS file returns as text/javascript
+		expect(getCorrectMimeType('index-pvgqwfs9.css', 'text/javascript;charset=utf-8')).toBe(
+			'text/css;charset=utf-8'
+		);
+	});
+
+	test('should preserve Bun type when extension mapping is correct', () => {
+		// When Bun correctly identifies the type, we override it anyway with our mapping
+		expect(getCorrectMimeType('styles.css', 'text/css;charset=utf-8')).toBe(
+			'text/css;charset=utf-8'
+		);
+	});
+});


### PR DESCRIPTION
## Problem

CSS files uploaded to the CDN (static.agentuity.com) were being served with incorrect `content-type: text/javascript` headers instead of `text/css`. This was caused by a bug in Bun.build where the `artifact.type` property returns incorrect MIME types.

Example:
```bash
curl -I "https://static.agentuity.com/deploy_27bb8a985969db3773a5c5f5dcbb23a0/web/chunk/index-pvgqwfs9.css"
# Returned: content-type: text/javascript;charset=utf-8
# Expected: content-type: text/css;charset=utf-8
```

## Solution

Added `getCorrectMimeType()` function that maps file extensions to correct MIME types, overriding Bun's incorrect type detection. The function:

- Maps common web assets (CSS, JS, JSON, images, fonts, source maps) to correct MIME types
- Falls back to Bun's type for unknown extensions
- Handles case-insensitive extensions
- Is fully tested with 10 unit tests

## Changes

- [`bundler.ts`](../packages/cli/src/cmd/build/bundler.ts#L22-L50): Added `getCorrectMimeType()` function
- [`bundler.ts`](../packages/cli/src/cmd/build/bundler.ts#L627): Use correct MIME type when building asset metadata
- [`mime-type.test.ts`](../packages/cli/test/build/mime-type.test.ts): Comprehensive unit tests

## Testing

- ✅ All existing tests pass
- ✅ 10 new unit tests for MIME type mapping
- ✅ Typecheck passes
- ✅ Lint passes

## Reference

Bun bug: https://github.com/oven-sh/bun/issues/20131