### PR TITLE
fix(canary): don't attempt to auto upgrade when running canary

### DIFF
--- a/packages/cli/src/utils/dependency-checker.ts
+++ b/packages/cli/src/utils/dependency-checker.ts
@@ -57,11 +57,15 @@ export async function checkAndUpgradeDependencies(
 		failed: [],
 	};
 
-	const packageJsonPath = join(projectDir, 'package.json');
 	const cliVersion = getVersion();
-
 	logger.debug('CLI version: %s', cliVersion);
 
+	// check if this is a canary and if so, skip this check
+	if (cliVersion.includes('-')) {
+		return result;
+	}
+
+	const packageJsonPath = join(projectDir, 'package.json');
 	// Read package.json
 	let packageJson: PackageJson;
 	try {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance for canary CLI versions by skipping redundant dependency upgrade checks during startup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->