### PR TITLE
perf: cache /cli/region response for 5 days

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,3 +1,4 @@
+import { mkdir } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { resolve, join } from 'node:path';
 import { Command } from 'commander';
@@ -720,7 +721,9 @@ async function getCachedRegions(logger: Logger): Promise<RegionList | null> {
 
 async function saveRegionsCache(regions: RegionList, logger: Logger): Promise<void> {
 	try {
-		const cachePath = join(getDefaultConfigDir(), REGIONS_CACHE_FILE);
+		const cacheDir = getDefaultConfigDir();
+		await mkdir(cacheDir, { recursive: true });
+		const cachePath = join(cacheDir, REGIONS_CACHE_FILE);
 		const data: RegionsCacheData = {
 			timestamp: Date.now(),
 			regions,


### PR DESCRIPTION
## Summary

Caches the regions list in `~/.config/agentuity/regions.json` to reduce API calls and improve command latency.

## Changes

- Added `fetchRegionsWithCache()` function that checks for cached regions before making an API call
- Cache expires after 5 days
- Falls back to API call if cache is missing, expired, or corrupted
- All cache operations are wrapped in try/catch to never break the command flow

## Benefits

- Reduces latency for commands that need to resolve regions
- Fewer unnecessary API calls since regions rarely change
- Cache failures are silent and gracefully fall back to API

## Related

This pairs with agentuity/app#967 which makes the `/cli/region` endpoint public.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CLI now caches region data (cached up to 5 days), reducing network requests and speeding up region lookups across commands.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->