### PR TITLE
fix(cli): prevent EMFILE error from symlink cycles in file watcher

### DIFF
--- a/packages/cli/src/cmd/dev/file-watcher.ts
+++ b/packages/cli/src/cmd/dev/file-watcher.ts
@@ -6,7 +6,7 @@
  */
 
 import { watch, type FSWatcher, statSync, readdirSync, lstatSync } from 'node:fs';
-import { resolve, basename, relative } from 'node:path';
+import { resolve, relative } from 'node:path';
 import type { Logger } from '../../types';
 import { createAgentTemplates, createAPITemplates } from './templates';
 


### PR DESCRIPTION
## Problem

Users running `agentuity dev` in projects with Bun workspace symlinks were encountering:

```
✗ Uncaught exception: EMFILE: too many open files, open '/path/to/node_modules/@agentuity/core/node_modules/@agentuity/test-utils/node_modules/@agentuity/core/...'
```

The deeply nested path shows circular symlink traversal.

## Root Cause

The file watcher used `fs.watch()` with `recursive: true`, which on Linux follows symlinks into `node_modules`. In Bun workspaces, packages are symlinked to each other, creating circular chains that exhaust file descriptors.

The `ignorePaths` array only filtered **events after they fired**, not the initial directory traversal.

## Solution

- Added `collectWatchDirs()` to manually walk the directory tree, skipping `node_modules` and other ignored directories **before** any watchers are created
- Detects symlink cycles using inode tracking (`dev:ino`)
- Uses `lstatSync` to detect symlinks without following them
- Uses `recursive: false` on each individual directory instead of relying on Node's recursive mode

## Testing

- Typecheck passes
- The fix prevents watchers from ever entering `node_modules` or following circular symlinks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File watcher now skips ignored directories (node_modules, dist, .git, etc.), prevents descriptor exhaustion and infinite loops from symlinks, and better filters change events to avoid unnecessary restarts.

* **New Features**
  * Detects newly created empty source directories to trigger scaffolding templates automatically.

* **Chores**
  * Improved startup logging reporting directories collected and watchers started for clearer diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->