### PR TITLE
fix: support router.on() and router.all() methods in route discovery

### DIFF
--- a/packages/cli/src/cmd/build/ast.ts
+++ b/packages/cli/src/cmd/build/ast.ts
@@ -1300,12 +1300,160 @@ export async function parseRoute(
 						const action = statement.expression.arguments[0];
 						let suffix = '';
 						let config: Record<string, unknown> | undefined;
+						// Supported HTTP methods that can be represented in BuildMetadata
+						const SUPPORTED_HTTP_METHODS = ['get', 'post', 'put', 'delete', 'patch'] as const;
+						type SupportedHttpMethod = (typeof SUPPORTED_HTTP_METHODS)[number];
+
+						const isSupportedHttpMethod = (m: string): m is SupportedHttpMethod =>
+							SUPPORTED_HTTP_METHODS.includes(m.toLowerCase() as SupportedHttpMethod);
+
 						switch (method) {
 							case 'use':
-							case 'on':
-							case 'all':
 							case 'route': {
-								// Skip Hono middleware/routing methods - they don't represent API routes
+								// Skip Hono middleware and sub-router mounting - they don't represent API routes
+								continue;
+							}
+							case 'on': {
+								// router.on(method | method[], path, handler)
+								// First arg is method(s), second arg is path
+								const methodArg = statement.expression.arguments[0];
+								const pathArg = statement.expression.arguments[1];
+
+								// Extract methods from first argument
+								const methods: SupportedHttpMethod[] = [];
+
+								if (methodArg && (methodArg as ASTLiteral).type === 'Literal') {
+									// Single method: router.on('GET', '/path', handler)
+									const raw = String((methodArg as ASTLiteral).value || '').toLowerCase();
+									if (isSupportedHttpMethod(raw)) {
+										methods.push(raw as SupportedHttpMethod);
+									}
+								} else if (methodArg && (methodArg as ASTNode).type === 'ArrayExpression') {
+									// Array of methods: router.on(['GET', 'POST'], '/path', handler)
+									const arr = methodArg as { elements: ASTNode[] };
+									for (const el of arr.elements) {
+										if (!el || (el as ASTLiteral).type !== 'Literal') continue;
+										const raw = String((el as ASTLiteral).value || '').toLowerCase();
+										if (isSupportedHttpMethod(raw)) {
+											methods.push(raw as SupportedHttpMethod);
+										}
+									}
+								}
+
+								// Skip if no supported methods or path is not a literal
+								if (methods.length === 0 || !pathArg || (pathArg as ASTLiteral).type !== 'Literal') {
+									continue;
+								}
+
+								const pathSuffix = String((pathArg as ASTLiteral).value);
+
+								// Create a route entry for each method
+								for (const httpMethod of methods) {
+									const thepath = `${routePrefix}/${routeName}/${pathSuffix}`
+										.replaceAll(/\/{2,}/g, '/')
+										.replaceAll(/\/$/g, '');
+									const id = generateRouteId(
+										projectId,
+										deploymentId,
+										'api',
+										httpMethod,
+										rel,
+										thepath,
+										version
+									);
+
+									// Check if this route uses validator middleware
+									const validatorInfo = hasValidatorCall(statement.expression.arguments);
+									const routeConfig: Record<string, unknown> = {};
+									if (validatorInfo.hasValidator) {
+										routeConfig.hasValidator = true;
+										if (validatorInfo.agentVariable) {
+											routeConfig.agentVariable = validatorInfo.agentVariable;
+											const agentImportPath = importMap.get(validatorInfo.agentVariable);
+											if (agentImportPath) {
+												routeConfig.agentImportPath = agentImportPath;
+											}
+										}
+										if (validatorInfo.inputSchemaVariable) {
+											routeConfig.inputSchemaVariable = validatorInfo.inputSchemaVariable;
+										}
+										if (validatorInfo.outputSchemaVariable) {
+											routeConfig.outputSchemaVariable = validatorInfo.outputSchemaVariable;
+										}
+										if (validatorInfo.stream !== undefined) {
+											routeConfig.stream = validatorInfo.stream;
+										}
+									}
+
+									routes.push({
+										id,
+										method: httpMethod,
+										type: 'api',
+										filename: rel,
+										path: thepath,
+										version,
+										config: Object.keys(routeConfig).length > 0 ? routeConfig : undefined,
+									});
+								}
+								continue;
+							}
+							case 'all': {
+								// router.all(path, handler) - matches all HTTP methods
+								// First arg is path (same as get/post/etc.)
+								if (!action || (action as ASTLiteral).type !== 'Literal') {
+									continue;
+								}
+
+								const pathSuffix = String((action as ASTLiteral).value);
+
+								// Create a route entry for each supported method
+								for (const httpMethod of SUPPORTED_HTTP_METHODS) {
+									const thepath = `${routePrefix}/${routeName}/${pathSuffix}`
+										.replaceAll(/\/{2,}/g, '/')
+										.replaceAll(/\/$/g, '');
+									const id = generateRouteId(
+										projectId,
+										deploymentId,
+										'api',
+										httpMethod,
+										rel,
+										thepath,
+										version
+									);
+
+									// Check if this route uses validator middleware
+									const validatorInfo = hasValidatorCall(statement.expression.arguments);
+									const routeConfig: Record<string, unknown> = {};
+									if (validatorInfo.hasValidator) {
+										routeConfig.hasValidator = true;
+										if (validatorInfo.agentVariable) {
+											routeConfig.agentVariable = validatorInfo.agentVariable;
+											const agentImportPath = importMap.get(validatorInfo.agentVariable);
+											if (agentImportPath) {
+												routeConfig.agentImportPath = agentImportPath;
+											}
+										}
+										if (validatorInfo.inputSchemaVariable) {
+											routeConfig.inputSchemaVariable = validatorInfo.inputSchemaVariable;
+										}
+										if (validatorInfo.outputSchemaVariable) {
+											routeConfig.outputSchemaVariable = validatorInfo.outputSchemaVariable;
+										}
+										if (validatorInfo.stream !== undefined) {
+											routeConfig.stream = validatorInfo.stream;
+										}
+									}
+
+									routes.push({
+										id,
+										method: httpMethod,
+										type: 'api',
+										filename: rel,
+										path: thepath,
+										version,
+										config: Object.keys(routeConfig).length > 0 ? routeConfig : undefined,
+									});
+								}
 								continue;
 							}
 							case 'get':

--- a/packages/cli/test/ast.test.ts
+++ b/packages/cli/test/ast.test.ts
@@ -131,7 +131,7 @@ export default router;
 		cleanup();
 	});
 
-	test('should skip on, all, and route methods without error', async () => {
+	test('should handle on and all methods, and skip route/use methods', async () => {
 		setup();
 		const routeFile = join(TEST_DIR, 'route.ts');
 		const code = `
@@ -153,9 +153,74 @@ export default router;
 		writeFileSync(routeFile, code);
 
 		const routes = await parseRoute(TEST_DIR, routeFile, 'proj_1', 'dep_1');
+		// on('GET', '/test') → 1 route
+		// all('/catch-all') → 5 routes (get, post, put, delete, patch)
+		// route('/api', subRouter) → 0 routes (skipped)
+		// use('*', authMiddleware()) → 0 routes (skipped)
+		// get('/users') → 1 route
+		// post('/users') → 1 route
+		expect(routes).toHaveLength(8);
+
+		// Group routes by path
+		const routesByPath = routes.reduce<Record<string, string[]>>((acc, r) => {
+			acc[r.path] ??= [];
+			acc[r.path].push(r.method);
+			return acc;
+		}, {});
+
+		expect(routesByPath['/api/test']).toEqual(['get']);
+		expect(routesByPath['/api/catch-all']?.sort()).toEqual(['delete', 'get', 'patch', 'post', 'put']);
+		expect(routesByPath['/api/users']?.sort()).toEqual(['get', 'post']);
+
+		cleanup();
+	});
+
+	test('should support on() with array of methods and wildcard path', async () => {
+		setup();
+		const routeFile = join(TEST_DIR, 'route.ts');
+		const code = `
+import { createRouter } from '@agentuity/runtime';
+
+const router = createRouter();
+
+router.on(['GET', 'POST'], '/auth/*', (c) => c.text('auth'));
+
+export default router;
+		`;
+		writeFileSync(routeFile, code);
+
+		const routes = await parseRoute(TEST_DIR, routeFile, 'proj_1', 'dep_1');
 		expect(routes).toHaveLength(2);
+
+		const methods = routes.map((r) => r.method).sort();
+		const paths = routes.map((r) => r.path);
+
+		expect(methods).toEqual(['get', 'post']);
+		expect(new Set(paths)).toEqual(new Set(['/api/auth/*']));
+
+		cleanup();
+	});
+
+	test('should skip unsupported HTTP methods in on()', async () => {
+		setup();
+		const routeFile = join(TEST_DIR, 'route.ts');
+		const code = `
+import { createRouter } from '@agentuity/runtime';
+
+const router = createRouter();
+
+// HEAD and OPTIONS are not supported in BuildMetadata, should be skipped
+router.on(['GET', 'HEAD', 'OPTIONS'], '/health', (c) => c.text('ok'));
+
+export default router;
+		`;
+		writeFileSync(routeFile, code);
+
+		const routes = await parseRoute(TEST_DIR, routeFile, 'proj_1', 'dep_1');
+		// Only GET should be captured, HEAD and OPTIONS are skipped
+		expect(routes).toHaveLength(1);
 		expect(routes[0].method).toBe('get');
-		expect(routes[1].method).toBe('post');
+		expect(routes[0].path).toBe('/api/health');
 
 		cleanup();
 	});


### PR DESCRIPTION
## Summary

Routes registered with `router.on()` and `router.all()` are now properly discovered by the build system and will appear in the web app.

## Problem

Routes like this were not being picked up:
```typescript
api.on(['GET', 'POST'], '/auth/*', mountBetterAuthRoutes(auth));
```

The AST parser was explicitly skipping `.on()` and `.all()` methods, treating them as middleware rather than API routes.

## Solution

- **`router.on(method | method[], path, handler)`** - Creates route entries for each supported HTTP method
- **`router.all(path, handler)`** - Creates 5 route entries (get, post, put, delete, patch)
- Unsupported methods (HEAD, OPTIONS) are silently filtered out
- `router.use()` and `router.route()` remain skipped (middleware/sub-router mounting)

## Example

| Code | Routes Generated |
|------|------------------|
| `router.on(['GET', 'POST'], '/auth/*', handler)` | GET /api/auth/*, POST /api/auth/* |
| `router.on('GET', '/test', handler)` | GET /api/test |
| `router.all('/catch-all', handler)` | GET, POST, PUT, DELETE, PATCH for /api/catch-all |

## Changes

- `packages/cli/src/cmd/build/ast.ts` - Added handlers for `.on()` and `.all()` methods
- `packages/cli/test/ast.test.ts` - Updated tests to verify new behavior

## Verification

- ✅ TypeScript type check passes
- ✅ ESLint passes
- ✅ All 400 tests pass
- ✅ Build completes successfully

Fixes #346

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Route definitions now support multiple HTTP methods in single declarations.
  * Enhanced route extraction with improved metadata generation for multi-method routes.

* **Tests**
  * Expanded test coverage for route extraction scenarios, including method array handling and validation of supported HTTP methods.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->