### PR TITLE
fix: add /client/ prefix to CDN base URL for production assets

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -139,9 +139,9 @@
       "name": "@agentuity/auth",
       "version": "0.0.97",
       "devDependencies": {
-        "@agentuity/react": "0.0.97",
-        "@agentuity/runtime": "0.0.97",
-        "@agentuity/test-utils": "0.0.97",
+        "@agentuity/react": "workspace:*",
+        "@agentuity/runtime": "workspace:*",
+        "@agentuity/test-utils": "workspace:*",
         "@clerk/backend": "^2.27.1",
         "@clerk/clerk-react": "^5.46.1",
         "@types/react": "^18.3.18",
@@ -150,8 +150,8 @@
         "typescript": "^5.8.3",
       },
       "peerDependencies": {
-        "@agentuity/react": "0.0.97",
-        "@agentuity/runtime": "0.0.97",
+        "@agentuity/react": "workspace:*",
+        "@agentuity/runtime": "workspace:*",
         "@clerk/backend": "^1.0.0",
         "@clerk/clerk-react": "^5.0.0",
         "hono": "^4.0.0",
@@ -206,7 +206,7 @@
         "zod": "^4.1.12",
       },
       "devDependencies": {
-        "@agentuity/test-utils": "0.0.97",
+        "@agentuity/test-utils": "workspace:*",
         "@types/bun": "latest",
         "bun-types": "latest",
         "typescript": "^5.9.0",
@@ -216,7 +216,7 @@
       "name": "@agentuity/react",
       "version": "0.0.97",
       "dependencies": {
-        "@agentuity/core": "0.0.97",
+        "@agentuity/core": "workspace:*",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -232,9 +232,9 @@
       "name": "@agentuity/runtime",
       "version": "0.0.97",
       "dependencies": {
-        "@agentuity/core": "0.0.97",
-        "@agentuity/schema": "0.0.97",
-        "@agentuity/server": "0.0.97",
+        "@agentuity/core": "workspace:*",
+        "@agentuity/schema": "workspace:*",
+        "@agentuity/server": "workspace:*",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/api-logs": "^0.207.0",
         "@opentelemetry/auto-instrumentations-node": "^0.66.0",
@@ -258,7 +258,7 @@
         "zod": "^4.1.12",
       },
       "devDependencies": {
-        "@agentuity/test-utils": "0.0.97",
+        "@agentuity/test-utils": "workspace:*",
         "@types/bun": "latest",
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.2",
@@ -275,10 +275,10 @@
       "name": "@agentuity/schema",
       "version": "0.0.97",
       "dependencies": {
-        "@agentuity/core": "0.0.97",
+        "@agentuity/core": "workspace:*",
       },
       "devDependencies": {
-        "@agentuity/test-utils": "0.0.97",
+        "@agentuity/test-utils": "workspace:*",
         "@types/bun": "latest",
         "bun-types": "latest",
         "typescript": "^5.9.0",
@@ -288,12 +288,12 @@
       "name": "@agentuity/server",
       "version": "0.0.97",
       "dependencies": {
-        "@agentuity/core": "0.0.97",
-        "@agentuity/schema": "0.0.97",
+        "@agentuity/core": "workspace:*",
+        "@agentuity/schema": "workspace:*",
         "zod": "^4.1.12",
       },
       "devDependencies": {
-        "@agentuity/test-utils": "0.0.97",
+        "@agentuity/test-utils": "workspace:*",
         "@types/bun": "latest",
         "@types/node": "^22.0.0",
         "bun-types": "latest",
@@ -304,7 +304,7 @@
       "name": "@agentuity/test-utils",
       "version": "0.0.97",
       "dependencies": {
-        "@agentuity/core": "0.0.97",
+        "@agentuity/core": "workspace:*",
       },
       "devDependencies": {
         "bun-types": "^1.3.3",

--- a/packages/cli/src/cmd/build/vite/vite-builder.ts
+++ b/packages/cli/src/cmd/build/vite/vite-builder.ts
@@ -89,7 +89,7 @@ export async function runViteBuild(options: ViteBuildOptions): Promise<void> {
 		const isLocalRegion = options.region === 'local';
 		const cdnBaseUrl =
 			!dev && deploymentId && !isLocalRegion
-				? `https://static.agentuity.com/${deploymentId}/`
+				? `https://static.agentuity.com/${deploymentId}/client/`
 				: undefined;
 
 		viteConfig = {


### PR DESCRIPTION
Fixes #213

## Problem
After deployment, the SPA was returning 404 errors when loading JavaScript assets. This was a regression in production deployments.

## Root Cause
- Assets are uploaded to S3 with paths like: `<deploymentId>/client/assets/main-abc123.js`
- CDN base URL was set to: `https://static.agentuity.com/<deploymentId>/`
- Vite generated asset references without the `/client/` prefix
- Browser tried to load: `https://static.agentuity.com/<deploymentId>/assets/main-abc123.js` (404)

## Solution
Added `/client/` to the CDN base URL so Vite generates correct asset paths:
```typescript
const cdnBaseUrl = `https://static.agentuity.com/${deploymentId}/client/`
```

## Testing
- ✅ Typecheck passed
- ✅ Build passed

Thread: https://ampcode.com/threads/T-019b2dd3-f678-707f-ab56-380a830f75f5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated production asset delivery path for improved compatibility and correct asset loading in production environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->