### PR TITLE
feat: add project association to sandbox create/run commands

### DIFF
--- a/packages/cli/src/cmd/cloud/sandbox/create.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/create.ts
@@ -25,6 +25,7 @@ export const createSubcommand = createCommand({
 	description: 'Create an interactive sandbox for multiple executions',
 	tags: ['slow', 'requires-auth'],
 	requires: { auth: true, region: true, org: true },
+	optional: { project: true },
 	examples: [
 		{
 			command: getCommand('cloud sandbox create'),
@@ -45,6 +46,10 @@ export const createSubcommand = createCommand({
 		{
 			command: getCommand('cloud sandbox create --env KEY=VAL'),
 			description: 'Create a sandbox with a specific environment variable',
+		},
+		{
+			command: getCommand('cloud sandbox create --project-id proj_123'),
+			description: 'Create a sandbox associated with a specific project',
 		},
 	],
 	schema: {
@@ -79,12 +84,14 @@ export const createSubcommand = createCommand({
 				.max(65535)
 				.optional()
 				.describe('Port to expose from the sandbox to the outside Internet (1024-65535)'),
+			projectId: z.string().optional().describe('Project ID to associate this sandbox with'),
 		}),
 		response: SandboxCreateResponseSchema,
 	},
 
 	async handler(ctx) {
-		const { opts, options, auth, region, config, logger, orgId } = ctx;
+		const { opts, options, auth, region, config, logger, orgId, project } = ctx;
+		const projectId = opts.projectId || project?.projectId;
 		const client = createSandboxClient(logger, auth, region);
 		const started = Date.now();
 
@@ -159,6 +166,7 @@ export const createSubcommand = createCommand({
 
 		const result = await sandboxCreate(client, {
 			options: {
+				projectId,
 				runtime: opts.runtime,
 				runtimeId: opts.runtimeId,
 				name: opts.name,

--- a/packages/cli/src/cmd/cloud/sandbox/list.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/list.ts
@@ -59,6 +59,10 @@ export const listSubcommand = createCommand({
 			command: getCommand('cloud sandbox list --limit 10 --offset 20'),
 			description: 'List with pagination',
 		},
+		{
+			command: getCommand('cloud sandbox list --all'),
+			description: 'List all sandboxes regardless of project context',
+		},
 	],
 	schema: {
 		options: z.object({
@@ -67,6 +71,7 @@ export const listSubcommand = createCommand({
 				.optional()
 				.describe('Filter by status'),
 			projectId: z.string().optional().describe('Filter by project ID'),
+			all: z.boolean().optional().describe('List all sandboxes regardless of project context'),
 			limit: z.number().optional().describe('Maximum number of results (default: 50, max: 100)'),
 			offset: z.number().optional().describe('Pagination offset'),
 		}),
@@ -77,7 +82,7 @@ export const listSubcommand = createCommand({
 		const { opts, options, auth, project, logger, orgId, config } = ctx;
 		const client = await getGlobalCatalystAPIClient(logger, auth, config?.name);
 
-		const projectId = opts.projectId || project?.projectId;
+		const projectId = opts.all ? undefined : opts.projectId || project?.projectId;
 
 		const result = await sandboxList(client, {
 			orgId,

--- a/packages/cli/src/cmd/cloud/sandbox/run.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/run.ts
@@ -20,6 +20,7 @@ export const runSubcommand = createCommand({
 	description: 'Run a one-shot command in a sandbox (creates, executes, destroys)',
 	tags: ['slow', 'requires-auth'],
 	requires: { auth: true, region: true, org: true },
+	optional: { project: true },
 	examples: [
 		{
 			command: getCommand('cloud sandbox run -- echo "hello world"'),
@@ -63,12 +64,14 @@ export const runSubcommand = createCommand({
 				.array(z.string())
 				.optional()
 				.describe('Apt packages to install (can be specified multiple times)'),
+			projectId: z.string().optional().describe('Project ID to associate this sandbox with'),
 		}),
 		response: SandboxRunResponseSchema,
 	},
 
 	async handler(ctx) {
-		const { args, opts, options, auth, region, config, logger, orgId } = ctx;
+		const { args, opts, options, auth, region, config, logger, orgId, project } = ctx;
+		const projectId = opts.projectId || project?.projectId;
 		const client = createSandboxClient(logger, auth, region);
 		const started = Date.now();
 
@@ -151,6 +154,7 @@ export const runSubcommand = createCommand({
 		try {
 			const result = await sandboxRun(client, {
 				options: {
+					projectId,
 					runtime: opts.runtime,
 					runtimeId: opts.runtimeId,
 					name: opts.name,

--- a/packages/cli/src/cmd/cloud/session/list.ts
+++ b/packages/cli/src/cmd/cloud/session/list.ts
@@ -53,6 +53,10 @@ export const listSubcommand = createSubcommand({
 			command: getCommand('cloud session list --env=production'),
 			description: 'Only production environment',
 		},
+		{
+			command: getCommand('cloud session list --all'),
+			description: 'List all sessions regardless of project context',
+		},
 	],
 	aliases: ['ls'],
 	requires: { auth: true },
@@ -76,6 +80,7 @@ export const listSubcommand = createSubcommand({
 				.default(10)
 				.describe('Number of sessions to list (1–100)'),
 			projectId: z.string().optional().describe('Filter by project ID'),
+			all: z.boolean().optional().describe('List all sessions regardless of project context'),
 			deploymentId: z.string().optional().describe('Filter by deployment ID'),
 			trigger: z.string().optional().describe('Filter by trigger type (api, cron, webhook)'),
 			env: z.string().optional().describe('Filter by environment'),
@@ -89,14 +94,14 @@ export const listSubcommand = createSubcommand({
 		response: SessionListResponseSchema,
 	},
 	webUrl: (ctx) => {
-		const projectId = ctx.opts?.projectId || ctx.project?.projectId;
+		const projectId = ctx.opts?.all ? undefined : ctx.opts?.projectId || ctx.project?.projectId;
 		return projectId ? `/projects/${encodeURIComponent(projectId)}/sessions` : undefined;
 	},
 	async handler(ctx) {
 		const { logger, auth, project, opts, options, config } = ctx;
 		const catalystClient = await getGlobalCatalystAPIClient(logger, auth, config?.name);
 
-		const projectId = opts.projectId || project?.projectId;
+		const projectId = opts.all ? undefined : opts.projectId || project?.projectId;
 
 		try {
 			const sessions = await sessionList(catalystClient, {

--- a/packages/cli/src/cmd/cloud/thread/list.ts
+++ b/packages/cli/src/cmd/cloud/thread/list.ts
@@ -34,6 +34,10 @@ export const listSubcommand = createSubcommand({
 			command: getCommand('cloud thread list --org-id=org_*'),
 			description: 'Filter by organization',
 		},
+		{
+			command: getCommand('cloud thread list --all'),
+			description: 'List all threads regardless of project context',
+		},
 	],
 	aliases: ['ls'],
 	requires: { auth: true },
@@ -58,6 +62,7 @@ export const listSubcommand = createSubcommand({
 				.describe('Number of threads to list (1–100)'),
 			orgId: z.string().optional().describe('Filter by organization ID'),
 			projectId: z.string().optional().describe('Filter by project ID'),
+			all: z.boolean().optional().describe('List all threads regardless of project context'),
 		}),
 		response: ThreadListResponseSchema,
 	},
@@ -65,7 +70,7 @@ export const listSubcommand = createSubcommand({
 		const { logger, auth, project, opts, options, config } = ctx;
 		const catalystClient = await getGlobalCatalystAPIClient(logger, auth, config?.name);
 
-		const projectId = opts.projectId || project?.projectId;
+		const projectId = opts.all ? undefined : opts.projectId || project?.projectId;
 		const orgId = opts.orgId;
 
 		try {

--- a/packages/core/src/services/sandbox.ts
+++ b/packages/core/src/services/sandbox.ts
@@ -178,6 +178,12 @@ export interface SandboxTimeoutConfig {
  */
 export interface SandboxCreateOptions {
 	/**
+	 * Project ID to associate the sandbox with.
+	 * If not provided, the sandbox will not be tied to a specific project.
+	 */
+	projectId?: string;
+
+	/**
 	 * Runtime name (e.g., "bun:1", "python:3.14").
 	 * If not specified, defaults to "bun:1".
 	 */

--- a/packages/server/src/api/sandbox/create.ts
+++ b/packages/server/src/api/sandbox/create.ts
@@ -5,6 +5,7 @@ import type { SandboxCreateOptions, SandboxStatus } from '@agentuity/core';
 
 const SandboxCreateRequestSchema = z
 	.object({
+		projectId: z.string().optional().describe('Project ID to associate the sandbox with'),
 		runtime: z.string().optional().describe('Runtime name (e.g., "bun:1", "python:3.14")'),
 		runtimeId: z.string().optional().describe('Runtime ID (e.g., "srt_xxx")'),
 		name: z.string().optional().describe('Optional sandbox name'),
@@ -127,6 +128,9 @@ export async function sandboxCreate(
 	const { options = {}, orgId } = params;
 	const body: z.infer<typeof SandboxCreateRequestSchema> = {};
 
+	if (options.projectId) {
+		body.projectId = options.projectId;
+	}
 	if (options.runtime) {
 		body.runtime = options.runtime;
 	}

--- a/packages/server/test/sandbox-client.test.ts
+++ b/packages/server/test/sandbox-client.test.ts
@@ -124,6 +124,34 @@ describe('SandboxClient', () => {
 
 			expect(sandbox.id).toBe('sandbox-456');
 		});
+
+		test('should create sandbox with projectId', async () => {
+			mockFetch(async (url, opts) => {
+				if (opts?.method === 'POST') {
+					const body = JSON.parse(opts.body as string);
+					expect(body.projectId).toBe('proj_123');
+
+					return new Response(
+						JSON.stringify({
+							success: true,
+							data: {
+								sandboxId: 'sandbox-789',
+								status: 'creating',
+							},
+						}),
+						{ status: 200, headers: { 'content-type': 'application/json' } }
+					);
+				}
+				return new Response(null, { status: 404 });
+			});
+
+			const client = new SandboxClient({ logger: createMockLogger() });
+			const sandbox = await client.create({
+				projectId: 'proj_123',
+			});
+
+			expect(sandbox.id).toBe('sandbox-789');
+		});
 	});
 
 	describe('sandbox instance methods', () => {

--- a/packages/vscode/src/core/cliClient.ts
+++ b/packages/vscode/src/core/cliClient.ts
@@ -578,11 +578,10 @@ export class CliClient {
 
 	/**
 	 * List sandboxes with optional filtering.
-	 * Runs from home directory to list all sandboxes since sandbox create
-	 * doesn't currently support project association.
+	 * Uses --all flag to list all sandboxes regardless of project context.
 	 */
 	async sandboxList(filter: SandboxListFilter = {}): Promise<CliResult<SandboxInfo[]>> {
-		const args = ['cloud', 'sandbox', 'list'];
+		const args = ['cloud', 'sandbox', 'list', '--all'];
 
 		if (filter.status) {
 			args.push('--status', filter.status);
@@ -597,12 +596,8 @@ export class CliClient {
 			args.push('--offset', String(filter.offset));
 		}
 
-		// Run from home directory to list all sandboxes
-		// CLI filters by project when run from project dir, but sandbox create
-		// doesn't support project association yet
 		const result = await this.exec<{ sandboxes: SandboxInfo[]; total: number }>(args, {
 			format: 'json',
-			cwd: os.homedir(),
 		});
 		if (result.success && result.data) {
 			return { success: true, data: result.data.sandboxes || [], exitCode: result.exitCode };


### PR DESCRIPTION
## Summary

Fixes #573 - CLI's `sandbox list` filters by project but `sandbox create` has no project association.

## Changes

### Core Types
- Added `projectId` field to `SandboxCreateOptions` interface in `@agentuity/core`

### Server SDK
- Added `projectId` to request schema and mapping in `sandboxCreate` function

### CLI Commands
- **`sandbox create`**: Added `optional: { project: true }` and `--project-id` flag. Sandboxes created in a project directory are now automatically associated with that project.
- **`sandbox run`**: Same changes as create (since `SandboxRunOptions` extends `SandboxCreateOptions`)
- **`sandbox list`**: Added `--all` flag to list all org sandboxes regardless of project context
- **`session list`**: Added `--all` flag for consistency
- **`thread list`**: Added `--all` flag for consistency

### VSCode Extension
- Updated `cliClient.sandboxList()` to use `--all` flag instead of the `cwd: os.homedir()` workaround

### Tests
- Added test case verifying `projectId` is passed in sandbox create request body

## How to Test

```bash
cd /path/to/agentuity-project  # contains agentuity.json
agentuity cloud sandbox create --runtime bun:1
agentuity cloud sandbox list  # Now shows the created sandbox
agentuity cloud sandbox list --all  # Shows all org sandboxes
```

## Verification

- ✅ Build passes
- ✅ Typecheck passes  
- ✅ Lint passes
- ✅ Sandbox-client tests pass (14/14)

## Amp Thread

https://ampcode.com/threads/T-019bb9b9-8eff-77bf-9c15-609b97611a30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Associate sandboxes and runs with a specific project via optional --project-id
  * Added --all to sandbox, session, and thread list commands to show items across all projects
  * VS Code extension now lists all sandboxes by default

* **Tests**
  * Added a test to verify sandbox creation with project association

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->