### PR TITLE
remove api_key from config (stored in keychain)

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -385,6 +385,7 @@ export async function getAuth(): Promise<AuthData | null> {
 				if (config?.auth) {
 					const configCopy = { ...config };
 					delete configCopy.auth;
+					cachedConfig = null; // Force cache refresh
 					await saveConfig(configCopy);
 				}
 				return {


### PR DESCRIPTION
## Overview

No changes detected in the diff. This PR appears to be a work-in-progress.

## Motivation

The `api_key` field should be removed from configuration files since credentials are now stored securely in the system keychain. Storing API keys in plain text config files poses a security risk.

## Changes

- **sdk**: No changes detected yet

## Status

⚠️ **Empty diff** - no changes have been committed to this branch yet.

## Next Steps

1. Identify where `api_key` is defined in config schemas
2. Remove the field from config types/interfaces
3. Update config parsing logic
4. Add migration path for existing configs
5. Update documentation

## Repository-Specific Changes

- No changes detected in diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * macOS Keychain authentication now clears stale or duplicate local authentication data when Keychain credentials are used, preventing conflicting credentials and ensuring a cleaner, consistent sign-in state for users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->