### PR TITLE
fix(cli): disable cursor escape sequences in CI environments

### DIFF
--- a/packages/cli/bin/cli.ts
+++ b/packages/cli/bin/cli.ts
@@ -18,6 +18,10 @@ import { checkForUpdates } from '../src/version-check';
 
 // Cleanup TTY state before exit
 function cleanupTTY() {
+	// Skip in CI - terminals don't support cursor control sequences
+	if (process.env.CI) {
+		return;
+	}
 	if (process.stdin.isTTY) {
 		try {
 			process.stdin.setRawMode(false);

--- a/packages/cli/src/tui.ts
+++ b/packages/cli/src/tui.ts
@@ -24,6 +24,10 @@ function ensureCursorRestoration(): void {
 	exitHandlerInstalled = true;
 
 	const restoreCursor = () => {
+		// Skip cursor restoration in CI - terminals don't support these sequences
+		if (process.env.CI) {
+			return;
+		}
 		// Restore cursor visibility
 		process.stderr.write('\x1B[?25h');
 	};
@@ -64,8 +68,12 @@ export const ICONS = {
 
 /**
  * Check if we should treat stdout as a TTY (real TTY or FORCE_COLOR set by fork wrapper)
+ * Returns false in CI environments since CI terminals don't support cursor control sequences
  */
 export function isTTYLike(): boolean {
+	if (process.env.CI) {
+		return false;
+	}
 	return process.stdout.isTTY || process.env.FORCE_COLOR === '1';
 }
 


### PR DESCRIPTION
## Problem

CLI output in CI environments was showing literal text `25l` and `25h` instead of properly hiding/showing the cursor. This happened because:

1. `isTTYLike()` returned `true` when `FORCE_COLOR=1` was set (common in CI for colored output)
2. This caused cursor escape sequences (`\x1B[?25l`/`\x1B[?25h`) to be written
3. CI terminals don't support DEC private mode sequences, so they output `25l`/`25h` as literal text

## Solution

- `isTTYLike()` now returns `false` when `CI` env var is set
- Exit handler and `cleanupTTY()` skip cursor operations in CI
- This disables animations and cursor control in CI while preserving colored output

## Changes

- `packages/cli/src/tui.ts`: Guard `isTTYLike()` and exit handler with CI check
- `packages/cli/bin/cli.ts`: Guard `cleanupTTY()` with CI check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal handling in CI/CD environments by preventing cursor control sequences and automatic terminal restoration operations, improving compatibility with automated pipelines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->