### PR TITLE
fix: make schema type detection minification-safe for workbench

### DIFF
--- a/packages/schema/src/base.ts
+++ b/packages/schema/src/base.ts
@@ -1,6 +1,12 @@
 import type { StandardSchemaV1 } from '@agentuity/core';
 
 /**
+ * Symbol used to identify schema types in a minification-safe way.
+ * Uses Symbol.for() to ensure the same symbol is used across bundled modules.
+ */
+export const SCHEMA_KIND = Symbol.for('@agentuity/schema-kind');
+
+/**
  * A validation issue from a failed schema validation.
  */
 export type ValidationIssue = StandardSchemaV1.Issue;

--- a/packages/schema/src/coerce/boolean.ts
+++ b/packages/schema/src/coerce/boolean.ts
@@ -1,5 +1,5 @@
 import type { Schema } from '../base';
-import { success, createParseMethods } from '../base';
+import { success, createParseMethods, SCHEMA_KIND } from '../base';
 import { optional } from '../utils/optional';
 import { nullable } from '../utils/nullable';
 
@@ -19,6 +19,7 @@ const parseMethods = createParseMethods<boolean>();
  * ```
  */
 export class CoerceBooleanSchema implements Schema<unknown, boolean> {
+	readonly [SCHEMA_KIND] = 'CoerceBooleanSchema';
 	description?: string;
 
 	readonly '~standard' = {

--- a/packages/schema/src/coerce/date.ts
+++ b/packages/schema/src/coerce/date.ts
@@ -1,5 +1,5 @@
 import type { Schema } from '../base';
-import { createIssue, failure, success, createParseMethods } from '../base';
+import { createIssue, failure, success, createParseMethods, SCHEMA_KIND } from '../base';
 import { optional } from '../utils/optional';
 import { nullable } from '../utils/nullable';
 
@@ -18,6 +18,7 @@ const parseMethods = createParseMethods<Date>();
  * ```
  */
 export class CoerceDateSchema implements Schema<unknown, Date> {
+	readonly [SCHEMA_KIND] = 'CoerceDateSchema';
 	description?: string;
 
 	readonly '~standard' = {

--- a/packages/schema/src/coerce/number.ts
+++ b/packages/schema/src/coerce/number.ts
@@ -1,5 +1,5 @@
 import type { Schema } from '../base';
-import { createIssue, failure, success, createParseMethods } from '../base';
+import { createIssue, failure, success, createParseMethods, SCHEMA_KIND } from '../base';
 import { optional } from '../utils/optional';
 import { nullable } from '../utils/nullable';
 
@@ -18,6 +18,7 @@ const parseMethods = createParseMethods<number>();
  * ```
  */
 export class CoerceNumberSchema implements Schema<unknown, number> {
+	readonly [SCHEMA_KIND] = 'CoerceNumberSchema';
 	description?: string;
 
 	readonly '~standard' = {

--- a/packages/schema/src/coerce/string.ts
+++ b/packages/schema/src/coerce/string.ts
@@ -1,5 +1,5 @@
 import type { Schema } from '../base';
-import { success, createParseMethods } from '../base';
+import { success, createParseMethods, SCHEMA_KIND } from '../base';
 import { optional } from '../utils/optional';
 import { nullable } from '../utils/nullable';
 
@@ -17,6 +17,7 @@ const parseMethods = createParseMethods<string>();
  * ```
  */
 export class CoerceStringSchema implements Schema<unknown, string> {
+	readonly [SCHEMA_KIND] = 'CoerceStringSchema';
 	description?: string;
 
 	readonly '~standard' = {

--- a/packages/schema/src/complex/array.ts
+++ b/packages/schema/src/complex/array.ts
@@ -1,5 +1,5 @@
 import type { Schema, Infer } from '../base';
-import { createIssue, failure, success, createParseMethods } from '../base';
+import { createIssue, failure, success, createParseMethods, SCHEMA_KIND } from '../base';
 import { optional } from '../utils/optional';
 import { nullable } from '../utils/nullable';
 
@@ -24,6 +24,7 @@ import { nullable } from '../utils/nullable';
 export class ArraySchema<T extends Schema<any, any>>
 	implements Schema<Array<Infer<T>>, Array<Infer<T>>>
 {
+	readonly [SCHEMA_KIND] = 'ArraySchema';
 	description?: string;
 	private parseMethods = createParseMethods<Array<Infer<T>>>();
 

--- a/packages/schema/src/complex/object.ts
+++ b/packages/schema/src/complex/object.ts
@@ -1,5 +1,5 @@
 import type { Schema, Infer } from '../base';
-import { createIssue, failure, success, createParseMethods } from '../base';
+import { createIssue, failure, success, createParseMethods, SCHEMA_KIND } from '../base';
 import { optional, OptionalSchema } from '../utils/optional';
 import { nullable } from '../utils/nullable';
 
@@ -64,6 +64,7 @@ type ExtendShape<T extends ObjectShape, U extends ObjectShape> = Omit<T, keyof U
 export class ObjectSchema<T extends ObjectShape>
 	implements Schema<InferObjectShape<T>, InferObjectShape<T>>
 {
+	readonly [SCHEMA_KIND] = 'ObjectSchema';
 	description?: string;
 	private parseMethods = createParseMethods<InferObjectShape<T>>();
 

--- a/packages/schema/src/complex/record.ts
+++ b/packages/schema/src/complex/record.ts
@@ -1,5 +1,5 @@
 import type { Schema, Infer } from '../base';
-import { createIssue, failure, success, createParseMethods } from '../base';
+import { createIssue, failure, success, createParseMethods, SCHEMA_KIND } from '../base';
 import { optional } from '../utils/optional';
 import { nullable } from '../utils/nullable';
 
@@ -21,6 +21,7 @@ import { nullable } from '../utils/nullable';
 export class RecordSchema<K extends Schema<string, string>, V extends Schema<any, any>>
 	implements Schema<Record<Infer<K>, Infer<V>>, Record<Infer<K>, Infer<V>>>
 {
+	readonly [SCHEMA_KIND] = 'RecordSchema';
 	description?: string;
 	private recordParseMethods = createParseMethods<Record<Infer<K>, Infer<V>>>();
 

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -9,7 +9,7 @@ export type {
 	SafeParseSuccess,
 	SafeParseError,
 } from './base';
-export { createIssue, success, failure, ValidationError } from './base';
+export { createIssue, success, failure, ValidationError, SCHEMA_KIND } from './base';
 
 export { StringSchema, string } from './primitives/string';
 export { NumberSchema, number } from './primitives/number';

--- a/packages/schema/src/json-schema.ts
+++ b/packages/schema/src/json-schema.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Schema } from './base';
+import { SCHEMA_KIND } from './base';
 import { string } from './primitives/string';
 import { number } from './primitives/number';
 import { boolean } from './primitives/boolean';
@@ -12,11 +13,12 @@ import { nullable } from './utils/nullable';
 import { union } from './utils/union';
 
 /**
- * Check schema type by constructor name (works across bundled modules).
- * Using instanceof fails when code is bundled or multiple copies of the package exist.
+ * Check schema type using a minification-safe SCHEMA_KIND tag.
+ * This works across bundled modules and after minification because it uses
+ * a Symbol.for() based tag rather than constructor.name which gets mangled.
  */
 function isSchemaType(schema: any, typeName: string): boolean {
-	return schema?.constructor?.name === typeName;
+	return schema?.[SCHEMA_KIND] === typeName;
 }
 
 /**

--- a/packages/schema/src/primitives/any.ts
+++ b/packages/schema/src/primitives/any.ts
@@ -1,5 +1,5 @@
 import type { Schema } from '../base';
-import { success, createParseMethods } from '../base';
+import { success, createParseMethods, SCHEMA_KIND } from '../base';
 import { optional } from '../utils/optional';
 import { nullable } from '../utils/nullable';
 
@@ -23,6 +23,7 @@ const parseMethods = createParseMethods<any>();
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export class AnySchema implements Schema<any, any> {
+	readonly [SCHEMA_KIND] = 'AnySchema';
 	description?: string;
 
 	readonly '~standard' = {

--- a/packages/schema/src/primitives/boolean.ts
+++ b/packages/schema/src/primitives/boolean.ts
@@ -1,5 +1,5 @@
 import type { Schema } from '../base';
-import { createIssue, failure, success, createParseMethods } from '../base';
+import { createIssue, failure, success, createParseMethods, SCHEMA_KIND } from '../base';
 import { optional } from '../utils/optional';
 import { nullable } from '../utils/nullable';
 
@@ -16,6 +16,7 @@ const parseMethods = createParseMethods<boolean>();
  * ```
  */
 export class BooleanSchema implements Schema<boolean, boolean> {
+	readonly [SCHEMA_KIND] = 'BooleanSchema';
 	description?: string;
 
 	readonly '~standard' = {

--- a/packages/schema/src/primitives/null.ts
+++ b/packages/schema/src/primitives/null.ts
@@ -1,5 +1,5 @@
 import type { Schema } from '../base';
-import { createIssue, failure, success, createParseMethods } from '../base';
+import { createIssue, failure, success, createParseMethods, SCHEMA_KIND } from '../base';
 import { optional } from '../utils/optional';
 import { nullable } from '../utils/nullable';
 
@@ -9,6 +9,7 @@ const parseMethods = createParseMethods<null>();
  * Schema for validating null values.
  */
 export class NullSchema implements Schema<null, null> {
+	readonly [SCHEMA_KIND] = 'NullSchema';
 	description?: string;
 
 	readonly '~standard' = {

--- a/packages/schema/src/primitives/number.ts
+++ b/packages/schema/src/primitives/number.ts
@@ -1,5 +1,5 @@
 import type { Schema } from '../base';
-import { createIssue, failure, success, createParseMethods } from '../base';
+import { createIssue, failure, success, createParseMethods, SCHEMA_KIND } from '../base';
 import { optional } from '../utils/optional';
 import { nullable } from '../utils/nullable';
 
@@ -18,6 +18,7 @@ const parseMethods = createParseMethods<number>();
  * ```
  */
 export class NumberSchema implements Schema<number, number> {
+	readonly [SCHEMA_KIND] = 'NumberSchema';
 	description?: string;
 	private _finite = false;
 	private _min?: number;

--- a/packages/schema/src/primitives/string.ts
+++ b/packages/schema/src/primitives/string.ts
@@ -1,5 +1,5 @@
 import type { Schema } from '../base';
-import { createIssue, failure, success, createParseMethods } from '../base';
+import { createIssue, failure, success, createParseMethods, SCHEMA_KIND } from '../base';
 import { optional } from '../utils/optional';
 import { nullable } from '../utils/nullable';
 
@@ -16,6 +16,7 @@ const parseMethods = createParseMethods<string>();
  * ```
  */
 export class StringSchema implements Schema<string, string> {
+	readonly [SCHEMA_KIND] = 'StringSchema';
 	description?: string;
 	private _min?: number;
 	private _max?: number;

--- a/packages/schema/src/primitives/undefined.ts
+++ b/packages/schema/src/primitives/undefined.ts
@@ -1,5 +1,5 @@
 import type { Schema } from '../base';
-import { createIssue, failure, success, createParseMethods } from '../base';
+import { createIssue, failure, success, createParseMethods, SCHEMA_KIND } from '../base';
 import { optional } from '../utils/optional';
 import { nullable } from '../utils/nullable';
 
@@ -9,6 +9,7 @@ const parseMethods = createParseMethods<undefined>();
  * Schema for validating undefined values.
  */
 export class UndefinedSchema implements Schema<undefined, undefined> {
+	readonly [SCHEMA_KIND] = 'UndefinedSchema';
 	description?: string;
 
 	readonly '~standard' = {

--- a/packages/schema/src/primitives/unknown.ts
+++ b/packages/schema/src/primitives/unknown.ts
@@ -1,5 +1,5 @@
 import type { Schema } from '../base';
-import { success, createParseMethods } from '../base';
+import { success, createParseMethods, SCHEMA_KIND } from '../base';
 import { optional } from '../utils/optional';
 import { nullable } from '../utils/nullable';
 
@@ -24,6 +24,7 @@ const parseMethods = createParseMethods<unknown>();
  * ```
  */
 export class UnknownSchema implements Schema<unknown, unknown> {
+	readonly [SCHEMA_KIND] = 'UnknownSchema';
 	description?: string;
 
 	readonly '~standard' = {

--- a/packages/schema/src/utils/literal.ts
+++ b/packages/schema/src/utils/literal.ts
@@ -1,5 +1,5 @@
 import type { Schema } from '../base';
-import { createIssue, failure, success, createParseMethods } from '../base';
+import { createIssue, failure, success, createParseMethods, SCHEMA_KIND } from '../base';
 import { optional } from '../utils/optional';
 import { nullable } from '../utils/nullable';
 
@@ -16,6 +16,7 @@ import { nullable } from '../utils/nullable';
  * ```
  */
 export class LiteralSchema<T extends string | number | boolean> implements Schema<T, T> {
+	readonly [SCHEMA_KIND] = 'LiteralSchema';
 	description?: string;
 	private parseMethods = createParseMethods<T>();
 

--- a/packages/schema/src/utils/nullable.ts
+++ b/packages/schema/src/utils/nullable.ts
@@ -1,5 +1,5 @@
 import type { Schema, Infer } from '../base';
-import { success, createParseMethods } from '../base';
+import { success, createParseMethods, SCHEMA_KIND } from '../base';
 
 /**
  * Schema for nullable values (T | null).
@@ -19,6 +19,7 @@ import { success, createParseMethods } from '../base';
 export class NullableSchema<T extends Schema<any, any>>
 	implements Schema<Infer<T> | null, Infer<T> | null>
 {
+	readonly [SCHEMA_KIND] = 'NullableSchema';
 	readonly schema: T;
 	description?: string;
 

--- a/packages/schema/src/utils/optional.ts
+++ b/packages/schema/src/utils/optional.ts
@@ -1,5 +1,5 @@
 import type { Schema, Infer } from '../base';
-import { success, createParseMethods } from '../base';
+import { success, createParseMethods, SCHEMA_KIND } from '../base';
 
 /**
  * Schema for optional values (T | undefined).
@@ -19,6 +19,7 @@ import { success, createParseMethods } from '../base';
 export class OptionalSchema<T extends Schema<any, any>>
 	implements Schema<Infer<T> | undefined, Infer<T> | undefined>
 {
+	readonly [SCHEMA_KIND] = 'OptionalSchema';
 	readonly schema: T;
 	description?: string;
 

--- a/packages/schema/src/utils/union.ts
+++ b/packages/schema/src/utils/union.ts
@@ -1,5 +1,5 @@
 import type { Schema, Infer } from '../base';
-import { createIssue, failure, createParseMethods } from '../base';
+import { createIssue, failure, createParseMethods, SCHEMA_KIND } from '../base';
 import { optional } from '../utils/optional';
 import { nullable } from '../utils/nullable';
 
@@ -29,6 +29,7 @@ type InferUnion<T extends Schema<any, any>[]> = Infer<T[number]>;
 export class UnionSchema<T extends Schema<any, any>[]>
 	implements Schema<InferUnion<T>, InferUnion<T>>
 {
+	readonly [SCHEMA_KIND] = 'UnionSchema';
 	description?: string;
 	private parseMethods = createParseMethods<InferUnion<T>>();
 

--- a/packages/schema/test/json-schema.test.ts
+++ b/packages/schema/test/json-schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { s } from '../src/index.js';
+import { s, SCHEMA_KIND } from '../src/index.js';
 
 describe('JSON Schema Conversion', () => {
 	describe('toJSONSchema', () => {
@@ -135,4 +135,151 @@ describe('JSON Schema Conversion', () => {
 			expect(reconstructedResult).toEqual(originalResult);
 		});
 	});
+
+	/* eslint-disable @typescript-eslint/no-explicit-any */
+	describe('SCHEMA_KIND (minification-safe type detection)', () => {
+		test('all primitive schemas should have SCHEMA_KIND tag', () => {
+			expect((s.string() as any)[SCHEMA_KIND]).toBe('StringSchema');
+			expect((s.number() as any)[SCHEMA_KIND]).toBe('NumberSchema');
+			expect((s.boolean() as any)[SCHEMA_KIND]).toBe('BooleanSchema');
+			expect((s.null() as any)[SCHEMA_KIND]).toBe('NullSchema');
+			expect((s.undefined() as any)[SCHEMA_KIND]).toBe('UndefinedSchema');
+			expect((s.unknown() as any)[SCHEMA_KIND]).toBe('UnknownSchema');
+			expect((s.any() as any)[SCHEMA_KIND]).toBe('AnySchema');
+		});
+
+		test('all complex schemas should have SCHEMA_KIND tag', () => {
+			expect((s.object({}) as any)[SCHEMA_KIND]).toBe('ObjectSchema');
+			expect((s.array(s.string()) as any)[SCHEMA_KIND]).toBe('ArraySchema');
+			expect((s.record(s.string(), s.number()) as any)[SCHEMA_KIND]).toBe('RecordSchema');
+		});
+
+		test('all utility schemas should have SCHEMA_KIND tag', () => {
+			expect((s.literal('test') as any)[SCHEMA_KIND]).toBe('LiteralSchema');
+			expect((s.optional(s.string()) as any)[SCHEMA_KIND]).toBe('OptionalSchema');
+			expect((s.nullable(s.string()) as any)[SCHEMA_KIND]).toBe('NullableSchema');
+			expect((s.union(s.string(), s.number()) as any)[SCHEMA_KIND]).toBe('UnionSchema');
+		});
+
+		test('all coerce schemas should have SCHEMA_KIND tag', () => {
+			expect((s.coerce.string() as any)[SCHEMA_KIND]).toBe('CoerceStringSchema');
+			expect((s.coerce.number() as any)[SCHEMA_KIND]).toBe('CoerceNumberSchema');
+			expect((s.coerce.boolean() as any)[SCHEMA_KIND]).toBe('CoerceBooleanSchema');
+			expect((s.coerce.date() as any)[SCHEMA_KIND]).toBe('CoerceDateSchema');
+		});
+
+		test('toJSONSchema works when constructor.name is mangled (simulated minification)', () => {
+			const stringSchema = s.string().describe('User name');
+			const objectSchema = s.object({
+				name: s.string(),
+				age: s.number(),
+			});
+			const arraySchema = s.array(s.boolean());
+			const unionSchema = s.union(s.string(), s.number());
+
+			// Simulate minification by overriding constructor.name
+			// This would break the old implementation that relied on constructor.name
+			Object.defineProperty(stringSchema.constructor, 'name', { value: 'a', configurable: true });
+			Object.defineProperty(objectSchema.constructor, 'name', { value: 'b', configurable: true });
+			Object.defineProperty(arraySchema.constructor, 'name', { value: 'c', configurable: true });
+			Object.defineProperty(unionSchema.constructor, 'name', { value: 'd', configurable: true });
+
+			// Verify constructor.name is actually mangled
+			expect(stringSchema.constructor.name).toBe('a');
+			expect(objectSchema.constructor.name).toBe('b');
+
+			// But SCHEMA_KIND tag is still present
+			expect((stringSchema as any)[SCHEMA_KIND]).toBe('StringSchema');
+			expect((objectSchema as any)[SCHEMA_KIND]).toBe('ObjectSchema');
+
+			// And toJSONSchema should still work correctly
+			const stringJson = s.toJSONSchema(stringSchema);
+			expect(stringJson.type).toBe('string');
+			expect(stringJson.description).toBe('User name');
+
+			const objectJson = s.toJSONSchema(objectSchema);
+			expect(objectJson.type).toBe('object');
+			expect(objectJson.properties).toHaveProperty('name');
+			expect(objectJson.properties).toHaveProperty('age');
+			expect(objectJson.required).toContain('name');
+			expect(objectJson.required).toContain('age');
+
+			const arrayJson = s.toJSONSchema(arraySchema);
+			expect(arrayJson.type).toBe('array');
+			expect(arrayJson.items).toHaveProperty('type', 'boolean');
+
+			const unionJson = s.toJSONSchema(unionSchema);
+			expect(unionJson.anyOf).toHaveLength(2);
+		});
+
+		test('SCHEMA_KIND uses Symbol.for for cross-bundle compatibility', () => {
+			// Verify that SCHEMA_KIND uses Symbol.for (global registry)
+			// This ensures the same symbol is used across different bundle copies
+			const localSymbol = Symbol.for('@agentuity/schema-kind');
+			expect(SCHEMA_KIND).toBe(localSymbol);
+
+			// Schemas created here should be identifiable by the global symbol
+			const schema = s.string();
+			expect((schema as any)[localSymbol]).toBe('StringSchema');
+		});
+
+		test('comprehensive toJSONSchema test for all schema types', () => {
+			// Test all schema types produce correct JSON Schema output
+			const schemas = [
+				{ schema: s.string(), expectedType: 'string' },
+				{ schema: s.number(), expectedType: 'number' },
+				{ schema: s.boolean(), expectedType: 'boolean' },
+				{ schema: s.null(), expectedType: 'null' },
+				{ schema: s.coerce.string(), expectedType: 'string' },
+				{ schema: s.coerce.number(), expectedType: 'number' },
+				{ schema: s.coerce.boolean(), expectedType: 'boolean' },
+			];
+
+			for (const { schema, expectedType } of schemas) {
+				const jsonSchema = s.toJSONSchema(schema);
+				expect(jsonSchema.type).toBe(expectedType);
+			}
+
+			// Object schema
+			const objSchema = s.object({ x: s.number() });
+			const objJson = s.toJSONSchema(objSchema);
+			expect(objJson.type).toBe('object');
+			expect(objJson.properties?.x?.type).toBe('number');
+
+			// Array schema
+			const arrSchema = s.array(s.string());
+			const arrJson = s.toJSONSchema(arrSchema);
+			expect(arrJson.type).toBe('array');
+			expect(arrJson.items?.type).toBe('string');
+
+			// Literal schema
+			const litSchema = s.literal('hello');
+			const litJson = s.toJSONSchema(litSchema);
+			expect(litJson.const).toBe('hello');
+			expect(litJson.type).toBe('string');
+
+			// Nullable schema
+			const nullableSchema = s.nullable(s.number());
+			const nullableJson = s.toJSONSchema(nullableSchema);
+			expect(nullableJson.anyOf).toHaveLength(2);
+
+			// Union schema
+			const unionSchema = s.union(s.string(), s.number(), s.boolean());
+			const unionJson = s.toJSONSchema(unionSchema);
+			expect(unionJson.anyOf).toHaveLength(3);
+
+			// Record schema
+			const recordSchema = s.record(s.string(), s.number());
+			const recordJson = s.toJSONSchema(recordSchema);
+			expect(recordJson.type).toBe('object');
+			expect((recordJson as any).additionalProperties?.type).toBe('number');
+
+			// Coerce date schema
+			const dateSchema = s.coerce.date();
+			const dateJson = s.toJSONSchema(dateSchema);
+			expect(dateJson.type).toBe('string');
+			expect((dateJson as any).format).toBe('date-time');
+		});
+	});
+	/* eslint-enable @typescript-eslint/no-explicit-any */
 });


### PR DESCRIPTION
## Summary

Fixes the regression in workbench schema display that only occurred in production builds.

**Root Cause:** The `isSchemaType()` function in `json-schema.ts` used `constructor.name` to identify schema types. JavaScript minifiers mangle class names in production builds (e.g., `StringSchema` → `a`), causing all type checks to fail and `toJSONSchema()` to return `{}`.

**Fix:** Added a minification-safe `SCHEMA_KIND` symbol using `Symbol.for()` that persists across bundled modules.

## Changes

- **`base.ts`**: Added `SCHEMA_KIND` symbol export using `Symbol.for('@agentuity/schema-kind')`
- **`index.ts`**: Exported `SCHEMA_KIND` for external access
- **`json-schema.ts`**: Updated `isSchemaType()` to use `SCHEMA_KIND` tag instead of `constructor.name`
- **18 schema class files**: Added `readonly [SCHEMA_KIND] = 'SchemaName'` tag to each class
- **`json-schema.test.ts`**: Added 7 comprehensive regression tests

## New Tests

1. All primitive schemas should have SCHEMA_KIND tag (7 schemas)
2. All complex schemas should have SCHEMA_KIND tag (object, array, record)
3. All utility schemas should have SCHEMA_KIND tag (literal, optional, nullable, union)
4. All coerce schemas should have SCHEMA_KIND tag (4 schemas)
5. toJSONSchema works when constructor.name is mangled (simulated minification)
6. SCHEMA_KIND uses Symbol.for for cross-bundle compatibility
7. Comprehensive toJSONSchema test for all schema types

## Why Zod Is Unaffected

Zod schemas use `_def.type` (a string literal like `"object"`) for detection, which is minification-safe. The server's `toJSONSchema` uses `z.toJSONSchema()` for Zod schemas.

## Verification

- ✅ `bun run build` - Passed
- ✅ `bun run typecheck` - Passed
- ✅ `bun run lint` - Passed
- ✅ `bun run test` - 116 tests passed (including 7 new tests)

Fixes #444

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added minification-safe schema type detection using a centralized symbol marker across all schema types, ensuring reliable type identification even in bundled or minified environments.

* **Tests**
  * Introduced comprehensive test suite validating schema kind markers on all schema variants and verifying type detection resilience under minification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->