### PR TITLE
fix: prevent event listener leaks in dev mode

### DIFF
--- a/packages/cli/src/cmd/dev/index.ts
+++ b/packages/cli/src/cmd/dev/index.ts
@@ -247,6 +247,7 @@ export const command = createCommand({
 		// Vite stays running and handles frontend changes via HMR
 		let shouldRestart = false;
 		let gravityProcess: ProcessLike | null = null;
+		let stdinListenerRegistered = false; // Track if stdin listener is already registered
 
 		const restartServer = () => {
 			shouldRestart = true;
@@ -453,8 +454,9 @@ export const command = createCommand({
 				// TODO: Integrate sync service with Vite's buildStart/buildEnd hooks
 				// The sync service will be called when metadata changes are detected
 
-				// Handle keyboard shortcuts
-				if (interactive && process.stdin.isTTY && process.stdout.isTTY) {
+				// Handle keyboard shortcuts - only register listener once
+				if (interactive && process.stdin.isTTY && process.stdout.isTTY && !stdinListenerRegistered) {
+					stdinListenerRegistered = true;
 					process.stdin.setRawMode(true);
 					process.stdin.resume();
 					process.stdin.setEncoding('utf8');

--- a/packages/runtime/src/devmode.ts
+++ b/packages/runtime/src/devmode.ts
@@ -78,12 +78,23 @@ const overlay = `
 </style>
 `;
 
+// Global controller to avoid registering multiple SIGINT listeners
+let globalController: AbortController | undefined;
+let globalSigintHandler: (() => void) | undefined;
+
 export function registerDevModeRoutes(router: Hono) {
-	const controller = new AbortController();
-	const signal = controller.signal;
-	process.on('SIGINT', () => {
-		controller.abort();
-	});
+	// Reuse existing controller or create new one
+	if (!globalController) {
+		globalController = new AbortController();
+		
+		// Only register SIGINT handler once
+		globalSigintHandler = () => {
+			globalController?.abort();
+		};
+		process.on('SIGINT', globalSigintHandler);
+	}
+	
+	const signal = globalController.signal;
 	router.get('/__dev__/reload', () => {
 		const stream = new ReadableStream({
 			start(controller): void {

--- a/packages/runtime/test/devmode-listener-leak.test.ts
+++ b/packages/runtime/test/devmode-listener-leak.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Hono } from 'hono';
+import { registerDevModeRoutes } from '../src/devmode';
+
+describe('Dev Mode Event Listener Leaks', () => {
+	let initialListenerCount: number;
+	let originalMaxListeners: number;
+
+	beforeEach(() => {
+		initialListenerCount = process.listenerCount('SIGINT');
+		originalMaxListeners = process.getMaxListeners();
+	});
+
+	afterEach(() => {
+		// Clean up any listeners added during tests
+		const listeners = process.listeners('SIGINT');
+		listeners.forEach((listener) => {
+			process.removeListener('SIGINT', listener);
+		});
+		process.setMaxListeners(originalMaxListeners);
+	});
+
+	test('registerDevModeRoutes should not leak SIGINT listeners on multiple calls', () => {
+		const router = new Hono();
+
+		// Call registerDevModeRoutes multiple times (simulating multiple restarts)
+		for (let i = 0; i < 15; i++) {
+			registerDevModeRoutes(router);
+		}
+
+		const finalListenerCount = process.listenerCount('SIGINT');
+		const listenersAdded = finalListenerCount - initialListenerCount;
+
+		// Should only add 1 listener total, not 15
+		expect(listenersAdded).toBeLessThanOrEqual(1);
+	});
+
+	test('registerDevModeRoutes should clean up listener when called again', () => {
+		const router1 = new Hono();
+		const router2 = new Hono();
+
+		registerDevModeRoutes(router1);
+		const afterFirst = process.listenerCount('SIGINT');
+
+		registerDevModeRoutes(router2);
+		const afterSecond = process.listenerCount('SIGINT');
+
+		// Second call should not add another listener
+		expect(afterSecond).toBe(afterFirst);
+	});
+});


### PR DESCRIPTION
Fixes #249

## Problem
MaxListenersExceededWarning occurred in dev mode after multiple hot reloads due to event listener leaks.

## Root Causes
1. packages/runtime/src/devmode.ts: Created new SIGINT listener on every registerDevModeRoutes call (happens on each hot reload)
2. packages/cli/src/cmd/dev/index.ts: Created new stdin.on data listener on every server restart in the while loop

## Solutions
1. runtime/devmode.ts: Use global AbortController and SIGINT handler - only register once
2. cli/dev/index.ts: Track stdin listener registration with flag - only register once outside restart loop

## Testing
- Added test/devmode-listener-leak.test.ts to reproduce and verify fix
- All 263 existing tests pass
- Typecheck, lint, and build succeed

## Changes
- Modified packages/runtime/src/devmode.ts to use global event listener management
- Modified packages/cli/src/cmd/dev/index.ts to prevent duplicate stdin listeners
- Added regression test in packages/runtime/test/devmode-listener-leak.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event listener registration leaks in the development environment that occurred during server restarts, preventing memory accumulation and improving development session stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->