### PR TITLE
fix(cli): prevent skipping past duplicate project name validation

### DIFF
--- a/packages/cli/src/tui/prompt.ts
+++ b/packages/cli/src/tui/prompt.ts
@@ -96,6 +96,7 @@ export class PromptFlow {
 			});
 
 			let hasError = false;
+			let hadValidationError = false;
 
 			const showPrompt = () => {
 				// Show prompt with active symbol
@@ -108,7 +109,8 @@ export class PromptFlow {
 
 			rl.on('line', async (input) => {
 				const trimmed = input.trim();
-				const value = trimmed.length > 0 ? trimmed : initial;
+				// After a validation error, require explicit input - don't fall back to initial
+				const value = trimmed.length > 0 ? trimmed : hadValidationError ? '' : initial;
 
 				// Validate
 				if (validate) {
@@ -129,6 +131,7 @@ export class PromptFlow {
 							// Use readline's prompt for the input line
 							rl.prompt();
 							hasError = true;
+							hadValidationError = true;
 							return;
 						}
 					} catch (error) {


### PR DESCRIPTION
## Summary

When a user entered a duplicate project name in the create wizard and saw the validation error, they could previously bypass it by simply pressing Enter to use the default value ('My First Agent').

## The Problem

In `prompt.text()`, when the user submits empty input, it falls back to the `initial` value. This meant:
1. User enters duplicate name → sees error
2. User presses Enter (empty input) → uses 'My First Agent' as fallback
3. If 'My First Agent' is not a duplicate, validation passes and flow continues

## The Fix

Added a `hadValidationError` flag that tracks when validation has failed. After a validation error occurs, empty input no longer falls back to the `initial` value - it's treated as an empty string, which triggers the 'Project name is required' validation, forcing the user to explicitly enter a valid name.

## Testing

- All unit tests pass (1226 tests)
- Typecheck passes
- Lint passes
- Build passes

Fixes #275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CLI prompt validation behavior to require explicit user input after validation errors instead of falling back to default values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->