### PR TITLE
fix: spinner not clearing during dev command

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1723,7 +1723,7 @@
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
-    "detect-libc": ["detect-libc@1.0.3", "", { "bin": { "detect-libc": "./bin/detect-libc.js" } }, "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="],
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
 
@@ -3085,6 +3085,8 @@
 
     "@langchain/core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "@parcel/watcher/detect-libc": ["detect-libc@1.0.3", "", { "bin": { "detect-libc": "./bin/detect-libc.js" } }, "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="],
+
     "@radix-ui/react-arrow/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
     "@radix-ui/react-collection/@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
@@ -3273,8 +3275,6 @@
 
     "langsmith/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
-    "lightningcss/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
-
     "lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "mailparser/iconv-lite": ["iconv-lite@0.7.0", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ=="],
@@ -3300,8 +3300,6 @@
     "path-scurry/lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
 
     "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
-
-    "prebuild-install/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "prebuild-install/tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
 

--- a/packages/cli/src/cmd/build/vite/server-bundler.ts
+++ b/packages/cli/src/cmd/build/vite/server-bundler.ts
@@ -95,7 +95,7 @@ export async function installExternalsAndBuild(options: ServerBundleOptions): Pr
 				}
 			}
 		} catch (error) {
-			logger.info('Failed to load agentuity.config.ts for externals:', error);
+			logger.debug('Failed to load agentuity.config.ts for externals:', error);
 		}
 	}
 

--- a/packages/cli/src/cmd/dev/index.ts
+++ b/packages/cli/src/cmd/dev/index.ts
@@ -640,7 +640,7 @@ export const command = createCommand({
 							);
 							previousMetadata = metadata;
 						}
-						await promises;
+						await Promise.all(promises);
 					},
 					clearOnSuccess: true,
 				});

--- a/packages/cli/src/cmd/dev/sync.ts
+++ b/packages/cli/src/cmd/dev/sync.ts
@@ -273,7 +273,7 @@ class DevmodeSyncService implements IDevmodeSyncService {
 		evalsToDelete: string[],
 		deploymentId: string
 	): Promise<void> {
-		this.logger.info(
+		this.logger.debug(
 			'[CLI EVAL SYNC] syncEvals called: %d to create, %d to delete',
 			evals.length,
 			evalsToDelete.length
@@ -360,24 +360,24 @@ class MockDevmodeSyncService implements IDevmodeSyncService {
 
 		// Log the requests that would be made
 		if (agentsToCreate.length > 0 || agentsToDelete.length > 0) {
-			this.logger.info(
+			this.logger.debug(
 				'[MOCK] Would make request: POST /cli/devmode/agent with %d agent(s) to create, %d agent(s) to delete',
 				agentsToCreate.length,
 				agentsToDelete.length
 			);
-			this.logger.info(
+			this.logger.debug(
 				'[MOCK] Request payload: %s',
 				JSON.stringify({ create: agentsToCreate, delete: agentsToDelete }, null, 2)
 			);
 		}
 
 		if (evalsToCreate.length > 0 || evalsToDelete.length > 0) {
-			this.logger.info(
+			this.logger.debug(
 				'[MOCK] Would make request: POST /cli/devmode/eval with %d eval(s) to create, %d eval(s) to delete',
 				evalsToCreate.length,
 				evalsToDelete.length
 			);
-			this.logger.info(
+			this.logger.debug(
 				'[MOCK] Request payload: %s',
 				JSON.stringify({ create: evalsToCreate, delete: evalsToDelete }, null, 2)
 			);
@@ -389,7 +389,7 @@ class MockDevmodeSyncService implements IDevmodeSyncService {
 			evalsToCreate.length === 0 &&
 			evalsToDelete.length === 0
 		) {
-			this.logger.info('[MOCK] No requests would be made (no changes detected)');
+			this.logger.debug('[MOCK] No requests would be made (no changes detected)');
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the "Building dev bundle" spinner not clearing after completion during `agentuity dev`.

## Problem

The spinner uses stderr for cursor positioning while `logger.info` writes to stdout via `console.log`. When stdout output occurred during the spinner callback (from sync.ts), it disrupted cursor tracking and prevented the spinner from properly clearing itself.

## Changes

- **sync.ts**: Change `logger.info` to `logger.debug` for internal sync diagnostic messages (these are implementation details, not user-facing)
- **server-bundler.ts**: Change `logger.info` to `logger.debug` for config loading errors
- **dev/index.ts**: Fix `await promises` → `await Promise.all(promises)` - awaiting an array is a no-op; this ensures prompt generation and sync complete before the spinner finishes

## Testing

Verified manually:
- `bun run dev` - spinner now clears properly
- `bun run dev --log-level error` - still works as before

Thread: https://ampcode.com/threads/T-019b4c0a-4191-704e-86ef-4ddc120179e4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved async task synchronization in development mode for more reliable concurrent operation completion.
  * Adjusted logging verbosity levels in development services for cleaner output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->