### PR TITLE
fix(server): add missing sandbox fields to get and list responses

### DIFF
--- a/packages/server/src/api/sandbox/get.ts
+++ b/packages/server/src/api/sandbox/get.ts
@@ -124,6 +124,7 @@ export async function sandboxGet(
 	if (resp.success) {
 		return {
 			sandboxId: resp.data.sandboxId,
+			identifier: resp.data.identifier,
 			name: resp.data.name,
 			description: resp.data.description,
 			status: resp.data.status as SandboxStatus,
@@ -145,6 +146,8 @@ export async function sandboxGet(
 			memoryByteSec: resp.data.memoryByteSec,
 			networkEgressBytes: resp.data.networkEgressBytes,
 			networkEnabled: resp.data.networkEnabled,
+			networkPort: resp.data.networkPort,
+			url: resp.data.url,
 			user: resp.data.user,
 			agent: resp.data.agent,
 			project: resp.data.project,

--- a/packages/server/src/api/sandbox/list.ts
+++ b/packages/server/src/api/sandbox/list.ts
@@ -105,6 +105,7 @@ export async function sandboxList(
 		return {
 			sandboxes: resp.data.sandboxes.map((s) => ({
 				sandboxId: s.sandboxId,
+				identifier: s.identifier,
 				name: s.name,
 				description: s.description,
 				status: s.status as SandboxStatus,
@@ -120,6 +121,8 @@ export async function sandboxList(
 				stdoutStreamUrl: s.stdoutStreamUrl,
 				stderrStreamUrl: s.stderrStreamUrl,
 				networkEnabled: s.networkEnabled,
+				networkPort: s.networkPort,
+				url: s.url,
 				org: s.org,
 			})),
 			total: resp.data.total,


### PR DESCRIPTION
## Summary

Add missing fields that were defined in the schema but not mapped in the return objects:

### Changes

**get.ts:**
- `identifier` - Short DNS hostname identifier
- `networkPort` - Network port exposed from the sandbox
- `url` - Public URL for the sandbox (when networkPort is configured)

**list.ts:**
- `identifier` - Short DNS hostname identifier  
- `networkPort` - Network port exposed from the sandbox
- `url` - Public URL for the sandbox (when networkPort is configured)

### Context

These fields are needed for the web UI to display network port configuration and public URL for sandboxes with exposed ports. The fields were already defined in the Zod schemas and core types, but were not being mapped in the return statements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sandbox API responses now include additional metadata: unique identifier, network port, and URL information for enhanced details in both single sandbox retrieval and bulk listing operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->