### PR TITLE
fix: set x-deployment header on all routes

### DIFF
--- a/packages/runtime/src/middleware.ts
+++ b/packages/runtime/src/middleware.ts
@@ -113,12 +113,12 @@ export function createBaseMiddleware(config: MiddlewareConfig) {
 			const endTime = performance.now();
 			const duration = ((endTime - started) / 1000).toFixed(1);
 			c.header(DURATION_HEADER, `${duration}s`);
-		}
 
-		// Set deployment header for all routes
-		const deploymentId = runtimeConfig.getDeploymentId();
-		if (deploymentId) {
-			c.header(DEPLOYMENT_HEADER, deploymentId);
+			// Set deployment header for all routes
+			const deploymentId = runtimeConfig.getDeploymentId();
+			if (deploymentId) {
+				c.header(DEPLOYMENT_HEADER, deploymentId);
+			}
 		}
 
 		if (!skipLogging && !isWebSocket) {


### PR DESCRIPTION
## Summary

The `x-deployment` header was only being set for API routes (`/api/*` and `/_agentuity/*`) because it was inside `createOtelMiddleware()`, which is only applied to those paths.

## Changes

Moved the deployment header logic from `createOtelMiddleware()` to `createBaseMiddleware()` so that all routes (including web routes) will include the `x-deployment` header in responses.

## Testing

- Typecheck passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Made deployment identification header emission consistent across all routes.
  * Removed redundant header emission during tracing/span completion to avoid duplicates and streamline behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->