### PR TITLE
feat: CLI improvements and sandbox port mapping

### DIFF
--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -223,11 +223,6 @@ export async function requireOrg(
 		return options.orgId;
 	}
 
-	// Check if org is saved in config preferences
-	if (config?.preferences?.orgId) {
-		return config.preferences.orgId;
-	}
-
 	// Fetch organizations
 	const orgs = await tui.spinner({
 		message: 'Fetching organizations',

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -684,8 +684,7 @@ async function getRegion(regions: RegionList): Promise<string> {
 
 interface ResolveRegionOptions {
 	options: Record<string, unknown>;
-	apiClient: APIClientType;
-	profileName: string;
+	regions: RegionList;
 	logger: Logger;
 	required: boolean;
 	region?: string;
@@ -775,10 +774,7 @@ async function fetchRegionsWithCache(
 }
 
 async function resolveRegion(opts: ResolveRegionOptions): Promise<string | undefined> {
-	const { options, apiClient, profileName, logger, required } = opts;
-
-	// Fetch regions (with caching)
-	const regions = await fetchRegionsWithCache(profileName, apiClient, logger);
+	const { options, regions, logger, required } = opts;
 
 	// No regions available
 	if (regions.length === 0) {
@@ -1009,18 +1005,27 @@ async function registerSubcommand(
 				if (opt.hasDefault) {
 					const defaultValue =
 						typeof opt.defaultValue === 'function' ? opt.defaultValue() : opt.defaultValue;
-					// For boolean flags with default true, only show the --no-* flag in help
-					// since that's the only actionable flag users need to know about.
-					// The positive flag is hidden but still functional.
+					// Register both positive and negative forms so both work,
+					// but only show one in help based on the default value
 					const baseDesc = desc.replace(/\s*\(use\s+--no-\S+\s+to\s+skip\)/i, '').trim();
 					const negatedDesc = baseDesc.toLowerCase().startsWith('run ')
 						? `Skip ${baseDesc.slice(4)}`
 						: `Do not ${baseDesc.charAt(0).toLowerCase()}${baseDesc.slice(1)}`;
-					cmd.option(`--no-${flag}`, negatedDesc);
-					const positiveOption = cmd.createOption(flagSpec, baseDesc);
-					positiveOption.default(defaultValue);
-					positiveOption.hideHelp();
-					cmd.addOption(positiveOption);
+
+					if (defaultValue === true) {
+						// Show --no-* in help, hide positive flag
+						cmd.option(`--no-${flag}`, negatedDesc);
+						const positiveOption = cmd.createOption(flagSpec, baseDesc);
+						positiveOption.default(defaultValue);
+						positiveOption.hideHelp();
+						cmd.addOption(positiveOption);
+					} else {
+						// Show positive flag in help, but also register --no-* hidden
+						cmd.option(flagSpec, desc);
+						const negativeOption = cmd.createOption(`--no-${flag}`, negatedDesc);
+						negativeOption.hideHelp();
+						cmd.addOption(negativeOption);
+					}
 				} else {
 					cmd.option(flagSpec, desc);
 				}
@@ -1239,19 +1244,23 @@ async function registerSubcommand(
 					}
 					if ((normalized.requiresRegion || normalized.optionalRegion) && ctx.apiClient) {
 						const apiClient: APIClientType = ctx.apiClient as APIClientType;
-						const region = await tui.spinner({
+						const regions = await tui.spinner({
 							message: 'Fetching cloud regions',
 							clearOnSuccess: true,
 							callback: async () => {
-								return resolveRegion({
-									options: options as Record<string, unknown>,
+								return fetchRegionsWithCache(
+									baseCtx.config?.name ?? defaultProfileName,
 									apiClient,
-									profileName: baseCtx.config?.name ?? defaultProfileName,
-									logger: baseCtx.logger,
-									required: !!normalized.requiresRegion,
-									region: project?.region,
-								});
+									baseCtx.logger
+								);
 							},
+						});
+						const region = await resolveRegion({
+							options: options as Record<string, unknown>,
+							regions,
+							logger: baseCtx.logger,
+							required: !!normalized.requiresRegion,
+							region: project?.region,
 						});
 						if (region) {
 							ctx.region = region;
@@ -1311,15 +1320,23 @@ async function registerSubcommand(
 				}
 				if ((normalized.requiresRegion || normalized.optionalRegion) && ctx.apiClient) {
 					const apiClient: APIClientType = ctx.apiClient as APIClientType;
-					const region = await tui.spinner('Fetching cloud regions', async () => {
-						return resolveRegion({
-							options: options as Record<string, unknown>,
-							apiClient,
-							profileName: baseCtx.config?.name ?? defaultProfileName,
-							logger: baseCtx.logger,
-							required: !!normalized.requiresRegion,
-							region: project?.region,
-						});
+					const regions = await tui.spinner({
+						message: 'Fetching cloud regions',
+						clearOnSuccess: true,
+						callback: async () => {
+							return fetchRegionsWithCache(
+								baseCtx.config?.name ?? defaultProfileName,
+								apiClient,
+								baseCtx.logger
+							);
+						},
+					});
+					const region = await resolveRegion({
+						options: options as Record<string, unknown>,
+						regions,
+						logger: baseCtx.logger,
+						required: !!normalized.requiresRegion,
+						region: project?.region,
 					});
 					if (region) {
 						ctx.region = region;
@@ -1426,10 +1443,20 @@ async function registerSubcommand(
 						auth
 					) {
 						const apiClient: APIClientType = ctx.apiClient as APIClientType;
+						const regions = await tui.spinner({
+							message: 'Fetching cloud regions',
+							clearOnSuccess: true,
+							callback: async () => {
+								return fetchRegionsWithCache(
+									baseCtx.config?.name ?? defaultProfileName,
+									apiClient,
+									baseCtx.logger
+								);
+							},
+						});
 						const region = await resolveRegion({
 							options: options as Record<string, unknown>,
-							apiClient,
-							profileName: baseCtx.config?.name ?? defaultProfileName,
+							regions,
 							logger: baseCtx.logger,
 							required: !!normalized.requiresRegion,
 							region: project?.region,
@@ -1491,12 +1518,23 @@ async function registerSubcommand(
 				}
 				if ((normalized.requiresRegion || normalized.optionalRegion) && ctx.apiClient) {
 					const apiClient: APIClientType = ctx.apiClient as APIClientType;
+					const regions = await tui.spinner({
+						message: 'Fetching cloud regions',
+						clearOnSuccess: true,
+						callback: async () => {
+							return fetchRegionsWithCache(
+								baseCtx.config?.name ?? defaultProfileName,
+								apiClient,
+								baseCtx.logger
+							);
+						},
+					});
 					const region = await resolveRegion({
 						options: options as Record<string, unknown>,
-						apiClient,
-						profileName: baseCtx.config?.name ?? defaultProfileName,
+						regions,
 						logger: baseCtx.logger,
 						required: !!normalized.requiresRegion,
+						region: project?.region,
 					});
 					if (region) {
 						ctx.region = region;
@@ -1603,10 +1641,20 @@ async function registerSubcommand(
 				}
 				if ((normalized.requiresRegion || normalized.optionalRegion) && ctx.apiClient) {
 					const apiClient: APIClientType = ctx.apiClient as APIClientType;
+					const regions = await tui.spinner({
+						message: 'Fetching cloud regions',
+						clearOnSuccess: true,
+						callback: async () => {
+							return fetchRegionsWithCache(
+								baseCtx.config?.name ?? defaultProfileName,
+								apiClient,
+								baseCtx.logger
+							);
+						},
+					});
 					const region = await resolveRegion({
 						options: options as Record<string, unknown>,
-						apiClient,
-						profileName: baseCtx.config?.name ?? defaultProfileName,
+						regions,
 						logger: baseCtx.logger,
 						required: !!normalized.requiresRegion,
 						region: project?.region,
@@ -1732,10 +1780,20 @@ export async function registerCommands(
 						}
 						if ((normalized.requiresRegion || normalized.optionalRegion) && ctx.apiClient) {
 							const apiClient: APIClientType = ctx.apiClient as APIClientType;
+							const regions = await tui.spinner({
+								message: 'Fetching cloud regions',
+								clearOnSuccess: true,
+								callback: async () => {
+									return fetchRegionsWithCache(
+										baseCtx.config?.name ?? defaultProfileName,
+										apiClient,
+										baseCtx.logger
+									);
+								},
+							});
 							const region = await resolveRegion({
 								options: baseCtx.options as unknown as Record<string, unknown>,
-								apiClient,
-								profileName: baseCtx.config?.name ?? defaultProfileName,
+								regions,
 								logger: baseCtx.logger,
 								required: !!normalized.requiresRegion,
 							});
@@ -1790,10 +1848,20 @@ export async function registerCommands(
 						}
 						if ((normalized.requiresRegion || normalized.optionalRegion) && ctx.apiClient) {
 							const apiClient: APIClientType = ctx.apiClient as APIClientType;
+							const regions = await tui.spinner({
+								message: 'Fetching cloud regions',
+								clearOnSuccess: true,
+								callback: async () => {
+									return fetchRegionsWithCache(
+										baseCtx.config?.name ?? defaultProfileName,
+										apiClient,
+										baseCtx.logger
+									);
+								},
+							});
 							const region = await resolveRegion({
 								options: baseCtx.options as unknown as Record<string, unknown>,
-								apiClient,
-								profileName: baseCtx.config?.name ?? defaultProfileName,
+								regions,
 								logger: baseCtx.logger,
 								required: !!normalized.requiresRegion,
 							});
@@ -1811,10 +1879,20 @@ export async function registerCommands(
 						}
 						if ((normalized.requiresRegion || normalized.optionalRegion) && ctx.apiClient) {
 							const apiClient = ctx.apiClient as APIClientType;
+							const regions = await tui.spinner({
+								message: 'Fetching cloud regions',
+								clearOnSuccess: true,
+								callback: async () => {
+									return fetchRegionsWithCache(
+										baseCtx.config?.name ?? defaultProfileName,
+										apiClient,
+										baseCtx.logger
+									);
+								},
+							});
 							const region = await resolveRegion({
 								options: baseCtx.options as unknown as Record<string, unknown>,
-								apiClient,
-								profileName: baseCtx.config?.name ?? defaultProfileName,
+								regions,
 								logger: baseCtx.logger,
 								required: !!normalized.requiresRegion,
 							});

--- a/packages/cli/src/cmd/cloud/agent/get.ts
+++ b/packages/cli/src/cmd/cloud/agent/get.ts
@@ -43,12 +43,20 @@ export const getSubcommand = createSubcommand({
 		}
 
 		// Display agent details
-		console.log(tui.bold('ID:          ') + agent.identifier);
-		console.log(tui.bold('Name:        ') + agent.name);
-		console.log(tui.bold('Description: ') + (agent.description || 'N/A'));
-		console.log(tui.bold('Dev Mode:    ') + (agent.devmode ? 'Yes' : 'No'));
-		console.log(tui.bold('Created:     ') + new Date(agent.createdAt).toLocaleString());
-		console.log(tui.bold('Updated:     ') + new Date(agent.updatedAt).toLocaleString());
+		tui.table(
+			[
+				{
+					ID: agent.identifier,
+					Name: agent.name,
+					Description: agent.description || 'N/A',
+					'Dev Mode': agent.devmode ? 'Yes' : 'No',
+					Created: new Date(agent.createdAt).toLocaleString(),
+					Updated: new Date(agent.updatedAt).toLocaleString(),
+				},
+			],
+			['ID', 'Name', 'Description', 'Dev Mode', 'Created', 'Updated'],
+			{ layout: 'vertical', padStart: '  ' }
+		);
 
 		// Display metadata if present
 		if (agent.metadata && Object.keys(agent.metadata).length > 0) {

--- a/packages/cli/src/cmd/cloud/deployment/show.ts
+++ b/packages/cli/src/cmd/cloud/deployment/show.ts
@@ -90,82 +90,85 @@ export const showSubcommand = createSubcommand({
 
 			// Skip TUI output in JSON mode
 			if (!options.json) {
-				const maxWidth = 18;
-				console.log(tui.bold('ID:'.padEnd(maxWidth)) + deployment.id);
-				console.log(tui.bold('Project:'.padEnd(maxWidth)) + projectId);
-				console.log(tui.bold('State:'.padEnd(maxWidth)) + (deployment.state || 'unknown'));
-				console.log(tui.bold('Active:'.padEnd(maxWidth)) + (deployment.active ? 'Yes' : 'No'));
-				console.log(
-					tui.bold('Created:'.padEnd(maxWidth)) +
-						new Date(deployment.createdAt).toLocaleString()
-				);
+				const tableData: Record<string, string> = {
+					ID: deployment.id,
+					Project: projectId,
+					State: deployment.state || 'unknown',
+					Active: deployment.active ? 'Yes' : 'No',
+					Created: new Date(deployment.createdAt).toLocaleString(),
+				};
 				if (deployment.updatedAt) {
-					console.log(
-						tui.bold('Updated:'.padEnd(maxWidth)) +
-							new Date(deployment.updatedAt).toLocaleString()
-					);
+					tableData['Updated'] = new Date(deployment.updatedAt).toLocaleString();
 				}
 				if (deployment.message) {
-					console.log(tui.bold('Message:'.padEnd(maxWidth)) + deployment.message);
+					tableData['Message'] = deployment.message;
 				}
 				if (deployment.tags.length > 0) {
-					console.log(tui.bold('Tags:'.padEnd(maxWidth)) + deployment.tags.join(', '));
+					tableData['Tags'] = deployment.tags.join(', ');
 				}
 				if (deployment.customDomains && deployment.customDomains.length > 0) {
-					console.log(
-						tui.bold('Domains:'.padEnd(maxWidth)) + deployment.customDomains.join(', ')
-					);
+					tableData['Domains'] = deployment.customDomains.join(', ');
 				}
 				if (deployment.cloudRegion) {
-					console.log(tui.bold('Region:'.padEnd(maxWidth)) + deployment.cloudRegion);
+					tableData['Region'] = deployment.cloudRegion;
 				}
 				if (deployment.resourceDb) {
-					console.log(tui.bold('Database:'.padEnd(maxWidth)) + deployment.resourceDb);
+					tableData['Database'] = deployment.resourceDb;
 				}
 				if (deployment.resourceStorage) {
-					console.log(tui.bold('Storage:'.padEnd(maxWidth)) + deployment.resourceStorage);
+					tableData['Storage'] = deployment.resourceStorage;
 				}
 				if (deployment.deploymentLogsURL) {
-					console.log(
-						tui.bold('Deployment Logs:'.padEnd(maxWidth)) +
-							tui.link(deployment.deploymentLogsURL)
-					);
+					tableData['Deployment Logs'] = tui.link(deployment.deploymentLogsURL);
 				}
 				if (deployment.buildLogsURL) {
-					console.log(
-						tui.bold('Build Logs:'.padEnd(maxWidth)) + tui.link(deployment.buildLogsURL)
-					);
+					tableData['Build Logs'] = tui.link(deployment.buildLogsURL);
 				}
+
+				tui.table([tableData], Object.keys(tableData), { layout: 'vertical', padStart: '  ' });
 
 				// Git metadata
 				const git = deployment.metadata?.git;
 				if (git) {
-					tui.newline();
-					tui.info('Git Information');
-					if (git.repo) console.log(`  Repo:     ${git.repo}`);
-					if (git.branch) console.log(`  Branch:   ${git.branch}`);
-					if (git.commit) console.log(`  Commit:   ${git.commit}`);
-					if (git.message) console.log(`  Message:  ${git.message}`);
-					if (git.url) console.log(`  URL:      ${git.url}`);
-					if (git.trigger) console.log(`  Trigger:  ${git.trigger}`);
-					if (git.provider) console.log(`  Provider: ${git.provider}`);
-					if (git.event) console.log(`  Event:    ${git.event}`);
+					const gitData: Record<string, string> = {};
+					if (git.repo) gitData['Repo'] = git.repo;
+					if (git.branch) gitData['Branch'] = git.branch;
+					if (git.commit) gitData['Commit'] = git.commit;
+					if (git.message) gitData['Message'] = git.message;
+					if (git.url) gitData['URL'] = git.url;
+					if (git.trigger) gitData['Trigger'] = git.trigger;
+					if (git.provider) gitData['Provider'] = git.provider;
+					if (git.event) gitData['Event'] = git.event;
 					if (git.pull_request) {
-						console.log(`  PR:       #${git.pull_request.number}`);
-						if (git.pull_request.url) console.log(`  PR URL:   ${git.pull_request.url}`);
+						gitData['PR'] = `#${git.pull_request.number}`;
+						if (git.pull_request.url) gitData['PR URL'] = git.pull_request.url;
 					}
-					if (git.buildUrl) console.log(`  Build:    ${git.buildUrl}`);
+					if (git.buildUrl) gitData['Build'] = git.buildUrl;
+
+					if (Object.keys(gitData).length > 0) {
+						tui.newline();
+						tui.info('Git Information');
+						tui.table([gitData], Object.keys(gitData), { layout: 'vertical', padStart: '  ' });
+					}
 				}
 
 				// Build metadata
 				const build = deployment.metadata?.build;
 				if (build) {
-					tui.newline();
-					tui.info('Build Information');
-					if (build.agentuity) console.log(`  Agentuity: ${build.agentuity}`);
-					if (build.bun) console.log(`  Bun:       ${build.bun}`);
-					if (build.platform) console.log(`  Platform:  ${build.platform}`);
-					if (build.arch) console.log(`  Arch:      ${build.arch}`);
+					const buildData: Record<string, string> = {};
+					if (build.agentuity) buildData['Agentuity'] = build.agentuity;
+					if (build.bun) buildData['Bun'] = build.bun;
+					if (build.platform) buildData['Platform'] = build.platform;
+					if (build.arch) buildData['Arch'] = build.arch;
+
+					if (Object.keys(buildData).length > 0) {
+						tui.newline();
+						tui.info('Build Information');
+						tui.table([buildData], Object.keys(buildData), {
+							layout: 'vertical',
+							padStart: '  ',
+						});
+					}
 				}
 			}
 

--- a/packages/cli/src/cmd/cloud/sandbox/create.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/create.ts
@@ -72,6 +72,13 @@ export const createSubcommand = createCommand({
 				.optional()
 				.describe('Apt packages to install (can be specified multiple times)'),
 			metadata: z.string().optional().describe('JSON object of user-defined metadata'),
+			port: z
+				.number()
+				.int()
+				.min(1024)
+				.max(65535)
+				.optional()
+				.describe('Port to expose from the sandbox to the outside Internet (1024-65535)'),
 		}),
 		response: SandboxCreateResponseSchema,
 	},
@@ -164,7 +171,10 @@ export const createSubcommand = createCommand({
 								disk: opts.disk,
 							}
 						: undefined,
-				network: opts.network ? { enabled: true } : undefined,
+				network:
+					opts.network || opts.port
+						? { enabled: opts.network || opts.port !== undefined, port: opts.port }
+						: undefined,
 				timeout: opts.idleTimeout ? { idle: opts.idleTimeout } : undefined,
 				env: Object.keys(envMap).length > 0 ? envMap : undefined,
 				command: hasFiles ? { exec: [], files } : undefined,

--- a/packages/cli/src/cmd/cloud/sandbox/execution/get.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/execution/get.ts
@@ -55,36 +55,39 @@ export const getSubcommand = createCommand({
 							? tui.colorError
 							: tui.colorMuted;
 
-			console.log(`${tui.muted('Execution:')}       ${tui.bold(result.executionId)}`);
-			console.log(`${tui.muted('Sandbox:')}         ${result.sandboxId}`);
-			console.log(`${tui.muted('Status:')}          ${statusColor(result.status)}`);
+			const tableData: Record<string, string | number> = {
+				Execution: tui.bold(result.executionId),
+				Sandbox: result.sandboxId,
+				Status: statusColor(result.status),
+			};
+
 			if (result.exitCode !== undefined) {
 				const exitCodeColor = result.exitCode === 0 ? tui.colorSuccess : tui.colorError;
-				console.log(
-					`${tui.muted('Exit Code:')}       ${exitCodeColor(String(result.exitCode))}`
-				);
+				tableData['Exit Code'] = exitCodeColor(String(result.exitCode));
 			}
 			if (result.durationMs !== undefined) {
-				console.log(`${tui.muted('Duration:')}        ${result.durationMs}ms`);
+				tableData['Duration'] = `${result.durationMs}ms`;
 			}
 			if (result.startedAt) {
-				console.log(`${tui.muted('Started:')}         ${result.startedAt}`);
+				tableData['Started'] = result.startedAt;
 			}
 			if (result.completedAt) {
-				console.log(`${tui.muted('Completed:')}       ${result.completedAt}`);
+				tableData['Completed'] = result.completedAt;
 			}
 			if (result.error) {
-				console.log(`${tui.muted('Error:')}           ${tui.colorError(result.error)}`);
+				tableData['Error'] = tui.colorError(result.error);
 			}
 			if (result.stdoutStreamUrl) {
-				console.log(`${tui.muted('Stdout:')}          ${result.stdoutStreamUrl}`);
+				tableData['Stdout'] = result.stdoutStreamUrl;
 			}
 			if (result.stderrStreamUrl) {
-				console.log(`${tui.muted('Stderr:')}          ${result.stderrStreamUrl}`);
+				tableData['Stderr'] = result.stderrStreamUrl;
 			}
 			if (result.command && result.command.length > 0) {
-				console.log(`${tui.muted('Command:')}         ${result.command.join(' ')}`);
+				tableData['Command'] = result.command.join(' ');
 			}
+
+			tui.table([tableData], Object.keys(tableData), { layout: 'vertical', padStart: '  ' });
 		}
 
 		return {

--- a/packages/cli/src/cmd/cloud/sandbox/get.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/get.ts
@@ -29,6 +29,7 @@ const SandboxGetResponseSchema = z.object({
 	dependencies: z.array(z.string()).optional().describe('Apt packages installed'),
 	metadata: z.record(z.string(), z.unknown()).optional().describe('User-defined metadata'),
 	resources: SandboxResourcesSchema.optional().describe('Resource limits'),
+	url: z.string().optional().describe('Public URL for the sandbox (if network port configured)'),
 });
 
 export const getSubcommand = createCommand({
@@ -72,57 +73,63 @@ export const getSubcommand = createCommand({
 							? tui.colorError
 							: tui.colorMuted;
 
-			console.log(`${tui.muted('Sandbox:')}         ${tui.bold(result.sandboxId)}`);
-			if (result.name) {
-				console.log(`${tui.muted('Name:')}            ${result.name}`);
-			}
-			if (result.description) {
-				console.log(`${tui.muted('Description:')}     ${result.description}`);
-			}
-			console.log(`${tui.muted('Status:')}          ${statusColor(result.status)}`);
-			console.log(`${tui.muted('Created:')}         ${result.createdAt}`);
-			if (result.runtimeName) {
-				console.log(`${tui.muted('Runtime:')}         ${result.runtimeName}`);
-			}
-			if (result.region) {
-				console.log(`${tui.muted('Region:')}          ${result.region}`);
-			}
-			if (result.snapshotId || result.snapshotTag) {
-				const snapshotDisplay = result.snapshotTag
-					? `${result.snapshotTag} ${tui.muted('(' + result.snapshotId + ')')}`
-					: result.snapshotId;
-				console.log(`${tui.muted('Snapshot:')}        ${snapshotDisplay}`);
-			}
-			console.log(`${tui.muted('Executions:')}      ${result.executions}`);
+			const snapshotDisplay =
+				result.snapshotId || result.snapshotTag
+					? result.snapshotTag
+						? result.snapshotId
+							? `${result.snapshotTag} ${tui.muted('(' + result.snapshotId + ')')}`
+							: result.snapshotTag
+						: result.snapshotId
+					: undefined;
+
+			let streamDisplay: string | undefined;
 			if (
 				result.stdoutStreamUrl &&
 				result.stderrStreamUrl &&
 				result.stdoutStreamUrl === result.stderrStreamUrl
 			) {
-				console.log(`${tui.muted('Stream:')}          ${tui.link(result.stdoutStreamUrl)}`);
-			} else {
-				if (result.stdoutStreamUrl) {
-					console.log(`${tui.muted('Stream (stdout):')} ${tui.link(result.stdoutStreamUrl)}`);
-				}
-				if (result.stderrStreamUrl) {
-					console.log(`${tui.muted('Stream (stderr):')} ${tui.link(result.stderrStreamUrl)}`);
-				}
+				streamDisplay = tui.link(result.stdoutStreamUrl);
 			}
-			if (result.dependencies && result.dependencies.length > 0) {
-				console.log(`${tui.muted('Dependencies:')}    ${result.dependencies.join(', ')}`);
-			}
+
+			const resourceParts: string[] = [];
 			if (result.resources) {
-				const resourceParts: string[] = [];
 				if (result.resources.memory) resourceParts.push(`memory=${result.resources.memory}`);
 				if (result.resources.cpu) resourceParts.push(`cpu=${result.resources.cpu}`);
 				if (result.resources.disk) resourceParts.push(`disk=${result.resources.disk}`);
-				if (resourceParts.length > 0) {
-					console.log(`${tui.muted('Resources:')}       ${resourceParts.join(', ')}`);
-				}
+			}
+
+			const tableData: Record<string, string | number> = {
+				Sandbox: tui.bold(result.sandboxId),
+			};
+
+			if (result.name) tableData['Name'] = result.name;
+			if (result.description) tableData['Description'] = result.description;
+			tableData['Status'] = statusColor(result.status);
+			tableData['Created'] = result.createdAt;
+			if (result.runtimeName) tableData['Runtime'] = result.runtimeName;
+			if (result.region) tableData['Region'] = result.region;
+			if (snapshotDisplay) tableData['Snapshot'] = snapshotDisplay;
+			tableData['Executions'] = result.executions;
+			if (streamDisplay) {
+				tableData['Stream'] = streamDisplay;
+			} else {
+				if (result.stdoutStreamUrl) tableData['Stream (stdout)'] = tui.link(result.stdoutStreamUrl);
+				if (result.stderrStreamUrl) tableData['Stream (stderr)'] = tui.link(result.stderrStreamUrl);
+			}
+			if (result.dependencies && result.dependencies.length > 0) {
+				tableData['Dependencies'] = result.dependencies.join(', ');
+			}
+			if (resourceParts.length > 0) {
+				tableData['Resources'] = resourceParts.join(', ');
 			}
 			if (result.metadata && Object.keys(result.metadata).length > 0) {
-				console.log(`${tui.muted('Metadata:')}        ${JSON.stringify(result.metadata)}`);
+				tableData['Metadata'] = JSON.stringify(result.metadata);
 			}
+			if (result.url) {
+				tableData['URL'] = tui.link(result.url);
+			}
+
+			tui.table([tableData], Object.keys(tableData), { layout: 'vertical', padStart: '  ' });
 		}
 
 		return {
@@ -142,6 +149,7 @@ export const getSubcommand = createCommand({
 			dependencies: result.dependencies,
 			metadata: result.metadata,
 			resources: result.resources,
+			url: result.url,
 		};
 	},
 });

--- a/packages/cli/src/cmd/cloud/sandbox/snapshot/build.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/snapshot/build.ts
@@ -190,7 +190,18 @@ async function resolveFileGlobs(
 		}
 	}
 
-	for (const pattern of exclusions) {
+	for (let pattern of exclusions) {
+		// If the pattern refers to a directory, auto-append /** to exclude all contents
+		const patternPath = join(directory, pattern);
+		try {
+			const stat = statSync(patternPath);
+			if (stat.isDirectory()) {
+				pattern = pattern.endsWith('/') ? `${pattern}**` : `${pattern}/**`;
+			}
+		} catch {
+			// Path doesn't exist or can't be stat'd, use pattern as-is
+		}
+
 		const glob = new Bun.Glob(pattern);
 		for await (const file of glob.scan({ cwd: directory, dot: true })) {
 			files.delete(file);
@@ -473,16 +484,20 @@ export const buildSubcommand = createCommand({
 			if (!options.json) {
 				tui.info(`${tui.bold('Dry Run')} - No upload will be performed`);
 				console.log('');
-				if (finalName) {
-					console.log(`  ${tui.muted('Name:'.padEnd(13))}         ${finalName}`);
-				}
-				console.log(`  ${tui.muted('Runtime:'.padEnd(13))}      ${buildConfig.runtime}`);
-				console.log(`  ${tui.muted('Tag:'.padEnd(13))}          ${opts.tag ?? 'latest'}`);
-				if (finalDescription) {
-					console.log(`  ${tui.muted('Description:'.padEnd(13))} ${finalDescription}`);
-				}
-				console.log(`  ${tui.muted('Size:'.padEnd(13))}         ${tui.formatBytes(totalSize)}`);
-				console.log(`  ${tui.muted('Files:'.padEnd(13))}        ${fileList.length}`);
+				tui.table(
+					[
+						{
+							Name: finalName,
+							Description: finalDescription ?? '-',
+							Runtime: buildConfig.runtime,
+							Tag: opts.tag ?? 'latest',
+							Size: tui.formatBytes(totalSize),
+							Files: fileList.length.toFixed(),
+						},
+					],
+					['Name', 'Description', 'Runtime', 'Tag', 'Size', 'Files'],
+					{ layout: 'vertical', padStart: '  ' }
+				);
 
 				if (buildConfig.dependencies && buildConfig.dependencies.length > 0) {
 					console.log('');
@@ -569,9 +584,16 @@ export const buildSubcommand = createCommand({
 				if (!options.json) {
 					tui.success(`Snapshot unchanged ${tui.bold(initResult.existingId!)}`);
 					console.log('');
-					console.log(`  ${tui.muted('Name:'.padEnd(13))}    ${initResult.existingName}`);
-					console.log(`  ${tui.muted('Tag:'.padEnd(13))}     ${initResult.existingTag ?? 'latest'}`);
-					console.log(`  ${tui.muted('Runtime:'.padEnd(13))} ${buildConfig.runtime}`);
+					tui.table(
+						[
+							{
+								Name: finalName,
+								Tag: opts.tag ?? 'latest',
+							},
+						],
+						['Name', 'Tag'],
+						{ layout: 'vertical', padStart: '  ' }
+					);
 				}
 
 				return {
@@ -630,17 +652,22 @@ export const buildSubcommand = createCommand({
 			if (!options.json) {
 				tui.success(`Created snapshot ${tui.bold(snapshot.snapshotId)}`);
 				console.log('');
-				console.log(`  ${tui.muted('Name:'.padEnd(13))}    ${snapshot.name}`);
-				console.log(`  ${tui.muted('Tag:'.padEnd(13))}     ${snapshot.tag ?? 'latest'}`);
-				console.log(`  ${tui.muted('Runtime:'.padEnd(13))} ${buildConfig.runtime}`);
-				if (snapshot.description) {
-					console.log(`  ${tui.muted('Description:'.padEnd(13))} ${snapshot.description}`);
-				}
-				console.log(
-					`  ${tui.muted('Size:'.padEnd(13))}    ${tui.formatBytes(snapshot.sizeBytes)}`
+
+				tui.table(
+					[
+						{
+							Name: snapshot.name,
+							Description: snapshot.description ?? '-',
+							Runtime: buildConfig.runtime,
+							Tag: snapshot.tag ?? 'latest',
+							Size: tui.formatBytes(snapshot.sizeBytes),
+							Files: snapshot.fileCount.toFixed(),
+							Created: snapshot.createdAt,
+						},
+					],
+					['Name', 'Description', 'Runtime', 'Tag', 'Size', 'Files', 'Created'],
+					{ layout: 'vertical', padStart: '  ' }
 				);
-				console.log(`  ${tui.muted('Files:'.padEnd(13))}   ${snapshot.fileCount}`);
-				console.log(`  ${tui.muted('Created:'.padEnd(13))} ${snapshot.createdAt}`);
 
 				if (buildConfig.dependencies && buildConfig.dependencies.length > 0) {
 					console.log('');

--- a/packages/cli/src/cmd/cloud/sandbox/snapshot/get.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/snapshot/get.ts
@@ -78,17 +78,21 @@ export const getSubcommand = createCommand({
 		);
 
 		if (!options.json) {
-			tui.info(`Snapshot: ${tui.bold(snapshot.snapshotId)}`);
-			console.log(`  ${tui.muted('Name:')}    ${snapshot.name}`);
+			const tableData: Record<string, string | number> = {
+				Snapshot: tui.bold(snapshot.snapshotId),
+				Name: snapshot.name,
+			};
 			if (snapshot.tag) {
-				console.log(`  ${tui.muted('Tag:')}     ${snapshot.tag}`);
+				tableData['Tag'] = snapshot.tag;
 			}
-			console.log(`  ${tui.muted('Size:')}    ${tui.formatBytes(snapshot.sizeBytes)}`);
-			console.log(`  ${tui.muted('Files:')}   ${snapshot.fileCount}`);
-			console.log(`  ${tui.muted('Created:')} ${snapshot.createdAt}`);
+			tableData['Size'] = tui.formatBytes(snapshot.sizeBytes);
+			tableData['Files'] = snapshot.fileCount;
+			tableData['Created'] = snapshot.createdAt;
 			if (snapshot.parentSnapshotId) {
-				console.log(`  ${tui.muted('Parent:')}  ${snapshot.parentSnapshotId}`);
+				tableData['Parent'] = snapshot.parentSnapshotId;
 			}
+
+			tui.table([tableData], Object.keys(tableData), { layout: 'vertical', padStart: '  ' });
 
 			if (
 				snapshot.userMetadata &&

--- a/packages/cli/src/cmd/cloud/session/get.ts
+++ b/packages/cli/src/cmd/cloud/session/get.ts
@@ -67,7 +67,7 @@ const SessionGetResponseSchema = z.object({
 				pending: z.boolean(),
 				success: z.boolean(),
 				error: z.string().nullable(),
-				result: z.string().nullable(),
+				result: z.record(z.string(), z.unknown()).nullable(),
 			})
 		)
 		.describe('Eval runs'),
@@ -171,48 +171,44 @@ export const getSubcommand = createSubcommand({
 				return result;
 			}
 
-			console.log(tui.bold('ID:          ') + session.id);
-			console.log(tui.bold('Project:     ') + session.project_id);
-			console.log(tui.bold('Deployment:  ') + (session.deployment_id || '-'));
-			console.log(tui.bold('Start:       ') + new Date(session.start_time).toLocaleString());
+			const tableData: Record<string, string> = {
+				ID: session.id,
+				Project: session.project_id,
+				Deployment: session.deployment_id || '-',
+				Start: new Date(session.start_time).toLocaleString(),
+			};
 			if (session.end_time) {
-				console.log(tui.bold('End:         ') + new Date(session.end_time).toLocaleString());
+				tableData['End'] = new Date(session.end_time).toLocaleString();
 			}
-			if (session.duration && session.end_time) {
-				console.log(
-					tui.bold('Duration:    ') + `${(session.duration / 1_000_000).toFixed(0)}ms`
-				);
+			if (session.duration != null && session.end_time != null) {
+				tableData['Duration'] = `${(session.duration / 1_000_000).toFixed(0)}ms`;
 			}
-			console.log(tui.bold('Method:      ') + session.method);
-			console.log(tui.bold('URL:         ') + tui.link(session.url, session.url));
-			console.log(tui.bold('Trigger:     ') + session.trigger);
+			tableData['Method'] = session.method;
+			tableData['URL'] = tui.link(session.url, session.url);
+			tableData['Trigger'] = session.trigger;
 			if (session.env !== 'production') {
-				console.log(tui.bold('Environment: ') + session.env);
+				tableData['Environment'] = session.env;
 			}
-			console.log(tui.bold('Dev Mode:    ') + (session.devmode ? 'Yes' : 'No'));
-			console.log(
-				tui.bold('Success:     ') +
-					(session.success ? tui.colorSuccess('✓') : tui.colorError('✗'))
-			);
-			console.log(tui.bold('Pending:     ') + (session.pending ? 'Yes' : 'No'));
+			tableData['Dev Mode'] = session.devmode ? 'Yes' : 'No';
+			tableData['Success'] = session.success ? tui.colorSuccess('✓') : tui.colorError('✗');
+			tableData['Pending'] = session.pending ? 'Yes' : 'No';
 			if (session.error) {
-				console.log(tui.bold('Error:       ') + tui.error(session.error));
+				tableData['Error'] = tui.colorError(session.error);
 			}
 			if (enriched.agents.length > 0) {
-				const agentDisplay = enriched.agents
+				tableData['Agents'] = enriched.agents
 					.map((agent: AgentInfo) => `${agent.name} ${tui.muted(`(${agent.identifier})`)}`)
 					.join(', ');
-				console.log(tui.bold('Agents:      ') + agentDisplay);
 			}
 			if (enriched.route) {
-				console.log(
-					tui.bold('Route:       ') +
-						`${enriched.route.method.toUpperCase()} ${enriched.route.path} ${tui.muted(`(${enriched.route.id})`)}`
-				);
+				tableData['Route'] =
+					`${enriched.route.method.toUpperCase()} ${enriched.route.path} ${tui.muted(`(${enriched.route.id})`)}`;
 			} else {
-				console.log(tui.bold('Route ID:    ') + session.route_id);
+				tableData['Route ID'] = session.route_id;
 			}
-			console.log(tui.bold('Thread ID:   ') + session.thread_id);
+			tableData['Thread ID'] = session.thread_id;
+
+			tui.table([tableData], Object.keys(tableData), { layout: 'vertical', padStart: '  ' });
 
 			if (enriched.evalRuns.length > 0) {
 				console.log('');

--- a/packages/cli/src/cmd/cloud/thread/get.ts
+++ b/packages/cli/src/cmd/cloud/thread/get.ts
@@ -59,20 +59,24 @@ export const getSubcommand = createSubcommand({
 				return result;
 			}
 
-			console.log(tui.bold('ID:          ') + thread.id);
-			console.log(tui.bold('Project:     ') + thread.project_id);
-			console.log(tui.bold('Created:     ') + new Date(thread.created_at).toLocaleString());
-			console.log(tui.bold('Updated:     ') + new Date(thread.updated_at).toLocaleString());
-			console.log(tui.bold('Deleted:     ') + (thread.deleted ? 'Yes' : 'No'));
+			const tableData: Record<string, string> = {
+				ID: thread.id,
+				Project: thread.project_id,
+				Created: new Date(thread.created_at).toLocaleString(),
+				Updated: new Date(thread.updated_at).toLocaleString(),
+				Deleted: thread.deleted ? 'Yes' : 'No',
+			};
 			if (thread.deleted_at) {
-				console.log(tui.bold('Deleted At:  ') + new Date(thread.deleted_at).toLocaleString());
+				tableData['Deleted At'] = new Date(thread.deleted_at).toLocaleString();
 			}
 			if (thread.deleted_by) {
-				console.log(tui.bold('Deleted By:  ') + thread.deleted_by);
+				tableData['Deleted By'] = thread.deleted_by;
 			}
 			if (thread.user_data) {
-				console.log(tui.bold('User Data:   ') + thread.user_data);
+				tableData['User Data'] = thread.user_data;
 			}
+
+			tui.table([tableData], Object.keys(tableData), { layout: 'vertical', padStart: '  ' });
 
 			return result;
 		} catch (ex) {

--- a/packages/cli/src/cmd/dev/file-watcher.ts
+++ b/packages/cli/src/cmd/dev/file-watcher.ts
@@ -55,6 +55,7 @@ export function createFileWatcher(options: FileWatcherOptions): FileWatcherManag
 		'.idea',
 		'.DS_Store',
 		'.playwright',
+		'.bun',
 		'src/generated',
 	]);
 
@@ -76,6 +77,7 @@ export function createFileWatcher(options: FileWatcherOptions): FileWatcherManag
 		'.dist',
 		'.vscode',
 		'.idea',
+		'.bun',
 		'.DS_Store',
 		'.playwright',
 		'src/web', // Vite handles frontend with HMR - no backend restart needed

--- a/packages/cli/src/tui.ts
+++ b/packages/cli/src/tui.ts
@@ -1675,11 +1675,14 @@ export async function selectOrganization(
 		);
 	}
 
+	// Find the index of the initial org to pre-select it in the list
+	const initialIndex = initial ? orgs.findIndex((o) => o.id === initial) : -1;
+
 	const response = await enquirer.prompt<{ action: string }>({
 		type: 'select',
 		name: 'action',
 		message: 'Select an organization',
-		initial: initial || (orgs.length === 1 ? orgs[0].id : undefined),
+		initial: initialIndex >= 0 ? initialIndex : 0,
 		choices: orgs.map((o) => ({ message: o.name, name: o.id })),
 	});
 
@@ -1830,6 +1833,11 @@ export interface TableOptions {
 	 * - 'auto': Automatically choose based on terminal width (default)
 	 */
 	layout?: 'horizontal' | 'vertical' | 'auto';
+
+	/**
+	 * the padding before any label
+	 */
+	padStart?: string;
 }
 
 /**
@@ -1838,10 +1846,11 @@ export interface TableOptions {
  */
 function calculateTableWidth<T extends Record<string, unknown>>(
 	data: T[],
-	columnNames: string[]
+	columnNames: string[],
+	padStart = ''
 ): number {
 	const columnWidths = columnNames.map((colName) => {
-		let maxWidth = getDisplayWidth(colName);
+		let maxWidth = getDisplayWidth(padStart + colName);
 		for (const row of data) {
 			const value = row[colName];
 			const valueStr = value !== undefined && value !== null ? String(value) : '';
@@ -1866,14 +1875,17 @@ function calculateTableWidth<T extends Record<string, unknown>>(
  */
 function renderVerticalTable<T extends Record<string, unknown>>(
 	data: T[],
-	columnNames: string[]
+	columnNames: string[],
+	padStart = ''
 ): string {
 	const lines: string[] = [];
 	const mutedColor = getColor('muted');
 	const reset = getColor('reset');
 
 	// Calculate max column name width for alignment
-	const maxLabelWidth = Math.max(...columnNames.map((name) => 1 + getDisplayWidth(name)));
+	const maxLabelWidth = Math.max(
+		...columnNames.map((name) => 1 + getDisplayWidth(padStart + name))
+	);
 
 	for (let i = 0; i < data.length; i++) {
 		const row = data[i];
@@ -1881,7 +1893,7 @@ function renderVerticalTable<T extends Record<string, unknown>>(
 		for (const colName of columnNames) {
 			const value = row[colName];
 			const valueStr = value !== undefined && value !== null ? String(value) : '';
-			const paddedLabel = `${colName}:`.padEnd(maxLabelWidth);
+			const paddedLabel = `${padStart}${colName}:`.padEnd(maxLabelWidth);
 			lines.push(`${mutedColor}${paddedLabel}${reset}  ${valueStr}`);
 		}
 
@@ -1942,13 +1954,13 @@ export function table<T extends Record<string, unknown>>(
 	// Determine layout mode
 	const layout = options?.layout ?? 'auto';
 	const termWidth = getTerminalWidth(80);
-	const tableWidth = calculateTableWidth(data, columnNames);
+	const tableWidth = calculateTableWidth(data, columnNames, options?.padStart);
 	const useVertical = layout === 'vertical' || (layout === 'auto' && tableWidth > termWidth);
 
 	let output: string;
 
 	if (useVertical) {
-		output = renderVerticalTable(data, columnNames);
+		output = renderVerticalTable(data, columnNames, options?.padStart);
 	} else {
 		// eslint-disable-next-line @typescript-eslint/no-require-imports
 		const Table = require('cli-table3') as new (options?: {

--- a/packages/core/src/services/sandbox.ts
+++ b/packages/core/src/services/sandbox.ts
@@ -151,6 +151,11 @@ export interface SandboxNetworkConfig {
 	 * Whether to enable outbound network access (default: false)
 	 */
 	enabled?: boolean;
+
+	/**
+	 * Port to expose from the sandbox to the outside Internet (1024-65535)
+	 */
+	port?: number;
 }
 
 /**
@@ -410,6 +415,11 @@ export interface SandboxInfo {
 	sandboxId: string;
 
 	/**
+	 * Short identifier used for DNS hostname
+	 */
+	identifier?: string;
+
+	/**
 	 * Sandbox name
 	 */
 	name?: string;
@@ -515,6 +525,16 @@ export interface SandboxInfo {
 	networkEnabled?: boolean;
 
 	/**
+	 * Network port exposed from the sandbox (1024-65535)
+	 */
+	networkPort?: number;
+
+	/**
+	 * Public URL for the sandbox (only set if networkPort is configured)
+	 */
+	url?: string;
+
+	/**
 	 * User who created the sandbox (if available)
 	 */
 	user?: SandboxUserInfo;
@@ -553,6 +573,13 @@ export interface ListSandboxesParams {
 	 * Filter by status
 	 */
 	status?: SandboxStatus;
+
+	/**
+	 * Filter by live status.
+	 * When true, returns sandboxes with status: creating, running, idle, or failed.
+	 * When false or undefined, returns all sandboxes.
+	 */
+	live?: boolean;
 
 	/**
 	 * Maximum number of results (default: 50, max: 100)

--- a/packages/server/src/api/sandbox/create.ts
+++ b/packages/server/src/api/sandbox/create.ts
@@ -24,6 +24,13 @@ const SandboxCreateRequestSchema = z
 		network: z
 			.object({
 				enabled: z.boolean().optional().describe('Whether network access is enabled'),
+				port: z
+					.number()
+					.int()
+					.min(1024)
+					.max(65535)
+					.optional()
+					.describe('Port to expose from the sandbox (1024-65535)'),
 			})
 			.optional()
 			.describe('Network configuration for the sandbox'),

--- a/packages/server/src/api/sandbox/get.ts
+++ b/packages/server/src/api/sandbox/get.ts
@@ -43,6 +43,7 @@ const SandboxOrgInfoSchema = z
 const SandboxInfoDataSchema = z
 	.object({
 		sandboxId: z.string().describe('Unique identifier for the sandbox'),
+		identifier: z.string().optional().describe('Short identifier for DNS hostname'),
 		name: z.string().optional().describe('Sandbox name'),
 		description: z.string().optional().describe('Sandbox description'),
 		status: z
@@ -72,6 +73,8 @@ const SandboxInfoDataSchema = z
 		memoryByteSec: z.number().optional().describe('Total memory usage in byte-seconds'),
 		networkEgressBytes: z.number().optional().describe('Total network egress in bytes'),
 		networkEnabled: z.boolean().optional().describe('Whether network access is enabled'),
+		networkPort: z.number().optional().describe('Network port exposed from the sandbox'),
+		url: z.string().optional().describe('Public URL for the sandbox (only set if networkPort is configured)'),
 		user: SandboxUserInfoSchema.optional().describe('User who created the sandbox'),
 		agent: SandboxAgentInfoSchema.optional().describe('Agent associated with the sandbox'),
 		project: SandboxProjectInfoSchema.optional().describe('Project associated with the sandbox'),

--- a/packages/server/src/api/sandbox/list.ts
+++ b/packages/server/src/api/sandbox/list.ts
@@ -13,6 +13,7 @@ const SandboxOrgInfoSchema = z
 const SandboxInfoSchema = z
 	.object({
 		sandboxId: z.string().describe('Unique identifier for the sandbox'),
+		identifier: z.string().optional().describe('Short identifier for DNS hostname'),
 		name: z.string().optional().describe('Sandbox name'),
 		description: z.string().optional().describe('Sandbox description'),
 		status: z
@@ -30,6 +31,8 @@ const SandboxInfoSchema = z
 		stdoutStreamUrl: z.string().optional().describe('URL for streaming stdout output'),
 		stderrStreamUrl: z.string().optional().describe('URL for streaming stderr output'),
 		networkEnabled: z.boolean().optional().describe('Whether network access is enabled'),
+		networkPort: z.number().optional().describe('Network port exposed from the sandbox'),
+		url: z.string().optional().describe('Public URL for the sandbox (only set if networkPort is configured)'),
 		org: SandboxOrgInfoSchema.describe('Organization associated with the sandbox'),
 	})
 	.describe('Summary information about a sandbox');
@@ -73,6 +76,9 @@ export async function sandboxList(
 	}
 	if (params?.status) {
 		queryParams.set('status', params.status);
+	}
+	if (params?.live !== undefined) {
+		queryParams.set('live', params.live.toString());
 	}
 	if (params?.limit !== undefined) {
 		queryParams.set('limit', params.limit.toString());

--- a/packages/server/src/api/session/get.ts
+++ b/packages/server/src/api/session/get.ts
@@ -14,7 +14,7 @@ const EvalRunSchema = z.object({
 	pending: z.boolean().describe('pending status'),
 	success: z.boolean().describe('success status'),
 	error: z.string().nullable().describe('error message'),
-	result: z.string().nullable().describe('result JSON'),
+	result: z.record(z.string(), z.unknown()).nullable().describe('result object'),
 });
 
 export interface SpanNode {


### PR DESCRIPTION
# feat: CLI improvements and sandbox port mapping

## Overview

Multiple CLI improvements including better output formatting, sandbox port mapping support, and various bug fixes.

## Changes

### Sandbox Port Mapping
- **packages/core/src/services/sandbox.ts**: Add `port` field to `SandboxNetworkConfig` interface (1024-65535)
- **packages/server/src/api/sandbox/create.ts**: Add `port` to request schema with validation
- **packages/cli/src/cmd/cloud/sandbox/create.ts**: Add `--port` flag; auto-enables network when port is specified

### CLI Output Improvements
- **packages/cli/src/tui.ts**: Improved table rendering and formatting utilities
- **packages/cli/src/cli.ts**: Better error handling and output formatting
- **packages/cli/src/cmd/cloud/sandbox/get.ts**: Improved sandbox details display
- **packages/cli/src/cmd/cloud/sandbox/snapshot/get.ts**: Better snapshot info display
- **packages/cli/src/cmd/cloud/sandbox/snapshot/build.ts**: Improved build output
- **packages/cli/src/cmd/cloud/sandbox/execution/get.ts**: Better execution details
- **packages/cli/src/cmd/cloud/session/get.ts**: Improved session info display
- **packages/cli/src/cmd/cloud/deployment/show.ts**: Better deployment details
- **packages/cli/src/cmd/cloud/agent/get.ts**: Improved agent info display
- **packages/cli/src/cmd/cloud/thread/get.ts**: Better thread details

### Bug Fixes
- **packages/cli/src/auth.ts**: Remove unused code
- **packages/cli/src/cmd/dev/file-watcher.ts**: Fix file watcher edge case
- **packages/server/src/api/sandbox/list.ts**: Add missing fields to list response
- **packages/server/src/api/session/get.ts**: Fix session response type

## Testing

- `bun run typecheck` passes
- Tested sandbox create with `--port 8080` flag


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Port option for sandbox networking; sandboxes can expose a public port and URL
  * Sandbox metadata now includes identifier, exposed port, networkPort and public URL
  * Filter sandboxes by live status

* **Bug Fixes**
  * File watcher now ignores bun-related directories

* **Improvements**
  * Organization selection prompts when no org ID provided with deterministic pre-selection
  * CLI outputs consolidated into consistent table-based displays
  * Region resolution flow refined for callers
  * Eval run results now represented as structured data rather than plain text

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->