### PR TITLE
fix(cli): add backward compatibility for useAPI route types

### DIFF
--- a/apps/testing/e2e-web/src/generated/routes.ts
+++ b/apps/testing/e2e-web/src/generated/routes.ts
@@ -203,6 +203,99 @@ declare module '@agentuity/frontend' {
 	}
 }
 
+// Backward compatibility: also augment @agentuity/react for older versions
+// that define RouteRegistry locally instead of re-exporting from @agentuity/frontend
+declare module '@agentuity/react' {
+	export interface RouteRegistry {
+	'POST /api/hello': {
+				inputSchema: POSTApiHelloInputSchema;
+				outputSchema: POSTApiHelloOutputSchema;
+				stream: typeof hello extends { stream?: infer S } ? S : false;
+				params: never;
+			};
+	'GET /api/organizations/:orgId/members/:memberId': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: { orgId: string; memberId: string };
+			};
+	'GET /api/search': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'GET /api/users/:userId': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: { userId: string };
+			};
+	}
+	export interface WebSocketRouteRegistry {
+	'/api/echo': {
+				inputSchema: GETApiEchoInputSchema;
+				outputSchema: GETApiEchoOutputSchema;
+				stream: false;
+				params: never;
+			};
+	}
+	export interface SSERouteRegistry {
+	'/api/events': {
+				inputSchema: GETApiEventsInputSchema;
+				outputSchema: GETApiEventsOutputSchema;
+				stream: false;
+				params: never;
+			};
+	}
+	export interface RPCRouteRegistry {
+		echo: {
+			/**
+			 * Route: GET /api/echo
+			 */
+			websocket: { input: GETApiEchoInput; output: GETApiEchoOutput; type: 'websocket'; params: never; paramsTuple: [] };
+		};
+		events: {
+			/**
+			 * Route: GET /api/events
+			 */
+			eventstream: { input: GETApiEventsInput; output: GETApiEventsOutput; type: 'sse'; params: never; paramsTuple: [] };
+		};
+		hello: {
+			/**
+			 * Route: POST /api/hello
+			 */
+			post: { input: POSTApiHelloInput; output: POSTApiHelloOutput; type: 'api'; params: never; paramsTuple: [] };
+		};
+		organizations: {
+			orgId: {
+				members: {
+					memberId: {
+						/**
+						 * Route: GET /api/organizations/:orgId/members/:memberId
+						 */
+						get: { input: never; output: never; type: 'api'; params: { orgId: string; memberId: string }; paramsTuple: [string, string] };
+					};
+				};
+			};
+		};
+		search: {
+			/**
+			 * Route: GET /api/search
+			 */
+			get: { input: never; output: never; type: 'api'; params: never; paramsTuple: [] };
+		};
+		users: {
+			userId: {
+				/**
+				 * Route: GET /api/users/:userId
+				 */
+				get: { input: never; output: never; type: 'api'; params: { userId: string }; paramsTuple: [string] };
+			};
+		};
+	}
+}
+
 /**
  * Runtime metadata for RPC routes.
  * Contains route type information for client routing decisions.

--- a/apps/testing/integration-suite/src/generated/routes.ts
+++ b/apps/testing/integration-suite/src/generated/routes.ts
@@ -573,6 +573,469 @@ declare module '@agentuity/frontend' {
 	}
 }
 
+// Backward compatibility: also augment @agentuity/react for older versions
+// that define RouteRegistry locally instead of re-exporting from @agentuity/frontend
+declare module '@agentuity/react' {
+	export interface RouteRegistry {
+	'GET /api/agent-ids/all': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'DELETE /api/agent-ids/clear': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'GET /api/agent-ids/last': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'POST /api/agent-ids/run': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'GET /api/agent-ids/verify/:sessionId': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: { sessionId: string };
+			};
+	'POST /api/agent/state': {
+				inputSchema: POSTApiAgentStateInputSchema;
+				outputSchema: POSTApiAgentStateOutputSchema;
+				stream: typeof statePersistenceAgent extends { stream?: infer S } ? S : false;
+				params: never;
+			};
+	'POST /api/agent/state-reader': {
+				inputSchema: POSTApiAgentStateReaderInputSchema;
+				outputSchema: POSTApiAgentStateReaderOutputSchema;
+				stream: typeof stateReaderAgent extends { stream?: infer S } ? S : false;
+				params: never;
+			};
+	'POST /api/agent/state-writer': {
+				inputSchema: POSTApiAgentStateWriterInputSchema;
+				outputSchema: POSTApiAgentStateWriterOutputSchema;
+				stream: typeof stateWriterAgent extends { stream?: infer S } ? S : false;
+				params: never;
+			};
+	'POST /api/auth/login': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'POST /api/auth/logout': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'GET /api/auth/verify': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'GET /api/custom-name/custom': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'POST /api/custom-name/test': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'GET /api/health': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'GET /api/middleware-test/analytics-info': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'GET /api/middleware-test/check-all': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'GET /api/middleware-test/check-auth': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'GET /api/middleware-test/query-database': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'GET /api/my-service/info': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'GET /api/my-service/status': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'GET /api/test/list': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'GET /api/test/run': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'GET /api/test/suites': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'GET /api/users/profile': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'PATCH /api/users/profile': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'DELETE /api/users/profile': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	}
+	export interface WebSocketRouteRegistry {
+	'/api/ws/broadcast': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'/api/ws/counter': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'/api/ws/echo': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	}
+	export interface SSERouteRegistry {
+	'/api/sse/abort-test': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'/api/sse/async-fetch': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'/api/sse/counter': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'/api/sse/error-handling': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'/api/sse/events': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'/api/sse/long-lived': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	'/api/sse/simple': {
+				inputSchema: never;
+				outputSchema: never;
+				stream: false;
+				params: never;
+			};
+	}
+	export interface RPCRouteRegistry {
+		agent: {
+			state: {
+				/**
+				 * Route: POST /api/agent/state
+				 */
+				post: { input: POSTApiAgentStateInput; output: POSTApiAgentStateOutput; type: 'api'; params: never; paramsTuple: [] };
+			};
+			stateReader: {
+				/**
+				 * Route: POST /api/agent/state-reader
+				 */
+				post: { input: POSTApiAgentStateReaderInput; output: POSTApiAgentStateReaderOutput; type: 'api'; params: never; paramsTuple: [] };
+			};
+			stateWriter: {
+				/**
+				 * Route: POST /api/agent/state-writer
+				 */
+				post: { input: POSTApiAgentStateWriterInput; output: POSTApiAgentStateWriterOutput; type: 'api'; params: never; paramsTuple: [] };
+			};
+		};
+		agentIds: {
+			all: {
+				/**
+				 * Route: GET /api/agent-ids/all
+				 */
+				get: { input: never; output: never; type: 'api'; params: never; paramsTuple: [] };
+			};
+			clear: {
+				/**
+				 * Route: DELETE /api/agent-ids/clear
+				 */
+				delete: { input: never; output: never; type: 'api'; params: never; paramsTuple: [] };
+			};
+			last: {
+				/**
+				 * Route: GET /api/agent-ids/last
+				 */
+				get: { input: never; output: never; type: 'api'; params: never; paramsTuple: [] };
+			};
+			run: {
+				/**
+				 * Route: POST /api/agent-ids/run
+				 */
+				post: { input: never; output: never; type: 'api'; params: never; paramsTuple: [] };
+			};
+			verify: {
+				sessionId: {
+					/**
+					 * Route: GET /api/agent-ids/verify/:sessionId
+					 */
+					get: { input: never; output: never; type: 'api'; params: { sessionId: string }; paramsTuple: [string] };
+				};
+			};
+		};
+		auth: {
+			login: {
+				/**
+				 * Route: POST /api/auth/login
+				 */
+				post: { input: never; output: never; type: 'api'; params: never; paramsTuple: [] };
+			};
+			logout: {
+				/**
+				 * Route: POST /api/auth/logout
+				 */
+				post: { input: never; output: never; type: 'api'; params: never; paramsTuple: [] };
+			};
+			verify: {
+				/**
+				 * Route: GET /api/auth/verify
+				 */
+				get: { input: never; output: never; type: 'api'; params: never; paramsTuple: [] };
+			};
+		};
+		customName: {
+			custom: {
+				/**
+				 * Route: GET /api/custom-name/custom
+				 */
+				get: { input: never; output: never; type: 'api'; params: never; paramsTuple: [] };
+			};
+			test: {
+				/**
+				 * Route: POST /api/custom-name/test
+				 */
+				post: { input: never; output: never; type: 'api'; params: never; paramsTuple: [] };
+			};
+		};
+		health: {
+			/**
+			 * Route: GET /api/health
+			 */
+			get: { input: never; output: never; type: 'api'; params: never; paramsTuple: [] };
+		};
+		middlewareTest: {
+			analyticsInfo: {
+				/**
+				 * Route: GET /api/middleware-test/analytics-info
+				 */
+				get: { input: never; output: never; type: 'api'; params: never; paramsTuple: [] };
+			};
+			checkAll: {
+				/**
+				 * Route: GET /api/middleware-test/check-all
+				 */
+				get: { input: never; output: never; type: 'api'; params: never; paramsTuple: [] };
+			};
+			checkAuth: {
+				/**
+				 * Route: GET /api/middleware-test/check-auth
+				 */
+				get: { input: never; output: never; type: 'api'; params: never; paramsTuple: [] };
+			};
+			queryDatabase: {
+				/**
+				 * Route: GET /api/middleware-test/query-database
+				 */
+				get: { input: never; output: never; type: 'api'; params: never; paramsTuple: [] };
+			};
+		};
+		myService: {
+			info: {
+				/**
+				 * Route: GET /api/my-service/info
+				 */
+				get: { input: never; output: never; type: 'api'; params: never; paramsTuple: [] };
+			};
+			status: {
+				/**
+				 * Route: GET /api/my-service/status
+				 */
+				get: { input: never; output: never; type: 'api'; params: never; paramsTuple: [] };
+			};
+		};
+		sse: {
+			abortTest: {
+				/**
+				 * Route: GET /api/sse/abort-test
+				 */
+				eventstream: { input: never; output: never; type: 'sse'; params: never; paramsTuple: [] };
+			};
+			asyncFetch: {
+				/**
+				 * Route: GET /api/sse/async-fetch
+				 */
+				eventstream: { input: never; output: never; type: 'sse'; params: never; paramsTuple: [] };
+			};
+			counter: {
+				/**
+				 * Route: GET /api/sse/counter
+				 */
+				eventstream: { input: never; output: never; type: 'sse'; params: never; paramsTuple: [] };
+			};
+			errorHandling: {
+				/**
+				 * Route: GET /api/sse/error-handling
+				 */
+				eventstream: { input: never; output: never; type: 'sse'; params: never; paramsTuple: [] };
+			};
+			events: {
+				/**
+				 * Route: GET /api/sse/events
+				 */
+				eventstream: { input: never; output: never; type: 'sse'; params: never; paramsTuple: [] };
+			};
+			longLived: {
+				/**
+				 * Route: GET /api/sse/long-lived
+				 */
+				eventstream: { input: never; output: never; type: 'sse'; params: never; paramsTuple: [] };
+			};
+			simple: {
+				/**
+				 * Route: GET /api/sse/simple
+				 */
+				eventstream: { input: never; output: never; type: 'sse'; params: never; paramsTuple: [] };
+			};
+		};
+		test: {
+			list: {
+				/**
+				 * Route: GET /api/test/list
+				 */
+				get: { input: never; output: never; type: 'api'; params: never; paramsTuple: [] };
+			};
+			run: {
+				/**
+				 * Route: GET /api/test/run
+				 */
+				get: { input: never; output: never; type: 'api'; params: never; paramsTuple: [] };
+			};
+			suites: {
+				/**
+				 * Route: GET /api/test/suites
+				 */
+				get: { input: never; output: never; type: 'api'; params: never; paramsTuple: [] };
+			};
+		};
+		users: {
+			profile: {
+				/**
+				 * Route: DELETE /api/users/profile
+				 */
+				delete: { input: never; output: never; type: 'api'; params: never; paramsTuple: [] };
+				/**
+				 * Route: GET /api/users/profile
+				 */
+				get: { input: never; output: never; type: 'api'; params: never; paramsTuple: [] };
+				/**
+				 * Route: PATCH /api/users/profile
+				 */
+				patch: { input: never; output: never; type: 'api'; params: never; paramsTuple: [] };
+			};
+		};
+		ws: {
+			broadcast: {
+				/**
+				 * Route: GET /api/ws/broadcast
+				 */
+				websocket: { input: never; output: never; type: 'websocket'; params: never; paramsTuple: [] };
+			};
+			counter: {
+				/**
+				 * Route: GET /api/ws/counter
+				 */
+				websocket: { input: never; output: never; type: 'websocket'; params: never; paramsTuple: [] };
+			};
+			echo: {
+				/**
+				 * Route: GET /api/ws/echo
+				 */
+				websocket: { input: never; output: never; type: 'websocket'; params: never; paramsTuple: [] };
+			};
+		};
+	}
+}
+
 /**
  * Runtime metadata for RPC routes.
  * Contains route type information for client routing decisions.

--- a/apps/testing/nextjs-app/README.md
+++ b/apps/testing/nextjs-app/README.md
@@ -29,14 +29,14 @@ Next.js rewrites `/api/*` requests to the Agentuity backend:
 
 ```typescript
 const nextConfig: NextConfig = {
-  async rewrites() {
-    return [
-      {
-        source: '/api/:path*',
-        destination: 'http://localhost:3500/api/:path*',
-      },
-    ];
-  },
+	async rewrites() {
+		return [
+			{
+				source: '/api/:path*',
+				destination: 'http://localhost:3500/api/:path*',
+			},
+		];
+	},
 };
 ```
 
@@ -46,9 +46,9 @@ Path aliases enable importing generated route types:
 
 ```json
 {
-  "paths": {
-    "@agentuity/routes": ["./agentuity/src/generated/routes.ts"]
-  }
+	"paths": {
+		"@agentuity/routes": ["./agentuity/src/generated/routes.ts"]
+	}
 }
 ```
 
@@ -63,18 +63,18 @@ import { useAPI, AgentuityProvider } from '@agentuity/react';
 import '@agentuity/routes'; // Side-effect import for type augmentation
 
 function EchoDemoInner() {
-  // TypeScript knows: input = { message: string }, output = { echo: string, timestamp: string }
-  const { data, invoke, isLoading, error } = useAPI('POST /api/echo');
+	// TypeScript knows: input = { message: string }, output = { echo: string, timestamp: string }
+	const { data, invoke, isLoading, error } = useAPI('POST /api/echo');
 
-  return (
-    <button onClick={() => invoke({ message: 'Hello!' })}>
-      Send Echo
-    </button>
-  );
+	return <button onClick={() => invoke({ message: 'Hello!' })}>Send Echo</button>;
 }
 
 export default function EchoDemo() {
-  return <AgentuityProvider><EchoDemoInner /></AgentuityProvider>;
+	return (
+		<AgentuityProvider>
+			<EchoDemoInner />
+		</AgentuityProvider>
+	);
 }
 ```
 
@@ -87,20 +87,20 @@ import { createAgent } from '@agentuity/runtime';
 import { s } from '@agentuity/schema';
 
 export const EchoInput = s.object({
-  message: s.string(),
+	message: s.string(),
 });
 
 export const EchoOutput = s.object({
-  echo: s.string(),
-  timestamp: s.string(),
+	echo: s.string(),
+	timestamp: s.string(),
 });
 
 const agent = createAgent('echo', {
-  schema: { input: EchoInput, output: EchoOutput },
-  handler: async (ctx, { message }) => ({
-    echo: message,
-    timestamp: new Date().toISOString(),
-  }),
+	schema: { input: EchoInput, output: EchoOutput },
+	handler: async (ctx, { message }) => ({
+		echo: message,
+		timestamp: new Date().toISOString(),
+	}),
 });
 ```
 

--- a/apps/testing/nextjs-app/agentuity/src/generated/README.md
+++ b/apps/testing/nextjs-app/agentuity/src/generated/README.md
@@ -15,6 +15,7 @@ This directory contains auto-generated TypeScript files created by the Agentuity
 ## For Developers
 
 Do not modify these files. Instead:
+
 - Add/modify agents in `src/agent/`
 - Add/modify routes in `src/api/`
 - Configure app in `app.ts`

--- a/apps/testing/tanstack-start/README.md
+++ b/apps/testing/tanstack-start/README.md
@@ -44,9 +44,9 @@ Path aliases enable importing generated route types:
 
 ```json
 {
-  "paths": {
-    "@agentuity/routes": ["./agentuity/src/generated/routes.ts"]
-  }
+	"paths": {
+		"@agentuity/routes": ["./agentuity/src/generated/routes.ts"]
+	}
 }
 ```
 
@@ -59,14 +59,10 @@ import { useAPI, AgentuityProvider } from '@agentuity/react';
 import '@agentuity/routes'; // Side-effect import for type augmentation
 
 function EchoDemoInner() {
-  // TypeScript knows: input = { message: string }, output = { echo: string, timestamp: string }
-  const { data, invoke, isLoading, error } = useAPI('POST /api/echo');
+	// TypeScript knows: input = { message: string }, output = { echo: string, timestamp: string }
+	const { data, invoke, isLoading, error } = useAPI('POST /api/echo');
 
-  return (
-    <button onClick={() => invoke({ message: 'Hello!' })}>
-      Send Echo
-    </button>
-  );
+	return <button onClick={() => invoke({ message: 'Hello!' })}>Send Echo</button>;
 }
 ```
 
@@ -79,20 +75,20 @@ import { createAgent } from '@agentuity/runtime';
 import { s } from '@agentuity/schema';
 
 export const EchoInput = s.object({
-  message: s.string(),
+	message: s.string(),
 });
 
 export const EchoOutput = s.object({
-  echo: s.string(),
-  timestamp: s.string(),
+	echo: s.string(),
+	timestamp: s.string(),
 });
 
 const agent = createAgent('echo', {
-  schema: { input: EchoInput, output: EchoOutput },
-  handler: async (ctx, { message }) => ({
-    echo: message,
-    timestamp: new Date().toISOString(),
-  }),
+	schema: { input: EchoInput, output: EchoOutput },
+	handler: async (ctx, { message }) => ({
+		echo: message,
+		timestamp: new Date().toISOString(),
+	}),
 });
 ```
 

--- a/apps/testing/tanstack-start/agentuity/src/generated/README.md
+++ b/apps/testing/tanstack-start/agentuity/src/generated/README.md
@@ -15,6 +15,7 @@ This directory contains auto-generated TypeScript files created by the Agentuity
 ## For Developers
 
 Do not modify these files. Instead:
+
 - Add/modify agents in `src/agent/`
 - Add/modify routes in `src/api/`
 - Configure app in `app.ts`

--- a/apps/testing/tanstack-start/agentuity/tsconfig.json
+++ b/apps/testing/tanstack-start/agentuity/tsconfig.json
@@ -6,28 +6,13 @@
 		"allowImportingTsExtensions": true,
 		"noEmit": true,
 		"jsx": "react-jsx",
-		"lib": [
-			"ESNext",
-			"DOM"
-		],
-		"types": [
-			"bun-types"
-		],
+		"lib": ["ESNext", "DOM"],
+		"types": ["bun-types"],
 		"skipLibCheck": true,
 		"paths": {
-			"@agents/*": [
-				"./src/agent/*"
-			]
+			"@agents/*": ["./src/agent/*"]
 		}
 	},
-	"include": [
-		"src/**/*",
-		"app.ts",
-		".agentuity/.agentuity_types.ts"
-	],
-	"exclude": [
-		"node_modules",
-		".agentuity",
-		"src/generated/routes.ts"
-	]
+	"include": ["src/**/*", "app.ts", ".agentuity/.agentuity_types.ts"],
+	"exclude": ["node_modules", ".agentuity", "src/generated/routes.ts"]
 }

--- a/packages/cli/src/cmd/build/vite/registry-generator.ts
+++ b/packages/cli/src/cmd/build/vite/registry-generator.ts
@@ -998,7 +998,28 @@ ${sseRouteEntries}
 ${rpcRegistryType}
 \t}
 }
-
+${
+	hasReactDependency
+		? `
+// Backward compatibility: also augment @agentuity/react for older versions
+// that define RouteRegistry locally instead of re-exporting from @agentuity/frontend
+declare module '@agentuity/react' {
+\texport interface RouteRegistry {
+${apiRouteEntries}
+\t}
+\texport interface WebSocketRouteRegistry {
+${websocketRouteEntries}
+\t}
+\texport interface SSERouteRegistry {
+${sseRouteEntries}
+\t}
+\texport interface RPCRouteRegistry {
+${rpcRegistryType}
+\t}
+}
+`
+		: ''
+}
 /**
  * Runtime metadata for RPC routes.
  * Contains route type information for client routing decisions.


### PR DESCRIPTION
## Problem

When using the canary CLI with released versions of `@agentuity/react` and `@agentuity/frontend`, the `useAPI` hook was failing with type errors like:

```
error[TS2769]: No overload matches this call.
  Argument of type '"GET /api/translate/history"' is not assignable to parameter of type 'never'.
```

## Root Cause

Commit d546a647 changed the CLI to generate module augmentations targeting only `@agentuity/frontend`. However, the **released** version of `@agentuity/react` defines `RouteRegistry` locally instead of re-exporting from `@agentuity/frontend`. This meant the generated augmentation never reached the types that `useAPI` was using.

## Solution

The CLI now generates module augmentations for **both** packages:
- `@agentuity/frontend` (canonical source for new versions)
- `@agentuity/react` (backward compatibility for older versions)

The `@agentuity/react` augmentation is only emitted when that package is detected in the user's `package.json`.

## Testing

- Added negative test to verify augmentation is skipped when `@agentuity/react` is not a dependency
- Verified fix against the demo-day project that was failing
- All 64 registry generator tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added route registry type exports to @agentuity/react module for backward compatibility with older React setups.

* **Documentation**
  * Improved README formatting for better readability.

* **Tests**
  * Expanded test coverage for backward compatibility scenarios across modules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->