### PR TITLE
Fix postinstall readout unreadable in light mode terminal

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -139,9 +139,9 @@
       "name": "@agentuity/auth",
       "version": "0.0.98",
       "devDependencies": {
-        "@agentuity/react": "0.0.98",
-        "@agentuity/runtime": "0.0.98",
-        "@agentuity/test-utils": "0.0.98",
+        "@agentuity/react": "workspace:*",
+        "@agentuity/runtime": "workspace:*",
+        "@agentuity/test-utils": "workspace:*",
         "@clerk/backend": "^2.27.1",
         "@clerk/clerk-react": "^5.46.1",
         "@types/react": "^18.3.18",
@@ -150,8 +150,8 @@
         "typescript": "^5.8.3",
       },
       "peerDependencies": {
-        "@agentuity/react": "0.0.98",
-        "@agentuity/runtime": "0.0.98",
+        "@agentuity/react": "workspace:*",
+        "@agentuity/runtime": "workspace:*",
         "@clerk/backend": "^1.0.0",
         "@clerk/clerk-react": "^5.0.0",
         "hono": "^4.0.0",
@@ -206,7 +206,7 @@
         "zod": "^4.1.12",
       },
       "devDependencies": {
-        "@agentuity/test-utils": "0.0.98",
+        "@agentuity/test-utils": "workspace:*",
         "@types/bun": "latest",
         "bun-types": "latest",
         "typescript": "^5.9.0",
@@ -216,7 +216,7 @@
       "name": "@agentuity/react",
       "version": "0.0.98",
       "dependencies": {
-        "@agentuity/core": "0.0.98",
+        "@agentuity/core": "workspace:*",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -232,9 +232,9 @@
       "name": "@agentuity/runtime",
       "version": "0.0.98",
       "dependencies": {
-        "@agentuity/core": "0.0.98",
-        "@agentuity/schema": "0.0.98",
-        "@agentuity/server": "0.0.98",
+        "@agentuity/core": "workspace:*",
+        "@agentuity/schema": "workspace:*",
+        "@agentuity/server": "workspace:*",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/api-logs": "^0.207.0",
         "@opentelemetry/auto-instrumentations-node": "^0.66.0",
@@ -258,7 +258,7 @@
         "zod": "^4.1.12",
       },
       "devDependencies": {
-        "@agentuity/test-utils": "0.0.98",
+        "@agentuity/test-utils": "workspace:*",
         "@types/bun": "latest",
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.2",
@@ -275,10 +275,10 @@
       "name": "@agentuity/schema",
       "version": "0.0.98",
       "dependencies": {
-        "@agentuity/core": "0.0.98",
+        "@agentuity/core": "workspace:*",
       },
       "devDependencies": {
-        "@agentuity/test-utils": "0.0.98",
+        "@agentuity/test-utils": "workspace:*",
         "@types/bun": "latest",
         "bun-types": "latest",
         "typescript": "^5.9.0",
@@ -288,12 +288,12 @@
       "name": "@agentuity/server",
       "version": "0.0.98",
       "dependencies": {
-        "@agentuity/core": "0.0.98",
-        "@agentuity/schema": "0.0.98",
+        "@agentuity/core": "workspace:*",
+        "@agentuity/schema": "workspace:*",
         "zod": "^4.1.12",
       },
       "devDependencies": {
-        "@agentuity/test-utils": "0.0.98",
+        "@agentuity/test-utils": "workspace:*",
         "@types/bun": "latest",
         "@types/node": "^22.0.0",
         "bun-types": "latest",
@@ -304,7 +304,7 @@
       "name": "@agentuity/test-utils",
       "version": "0.0.98",
       "dependencies": {
-        "@agentuity/core": "0.0.98",
+        "@agentuity/core": "workspace:*",
       },
       "devDependencies": {
         "bun-types": "^1.3.3",

--- a/packages/cli/src/banner.ts
+++ b/packages/cli/src/banner.ts
@@ -29,9 +29,30 @@ export function generateBanner(version?: string, compact?: true): string {
 	const versionLabel = ' Version:        '; // Include leading space
 	const versionLink = LINKS
 		? link(getReleaseUrl(_version), _version, WHITE ?? undefined)
-		: _version;
+		: WHITE + _version + RESET;
 	const versionLinkWidth = getDisplayWidth(stripAnsi(versionLink));
 	const versionPadding = width - versionLabel.length - versionLinkWidth - 1;
+
+	const docsLabel = ' Docs:           ';
+	const docsLink = LINKS
+		? link('https://preview.agentuity.dev', 'preview.agentuity.dev', WHITE!)
+		: WHITE + 'https://preview.agentuity.dev' + RESET;
+	const docsWidth = getDisplayWidth(stripAnsi(docsLink));
+	const docsPadding = width - docsLabel.length - docsWidth - 1;
+
+	const communityLabel = ' Community:      ';
+	const communityLink = LINKS
+		? link('https://discord.gg/agentuity', 'discord.gg/agentuity', WHITE!)
+		: WHITE + 'https://discord.gg/agentuity' + RESET;
+	const communityWidth = getDisplayWidth(stripAnsi(communityLink));
+	const communityPadding = width - communityLabel.length - communityWidth - 1;
+
+	const dashboardLabel = ' Dashboard:      ';
+	const dashboardLink = LINKS
+		? link('https://app-v1.agentuity.com', 'app-v1.agentuity.com', WHITE!)
+		: WHITE + 'https://app-v1.agentuity.com' + RESET;
+	const dashboardWidth = getDisplayWidth(stripAnsi(dashboardLink));
+	const dashboardPadding = width - dashboardLabel.length - dashboardWidth - 1;
 
 	const lines = [
 		CYAN + '╭────────────────────────────────────────────────────╮' + RESET,
@@ -44,19 +65,13 @@ export function generateBanner(version?: string, compact?: true): string {
 				RESET,
 		compact
 			? undefined
-			: CYAN +
-				`│ Docs:           ${link('https://preview.agentuity.dev', undefined, WHITE!)}${CYAN}      │` +
-				RESET,
+			: CYAN + `│${docsLabel}${docsLink + ''.padEnd(docsPadding) + CYAN} │` + RESET,
 		compact
 			? undefined
-			: CYAN +
-				`│ Community:      ${link('https://discord.gg/agentuity', undefined, WHITE!)}${CYAN}       │` +
-				RESET,
+			: CYAN + `│${communityLabel}${communityLink + ''.padEnd(communityPadding) + CYAN} │` + RESET,
 		compact
 			? undefined
-			: CYAN +
-				`│ Dashboard:      ${link('https://app-v1.agentuity.com', undefined, WHITE!)}${CYAN}       │` +
-				RESET,
+			: CYAN + `│${dashboardLabel}${dashboardLink + ''.padEnd(dashboardPadding) + CYAN} │` + RESET,
 		CYAN + '╰────────────────────────────────────────────────────╯' + RESET,
 	].filter(Boolean) as string[];
 

--- a/packages/cli/src/cmd/setup/index.ts
+++ b/packages/cli/src/cmd/setup/index.ts
@@ -29,10 +29,10 @@ export const command = createCommand({
 			tui.output(`${tui.muted('To get started, run:')}`);
 			tui.newline();
 			tui.output(
-				`${getCommand('login')}        ${tui.muted('Login to an existing account (or signup)')}`
+				`${tui.colorPrimary(getCommand('login'))}        ${tui.muted('Login to an existing account (or signup)')}`
 			);
-			tui.output(`${getCommand('create')}       ${tui.muted('Create a project')}`);
-			tui.output(`${getCommand('help')}         ${tui.muted('List commands and options')}`);
+			tui.output(`${tui.colorPrimary(getCommand('create'))}       ${tui.muted('Create a project')}`);
+			tui.output(`${tui.colorPrimary(getCommand('help'))}         ${tui.muted('List commands and options')}`);
 		} else {
 			tui.success('Welcome back! 🙌');
 		}


### PR DESCRIPTION
Fixes #211

## Changes

- Use adaptive `tui.colorPrimary()` for commands in setup output, which displays black in light mode and white in dark mode
- Calculate proper padding for banner links when hyperlinks are not supported
- Include `https://` prefix in non-hyperlink URLs for clarity

## Testing

Tested with `TERM=dumb` to simulate terminals without hyperlink support - banner borders now align correctly and text is readable in both light and dark modes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved CLI banner display with better link rendering and layout alignment, including proper styling when hyperlinks are unavailable.
  * Added color highlighting to setup command instructions for enhanced visual clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->