### PR TITLE
fix: ensure all generated files are committed during project create

### DIFF
--- a/packages/cli/src/cmd/project/download.ts
+++ b/packages/cli/src/cmd/project/download.ts
@@ -375,9 +375,9 @@ export async function setupProject(options: SetupOptions): Promise<void> {
 	// Build project
 	if (!noBuild) {
 		const exitCode = await tui.runCommand({
-			command: 'bun run build',
+			command: 'bun run build --dev',
 			cwd: dest,
-			cmd: ['bun', 'run', 'build'],
+			cmd: ['bun', 'run', 'build', '--dev'],
 			clearOnSuccess: true,
 		});
 		if (exitCode !== 0) {
@@ -385,6 +385,12 @@ export async function setupProject(options: SetupOptions): Promise<void> {
 		}
 	}
 
+	// Generate and write AGENTS.md files for the CLI and source folders
+	// Always overwrite during project setup to ensure fresh content
+	await writeAgentsDocs(dest);
+}
+
+export async function initGitRepo(dest: string): Promise<void> {
 	// Initialize git repository if git is available
 	// Check for real git (not macOS stub that triggers Xcode CLT popup)
 	const { isGitAvailable, getDefaultBranch } = await import('../../git-helper');
@@ -435,10 +441,6 @@ export async function setupProject(options: SetupOptions): Promise<void> {
 			clearOnSuccess: true,
 		});
 	}
-
-	// Generate and write AGENTS.md files for the CLI and source folders
-	// Always overwrite during project setup to ensure fresh content
-	await writeAgentsDocs(dest);
 }
 
 async function replaceInFiles(dir: string, projectName: string, dirName: string): Promise<void> {

--- a/packages/cli/src/cmd/project/template-flow.ts
+++ b/packages/cli/src/cmd/project/template-flow.ts
@@ -18,7 +18,7 @@ import * as tui from '../../tui';
 import { createPrompt, note } from '../../tui';
 import { playSound } from '../../sound';
 import { fetchTemplates, type TemplateInfo } from './templates';
-import { downloadTemplate, setupProject } from './download';
+import { downloadTemplate, setupProject, initGitRepo } from './download';
 import { type AuthData, type Config } from '../../types';
 import { ErrorCode } from '../../errors';
 import type { APIClient } from '../../api';
@@ -422,6 +422,9 @@ export async function runCreateFlow(options: CreateFlowOptions): Promise<void> {
 			});
 		}
 	}
+
+	// Initialize git repository after all files are generated
+	await initGitRepo(dest);
 
 	// Show completion message
 	if (!skipPrompts) {


### PR DESCRIPTION
## Summary

Fixes an issue where `agentuity.json`, `.vscode/`, and `AGENTS.md` files were showing as uncommitted changes after running `agentuity project create`.

## Changes

1. **Use dev build during setup**: Changed `bun run build` to `bun run build --dev` to skip type checking during project creation
2. **Extracted git initialization**: Created a new `initGitRepo()` function that handles git init, add, and commit
3. **Moved git commit to end of flow**: The git repository is now initialized at the very end of `runCreateFlow`, after:
   - Template download and setup
   - Dependency installation  
   - Build step
   - AGENTS.md generation
   - Project registration with API
   - `createProjectConfig()` which generates `agentuity.json` and `.vscode/`

This ensures all generated files are included in the initial commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic Git repository initialization now runs after project setup, creating an initial commit with all staged files.
  * AGENTS.md file is automatically generated and updated following project setup.

* **Chores**
  * Updated build command to include development mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->