### PR TITLE
feat(cli): check write permissions before upgrade

### DIFF
--- a/packages/cli/test/upgrade.test.ts
+++ b/packages/cli/test/upgrade.test.ts
@@ -100,7 +100,11 @@ describe('upgrade command', () => {
 	});
 
 	test('PermissionError has correct properties', () => {
-		const error = new PermissionError('/usr/local/bin/agentuity', 'Cannot write to file');
+		const error = new PermissionError({
+			binaryPath: '/usr/local/bin/agentuity',
+			reason: 'Cannot write to file',
+			message: 'Permission denied: Cannot write to file',
+		});
 		expect(error.name).toBe('PermissionError');
 		expect(error.binaryPath).toBe('/usr/local/bin/agentuity');
 		expect(error.reason).toBe('Cannot write to file');
@@ -108,7 +112,10 @@ describe('upgrade command', () => {
 	});
 
 	test('PermissionError is an instance of Error', () => {
-		const error = new PermissionError('/usr/local/bin/agentuity', 'test');
+		const error = new PermissionError({
+			binaryPath: '/usr/local/bin/agentuity',
+			reason: 'test',
+		});
 		expect(error instanceof Error).toBe(true);
 		expect(error instanceof PermissionError).toBe(true);
 	});


### PR DESCRIPTION
## Summary

Fixes #269

When the CLI upgrade command fails due to lack of write permissions on the binary, the error message was unhelpful (just "Failed with exit code 1"). This PR adds early permission checking with a clear, actionable error message.

## Changes

- Added `PermissionError` class with `binaryPath` and `reason` properties
- Added `checkWritePermission()` function that checks both binary and parent directory
- Permission check runs **before** the confirmation prompt (after showing version info)
- Shows helpful error message with solutions

## New Error Output

```
ℹ Current version: 0.0.100
ℹ Latest version:  0.0.101

⚠ What's changed:  https://github.com/agentuity/sdk/compare/v0.0.100...v0.0.101
✓ Release notes:   https://github.com/agentuity/sdk/releases/tag/v0.0.101

✗ Unable to upgrade: permission denied

ℹ The CLI binary at /usr/local/bin/agentuity is not writable.

ℹ To fix this, you can either:
ℹ   1. Run with elevated permissions: sudo agentuity upgrade
ℹ   2. Reinstall to a user-writable location
```

## Testing

- Added tests for `PermissionError` class
- All existing upgrade tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI now performs permission validation before initiating upgrades, preventing failures due to insufficient write access.
  * Enhanced error messages guide users to resolve permission issues by re-running with elevated privileges or reinstalling to a writable location.

* **Tests**
  * Added tests to verify permission error handling and messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->