### PR TITLE
Exclude some additional commands from skills

### DIFF
--- a/packages/cli/src/cmd/ai/skills/generator.ts
+++ b/packages/cli/src/cmd/ai/skills/generator.ts
@@ -13,7 +13,15 @@ interface SkillInfo {
 	fullCommandPath: string[];
 }
 
-const EXCLUDED_COMMANDS = new Set(['ai', 'help', 'version']);
+const EXCLUDED_COMMANDS = new Set([
+	'ai',
+	'help',
+	'version',
+	'canary',
+	'setup',
+	'profile',
+	'upgrade',
+]);
 
 function isValidSkillName(name: string): boolean {
 	if (name.length < 1 || name.length > 64) return false;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Expanded the list of commands excluded during AI skill generation. The following commands are now prevented from being included in skill generation: ai, help, version, canary, setup, profile, and upgrade.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->