### PR TITLE
Fix regression: Remove import.meta.main check that prevented dev server from starting

### DIFF
--- a/packages/cli/src/cmd/build/entry-generator.ts
+++ b/packages/cli/src/cmd/build/entry-generator.ts
@@ -290,9 +290,7 @@ if (existsSync(workbenchIndexPath)) {
 	// Server startup (same for dev and prod - Bun.serve with native WebSocket)
 	const serverStartup = `
 // Start Bun server${isDev ? ' (dev mode with Vite asset proxy)' : ''}
-if (typeof Bun !== 'undefined' && !import.meta.main) {
-	// Not the main module, skip server startup (this is being imported/analyzed)
-} else if (typeof Bun !== 'undefined') {
+if (typeof Bun !== 'undefined') {
 	// Enable process exit protection now that we're starting the server
 	enableProcessExitProtection();
 	

--- a/packages/cli/src/cmd/build/vite/bun-dev-server.ts
+++ b/packages/cli/src/cmd/build/vite/bun-dev-server.ts
@@ -42,7 +42,7 @@ export async function startBunDevServer(options: BunDevServerOptions): Promise<B
 	}
 
 	// Step 1: Start Vite asset server FIRST and get its dynamic port
-	logger.info('🎨 Starting Vite asset server for HMR...');
+	logger.debug('🎨 Starting Vite asset server for HMR...');
 	const viteAssetServer = await startViteAssetServer({
 		rootDir,
 		logger,
@@ -51,7 +51,7 @@ export async function startBunDevServer(options: BunDevServerOptions): Promise<B
 	const vitePort = viteAssetServer.port;
 
 	// Step 2: Generate entry file with Vite port for asset proxying
-	logger.info('📝 Generating entry file with asset proxy configuration...');
+	logger.debug('📝 Generating entry file with asset proxy configuration...');
 	const { generateEntryFile } = await import('../entry-generator');
 	await generateEntryFile({
 		rootDir,
@@ -64,9 +64,46 @@ export async function startBunDevServer(options: BunDevServerOptions): Promise<B
 	});
 
 	// Step 3: Load the generated app - this will start Bun.serve() internally
-	logger.info('📦 Loading generated app (Bun server will start)...');
+	logger.debug('📦 Loading generated app (Bun server will start)...');
 	const appPath = `${rootDir}/.agentuity/app.generated.ts`;
+	
+	// Set PORT env var so the generated app uses the correct port
+	process.env.PORT = String(port);
+	
 	await import(appPath);
+
+	// Wait for server to actually start listening
+	// The generated app sets (globalThis as any).__AGENTUITY_SERVER__ when server starts
+	const maxRetries = 50; // Increased retries for slower systems
+	const retryDelay = 100; // ms
+	let serverReady = false;
+
+	for (let i = 0; i < maxRetries; i++) {
+		// Check if global server object exists
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		if ((globalThis as any).__AGENTUITY_SERVER__) {
+			// Server object exists, now verify it's actually listening by making a request
+			try {
+				await fetch(`http://127.0.0.1:${port}/`, {
+					method: 'HEAD',
+					signal: AbortSignal.timeout(1000),
+				});
+				// Any response (even 404) means server is listening
+				serverReady = true;
+				break;
+			} catch {
+				// Connection refused or timeout - server not ready yet
+			}
+		}
+		// Wait before next check
+		await new Promise((resolve) => setTimeout(resolve, retryDelay));
+	}
+
+	if (!serverReady) {
+		throw new Error(
+			`Bun server failed to start on port ${port} after ${maxRetries * retryDelay}ms`
+		);
+	}
 
 	logger.info(`✅ Bun dev server started on http://127.0.0.1:${port}`);
 	logger.debug(`Asset requests (/@vite/*, /src/web/*, etc.) proxied to Vite:${vitePort}`);


### PR DESCRIPTION
PR #192 introduced a regression where the dev server would not start when
accessed via http://127.0.0.1:3500. The root cause was in entry-generator.ts
which added a check to skip server startup when !import.meta.main (not the
main module). This prevented Bun.serve() from being called when the generated
app file was dynamically imported by bun-dev-server.ts.

Changes:
- Remove import.meta.main check in entry-generator.ts
- Add server readiness polling in bun-dev-server.ts to ensure server is
  listening before returning (checks both global server object and actual
  network connectivity)

Testing:
- Verified dev server starts and responds to requests at http://127.0.0.1:3500
- All 303 CLI tests pass
- Typecheck passes

Amp-Thread-ID: https://ampcode.com/threads/T-019b2dc5-1a65-7639-afee-6020af627f97
Co-authored-by: Amp <amp@ampcode.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bun server now starts unconditionally when available.
  * Added server readiness verification to prevent incomplete initialization.
  * Improved error messaging when server fails to start within timeout.
  * Reduced startup log verbosity by moving routine messages to debug level.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->