### PR TITLE
fix(cli): fix automatic update detection for compiled binaries

### DIFF
--- a/packages/cli/src/cmd/upgrade/index.ts
+++ b/packages/cli/src/cmd/upgrade/index.ts
@@ -59,10 +59,9 @@ export function isRunningFromExecutable(): boolean {
 	const scriptPath = process.argv[1] || '';
 
 	// Check if running from compiled binary (uses Bun's virtual filesystem)
-	// When compiled with `bun build --compile`, the path is in the virtual /$bunfs/root/ directory
-	const isCompiledBinary = process.argv[0] === 'bun' && scriptPath.startsWith('/$bunfs/root/');
-
-	if (isCompiledBinary) {
+	// When compiled with `bun build --compile`, the script path is in the virtual /$bunfs/root/ directory
+	// Note: process.argv[0] is the executable path (e.g., /usr/local/bin/agentuity), not 'bun'
+	if (scriptPath.startsWith('/$bunfs/root/')) {
 		return true;
 	}
 


### PR DESCRIPTION
## Problem

The automatic upgrade detection was never triggering for users running the globally installed CLI binary. Users with outdated versions were not being prompted to upgrade even after new releases.

## Root Cause

The `isRunningFromExecutable()` function in `src/cmd/upgrade/index.ts` had a faulty check:

```typescript
const isCompiledBinary = process.argv[0] === 'bun' && scriptPath.startsWith('/$bunfs/root/');
```

For compiled Bun binaries, `process.argv[0]` is the **executable path** (e.g., `/usr/local/bin/agentuity`), not the string `'bun'`. This condition was always false for compiled binaries, causing the version check to be skipped.

## Fix

Simplified the check to only use `process.argv[1]` (the script path), which reliably starts with `/$bunfs/root/` for compiled binaries:

```typescript
if (scriptPath.startsWith('/$bunfs/root/')) {
    return true;
}
```

## Testing

- All existing tests pass
- Typecheck passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of compiled binaries in the upgrade command for more reliable execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->