### PR TITLE
fix(runtime): add file-level test isolation to compression tests

### DIFF
--- a/packages/runtime/test/compression.test.ts
+++ b/packages/runtime/test/compression.test.ts
@@ -7,7 +7,15 @@
  * logic (config resolution, bypasses) rather than actual compression.
  */
 
-import { expect, describe, beforeEach, afterEach, test as baseTest } from 'bun:test';
+import {
+	expect,
+	describe,
+	beforeAll,
+	beforeEach,
+	afterEach,
+	afterAll,
+	test as baseTest,
+} from 'bun:test';
 
 // Use serial tests to avoid race conditions with global app config state
 const test = baseTest.serial;
@@ -30,8 +38,18 @@ function clearAppConfig() {
 	delete (globalThis as any).__AGENTUITY_APP_CONFIG__;
 }
 
-// Tests use global app config state, so beforeEach/afterEach ensure isolation
+// Tests use global app config state, so beforeAll/afterAll ensure file-level isolation
+// and beforeEach/afterEach ensure test-level isolation
 describe('Compression Middleware', () => {
+	// Clear at file level to ensure isolation from other test files
+	beforeAll(() => {
+		clearAppConfig();
+	});
+
+	afterAll(() => {
+		clearAppConfig();
+	});
+
 	beforeEach(() => {
 		clearAppConfig();
 	});


### PR DESCRIPTION
## Summary

Fixes flaky CI test failures in compression.test.ts caused by cross-file test pollution.

## Problem

Two compression tests were failing intermittently in CI:
- `compression: false in app config disables compression`
- `reads config from app state at request time`

The tests always passed locally but failed sporadically in CI due to test execution order differences.

## Root Cause

Both `compression.test.ts` and `cors-trusted.test.ts` use the global `__AGENTUITY_APP_CONFIG__` state:
- `cors-trusted.test.ts` had proper file-level cleanup with `beforeAll`/`afterAll`
- `compression.test.ts` only had test-level cleanup with `beforeEach`/`afterEach`

When test files ran in different orders in CI, residual global state from CORS tests leaked into compression tests.

## Fix

Added `beforeAll`/`afterAll` hooks to `compression.test.ts` to ensure file-level isolation, matching the pattern already used in `cors-trusted.test.ts`.

## Testing

- Ran `bun run test:unit` 5 times locally with 0 failures
- All 548 runtime tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation through enhanced lifecycle management to ensure more reliable test execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->