### PR TITLE
fix: sync env & secrets for local forked deploys

### DIFF
--- a/packages/cli/src/cmd/cloud/deploy.ts
+++ b/packages/cli/src/cmd/cloud/deploy.ts
@@ -332,7 +332,9 @@ export const deploySubcommand = createSubcommand({
 						label: 'Sync Env & Secrets',
 						run: async () => {
 							try {
-								if (useExistingDeployment) {
+								const isCIBuild =
+									useExistingDeployment && process.env.AGENTUITY_FORK_PARENT !== '1';
+								if (isCIBuild) {
 									return stepSkipped('skipped in CI build');
 								}
 								// Read env file


### PR DESCRIPTION
## Problem

Local deploys were incorrectly skipping the 'Sync Env & Secrets' step with the message 'skipped in CI build'.

## Root Cause

The deploy fork wrapper sets `AGENTUITY_DEPLOYMENT` for child processes (same mechanism used by CI builds). The env sync step was checking `useExistingDeployment` to skip syncing, but this flag is true for both:
1. CI builds (should skip sync)
2. Local forked child processes (should NOT skip sync)

## Solution

Check for `AGENTUITY_FORK_PARENT` environment variable to distinguish local forked children from actual CI builds. Only skip env sync when it's a true CI build (has `AGENTUITY_DEPLOYMENT` but NOT `AGENTUITY_FORK_PARENT`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated environment and secrets synchronization logic for existing deployments to properly distinguish between CI and non-CI build environments, ensuring variables sync correctly outside CI pipelines while maintaining previous skip behavior during CI builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->