### PR TITLE
fix(cli): bundle @babel packages instead of externalizing

### DIFF
--- a/packages/cli/src/cmd/build/vite/server-bundler.ts
+++ b/packages/cli/src/cmd/build/vite/server-bundler.ts
@@ -66,7 +66,9 @@ export async function installExternalsAndBuild(options: ServerBundleOptions): Pr
 
 	// Build tool externals: packages that should be external but NOT installed
 	// These are devDependencies that may exist in node_modules but aren't needed at runtime
-	const buildToolExternals = ['@babel/*', 'lightningcss', '@vitejs/*', 'vite', 'esbuild'];
+	// NOTE: @babel/* is NOT externalized because some runtime deps (e.g., puppeteer → cosmiconfig → parse-json)
+	// require @babel/code-frame at runtime. Babel packages are pure JS and bundle fine.
+	const buildToolExternals = ['lightningcss', '@vitejs/*', 'vite', 'esbuild'];
 
 	// Load custom externals and define from agentuity.config.ts if it exists
 	const customExternals: string[] = [];


### PR DESCRIPTION
## Problem

Deployments with puppeteer fail with:
```
Cannot find module '@babel/code-frame' from '/home/agentuity/app/app.js'
```

## Cause

The dependency chain `puppeteer → cosmiconfig → parse-json → @babel/code-frame` requires babel at runtime, but `@babel/*` was in `buildToolExternals` (externalized but not installed).

## Solution

Remove `@babel/*` from `buildToolExternals`. Babel packages are pure JS and bundle fine - no need to externalize them.

## Testing

Verified with screenshot project deployment - now works correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build dependency handling to ensure required packages are properly included during the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->