### PR TITLE
fix: add --external flags to test-upgrade.sh compile step

### DIFF
--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -36,7 +36,15 @@ print_info() {
 # Build compiled executable for testing
 build_executable() {
 	print_info "Building compiled executable..."
-	(cd "$CLI_DIR" && bun build --compile --minify --sourcemap bin/cli.ts --outfile agentuity) > /dev/null 2>&1
+	(cd "$CLI_DIR" && bun build --compile --minify --sourcemap \
+		--external vite \
+		--external @vitejs/plugin-react \
+		--external @hono/vite-dev-server \
+		--external @hono/vite-build \
+		--external lightningcss \
+		--external esbuild \
+		--external rollup \
+		bin/cli.ts --outfile agentuity) > /dev/null 2>&1
 	if [ ! -f "$CLI_COMPILED" ]; then
 		print_error "Failed to build executable"
 		return 1


### PR DESCRIPTION
## Problem
The `Test Upgrade Command` CI job was failing on main with:
```
error: Could not resolve: "@babel/preset-typescript/package.json"
error: Could not resolve: "../pkg"
```

## Root Cause
The `scripts/test-upgrade.sh` script compiles the CLI executable without `--external` flags for Vite dependencies (vite, lightningcss, esbuild, etc.). When these dependencies get bundled into the executable, Bun fails to resolve their internal package.json files.

## Solution
Add the same `--external` flags that `scripts/build-executables.ts` uses:
- vite
- @vitejs/plugin-react
- @hono/vite-dev-server
- @hono/vite-build
- lightningcss
- esbuild
- rollup

## Testing
✅ Local test passes: `./scripts/test-upgrade.sh`
✅ All 6 upgrade tests pass
✅ Executable builds and runs successfully

Fixes the CI failure from commit eb1ad5f (PR #221).