### PR TITLE
fix(cli): prevent dev server restart loop from directory mtime updates

### DIFF
--- a/packages/cli/src/cmd/dev/file-watcher.ts
+++ b/packages/cli/src/cmd/dev/file-watcher.ts
@@ -44,10 +44,18 @@ export function createFileWatcher(options: FileWatcherOptions): FileWatcherManag
 		'.opencode',
 		'node_modules',
 		'.git',
+		'.github',
 		'dist',
 		'build',
 		'.next',
 		'.turbo',
+		'.npm',
+		'.dist',
+		'.vscode',
+		'.idea',
+		'.DS_Store',
+		'.playwright',
+		'src/generated',
 	]);
 
 	// Paths to ignore for file change events (but may still be traversed)
@@ -59,11 +67,19 @@ export function createFileWatcher(options: FileWatcherOptions): FileWatcherManag
 		'.opencode',
 		'node_modules',
 		'.git',
+		'.github',
 		'dist',
 		'build',
 		'.next',
 		'.turbo',
+		'.npm',
+		'.dist',
+		'.vscode',
+		'.idea',
+		'.DS_Store',
+		'.playwright',
 		'src/web', // Vite handles frontend with HMR - no backend restart needed
+		'src/generated', // Generated files shouldn't trigger rebuilds
 	];
 
 	/**
@@ -184,7 +200,11 @@ export function createFileWatcher(options: FileWatcherOptions): FileWatcherManag
 				}
 			} catch (error) {
 				// File might have been deleted or doesn't exist yet - this is normal
-				logger.trace('Unable to check directory for template creation (%s): %s', changedFile, error);
+				logger.trace(
+					'Unable to check directory for template creation (%s): %s',
+					changedFile,
+					error
+				);
 			}
 		}
 


### PR DESCRIPTION
## Problem

The dev server was stuck in an infinite restart loop even when no user changes were made. The logs showed repeated restarts triggered by directory paths like `src/src`, `src/generated/generated`, etc.

## Root Cause

The file watcher was triggering restarts when directory metadata changed (mtime updates when files inside the directory are modified):

1. Build generates files in `src/generated/`
2. This updates mtime on the `src/generated/` directory
3. Watcher fires `change` event for the directory itself
4. Triggers restart, which rebuilds, updating mtime again → loop

## Solution

Filter out `change` events on directories while still allowing `rename` events for new directory scaffolding (agent/API templates).

## Testing

- Verified typecheck passes
- Fix prevents directory mtime updates from triggering restarts
- `rename` events still work for scaffolding new agent/API directories

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate detection of newly created empty directories to trigger scaffolding only when appropriate, preventing spurious template generation.
  * Improved error handling and logging around directory checks to surface specific failures during template decisions.
  * Filters out directory-only modification events to avoid unnecessary processing and reduce unwanted restarts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->