### PR TITLE
fix: add fallback for empty error messages

### DIFF
--- a/packages/cli/src/steps.ts
+++ b/packages/cli/src/steps.ts
@@ -518,7 +518,8 @@ async function runStepsTUI(steps: Step[]): Promise<void> {
 			// Handle errors
 			if (stepState.status === 'error') {
 				const errorColor = getColor('red');
-				console.error(`\n${errorColor}Error: ${stepState.errorMessage}${COLORS.reset}`);
+				const errorMsg = stepState.errorMessage || 'An unknown error occurred';
+				console.error(`\n${errorColor}Error: ${errorMsg}${COLORS.reset}`);
 				if (
 					stepState.errorCause instanceof ValidationInputError ||
 					stepState.errorCause instanceof ValidationOutputError
@@ -611,7 +612,8 @@ async function runStepsPlain(steps: Step[]): Promise<void> {
 				console.log('');
 			}
 			const errorColor = getColor('red');
-			console.error(`\n${errorColor}Error: ${outcome.message}${COLORS.reset}`);
+			const errorMsg = outcome.message || 'An unknown error occurred';
+			console.error(`\n${errorColor}Error: ${errorMsg}${COLORS.reset}`);
 			if (
 				outcome.cause instanceof ValidationInputError ||
 				outcome.cause instanceof ValidationOutputError

--- a/packages/server/src/api/project/deploy.ts
+++ b/packages/server/src/api/project/deploy.ts
@@ -302,7 +302,9 @@ export async function projectDeploymentComplete(
 	if (resp.success) {
 		return resp.data;
 	}
-	throw new ProjectResponseError({ message: resp.message });
+	throw new ProjectResponseError({
+		message: resp.message || 'Deployment completion failed with unknown error',
+	});
 }
 
 /**


### PR DESCRIPTION
## Problem
When the API returns an empty error message (due to HTTP/2 having empty `statusText`), the CLI was printing just `Error: ` with no details.

## Solution
Add fallback messages to ensure users always see meaningful error text.

## Changes
- `packages/cli/src/steps.ts`: Add fallback 'An unknown error occurred' when printing errors
- `packages/server/src/api/project/deploy.ts`: Add fallback in `projectDeploymentComplete`

## Before
```
Error: 
```

## After
```
Error: An unknown error occurred
```

## Related
This is the client-side fix. The server-side fix in agentuity/app will ensure proper error messages are returned from the API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages in CLI operations and deployment processes by ensuring error information is always displayed, even when specific error details are unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->