### PR TITLE
Remove sandboxId from snapshot responses and add metadata to sandbox

### DIFF
--- a/.github/workflows/package-smoke-test.yaml
+++ b/.github/workflows/package-smoke-test.yaml
@@ -136,6 +136,14 @@ jobs:
          - name: Run cloud deployment tests
            run: bash scripts/test-cloud-deployment.sh
 
+         - name: Upload deployment logs
+           if: failure()
+           uses: actions/upload-artifact@v4
+           with:
+              name: deployment-logs
+              path: ~/.config/agentuity/logs/
+              if-no-files-found: ignore
+
          - name: Cleanup
            if: always()
            run: rm -rf apps/testing/cloud-deployment/.env

--- a/packages/cli/src/cmd/cloud/sandbox/get.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/get.ts
@@ -16,6 +16,10 @@ const SandboxGetResponseSchema = z.object({
 	stdoutStreamUrl: z.string().optional().describe('URL to stdout output stream'),
 	stderrStreamUrl: z.string().optional().describe('URL to stderr output stream'),
 	dependencies: z.array(z.string()).optional().describe('Apt packages installed'),
+	metadata: z
+		.record(z.string(), z.unknown())
+		.optional()
+		.describe('User-defined metadata'),
 });
 
 export const getSubcommand = createCommand({
@@ -84,6 +88,9 @@ export const getSubcommand = createCommand({
 			if (result.dependencies && result.dependencies.length > 0) {
 				console.log(`${tui.muted('Dependencies:')}    ${result.dependencies.join(', ')}`);
 			}
+			if (result.metadata && Object.keys(result.metadata).length > 0) {
+				console.log(`${tui.muted('Metadata:')}        ${JSON.stringify(result.metadata)}`);
+			}
 		}
 
 		return {
@@ -97,6 +104,7 @@ export const getSubcommand = createCommand({
 			stdoutStreamUrl: result.stdoutStreamUrl,
 			stderrStreamUrl: result.stderrStreamUrl,
 			dependencies: result.dependencies,
+			metadata: result.metadata,
 		};
 	},
 });

--- a/packages/cli/src/cmd/cloud/sandbox/snapshot/create.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/snapshot/create.ts
@@ -7,7 +7,6 @@ import { snapshotCreate } from '@agentuity/server';
 
 const SnapshotCreateResponseSchema = z.object({
 	snapshotId: z.string().describe('Snapshot ID'),
-	sandboxId: z.string().describe('Source sandbox ID'),
 	tag: z.string().optional().nullable().describe('Snapshot tag'),
 	sizeBytes: z.number().describe('Snapshot size in bytes'),
 	fileCount: z.number().describe('Number of files in snapshot'),
@@ -59,7 +58,6 @@ export const createSubcommand = createCommand({
 
 		return {
 			snapshotId: snapshot.snapshotId,
-			sandboxId: snapshot.sandboxId,
 			tag: snapshot.tag ?? undefined,
 			sizeBytes: snapshot.sizeBytes,
 			fileCount: snapshot.fileCount,

--- a/packages/cli/src/cmd/cloud/sandbox/snapshot/get.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/snapshot/get.ts
@@ -21,7 +21,6 @@ const SandboxInfoSchema = z.object({
 
 const SnapshotGetResponseSchema = z.object({
 	snapshotId: z.string().describe('Snapshot ID'),
-	sandboxId: z.string().describe('Source sandbox ID'),
 	tag: z.string().nullable().optional().describe('Snapshot tag'),
 	sizeBytes: z.number().describe('Snapshot size in bytes'),
 	fileCount: z.number().describe('Number of files'),
@@ -74,7 +73,6 @@ export const getSubcommand = createCommand({
 
 		if (!options.json) {
 			tui.info(`Snapshot: ${tui.bold(snapshot.snapshotId)}`);
-			console.log(`  ${tui.muted('Sandbox:')} ${snapshot.sandboxId}`);
 			if (snapshot.tag) {
 				console.log(`  ${tui.muted('Tag:')}     ${snapshot.tag}`);
 			}

--- a/packages/cli/src/cmd/cloud/sandbox/snapshot/list.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/snapshot/list.ts
@@ -7,7 +7,6 @@ import { snapshotList } from '@agentuity/server';
 
 const SnapshotInfoSchema = z.object({
 	snapshotId: z.string(),
-	sandboxId: z.string(),
 	tag: z.string().nullable().optional(),
 	sizeBytes: z.number(),
 	fileCount: z.number(),
@@ -64,7 +63,6 @@ export const listSubcommand = createCommand({
 					return {
 						ID: snap.snapshotId,
 						Tag: snap.tag ?? '-',
-						Sandbox: snap.sandboxId,
 						Size: tui.formatBytes(snap.sizeBytes),
 						Files: snap.fileCount,
 						'Created At': snap.createdAt,
@@ -73,7 +71,6 @@ export const listSubcommand = createCommand({
 				tui.table(tableData, [
 					{ name: 'ID', alignment: 'left' },
 					{ name: 'Tag', alignment: 'left' },
-					{ name: 'Sandbox', alignment: 'left' },
 					{ name: 'Size', alignment: 'right' },
 					{ name: 'Files', alignment: 'right' },
 					{ name: 'Created At', alignment: 'left' },

--- a/packages/core/src/services/sandbox.ts
+++ b/packages/core/src/services/sandbox.ts
@@ -178,6 +178,12 @@ export interface SandboxCreateOptions {
 	 * These are installed via `apt install` before executing any commands.
 	 */
 	dependencies?: string[];
+
+	/**
+	 * Optional user-defined metadata to associate with the sandbox.
+	 * This can be used to store arbitrary key-value data for tracking or identification.
+	 */
+	metadata?: Record<string, unknown>;
 }
 
 /**
@@ -309,6 +315,11 @@ export interface SandboxInfo {
 	 * Apt packages installed in the sandbox
 	 */
 	dependencies?: string[];
+
+	/**
+	 * User-defined metadata associated with the sandbox
+	 */
+	metadata?: Record<string, unknown>;
 }
 
 /**

--- a/packages/server/src/api/sandbox/create.ts
+++ b/packages/server/src/api/sandbox/create.ts
@@ -65,6 +65,10 @@ const SandboxCreateRequestSchema = z
 			.array(z.string())
 			.optional()
 			.describe('Apt packages to install when creating the sandbox'),
+		metadata: z
+			.record(z.string(), z.unknown())
+			.optional()
+			.describe('Optional user-defined metadata to associate with the sandbox'),
 	})
 	.describe('Request body for creating a new sandbox');
 
@@ -142,6 +146,9 @@ export async function sandboxCreate(
 	}
 	if (options.dependencies && options.dependencies.length > 0) {
 		body.dependencies = options.dependencies;
+	}
+	if (options.metadata) {
+		body.metadata = options.metadata;
 	}
 
 	const queryParams = new URLSearchParams();

--- a/packages/server/src/api/sandbox/get.ts
+++ b/packages/server/src/api/sandbox/get.ts
@@ -20,6 +20,10 @@ const SandboxInfoDataSchema = z
 			.array(z.string())
 			.optional()
 			.describe('Apt packages installed in the sandbox'),
+		metadata: z
+			.record(z.string(), z.unknown())
+			.optional()
+			.describe('User-defined metadata associated with the sandbox'),
 	})
 	.describe('Detailed information about a sandbox');
 
@@ -67,6 +71,7 @@ export async function sandboxGet(
 			stdoutStreamUrl: resp.data.stdoutStreamUrl,
 			stderrStreamUrl: resp.data.stderrStreamUrl,
 			dependencies: resp.data.dependencies,
+			metadata: resp.data.metadata as Record<string, unknown> | undefined,
 		};
 	}
 

--- a/packages/server/src/api/sandbox/snapshot.ts
+++ b/packages/server/src/api/sandbox/snapshot.ts
@@ -14,7 +14,6 @@ const SnapshotFileInfoSchema = z
 const SnapshotInfoSchema = z
 	.object({
 		snapshotId: z.string().describe('Unique identifier for the snapshot'),
-		sandboxId: z.string().describe('ID of the sandbox this snapshot was created from'),
 		tag: z.string().nullable().optional().describe('User-defined tag for the snapshot'),
 		sizeBytes: z.number().describe('Total size of the snapshot in bytes'),
 		fileCount: z.number().describe('Number of files in the snapshot'),
@@ -47,7 +46,6 @@ export interface SnapshotFileInfo {
 
 export interface SnapshotInfo {
 	snapshotId: string;
-	sandboxId: string;
 	tag?: string | null;
 	sizeBytes: number;
 	fileCount: number;


### PR DESCRIPTION
## Summary

This PR makes two changes:

1. **Remove sandboxId from snapshot responses** - The sandbox ID was confusing for users because the sandbox could be deleted and the snapshot isn't directly connected.

2. **Add metadata to sandbox** - Adds optional user-defined metadata (JSON object) that can be passed when creating a sandbox and is displayed in sandbox get details.

### Changes

- Removed `sandboxId` from snapshot schemas and responses (create, get, list)
- Added `metadata` to `SandboxCreateOptions` and `SandboxInfo` in core
- Added `--metadata` CLI option to `sandbox create` command (accepts JSON string)
- Updated `sandbox get` to display metadata if present
- Updated server API schemas to include metadata in create request and get response

## Thread
https://ampcode.com/threads/T-019b80d1-b895-760d-9d75-314dfed10d2b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add sandbox metadata: attach custom JSON metadata when creating a sandbox and view it when fetching sandbox details.

* **Changes**
  * Remove sandbox identifier from snapshot responses, listings and CLI output, simplifying snapshot payloads and UI columns.

* **Chores**
  * CI: upload deployment logs on cloud deployment test failures for easier debugging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->