### PR TITLE
fix: thread state not persisting correctly in LocalThreadProvider

### DIFF
--- a/packages/runtime/test/local-thread-provider.test.ts
+++ b/packages/runtime/test/local-thread-provider.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Integration tests for LocalThreadProvider logic.
+ * Tests thread persistence by directly testing the save/restore format handling.
+ */
+
+import { test, expect, describe } from 'bun:test';
+import { DefaultThread, parseThreadData, type ThreadProvider } from '../src/session';
+
+describe('LocalThreadProvider format handling', () => {
+	test('saves and restores thread state correctly using getSerializedState', () => {
+		const mockProvider = {} as ThreadProvider;
+
+		const thread1 = new DefaultThread(mockProvider, 'thrd_test123');
+		thread1.state.set('messages', [{ id: '1', content: 'hello' }]);
+		thread1.state.set('counter', 42);
+
+		const serialized = thread1.getSerializedState();
+
+		const { flatStateJson, metadata } = parseThreadData(serialized);
+		const thread2 = new DefaultThread(mockProvider, 'thrd_test123', flatStateJson, metadata);
+
+		if (flatStateJson) {
+			const data = JSON.parse(flatStateJson);
+			for (const [key, value] of Object.entries(data)) {
+				thread2.state.set(key, value);
+			}
+		}
+
+		expect(thread2.state.get('messages')).toEqual([{ id: '1', content: 'hello' }]);
+		expect(thread2.state.get('counter')).toBe(42);
+	});
+
+	test('restores metadata correctly', () => {
+		const mockProvider = {} as ThreadProvider;
+
+		const thread1 = new DefaultThread(mockProvider, 'thrd_test456');
+		thread1.state.set('data', 'test');
+		thread1.metadata.userId = 'user123';
+		thread1.metadata.role = 'admin';
+
+		const serialized = thread1.getSerializedState();
+
+		const { flatStateJson, metadata } = parseThreadData(serialized);
+		const thread2 = new DefaultThread(mockProvider, 'thrd_test456', flatStateJson, metadata);
+
+		if (flatStateJson) {
+			const data = JSON.parse(flatStateJson);
+			for (const [key, value] of Object.entries(data)) {
+				thread2.state.set(key, value);
+			}
+		}
+
+		expect(thread2.metadata.userId).toBe('user123');
+		expect(thread2.metadata.role).toBe('admin');
+	});
+
+	test('multiple save/restore cycles preserve state correctly', () => {
+		const mockProvider = {} as ThreadProvider;
+
+		let serialized: string;
+
+		const thread1 = new DefaultThread(mockProvider, 'thrd_multi');
+		thread1.state.set('messages', ['msg1']);
+		serialized = thread1.getSerializedState();
+
+		const { flatStateJson: flat1, metadata: meta1 } = parseThreadData(serialized);
+		const thread2 = new DefaultThread(mockProvider, 'thrd_multi', flat1, meta1);
+		if (flat1) {
+			const data = JSON.parse(flat1);
+			for (const [key, value] of Object.entries(data)) {
+				thread2.state.set(key, value);
+			}
+		}
+		const messages2 = thread2.state.get('messages') as string[];
+		messages2.push('msg2');
+		thread2.state.set('messages', messages2);
+		serialized = thread2.getSerializedState();
+
+		const { flatStateJson: flat2, metadata: meta2 } = parseThreadData(serialized);
+		const thread3 = new DefaultThread(mockProvider, 'thrd_multi', flat2, meta2);
+		if (flat2) {
+			const data = JSON.parse(flat2);
+			for (const [key, value] of Object.entries(data)) {
+				thread3.state.set(key, value);
+			}
+		}
+		const messages3 = thread3.state.get('messages') as string[];
+		messages3.push('msg3');
+		thread3.state.set('messages', messages3);
+		serialized = thread3.getSerializedState();
+
+		const { flatStateJson: flat3, metadata: meta3 } = parseThreadData(serialized);
+		const thread4 = new DefaultThread(mockProvider, 'thrd_multi', flat3, meta3);
+		if (flat3) {
+			const data = JSON.parse(flat3);
+			for (const [key, value] of Object.entries(data)) {
+				thread4.state.set(key, value);
+			}
+		}
+
+		expect(thread4.state.get('messages')).toEqual(['msg1', 'msg2', 'msg3']);
+	});
+
+	test('does not mark as dirty if not modified after restore', () => {
+		const mockProvider = {} as ThreadProvider;
+
+		const thread1 = new DefaultThread(mockProvider, 'thrd_nodirty');
+		thread1.state.set('value', 'original');
+		const serialized = thread1.getSerializedState();
+
+		const { flatStateJson, metadata } = parseThreadData(serialized);
+		const thread2 = new DefaultThread(mockProvider, 'thrd_nodirty', flatStateJson, metadata);
+		if (flatStateJson) {
+			const data = JSON.parse(flatStateJson);
+			for (const [key, value] of Object.entries(data)) {
+				thread2.state.set(key, value);
+			}
+		}
+
+		expect(thread2.isDirty()).toBe(false);
+	});
+
+	test('handles empty thread correctly', () => {
+		const mockProvider = {} as ThreadProvider;
+
+		const thread = new DefaultThread(mockProvider, 'thrd_empty');
+
+		expect(thread.state.size).toBe(0);
+		expect(Object.keys(thread.metadata)).toHaveLength(0);
+		expect(thread.isDirty()).toBe(false);
+	});
+
+	test('handles backwards compatible old format data', () => {
+		const mockProvider = {} as ThreadProvider;
+		const oldFormatData = JSON.stringify({ messages: ['old', 'data'], counter: 10 });
+
+		const { flatStateJson, metadata } = parseThreadData(oldFormatData);
+		const thread = new DefaultThread(mockProvider, 'thrd_oldformat', flatStateJson, metadata);
+		if (flatStateJson) {
+			const data = JSON.parse(flatStateJson);
+			for (const [key, value] of Object.entries(data)) {
+				thread.state.set(key, value);
+			}
+		}
+
+		expect(thread.state.get('messages')).toEqual(['old', 'data']);
+		expect(thread.state.get('counter')).toBe(10);
+		expect(thread.state.has('state')).toBe(false);
+	});
+
+	test('handles new format data correctly', () => {
+		const mockProvider = {} as ThreadProvider;
+		const newFormatData = JSON.stringify({
+			state: { messages: ['new', 'format'] },
+			metadata: { userId: 'user789' },
+		});
+
+		const { flatStateJson, metadata } = parseThreadData(newFormatData);
+		const thread = new DefaultThread(mockProvider, 'thrd_newformat', flatStateJson, metadata);
+		if (flatStateJson) {
+			const data = JSON.parse(flatStateJson);
+			for (const [key, value] of Object.entries(data)) {
+				thread.state.set(key, value);
+			}
+		}
+
+		expect(thread.state.get('messages')).toEqual(['new', 'format']);
+		expect(thread.state.has('state')).toBe(false);
+		expect(thread.metadata.userId).toBe('user789');
+	});
+
+	test('complex state with nested objects persists correctly', () => {
+		const mockProvider = {} as ThreadProvider;
+
+		const thread1 = new DefaultThread(mockProvider, 'thrd_complex');
+		const complexState = {
+			messages: [
+				{ id: '1', content: 'hello', metadata: { sentiment: 'positive' } },
+				{ id: '2', content: 'world', metadata: { sentiment: 'neutral' } },
+			],
+			config: {
+				nested: {
+					deeply: {
+						value: 42,
+						array: [1, 2, 3],
+					},
+				},
+			},
+		};
+
+		thread1.state.set('data', complexState);
+		const serialized = thread1.getSerializedState();
+
+		const { flatStateJson, metadata } = parseThreadData(serialized);
+		const thread2 = new DefaultThread(mockProvider, 'thrd_complex', flatStateJson, metadata);
+		if (flatStateJson) {
+			const data = JSON.parse(flatStateJson);
+			for (const [key, value] of Object.entries(data)) {
+				thread2.state.set(key, value);
+			}
+		}
+
+		const restored = thread2.state.get('data') as typeof complexState;
+
+		expect(restored.messages).toHaveLength(2);
+		expect(restored.messages[0].metadata.sentiment).toBe('positive');
+		expect(restored.config.nested.deeply.value).toBe(42);
+		expect(restored.config.nested.deeply.array).toEqual([1, 2, 3]);
+	});
+
+	test('data with "state" key is interpreted as new format', () => {
+		const mockProvider = {} as ThreadProvider;
+		const dataWithStateKey = JSON.stringify({
+			state: { actualData: 'stored in state wrapper' },
+			metadata: { userId: 'user123' },
+		});
+
+		const { flatStateJson, metadata } = parseThreadData(dataWithStateKey);
+
+		expect(flatStateJson).toBe(JSON.stringify({ actualData: 'stored in state wrapper' }));
+		expect(metadata).toEqual({ userId: 'user123' });
+
+		const thread = new DefaultThread(mockProvider, 'thrd_test', flatStateJson, metadata);
+		if (flatStateJson) {
+			const data = JSON.parse(flatStateJson);
+			for (const [key, value] of Object.entries(data)) {
+				thread.state.set(key, value);
+			}
+		}
+
+		expect(thread.state.get('actualData')).toBe('stored in state wrapper');
+		expect(thread.state.has('state')).toBe(false);
+	});
+});

--- a/packages/runtime/test/thread-persistence.test.ts
+++ b/packages/runtime/test/thread-persistence.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Tests for thread state persistence.
+ * Validates that thread state is correctly serialized, saved, and restored.
+ */
+
+import { test, expect, describe } from 'bun:test';
+import { DefaultThread, parseThreadData, type ThreadProvider } from '../src/session';
+
+describe('parseThreadData', () => {
+	test('returns empty object for undefined input', () => {
+		const result = parseThreadData(undefined);
+		expect(result).toEqual({});
+	});
+
+	test('returns empty object for empty string', () => {
+		const result = parseThreadData('');
+		expect(result).toEqual({});
+	});
+
+	test('handles new format with state only', () => {
+		const input = JSON.stringify({ state: { messages: ['hello', 'world'] } });
+		const result = parseThreadData(input);
+
+		expect(result.flatStateJson).toBe(JSON.stringify({ messages: ['hello', 'world'] }));
+		expect(result.metadata).toBeUndefined();
+	});
+
+	test('handles new format with metadata only', () => {
+		const input = JSON.stringify({ metadata: { userId: 'user123' } });
+		const result = parseThreadData(input);
+
+		expect(result.flatStateJson).toBeUndefined();
+		expect(result.metadata).toEqual({ userId: 'user123' });
+	});
+
+	test('handles new format with both state and metadata', () => {
+		const input = JSON.stringify({
+			state: { messages: ['test'] },
+			metadata: { userId: 'user123', role: 'admin' },
+		});
+		const result = parseThreadData(input);
+
+		expect(result.flatStateJson).toBe(JSON.stringify({ messages: ['test'] }));
+		expect(result.metadata).toEqual({ userId: 'user123', role: 'admin' });
+	});
+
+	test('handles old flat format (backwards compatibility)', () => {
+		const input = JSON.stringify({ messages: ['old', 'format'], counter: 42 });
+		const result = parseThreadData(input);
+
+		expect(result.flatStateJson).toBe(input);
+		expect(result.metadata).toBeUndefined();
+	});
+
+	test('handles invalid JSON gracefully', () => {
+		const result = parseThreadData('not valid json {{{');
+
+		expect(result.flatStateJson).toBe('not valid json {{{');
+		expect(result.metadata).toBeUndefined();
+	});
+
+	test('handles non-object JSON values', () => {
+		const result = parseThreadData('"just a string"');
+		expect(result.flatStateJson).toBe('"just a string"');
+	});
+
+	test('handles null metadata gracefully', () => {
+		const input = JSON.stringify({ state: { key: 'value' }, metadata: null });
+		const result = parseThreadData(input);
+
+		expect(result.flatStateJson).toBe(JSON.stringify({ key: 'value' }));
+		expect(result.metadata).toBeUndefined();
+	});
+
+	test('handles non-object metadata gracefully', () => {
+		const input = JSON.stringify({ state: { key: 'value' }, metadata: 'invalid' });
+		const result = parseThreadData(input);
+
+		expect(result.flatStateJson).toBe(JSON.stringify({ key: 'value' }));
+		expect(result.metadata).toBeUndefined();
+	});
+});
+
+describe('DefaultThread isDirty', () => {
+	test('returns false for empty new thread', () => {
+		const mockProvider = {} as ThreadProvider;
+		const thread = new DefaultThread(mockProvider, 'thrd_test123');
+
+		expect(thread.isDirty()).toBe(false);
+	});
+
+	test('returns true after setting state on new thread', () => {
+		const mockProvider = {} as ThreadProvider;
+		const thread = new DefaultThread(mockProvider, 'thrd_test123');
+
+		thread.state.set('messages', ['hello']);
+
+		expect(thread.isDirty()).toBe(true);
+	});
+
+	test('returns false when state matches initialStateJson', () => {
+		const mockProvider = {} as ThreadProvider;
+		const initialState = { messages: ['hello'] };
+		const thread = new DefaultThread(mockProvider, 'thrd_test123', JSON.stringify(initialState));
+
+		thread.state.set('messages', ['hello']);
+
+		expect(thread.isDirty()).toBe(false);
+	});
+
+	test('returns true when state differs from initialStateJson', () => {
+		const mockProvider = {} as ThreadProvider;
+		const initialState = { messages: ['hello'] };
+		const thread = new DefaultThread(mockProvider, 'thrd_test123', JSON.stringify(initialState));
+
+		thread.state.set('messages', ['hello']);
+		thread.state.set('messages', ['hello', 'world']);
+
+		expect(thread.isDirty()).toBe(true);
+	});
+
+	test('returns true when adding new key to existing state', () => {
+		const mockProvider = {} as ThreadProvider;
+		const initialState = { messages: ['hello'] };
+		const thread = new DefaultThread(mockProvider, 'thrd_test123', JSON.stringify(initialState));
+
+		thread.state.set('messages', ['hello']);
+		thread.state.set('counter', 1);
+
+		expect(thread.isDirty()).toBe(true);
+	});
+
+	test('returns true when removing key from existing state', () => {
+		const mockProvider = {} as ThreadProvider;
+		const initialState = { messages: ['hello'], counter: 1 };
+		const thread = new DefaultThread(mockProvider, 'thrd_test123', JSON.stringify(initialState));
+
+		thread.state.set('messages', ['hello']);
+		thread.state.set('counter', 1);
+		thread.state.delete('counter');
+
+		expect(thread.isDirty()).toBe(true);
+	});
+});
+
+describe('DefaultThread getSerializedState', () => {
+	test('returns empty string for empty thread', () => {
+		const mockProvider = {} as ThreadProvider;
+		const thread = new DefaultThread(mockProvider, 'thrd_test123');
+
+		expect(thread.getSerializedState()).toBe('');
+	});
+
+	test('returns envelope with state only when no metadata', () => {
+		const mockProvider = {} as ThreadProvider;
+		const thread = new DefaultThread(mockProvider, 'thrd_test123');
+
+		thread.state.set('messages', ['hello']);
+
+		const serialized = thread.getSerializedState();
+		const parsed = JSON.parse(serialized);
+
+		expect(parsed.state).toEqual({ messages: ['hello'] });
+		expect(parsed.metadata).toBeUndefined();
+	});
+
+	test('returns envelope with metadata only when no state', () => {
+		const mockProvider = {} as ThreadProvider;
+		const thread = new DefaultThread(mockProvider, 'thrd_test123');
+
+		thread.metadata.userId = 'user123';
+
+		const serialized = thread.getSerializedState();
+		const parsed = JSON.parse(serialized);
+
+		expect(parsed.state).toBeUndefined();
+		expect(parsed.metadata).toEqual({ userId: 'user123' });
+	});
+
+	test('returns envelope with both state and metadata', () => {
+		const mockProvider = {} as ThreadProvider;
+		const thread = new DefaultThread(mockProvider, 'thrd_test123');
+
+		thread.state.set('messages', ['hello']);
+		thread.metadata.userId = 'user123';
+
+		const serialized = thread.getSerializedState();
+		const parsed = JSON.parse(serialized);
+
+		expect(parsed.state).toEqual({ messages: ['hello'] });
+		expect(parsed.metadata).toEqual({ userId: 'user123' });
+	});
+
+	test('handles complex nested state', () => {
+		const mockProvider = {} as ThreadProvider;
+		const thread = new DefaultThread(mockProvider, 'thrd_test123');
+
+		thread.state.set('messages', [
+			{ id: '1', content: 'hello', timestamp: '2024-01-01' },
+			{ id: '2', content: 'world', timestamp: '2024-01-02' },
+		]);
+		thread.state.set('config', { nested: { deeply: { value: 42 } } });
+
+		const serialized = thread.getSerializedState();
+		const parsed = JSON.parse(serialized);
+
+		expect(parsed.state.messages).toHaveLength(2);
+		expect(parsed.state.messages[0].content).toBe('hello');
+		expect(parsed.state.config.nested.deeply.value).toBe(42);
+	});
+});
+
+describe('Thread state round-trip', () => {
+	test('serialize then parse preserves state', () => {
+		const mockProvider = {} as ThreadProvider;
+		const thread = new DefaultThread(mockProvider, 'thrd_test123');
+
+		thread.state.set('messages', ['hello', 'world']);
+		thread.state.set('counter', 42);
+
+		const serialized = thread.getSerializedState();
+		const { flatStateJson } = parseThreadData(serialized);
+
+		expect(flatStateJson).toBeDefined();
+		const restored = JSON.parse(flatStateJson!);
+
+		expect(restored.messages).toEqual(['hello', 'world']);
+		expect(restored.counter).toBe(42);
+	});
+
+	test('serialize then parse preserves metadata', () => {
+		const mockProvider = {} as ThreadProvider;
+		const thread = new DefaultThread(mockProvider, 'thrd_test123');
+
+		thread.metadata.userId = 'user123';
+		thread.metadata.tags = ['important', 'urgent'];
+
+		const serialized = thread.getSerializedState();
+		const { metadata } = parseThreadData(serialized);
+
+		expect(metadata).toBeDefined();
+		expect(metadata!.userId).toBe('user123');
+		expect(metadata!.tags).toEqual(['important', 'urgent']);
+	});
+
+	test('full round-trip: create -> modify -> serialize -> parse -> restore', () => {
+		const mockProvider = {} as ThreadProvider;
+
+		const thread1 = new DefaultThread(mockProvider, 'thrd_test123');
+		thread1.state.set('messages', [{ id: '1', content: 'hello' }]);
+		thread1.state.set('counter', 1);
+		thread1.metadata.userId = 'user123';
+
+		const serialized = thread1.getSerializedState();
+		const { flatStateJson, metadata } = parseThreadData(serialized);
+
+		const thread2 = new DefaultThread(mockProvider, 'thrd_test456', flatStateJson, metadata);
+		if (flatStateJson) {
+			const data = JSON.parse(flatStateJson);
+			for (const [key, value] of Object.entries(data)) {
+				thread2.state.set(key, value);
+			}
+		}
+
+		expect(thread2.state.get('messages')).toEqual([{ id: '1', content: 'hello' }]);
+		expect(thread2.state.get('counter')).toBe(1);
+		expect(thread2.metadata.userId).toBe('user123');
+	});
+
+	test('round-trip: restored thread is not dirty if unchanged', () => {
+		const mockProvider = {} as ThreadProvider;
+
+		const thread1 = new DefaultThread(mockProvider, 'thrd_test123');
+		thread1.state.set('messages', ['hello']);
+
+		const serialized = thread1.getSerializedState();
+		const { flatStateJson, metadata } = parseThreadData(serialized);
+
+		const thread2 = new DefaultThread(mockProvider, 'thrd_test456', flatStateJson, metadata);
+		if (flatStateJson) {
+			const data = JSON.parse(flatStateJson);
+			for (const [key, value] of Object.entries(data)) {
+				thread2.state.set(key, value);
+			}
+		}
+
+		expect(thread2.isDirty()).toBe(false);
+	});
+
+	test('round-trip: restored thread is dirty if modified', () => {
+		const mockProvider = {} as ThreadProvider;
+
+		const thread1 = new DefaultThread(mockProvider, 'thrd_test123');
+		thread1.state.set('messages', ['hello']);
+
+		const serialized = thread1.getSerializedState();
+		const { flatStateJson, metadata } = parseThreadData(serialized);
+
+		const thread2 = new DefaultThread(mockProvider, 'thrd_test456', flatStateJson, metadata);
+		if (flatStateJson) {
+			const data = JSON.parse(flatStateJson);
+			for (const [key, value] of Object.entries(data)) {
+				thread2.state.set(key, value);
+			}
+		}
+
+		thread2.state.set('messages', ['hello', 'world']);
+
+		expect(thread2.isDirty()).toBe(true);
+	});
+});
+
+describe('Backwards compatibility', () => {
+	test('old format state is correctly restored', () => {
+		const mockProvider = {} as ThreadProvider;
+		const oldFormatJson = JSON.stringify({ messages: ['old', 'format'], counter: 10 });
+
+		const { flatStateJson } = parseThreadData(oldFormatJson);
+
+		const thread = new DefaultThread(mockProvider, 'thrd_test123', flatStateJson);
+		if (flatStateJson) {
+			const data = JSON.parse(flatStateJson);
+			for (const [key, value] of Object.entries(data)) {
+				thread.state.set(key, value);
+			}
+		}
+
+		expect(thread.state.get('messages')).toEqual(['old', 'format']);
+		expect(thread.state.get('counter')).toBe(10);
+	});
+
+	test('old format does not mistakenly populate "state" or "metadata" keys', () => {
+		const mockProvider = {} as ThreadProvider;
+		const oldFormatJson = JSON.stringify({ messages: ['test'], userId: 'user123' });
+
+		const { flatStateJson } = parseThreadData(oldFormatJson);
+
+		const thread = new DefaultThread(mockProvider, 'thrd_test123', flatStateJson);
+		if (flatStateJson) {
+			const data = JSON.parse(flatStateJson);
+			for (const [key, value] of Object.entries(data)) {
+				thread.state.set(key, value);
+			}
+		}
+
+		expect(thread.state.has('state')).toBe(false);
+		expect(thread.state.has('metadata')).toBe(false);
+		expect(thread.state.get('messages')).toEqual(['test']);
+		expect(thread.state.get('userId')).toBe('user123');
+	});
+});

--- a/packages/runtime/test/websocket-thread-persistence.test.ts
+++ b/packages/runtime/test/websocket-thread-persistence.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Integration tests for WebSocket thread persistence.
+ * Tests the full lifecycle of thread state save/restore via WebSocket.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { WebSocketServer } from 'ws';
+import type { WebSocket } from 'ws';
+import {
+	ThreadWebSocketClient,
+	parseThreadData,
+	type ThreadWebSocketClientOptions,
+} from '../src/session';
+
+const testOptions: ThreadWebSocketClientOptions = {
+	connectionTimeoutMs: 100,
+	requestTimeoutMs: 100,
+	reconnectBaseDelayMs: 10,
+	reconnectMaxDelayMs: 300,
+	maxReconnectAttempts: 5,
+};
+
+describe('WebSocket Thread Persistence', () => {
+	let wss: WebSocketServer;
+	let port: number;
+	let connections: WebSocket[] = [];
+	let storedThreads: Map<string, string>;
+
+	beforeAll(async () => {
+		storedThreads = new Map();
+
+		wss = new WebSocketServer({ port: 0 });
+
+		wss.on('connection', (ws: WebSocket) => {
+			connections.push(ws);
+
+			ws.on('message', (data: Buffer) => {
+				try {
+					const message = JSON.parse(data.toString());
+
+					if ('authorization' in message) {
+						ws.send(JSON.stringify({ success: true }));
+						return;
+					}
+
+					if ('action' in message && 'id' in message) {
+						if (message.action === 'restore') {
+							const threadId = message.data.thread_id;
+							const stored = storedThreads.get(threadId);
+							ws.send(
+								JSON.stringify({
+									id: message.id,
+									success: true,
+									data: stored,
+								})
+							);
+						} else if (message.action === 'save') {
+							const threadId = message.data.thread_id;
+							const userData = message.data.user_data;
+							storedThreads.set(threadId, userData);
+							ws.send(JSON.stringify({ id: message.id, success: true }));
+						} else if (message.action === 'delete') {
+							const threadId = message.data.thread_id;
+							storedThreads.delete(threadId);
+							ws.send(JSON.stringify({ id: message.id, success: true }));
+						}
+					}
+				} catch {
+					// Ignore parse errors
+				}
+			});
+		});
+
+		await new Promise<void>((resolve) => {
+			wss.on('listening', () => {
+				const address = wss.address() as { port: number };
+				port = address.port;
+				resolve();
+			});
+		});
+	});
+
+	afterAll(() => {
+		for (const ws of connections) {
+			ws.close();
+		}
+		wss.close();
+	});
+
+	beforeEach(() => {
+		for (const ws of connections) {
+			if (ws.readyState === 1) {
+				ws.close();
+			}
+		}
+		connections = [];
+		storedThreads.clear();
+	});
+
+	test('saves thread state in new envelope format', async () => {
+		const client = new ThreadWebSocketClient('test-key', `ws://localhost:${port}`, testOptions);
+		await client.connect();
+
+		const stateData = JSON.stringify({
+			state: { messages: ['hello', 'world'] },
+			metadata: { userId: 'user123' },
+		});
+
+		await client.save('thrd_test1', stateData);
+
+		const stored = storedThreads.get('thrd_test1');
+		expect(stored).toBe(stateData);
+
+		client.cleanup();
+	});
+
+	test('restores thread state correctly', async () => {
+		const stateData = JSON.stringify({
+			state: { messages: ['saved', 'message'] },
+			metadata: { role: 'admin' },
+		});
+		storedThreads.set('thrd_test2', stateData);
+
+		const client = new ThreadWebSocketClient('test-key', `ws://localhost:${port}`, testOptions);
+		await client.connect();
+
+		const restored = await client.restore('thrd_test2');
+
+		expect(restored).toBe(stateData);
+
+		const { flatStateJson, metadata } = parseThreadData(restored);
+		expect(flatStateJson).toBe(JSON.stringify({ messages: ['saved', 'message'] }));
+		expect(metadata).toEqual({ role: 'admin' });
+
+		client.cleanup();
+	});
+
+	test('returns undefined for non-existent thread', async () => {
+		const client = new ThreadWebSocketClient('test-key', `ws://localhost:${port}`, testOptions);
+		await client.connect();
+
+		const restored = await client.restore('thrd_nonexistent');
+
+		expect(restored).toBeUndefined();
+
+		client.cleanup();
+	});
+
+	test('deletes thread from storage', async () => {
+		storedThreads.set('thrd_delete', JSON.stringify({ state: { data: 'to delete' } }));
+
+		const client = new ThreadWebSocketClient('test-key', `ws://localhost:${port}`, testOptions);
+		await client.connect();
+
+		await client.delete('thrd_delete');
+
+		expect(storedThreads.has('thrd_delete')).toBe(false);
+
+		client.cleanup();
+	});
+
+	test('full round-trip: save -> restore -> modify -> save -> restore', async () => {
+		const client = new ThreadWebSocketClient('test-key', `ws://localhost:${port}`, testOptions);
+		await client.connect();
+
+		const state1 = JSON.stringify({
+			state: { messages: ['first'] },
+			metadata: { userId: 'user1' },
+		});
+		await client.save('thrd_roundtrip', state1);
+
+		const restored1 = await client.restore('thrd_roundtrip');
+		const { flatStateJson: flat1 } = parseThreadData(restored1);
+		expect(JSON.parse(flat1!)).toEqual({ messages: ['first'] });
+
+		const state2 = JSON.stringify({
+			state: { messages: ['first', 'second'] },
+			metadata: { userId: 'user1' },
+		});
+		await client.save('thrd_roundtrip', state2);
+
+		const restored2 = await client.restore('thrd_roundtrip');
+		const { flatStateJson: flat2 } = parseThreadData(restored2);
+		expect(JSON.parse(flat2!)).toEqual({ messages: ['first', 'second'] });
+
+		client.cleanup();
+	});
+
+	test('handles old format data on restore', async () => {
+		const oldFormatData = JSON.stringify({ messages: ['old', 'format'], counter: 5 });
+		storedThreads.set('thrd_oldformat', oldFormatData);
+
+		const client = new ThreadWebSocketClient('test-key', `ws://localhost:${port}`, testOptions);
+		await client.connect();
+
+		const restored = await client.restore('thrd_oldformat');
+		const { flatStateJson, metadata } = parseThreadData(restored);
+
+		expect(flatStateJson).toBe(oldFormatData);
+		expect(metadata).toBeUndefined();
+
+		const parsed = JSON.parse(flatStateJson!);
+		expect(parsed.messages).toEqual(['old', 'format']);
+		expect(parsed.counter).toBe(5);
+
+		client.cleanup();
+	});
+
+	test('handles complex nested state', async () => {
+		const client = new ThreadWebSocketClient('test-key', `ws://localhost:${port}`, testOptions);
+		await client.connect();
+
+		const complexState = {
+			state: {
+				messages: [
+					{ id: '1', content: 'hello', metadata: { sentiment: 'positive' } },
+					{ id: '2', content: 'world', metadata: { sentiment: 'neutral' } },
+				],
+				config: {
+					nested: { deeply: { value: 42 } },
+				},
+			},
+			metadata: { userId: 'user123', tags: ['important', 'urgent'] },
+		};
+
+		await client.save('thrd_complex', JSON.stringify(complexState));
+
+		const restored = await client.restore('thrd_complex');
+		const { flatStateJson, metadata } = parseThreadData(restored);
+
+		const state = JSON.parse(flatStateJson!);
+		expect(state.messages).toHaveLength(2);
+		expect(state.messages[0].metadata.sentiment).toBe('positive');
+		expect(state.config.nested.deeply.value).toBe(42);
+		expect(metadata?.tags).toEqual(['important', 'urgent']);
+
+		client.cleanup();
+	});
+
+	test('multiple threads are isolated', async () => {
+		const client = new ThreadWebSocketClient('test-key', `ws://localhost:${port}`, testOptions);
+		await client.connect();
+
+		await client.save('thrd_a', JSON.stringify({ state: { value: 'a' } }));
+		await client.save('thrd_b', JSON.stringify({ state: { value: 'b' } }));
+		await client.save('thrd_c', JSON.stringify({ state: { value: 'c' } }));
+
+		const restoredA = await client.restore('thrd_a');
+		const restoredB = await client.restore('thrd_b');
+		const restoredC = await client.restore('thrd_c');
+
+		expect(JSON.parse(parseThreadData(restoredA).flatStateJson!)).toEqual({ value: 'a' });
+		expect(JSON.parse(parseThreadData(restoredB).flatStateJson!)).toEqual({ value: 'b' });
+		expect(JSON.parse(parseThreadData(restoredC).flatStateJson!)).toEqual({ value: 'c' });
+
+		client.cleanup();
+	});
+
+	test('overwriting thread replaces all data', async () => {
+		const client = new ThreadWebSocketClient('test-key', `ws://localhost:${port}`, testOptions);
+		await client.connect();
+
+		await client.save(
+			'thrd_overwrite',
+			JSON.stringify({
+				state: { old: 'data', toRemove: true },
+			})
+		);
+
+		await client.save(
+			'thrd_overwrite',
+			JSON.stringify({
+				state: { new: 'data' },
+			})
+		);
+
+		const restored = await client.restore('thrd_overwrite');
+		const { flatStateJson } = parseThreadData(restored);
+		const state = JSON.parse(flatStateJson!);
+
+		expect(state.new).toBe('data');
+		expect(state.old).toBeUndefined();
+		expect(state.toRemove).toBeUndefined();
+
+		client.cleanup();
+	});
+});


### PR DESCRIPTION
## Summary
Fixes #351

Thread state was not persisting correctly when using `LocalThreadProvider`. The issue was that `LocalThreadProvider.restore()` did not correctly parse the new serialization format (`{ state, metadata }`) used by `getSerializedState()`. This caused `thread.state.get('messages')` to return `undefined` even after data was saved.

## Root Cause
When `getSerializedState()` saves thread data, it uses a new envelope format:
```json
{ "state": {...}, "metadata": {...} }
```

But `LocalThreadProvider.restore()` was treating this as the actual state, so it was setting:
- `thread.state.set('state', {...})`
- `thread.state.set('metadata', {...})`

Instead of correctly populating the state Map with the actual keys (`messages`, `counter`, etc.).

## Changes
- **Added `parseThreadData()` helper function** - Handles both old (flat) and new (`{ state, metadata }`) serialization formats consistently
- **Fixed `LocalThreadProvider.restore()`** - Now uses `parseThreadData()` to correctly extract state and metadata from the envelope
- **Refactored `DefaultThreadProvider.restore()`** - Uses the shared helper for consistency
- **Updated documentation** - `RedisThreadProvider` example now shows correct serialization patterns

## Tests Added
- `thread-persistence.test.ts`: 28 unit tests for `parseThreadData`, `isDirty`, `getSerializedState`, round-trip, and backwards compatibility
- `websocket-thread-persistence.test.ts`: 9 integration tests for WebSocket save/restore lifecycle
- `local-thread-provider.test.ts`: 9 tests for format handling

## Verification
- ✅ `bun run typecheck` - All packages pass
- ✅ `bun run lint` - No errors
- ✅ `bun run build` - All packages build successfully
- ✅ `bun run test` - All tests pass (46 new thread persistence tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Thread state restoration now robustly supports both legacy and new data formats
  * Enhanced metadata preservation and recovery during thread save and restore operations
  * Improved error tolerance for malformed or missing thread state data

* **Tests**
  * Added comprehensive integration test suites validating thread persistence across backwards compatibility, metadata handling, and complex state serialization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->