### PR TITLE
fix: improve Vite port conflict feedback and HMR reliability

### DIFF
--- a/packages/cli/src/cmd/build/vite/vite-asset-server-config.ts
+++ b/packages/cli/src/cmd/build/vite/vite-asset-server-config.ts
@@ -94,11 +94,11 @@ export async function generateAssetServerConfig(
 			},
 
 			// HMR configuration - client must connect to Vite asset server directly
+			// Do NOT set port/clientPort - let Vite use the actual server port it binds to
+			// (important when strictPort: false and Vite falls back to an alternate port)
 			hmr: {
 				protocol: 'ws',
 				host: '127.0.0.1',
-				port, // HMR WebSocket on same port as HTTP
-				clientPort: port, // Tell client to connect to this port (not origin 3500)
 			},
 
 			// Don't open browser - Bun server will be the entry point
@@ -151,7 +151,11 @@ export async function generateAssetServerConfig(
 		// Custom logger to integrate with our logger
 		customLogger: {
 			info(msg: string) {
-				if (!msg.includes('[vite]')) {
+				// Show port-related messages at info level (important for debugging port conflicts)
+				// Keep other Vite info messages (like HMR updates) at debug to avoid noise
+				if (msg.includes('Port') || msg.includes('port')) {
+					logger.info(`[Vite Asset] ${msg}`);
+				} else {
 					logger.debug(`[Vite Asset] ${msg}`);
 				}
 			},

--- a/packages/cli/src/cmd/build/vite/vite-asset-server.ts
+++ b/packages/cli/src/cmd/build/vite/vite-asset-server.ts
@@ -111,9 +111,12 @@ export async function startViteAssetServer(
 		actualPort = getPortFromHttpServer() ?? preferredPort;
 	}
 
-	logger.debug(`✅ Vite asset server started on port ${actualPort}`);
-	if (actualPort !== preferredPort) {
-		logger.debug(`Port ${preferredPort} was taken, using ${actualPort} instead`);
+	if (actualPort === preferredPort) {
+		logger.info(`Vite asset server running on port ${actualPort}`);
+	} else {
+		logger.warn(
+			`Vite asset server running on port ${actualPort} (preferred port ${preferredPort} was in use)`
+		);
 	}
 	logger.debug(`Asset server will handle: HMR, React transformation, source maps`);
 	logger.debug(`HMR WebSocket configured to connect to ws://127.0.0.1:${actualPort}`);

--- a/packages/cli/test/cmd/build/vite/hmr-port-config.test.ts
+++ b/packages/cli/test/cmd/build/vite/hmr-port-config.test.ts
@@ -1,0 +1,89 @@
+import { describe, test, expect } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { generateAssetServerConfig } from '../../../../src/cmd/build/vite/vite-asset-server-config';
+import type { Logger } from '../../../../src/types';
+
+/**
+ * Test suite for HMR port configuration
+ *
+ * This verifies that the HMR configuration does not hardcode port values,
+ * allowing Vite to automatically use the actual server port when it falls
+ * back to an alternate port due to port conflicts.
+ *
+ * GitHub Issue: https://github.com/agentuity/sdk/issues/542
+ */
+describe('Vite HMR Port Configuration', () => {
+	const mockLogger: Logger = {
+		trace: () => {},
+		debug: () => {},
+		info: () => {},
+		warn: () => {},
+		error: () => {},
+		fatal: () => {
+			throw new Error('Fatal error');
+		},
+		child: () => mockLogger,
+	};
+
+	test('HMR config should not hardcode port values', async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), 'agentuity-hmr-test-'));
+		try {
+			// Create minimal project structure
+			writeFileSync(
+				join(tempDir, 'package.json'),
+				JSON.stringify({ name: 'test', dependencies: {} })
+			);
+			mkdirSync(join(tempDir, 'src'), { recursive: true });
+
+			const config = await generateAssetServerConfig({
+				rootDir: tempDir,
+				logger: mockLogger,
+				port: 5173,
+			});
+
+			// Verify HMR config exists
+			expect(config.server?.hmr).toBeDefined();
+
+			const hmrConfig = config.server?.hmr as Record<string, unknown>;
+
+			// HMR port and clientPort should NOT be set
+			// This allows Vite to use the actual server port when it falls back
+			expect(hmrConfig.port).toBeUndefined();
+			expect(hmrConfig.clientPort).toBeUndefined();
+
+			// These should still be set for proper HMR routing
+			expect(hmrConfig.protocol).toBe('ws');
+			expect(hmrConfig.host).toBe('127.0.0.1');
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test('server config should allow port fallback with strictPort: false', async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), 'agentuity-hmr-test-'));
+		try {
+			// Create minimal project structure
+			writeFileSync(
+				join(tempDir, 'package.json'),
+				JSON.stringify({ name: 'test', dependencies: {} })
+			);
+			mkdirSync(join(tempDir, 'src'), { recursive: true });
+
+			const config = await generateAssetServerConfig({
+				rootDir: tempDir,
+				logger: mockLogger,
+				port: 5173,
+			});
+
+			// strictPort should be false to allow Vite to choose alternate ports
+			expect(config.server?.strictPort).toBe(false);
+
+			// The requested port should still be set
+			expect(config.server?.port).toBe(5173);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Fixes the silent failure when Vite's default port 5173 is already in use during `agentuity dev`.

## Problem

When running `agentuity dev`, if port 5173 (Vite's default port) was already in use:
1. The port conflict message only appeared at DEBUG level, invisible to users
2. The HMR configuration hardcoded port values, potentially breaking HMR when Vite chose an alternate port
3. Vite's own informative port messages were being suppressed

## Solution

### 1. Improved port fallback logging
Changed log levels in `vite-asset-server.ts`:
- **Info level**: When Vite starts on the preferred port
- **Warn level**: When Vite falls back to an alternate port with a clear message like:
  ```
  ⚠ Vite asset server running on port 5174 (preferred port 5173 was in use)
  ```

### 2. Fixed HMR configuration
Removed hardcoded `hmr.port` and `hmr.clientPort` from `vite-asset-server-config.ts`. This allows Vite to automatically use the actual server port for HMR WebSocket connections, fixing potential HMR breakage when using alternate ports.

### 3. Surfaced port-related Vite messages
Updated the custom logger to show port-related messages at info level while keeping other Vite messages (like HMR updates) at debug to avoid noise.

## Testing

- Added `hmr-port-config.test.ts` to verify HMR config doesn't hardcode ports
- All 139 Vite-related tests pass
- Manual testing: Block port 5173, run `agentuity dev`, confirm warning is shown and HMR works

## Files Changed

- `packages/cli/src/cmd/build/vite/vite-asset-server.ts` - Improved logging
- `packages/cli/src/cmd/build/vite/vite-asset-server-config.ts` - Fixed HMR config & logger
- `packages/cli/test/cmd/build/vite/hmr-port-config.test.ts` - New regression test

Resolves #542

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed port mismatch issues in the asset server when dynamically assigning ports.

* **Improvements**
  * Enhanced startup logging to display warnings when the actual port differs from the preferred port.

* **Tests**
  * Added tests for asset server port configuration handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->