### PR TITLE
fix: omit params property for routes without path parameters

### DIFF
--- a/packages/frontend/test/client-path-params.test.ts
+++ b/packages/frontend/test/client-path-params.test.ts
@@ -431,5 +431,59 @@ describe('Client path params', () => {
 			expect(capturedUrl).toBe('http://localhost:3000/api/hello?debug=true');
 			expect(capturedBody).toBe('{"name":"World"}');
 		});
+
+		test('should work with GET routes without any params', async () => {
+			interface TestRegistry {
+				health: {
+					get: {
+						input: never;
+						output: { status: string };
+						type: 'api';
+						params: never;
+						paramsTuple: [];
+					};
+				};
+			}
+
+			const metadata = {
+				health: {
+					get: { type: 'api', path: '/api/health' },
+				},
+			};
+
+			const client = createClient<TestRegistry>({ baseUrl: 'http://localhost:3000' }, metadata);
+
+			// Should work without any arguments - no params needed
+			await client.health.get();
+
+			expect(capturedUrl).toBe('http://localhost:3000/api/health');
+		});
+
+		test('should work with GET routes that only have query params', async () => {
+			interface TestRegistry {
+				search: {
+					get: {
+						input: never;
+						output: { results: string[] };
+						type: 'api';
+						params: never;
+						paramsTuple: [];
+					};
+				};
+			}
+
+			const metadata = {
+				search: {
+					get: { type: 'api', path: '/api/search' },
+				},
+			};
+
+			const client = createClient<TestRegistry>({ baseUrl: 'http://localhost:3000' }, metadata);
+
+			// Should work with query params only - no path params
+			await client.search.get({ query: { q: 'test', limit: '10' } });
+
+			expect(capturedUrl).toBe('http://localhost:3000/api/search?q=test&limit=10');
+		});
 	});
 });

--- a/packages/react/src/api.ts
+++ b/packages/react/src/api.ts
@@ -112,10 +112,8 @@ type UseAPICommonOptions<TRoute extends RouteKey> = {
 				input?: RouteInput<TRoute>;
 			}) &
 	(RoutePathParams<TRoute> extends never
-		? {
-				/** No path parameters for this route */
-				params?: never;
-			}
+		? // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+			{} // No params property - omit entirely for routes without path parameters
 		: {
 				/** Path parameters for routes with dynamic segments (e.g., { id: '123' } for /users/:id) */
 				params: RoutePathParams<TRoute>;

--- a/packages/react/test/createClient.test.tsx
+++ b/packages/react/test/createClient.test.tsx
@@ -1,5 +1,5 @@
-import { describe, test, expect } from 'bun:test';
-import { setGlobalBaseUrl, getGlobalBaseUrl } from '../src/client';
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { setGlobalBaseUrl, getGlobalBaseUrl, createClient, createAPIClient } from '../src/client';
 
 describe('React createClient', () => {
 	describe('Global baseUrl helpers', () => {
@@ -20,6 +20,174 @@ describe('React createClient', () => {
 
 			setGlobalBaseUrl('https://v2.example.com');
 			expect(getGlobalBaseUrl()).toBe('https://v2.example.com');
+		});
+	});
+
+	describe('RPC client - routes without path params', () => {
+		let originalFetch: typeof globalThis.fetch;
+		let capturedUrl: string | undefined;
+
+		beforeEach(() => {
+			originalFetch = globalThis.fetch;
+			setGlobalBaseUrl('http://localhost:3000');
+		});
+
+		afterEach(() => {
+			globalThis.fetch = originalFetch;
+		});
+
+		test('createClient should work with routes that have no params', async () => {
+			globalThis.fetch = async (url) => {
+				capturedUrl = url instanceof Request ? url.url : url.toString();
+				return new Response(JSON.stringify({ status: 'ok' }), {
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				});
+			};
+
+			interface TestRegistry {
+				health: {
+					get: {
+						input: never;
+						output: { status: string };
+						type: 'api';
+						params: never;
+						paramsTuple: [];
+					};
+				};
+			}
+
+			const metadata = {
+				health: {
+					get: { type: 'api', path: '/api/health' },
+				},
+			};
+
+			const client = createClient<TestRegistry>({}, metadata);
+
+			// Should work without any arguments - no params needed
+			const result = await client.health.get();
+
+			expect(capturedUrl).toBe('http://localhost:3000/api/health');
+			expect(result).toEqual({ status: 'ok' });
+		});
+
+		test('createClient should work with POST routes that have no path params but have input', async () => {
+			let capturedBody: string | undefined;
+
+			globalThis.fetch = async (url, init) => {
+				capturedUrl = url instanceof Request ? url.url : url.toString();
+				capturedBody = init?.body as string;
+				return new Response(JSON.stringify({ greeting: 'Hello World!' }), {
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				});
+			};
+
+			interface TestRegistry {
+				hello: {
+					post: {
+						input: { name: string };
+						output: { greeting: string };
+						type: 'api';
+						params: never;
+						paramsTuple: [];
+					};
+				};
+			}
+
+			const metadata = {
+				hello: {
+					post: { type: 'api', path: '/api/hello' },
+				},
+			};
+
+			const client = createClient<TestRegistry>({}, metadata);
+
+			// Should accept input directly without any path params
+			const result = await client.hello.post({ name: 'World' });
+
+			expect(capturedUrl).toBe('http://localhost:3000/api/hello');
+			expect(capturedBody).toBe('{"name":"World"}');
+			expect(result).toEqual({ greeting: 'Hello World!' });
+		});
+
+		test('createClient should work with query params but no path params', async () => {
+			globalThis.fetch = async (url) => {
+				capturedUrl = url instanceof Request ? url.url : url.toString();
+				return new Response(JSON.stringify({ results: ['a', 'b'] }), {
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				});
+			};
+
+			interface TestRegistry {
+				search: {
+					get: {
+						input: never;
+						output: { results: string[] };
+						type: 'api';
+						params: never;
+						paramsTuple: [];
+					};
+				};
+			}
+
+			const metadata = {
+				search: {
+					get: { type: 'api', path: '/api/search' },
+				},
+			};
+
+			const client = createClient<TestRegistry>({}, metadata);
+
+			// Should work with query params only - no path params needed
+			const result = await client.search.get({ query: { q: 'test' } });
+
+			expect(capturedUrl).toBe('http://localhost:3000/api/search?q=test');
+			expect(result).toEqual({ results: ['a', 'b'] });
+		});
+
+		test('createAPIClient should work with routes that have no params', async () => {
+			globalThis.fetch = async (url) => {
+				capturedUrl = url instanceof Request ? url.url : url.toString();
+				return new Response(JSON.stringify({ version: '1.0.0' }), {
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				});
+			};
+
+			// Set up global metadata (simulating what generated code does)
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			(globalThis as any).__rpcRouteMetadata = {
+				version: {
+					get: { type: 'api', path: '/api/version' },
+				},
+			};
+
+			interface TestRegistry {
+				version: {
+					get: {
+						input: never;
+						output: { version: string };
+						type: 'api';
+						params: never;
+						paramsTuple: [];
+					};
+				};
+			}
+
+			const api = createAPIClient<TestRegistry>();
+
+			// Should work without any arguments
+			const result = await api.version.get();
+
+			expect(capturedUrl).toBe('http://localhost:3000/api/version');
+			expect(result).toEqual({ version: '1.0.0' });
+
+			// Clean up
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			delete (globalThis as any).__rpcRouteMetadata;
 		});
 	});
 });

--- a/packages/react/test/useAPI-params.test.tsx
+++ b/packages/react/test/useAPI-params.test.tsx
@@ -135,6 +135,38 @@ describe('useAPI - Path Params', () => {
 	});
 });
 
+describe('useAPI - Routes Without Path Params', () => {
+	test('should not require params property for routes without path parameters', async () => {
+		const { result } = renderHook(
+			() =>
+				useAPI({
+					route: 'GET /search',
+					// Note: no 'params' property needed - this is the regression test
+					// Previously, the type included 'params?: never' which showed up confusingly in IDE
+				}),
+			{ wrapper }
+		);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(capturedUrl).toBe('http://localhost:3000/search');
+	});
+
+	test('should work with only query params and no path params', async () => {
+		const { result } = renderHook(
+			() =>
+				useAPI({
+					route: 'GET /search',
+					query: { q: 'hello' },
+				}),
+			{ wrapper }
+		);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(capturedUrl).toContain('/search?');
+		expect(capturedUrl).toContain('q=hello');
+	});
+});
+
 describe('useAPI - Query Params', () => {
 	test('should append query parameters to URL', async () => {
 		const { result } = renderHook(


### PR DESCRIPTION
## Summary

Routes without path parameters were showing a confusing `params?: never` in IDE hovers and TypeScript type displays. This caused confusion when users saw 'params are missing' messages for routes that don't need any path parameters.

## Root Cause

The `UseAPICommonOptions` type in `packages/react/src/api.ts` included `params?: never` for routes without path parameters. While semantically correct, this caused:

1. IDE hovers to show a `params` property even for routes that don't need it
2. Confusing TypeScript error messages mentioning 'params' for routes without path parameters

## The Fix

Changed the conditional type from:
```typescript
(RoutePathParams<TRoute> extends never
    ? { params?: never }
    : { params: RoutePathParams<TRoute> })
```

To:
```typescript
(RoutePathParams<TRoute> extends never
    ? {} // No params property at all
    : { params: RoutePathParams<TRoute> })
```

## Effects

- Routes without path params no longer show `params` in IDE hovers
- Routes with path params still require `params` correctly  
- Excess property check still catches if someone tries to pass `params` to a route that doesn't need them

## Testing

Added comprehensive tests for:
- `useAPI` hook with routes without path parameters
- RPC client (`createClient`/`createAPIClient`) with routes without path parameters
- GET routes without any params
- GET routes with only query params (no path params)
- POST routes with input but no path params

All existing tests continue to pass.

Fixes #417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified type signatures for API routes without path parameters—params property is now omitted when not needed, reducing unnecessary type declarations.

* **Tests**
  * Added comprehensive test coverage for API routes without path parameters.
  * Added tests verifying correct URL construction for query-only routes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->