### PR TITLE
fix: use never types for routes with validators but no extracted schemas

### DIFF
--- a/packages/cli/src/cmd/build/vite/registry-generator.ts
+++ b/packages/cli/src/cmd/build/vite/registry-generator.ts
@@ -289,12 +289,11 @@ function generateRPCRegistryType(
 			.replace(/_+/g, '_');
 		const pascalName = toPascalCase(safeName);
 
-		// Only reference type names if route has schemas, otherwise use 'never'
+		// Only reference type names if route has actual schemas extracted, otherwise use 'never'
+		// Note: hasValidator may be true (e.g., zValidator('query', ...)) but no schemas extracted
+		// because only 'json' validators extract input schemas
 		const hasSchemas =
-			route.hasValidator ||
-			route.inputSchemaVariable ||
-			route.outputSchemaVariable ||
-			route.agentVariable;
+			route.inputSchemaVariable || route.outputSchemaVariable || route.agentVariable;
 
 		current[terminalMethod] = {
 			input: hasSchemas ? `${pascalName}Input` : 'never',
@@ -725,12 +724,10 @@ export function generateRouteRegistry(
 			.replace(/_+/g, '_');
 		const pascalName = toPascalCase(safeName);
 
-		if (
-			!route.hasValidator &&
-			!route.inputSchemaVariable &&
-			!route.outputSchemaVariable &&
-			!route.agentVariable
-		) {
+		// Use 'never' types if no schemas were actually extracted
+		// Note: hasValidator may be true (e.g., zValidator('query', ...)) but no schemas extracted
+		// because only 'json' validators extract input schemas
+		if (!route.inputSchemaVariable && !route.outputSchemaVariable && !route.agentVariable) {
 			const streamValue = route.stream === true ? 'true' : 'false';
 			return `\t'${routeKey}': {
 \t\tinputSchema: never;


### PR DESCRIPTION
## Summary

Fixes #291

Routes using `zValidator('query', ...)` (like `GET /api/traces`, `GET /api/logs`, `GET /api/services`) were generating TypeScript types that referenced non-existent schema types (e.g., `GETApiTracesInputSchema`) instead of using `never`.

## Root Cause

In `registry-generator.ts`, two places checked `route.hasValidator` to determine if schema types should be generated:

1. `addRoute` function
2. `generateRouteEntry` function

The problem: `zValidator('query', ...)` sets `hasValidator: true` but does NOT extract schemas (by design, only `'json'` target extracts schemas). This caused the code to reference schema types that were never generated.

## Fix

Changed both conditions to check if **actual schemas were extracted** (`inputSchemaVariable`, `outputSchemaVariable`, `agentVariable`) rather than just if a validator was present:

**Before:**
```typescript
const hasSchemas = route.hasValidator || route.inputSchemaVariable || ...
```

**After:**
```typescript
const hasSchemas = route.inputSchemaVariable || route.outputSchemaVariable || route.agentVariable;
```

## Testing

- Added regression test that reproduces the exact bug scenario
- All 401 unit tests pass
- TypeScript typecheck passes
- Build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type generation for routes with validators that don't produce extractable schemas, ensuring correct handling and preventing references to non-existent schema types.

* **Tests**
  * Added test coverage for validator-only routes to prevent regressions related to type generation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->