### PR TITLE
fix: make logs gitignore pattern specific to root directory

### DIFF
--- a/templates/_base/gitignore
+++ b/templates/_base/gitignore
@@ -15,7 +15,7 @@ coverage
 
 # logs
 
-logs
+/logs
 _.log
 report.[0-9]_.[0-9]_.[0-9]_.[0-9]\*.json
 


### PR DESCRIPTION
Fixes #184

Changed `logs` to `/logs` in the gitignore template to prevent ignoring routes or folders named 'logs' in subdirectories. 

The issue occurred in opscenter where a route folder called `logs` was being ignored by git due to the overly broad pattern.

**Changes:**
- Updated `sdk/templates/_base/gitignore` to use `/logs` (root-only) instead of `logs` (all directories)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `.gitignore` template to use a root-relative path for the logs directory exclusion, ensuring consistent project configuration across installations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->