### PR TITLE
fix(runtime): Set Content-Type header for stream routes

### DIFF
--- a/packages/cli/test/build/fixtures/plugin-integration-simple/agentuity.config.ts
+++ b/packages/cli/test/build/fixtures/plugin-integration-simple/agentuity.config.ts
@@ -1,0 +1,14 @@
+import tailwindcss from 'bun-plugin-tailwind';
+
+export default function config(phase, context) {
+	context.logger.info('Config executed for phase: ' + phase);
+
+	if (phase === 'web') {
+		context.logger.info('Adding Tailwind plugin for web phase');
+		return {
+			plugins: [tailwindcss],
+		};
+	}
+
+	return {};
+}


### PR DESCRIPTION
## Summary

`router.stream()` now sets `Content-Type: application/octet-stream` header before calling `honoStream()`. This allows client-side hooks like `useAPI` to detect streaming responses and handle them correctly.

## Problem

Without this header, the `useAPI` hook in `@agentuity/react` (lines 521-524 of `api.ts`) checks for specific content types to enable streaming:

```typescript
if (
  contentType.includes('text/event-stream') ||
  contentType.includes('application/octet-stream')
) {
  // Handle as stream...
}
```

When no Content-Type is set, streaming responses fall through to regular JSON/text parsing which waits for the entire response before processing - breaking real-time streaming on the client.

## Solution

Add `c.header('Content-Type', 'application/octet-stream')` before calling `honoStream()` in the `router.stream()` wrapper.

## Testing

Tested with air-new project - streaming now works correctly with tokens arriving incrementally.

Fixes #179

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming responses now include proper content-type headers for improved client detection and compatibility.

* **Chores**
  * Removed legacy phase-based plugin configuration from test fixtures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->