### PR TITLE
fix: hide workbench metadata.json from session tracking

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,7 @@
     },
     "apps/create-agentuity": {
       "name": "create-agentuity",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "bin": {
         "create-agentuity": "./bin.js",
       },
@@ -45,7 +45,7 @@
     },
     "apps/testing": {
       "name": "testing",
-      "version": "0.1.1",
+      "version": "0.1.2",
     },
     "apps/testing/auth-package-app": {
       "name": "auth-package-app",
@@ -146,7 +146,7 @@
     },
     "packages/auth": {
       "name": "@agentuity/auth",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "better-auth": "^1.4.9",
         "drizzle-orm": "^0.45.0",
@@ -170,7 +170,7 @@
     },
     "packages/cli": {
       "name": "@agentuity/cli",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "bin": {
         "agentuity": "./bin/cli.ts",
       },
@@ -209,7 +209,7 @@
     },
     "packages/core": {
       "name": "@agentuity/core",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "zod": "^4.3.5",
       },
@@ -222,7 +222,7 @@
     },
     "packages/evals": {
       "name": "@agentuity/evals",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@agentuity/core": "workspace:*",
         "@agentuity/runtime": "workspace:*",
@@ -239,7 +239,7 @@
     },
     "packages/frontend": {
       "name": "@agentuity/frontend",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@agentuity/core": "workspace:*",
       },
@@ -252,7 +252,7 @@
     },
     "packages/react": {
       "name": "@agentuity/react",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@agentuity/core": "workspace:*",
         "@agentuity/frontend": "workspace:*",
@@ -271,7 +271,7 @@
     },
     "packages/runtime": {
       "name": "@agentuity/runtime",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@agentuity/auth": "workspace:*",
         "@agentuity/core": "workspace:*",
@@ -313,7 +313,7 @@
     },
     "packages/schema": {
       "name": "@agentuity/schema",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@agentuity/core": "workspace:*",
       },
@@ -326,7 +326,7 @@
     },
     "packages/server": {
       "name": "@agentuity/server",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@agentuity/core": "workspace:*",
         "@agentuity/schema": "workspace:*",
@@ -342,7 +342,7 @@
     },
     "packages/test-utils": {
       "name": "@agentuity/test-utils",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@agentuity/core": "workspace:*",
       },
@@ -352,7 +352,7 @@
     },
     "packages/vscode": {
       "name": "agentuity-vscode",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "jsonc-parser": "^3.3.1",
       },
@@ -365,7 +365,7 @@
     },
     "packages/workbench": {
       "name": "@agentuity/workbench",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@agentuity/core": "workspace:*",
         "@agentuity/react": "workspace:*",


### PR DESCRIPTION
## Summary

Adds a generalized mechanism to exclude specific paths from OTEL session tracking. The `/_agentuity/workbench/metadata.json` route is now skipped to prevent it from appearing in the sessions list.

## Changes

- Added `OTEL_SESSION_SKIP_PATHS` Set in `middleware.ts` for paths that should skip session tracking
- Added check in `createOtelMiddleware()` to skip session tracking for paths in the skip list

## Why

Similar to #447, metadata.json requests were cluttering the sessions view. This solution is generalized so additional paths can easily be added to the skip list in the future.

## Testing

- ✅ Build passed
- ✅ Typecheck passed
- ✅ Lint passed
- ✅ All 548 runtime tests passed

Closes #481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized session tracking to skip unnecessary tracking for specific internal operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->