### PR TITLE
fix(cli): skip template selection when only one template available

### DIFF
--- a/packages/cli/src/cmd/project/template-flow.ts
+++ b/packages/cli/src/cmd/project/template-flow.ts
@@ -196,7 +196,7 @@ export async function runCreateFlow(options: CreateFlowOptions): Promise<void> {
 			return;
 		}
 		selectedTemplate = found;
-	} else if (skipPrompts) {
+	} else if (skipPrompts || templates.length === 1) {
 		selectedTemplate = templates[0];
 	} else {
 		let maxLength = 15;
@@ -246,8 +246,8 @@ export async function runCreateFlow(options: CreateFlowOptions): Promise<void> {
 		logger,
 	});
 
-	// Re-display template selection after spinners clear it
-	if (!skipPrompts) {
+	// Re-display template selection after spinners clear it (only if user actually selected)
+	if (!skipPrompts && templates.length > 1) {
 		const { symbols, tuiColors } = tui;
 		console.log(`${tuiColors.completed(symbols.completed)}  Select a template:`);
 		console.log(`${tuiColors.secondary(symbols.bar)}  ${tuiColors.muted(selectedTemplate.name)}`);


### PR DESCRIPTION
When there's only one template, automatically select it instead of showing the 'Select a template' prompt. Also skips re-displaying the template selection confirmation in this case.

## Changes

- Modified `packages/cli/src/cmd/project/template-flow.ts`:
  - Added `templates.length === 1` check to auto-select when only one template exists
  - Updated re-display logic to skip showing 'Select a template' when selection was skipped

## Testing

Tested locally with `bun bin/cli.ts project create` - correctly skips template selection prompt.

Thread: https://ampcode.com/threads/T-019b9a12-fe1f-743c-84f5-90fc9e4c9f83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template selection flow: when only one template is available, it's now auto-selected even when interactive prompts are enabled.
  * Enhanced UI behavior: eliminated unnecessary re-prompting when a single template exists or prompts are skipped.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->