### PR TITLE
fix(auth): Only delete the api_key not the entire auth

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -383,10 +383,8 @@ export async function getAuth(): Promise<AuthData | null> {
 			if (keychainAuth) {
 				// If there's auth api_key in the config file, remove it since we have it in keychain
 				if (config?.auth?.api_key) {
-					const configCopy = { ...config };
-					if (configCopy.auth?.api_key) {
-						delete configCopy.auth.api_key; // don't store in config since its in keychain
-					}
+					const { api_key: _, ...authWithoutApiKey } = config.auth;
+					const configCopy = { ...config, auth: authWithoutApiKey };
 					cachedConfig = null; // Force cache refresh
 					await saveConfig(configCopy);
 				}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * macOS keychain refresh now preserves additional authentication fields (e.g., linked user ID) when updating credentials, preventing unintended loss of stored auth metadata while refreshing the API key.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->