### PR TITLE
fix: include agentVariable in route type generation filters

### DIFF
--- a/packages/cli/src/cmd/build/vite/registry-generator.ts
+++ b/packages/cli/src/cmd/build/vite/registry-generator.ts
@@ -478,7 +478,7 @@ export function generateRouteRegistry(
 	// Collect agent and schema imports from routes with validators or exported schemas
 	allRoutes.forEach((route) => {
 		const hasSchemaVars = !!route.inputSchemaVariable || !!route.outputSchemaVariable;
-		if (!route.hasValidator && !hasSchemaVars) return;
+		if (!route.hasValidator && !hasSchemaVars && !route.agentVariable) return;
 
 		// Collect agent imports (when using agent.validator())
 		if (
@@ -592,7 +592,7 @@ export function generateRouteRegistry(
 
 	// Add InferInput/InferOutput imports if we have any routes with schemas
 	const hasSchemas = allRoutes.some(
-		(r) => r.hasValidator || r.inputSchemaVariable || r.outputSchemaVariable
+		(r) => r.hasValidator || r.inputSchemaVariable || r.outputSchemaVariable || r.agentVariable
 	);
 	const typeImports = hasSchemas
 		? `import type { InferInput, InferOutput } from '@agentuity/core';\n`
@@ -600,7 +600,9 @@ export function generateRouteRegistry(
 
 	// Generate individual route schema types
 	const routeSchemaTypes = allRoutes
-		.filter((r) => r.hasValidator || r.inputSchemaVariable || r.outputSchemaVariable)
+		.filter(
+			(r) => r.hasValidator || r.inputSchemaVariable || r.outputSchemaVariable || r.agentVariable
+		)
 		.map((route) => {
 			const routeKey = route.method ? `${route.method.toUpperCase()} ${route.path}` : route.path;
 			const safeName = routeKey
@@ -707,7 +709,12 @@ export function generateRouteRegistry(
 			.replace(/_+/g, '_');
 		const pascalName = toPascalCase(safeName);
 
-		if (!route.hasValidator && !route.inputSchemaVariable && !route.outputSchemaVariable) {
+		if (
+			!route.hasValidator &&
+			!route.inputSchemaVariable &&
+			!route.outputSchemaVariable &&
+			!route.agentVariable
+		) {
 			const streamValue = route.stream === true ? 'true' : 'false';
 			return `\t'${routeKey}': {
 \t\tinputSchema: never;


### PR DESCRIPTION
## Summary

Fixes #291

Routes with `agentVariable` were not having their types generated because `agentVariable` was missing from the filters that determine which routes should have type definitions generated.

## Problem

When routes like `GET /api/services`, `GET /api/logs`, and `GET /api/traces` used `agent.validator()`, the types were referenced in the `RPCRouteRegistry` but the actual type definitions (like `GETApiLogsInputSchema`) were not generated, causing TypeScript errors.

## Root Cause

The `agentVariable` property was included in the `hasSchemas` check that determines whether to reference type names (vs using `'never'`), but was missing from:
1. The filter that determines which routes to generate type definitions for
2. The filter that determines which routes to import schemas from
3. The condition that determines whether to use `never` for route schema types

## Changes

**packages/cli/src/cmd/build/vite/registry-generator.ts:**
- Line 481: Added `&& !route.agentVariable` to the early-return condition
- Lines 594-595: Added `|| r.agentVariable` to the `hasSchemas` check
- Lines 603-604: Added `|| r.agentVariable` to the route schema types filter
- Lines 712-716: Added `&& !route.agentVariable` to the `never` fallback condition

## Testing

Added 5 unit tests to verify:
- Routes with `agentVariable` generate types for `services`, `logs`, `traces` endpoints
- Schema type generation filter includes `agentVariable`
- Routes without validator/schemas correctly use `never`
- Imports are generated for routes with `agentVariable`
- Routes with `inputSchemaVariable` work without `hasValidator`

All tests pass:
```
bun test registry-generator
12 pass, 3 skip, 0 fail
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended route inclusion criteria to support routes using agent variables, enabling proper type handling and imports for agent-based route validation.

* **Tests**
  * Added comprehensive test coverage for route registry generation with agent variables.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->