### PR TITLE
fix(integration-suite): fix CLI vector tests failing with wrong working directory

### DIFF
--- a/apps/testing/integration-suite/scripts/ci-test.sh
+++ b/apps/testing/integration-suite/scripts/ci-test.sh
@@ -79,6 +79,14 @@ if [ -n "$OPENAI_API_KEY" ]; then
         echo -e "${GREEN}✓${NC} OpenAI API key configured for vector operations"
 fi
 
+# Also create .env in project directory for CLI commands (they run from project dir, not .agentuity)
+# The CLI looks for SDK key in the project directory's .env file
+echo "AGENTUITY_SDK_KEY=$AGENTUITY_SDK_KEY" > "$APP_DIR/.env"
+echo "AGENTUITY_REGION=$REGION" >> "$APP_DIR/.env"
+if [ -n "$OPENAI_API_KEY" ]; then
+        echo "OPENAI_API_KEY=$OPENAI_API_KEY" >> "$APP_DIR/.env"
+fi
+
 echo -e "${GREEN}✓${NC} Environment configured (region: $REGION)"
 
 # Set service URLs based on region (required for LLM patching)

--- a/apps/testing/integration-suite/src/test/cli-vector.ts
+++ b/apps/testing/integration-suite/src/test/cli-vector.ts
@@ -26,7 +26,7 @@ test('cli-vector', 'help-command', async () => {
 	assert(result.stdout !== undefined, 'Help should produce output');
 });
 
-// Test 2: Upsert command structure
+// Test 2: Upsert command
 test('cli-vector', 'upsert-command', async () => {
 	const authenticated = await isAuthenticated();
 
@@ -37,20 +37,18 @@ test('cli-vector', 'upsert-command', async () => {
 	const namespace = uniqueId('vec-ns');
 	const key = uniqueId('vec-key');
 
-	// Test upsert command structure (may fail without proper args)
 	const result = await cliAgent.run({
 		command: 'cloud vector upsert',
 		args: [namespace, key, '--document', 'test document for vector storage'],
+		expectJSON: true,
 	});
 
-	// Command should execute
-	assert(
-		result.stdout !== undefined || result.stderr !== undefined,
-		'Upsert should produce output'
-	);
+	// Command should succeed
+	assert(result.exitCode === 0, `Upsert command failed with exit code ${result.exitCode}`);
+	assert(result.json !== undefined, 'Upsert should return JSON output');
 });
 
-// Test 3: Search command structure
+// Test 3: Search command
 test('cli-vector', 'search-command', async () => {
 	const authenticated = await isAuthenticated();
 
@@ -64,16 +62,15 @@ test('cli-vector', 'search-command', async () => {
 	const result = await cliAgent.run({
 		command: 'cloud vector search',
 		args: [namespace, query],
+		expectJSON: true,
 	});
 
-	// Command should execute
-	assert(
-		result.stdout !== undefined || result.stderr !== undefined,
-		'Search should produce output'
-	);
+	// Command should succeed (empty results is fine for non-existent namespace)
+	assert(result.exitCode === 0, `Search command failed with exit code ${result.exitCode}`);
+	assert(result.json !== undefined, 'Search should return JSON output');
 });
 
-// Test 4: Get command structure
+// Test 4: Get command
 test('cli-vector', 'get-command', async () => {
 	const authenticated = await isAuthenticated();
 
@@ -87,13 +84,15 @@ test('cli-vector', 'get-command', async () => {
 	const result = await cliAgent.run({
 		command: 'cloud vector get',
 		args: [namespace, key],
+		expectJSON: true,
 	});
 
-	// Command should execute
-	assert(result.stdout !== undefined || result.stderr !== undefined, 'Get should produce output');
+	// Command should succeed (not found is returned as JSON, not an error)
+	assert(result.exitCode === 0, `Get command failed with exit code ${result.exitCode}`);
+	assert(result.json !== undefined, 'Get should return JSON output');
 });
 
-// Test 5: Delete command structure
+// Test 5: Delete command
 test('cli-vector', 'delete-command', async () => {
 	const authenticated = await isAuthenticated();
 
@@ -107,13 +106,12 @@ test('cli-vector', 'delete-command', async () => {
 	const result = await cliAgent.run({
 		command: 'cloud vector delete',
 		args: [namespace, key, '--confirm'],
+		expectJSON: true,
 	});
 
-	// Command should execute
-	assert(
-		result.stdout !== undefined || result.stderr !== undefined,
-		'Delete should produce output'
-	);
+	// Command should succeed (deleting non-existent key is idempotent)
+	assert(result.exitCode === 0, `Delete command failed with exit code ${result.exitCode}`);
+	assert(result.json !== undefined, 'Delete should return JSON output');
 });
 
 // Test 6: Stats command - all namespaces
@@ -154,7 +152,10 @@ test('cli-vector', 'stats-namespace-command', async () => {
 	});
 
 	// Command should succeed
-	assert(result.exitCode === 0, `Stats namespace command failed with exit code ${result.exitCode}`);
+	assert(
+		result.exitCode === 0,
+		`Stats namespace command failed with exit code ${result.exitCode}`
+	);
 
 	// JSON output should contain namespace stats structure
 	assert(result.json !== undefined, 'Stats namespace should return JSON output');
@@ -269,5 +270,8 @@ test('cli-vector', 'upsert-with-metadata-command', async () => {
 	assert(typeof result.json === 'object', 'Upsert JSON should be an object');
 	assert('success' in result.json, 'Upsert should include success field');
 	assert('key' in result.json, 'Upsert should include key field');
-	assert(result.json.key === key, `Upsert key should match: expected ${key}, got ${result.json.key}`);
+	assert(
+		result.json.key === key,
+		`Upsert key should match: expected ${key}, got ${result.json.key}`
+	);
 });


### PR DESCRIPTION
## Summary

Fixes CLI vector tests that were failing in CI with exit codes 4 (PROJECT_NOT_FOUND) and 1 (GENERAL_ERROR).

## Root Cause

The CLI tests were running from the `.agentuity/` directory (where the built app runs), but the CLI commands expected to find `agentuity.json` in the parent `integration-suite/` directory. This caused:

1. **Exit code 4**: `ProjectConfigNotFoundExpection` - CLI couldn't find project config
2. **Exit code 1**: After fixing cwd, CLI still failed because `AGENTUITY_PROFILE` was hardcoded to `local`, making CLI look for `.env.local` instead of `.env`

## Changes

### `src/test/helpers/cli.ts`
- Added `findProjectDir()` to locate the directory containing `agentuity.json`
- CLI commands now run with `cwd(PROJECT_DIR)` to find the project config
- Removed hardcoded `AGENTUITY_PROFILE: 'local'` - now uses whatever profile is set in environment

### `scripts/ci-test.sh`
- Added creation of `$APP_DIR/.env` with SDK key and region for CLI commands (in addition to `.agentuity/.env` for the server)

### `src/test/cli-vector.ts`
- Updated weak assertions that only checked for stdout/stderr presence
- Now properly validates `exitCode === 0` and `json !== undefined`

## Test Results

- CLI vector tests: **11/11 passed** ✅
- Full suite: 242/252 passed (10 failures are pre-existing unrelated issues with `http-state-persistence` and `env-loading` tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CLI runtime environment configuration to support project-level settings
  * Enhanced test framework with more reliable verification of CLI command outputs

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->