### PR TITLE
cli: remove always-skipped 'Create Deployment' step

### DIFF
--- a/packages/cli/src/cmd/cloud/deploy.ts
+++ b/packages/cli/src/cmd/cloud/deploy.ts
@@ -370,25 +370,7 @@ export const deploySubcommand = createSubcommand({
 							}
 						},
 					},
-					{
-						label: 'Create Deployment',
-						run: async () => {
-							if (useExistingDeployment) {
-								return stepSkipped('using pre-created deployment');
-							}
-							try {
-								deployment = await projectDeploymentCreate(
-									apiClient,
-									project.projectId,
-									project.deployment
-								);
-								return stepSuccess();
-							} catch (ex) {
-								const _ex = ex as { message?: string };
-								return stepError(_ex.message ?? String(_ex), ex as Error);
-							}
-						},
-					},
+
 					{
 						label: 'Build, Verify and Package',
 						run: async () => {


### PR DESCRIPTION
The deployment is always pre-created either in the parent fork process or passed via `AGENTUITY_DEPLOYMENT` env var, so this step was always showing as skipped:

```
○ Create Deployment (using pre-created deployment)
```

This PR removes the step entirely for a cleaner deploy output.

Fixes #452

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified the deploy command workflow by removing an intermediate step in the deployment process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->