### PR TITLE
fix: add early validation for database name in template-flow prompt

### DIFF
--- a/packages/cli/src/cmd/project/template-flow.ts
+++ b/packages/cli/src/cmd/project/template-flow.ts
@@ -10,6 +10,7 @@ import {
 	getServiceUrls,
 	APIClient as ServerAPIClient,
 	createResources,
+	validateDatabaseName,
 } from '@agentuity/server';
 import type { Logger } from '@agentuity/core';
 import * as tui from '../../tui';
@@ -342,10 +343,17 @@ export async function runCreateFlow(options: CreateFlowOptions): Promise<void> {
 		}
 		switch (choices.db_action) {
 			case 'Create New': {
-				const dbName = await prompt.text({
+				const dbNameInput = await prompt.text({
 					message: 'Database name',
-					hint: 'Optional - press Enter to auto-generate',
+					hint: 'Optional - lowercase letters, digits, underscores only',
+					validate: (value: string) => {
+						const trimmed = value.trim();
+						if (trimmed === '') return true;
+						const result = validateDatabaseName(trimmed);
+						return result.valid ? true : result.error!;
+					},
 				});
+				const dbName = dbNameInput.trim() || undefined;
 				const dbDescription = await prompt.text({
 					message: 'Database description',
 					hint: 'Optional - press Enter to skip',
@@ -357,7 +365,7 @@ export async function runCreateFlow(options: CreateFlowOptions): Promise<void> {
 						return createResources(catalystClient, orgId, region!, [
 							{
 								type: 'db',
-								name: dbName || undefined,
+								name: dbName,
 								description: dbDescription || undefined,
 							},
 						]);

--- a/packages/server/test/validation.test.ts
+++ b/packages/server/test/validation.test.ts
@@ -1,0 +1,107 @@
+import { describe, test, expect } from 'bun:test';
+import { validateDatabaseName, validateBucketName } from '../src/api/region/create';
+
+describe('validateDatabaseName', () => {
+	test('should accept valid database names', () => {
+		expect(validateDatabaseName('mydb')).toEqual({ valid: true });
+		expect(validateDatabaseName('my_db')).toEqual({ valid: true });
+		expect(validateDatabaseName('_private')).toEqual({ valid: true });
+		expect(validateDatabaseName('db123')).toEqual({ valid: true });
+		expect(validateDatabaseName('a')).toEqual({ valid: true });
+		expect(validateDatabaseName('test_db_123')).toEqual({ valid: true });
+	});
+
+	test('should reject names starting with a number', () => {
+		const result = validateDatabaseName('123db');
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain('must start with a letter or underscore');
+	});
+
+	test('should reject uppercase letters', () => {
+		const result = validateDatabaseName('MyDB');
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain('must be lowercase');
+	});
+
+	test('should reject hyphens', () => {
+		const result = validateDatabaseName('my-db');
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain('must start with a letter or underscore');
+	});
+
+	test('should reject special characters', () => {
+		const result = validateDatabaseName('my@db');
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain('must start with a letter or underscore');
+	});
+
+	test('should reject names that are too long', () => {
+		const longName = 'a'.repeat(64);
+		const result = validateDatabaseName(longName);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain('too long');
+	});
+
+	test('should accept maximum length names', () => {
+		const maxName = 'a'.repeat(63);
+		expect(validateDatabaseName(maxName)).toEqual({ valid: true });
+	});
+
+	test('should reject empty names', () => {
+		const result = validateDatabaseName('');
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain('too short');
+	});
+});
+
+describe('validateBucketName', () => {
+	test('should accept valid bucket names', () => {
+		expect(validateBucketName('my-bucket')).toEqual({ valid: true });
+		expect(validateBucketName('my.bucket')).toEqual({ valid: true });
+		expect(validateBucketName('bucket123')).toEqual({ valid: true });
+		expect(validateBucketName('abc')).toEqual({ valid: true });
+	});
+
+	test('should reject names that are too short', () => {
+		const result = validateBucketName('ab');
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain('too short');
+	});
+
+	test('should reject names that are too long', () => {
+		const longName = 'a'.repeat(64);
+		const result = validateBucketName(longName);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain('too long');
+	});
+
+	test('should reject uppercase letters', () => {
+		const result = validateBucketName('MyBucket');
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain('lowercase');
+	});
+
+	test('should reject xn-- prefix', () => {
+		const result = validateBucketName('xn--bucket');
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain('xn--');
+	});
+
+	test('should reject -s3alias suffix', () => {
+		const result = validateBucketName('bucket-s3alias');
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain('-s3alias');
+	});
+
+	test('should reject adjacent periods', () => {
+		const result = validateBucketName('my..bucket');
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain('adjacent periods');
+	});
+
+	test('should reject IP address format', () => {
+		const result = validateBucketName('192.168.1.1');
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain('IP address');
+	});
+});


### PR DESCRIPTION
## Summary

Adds early validation for database names in the CLI template-flow prompt, preventing confusing API-level errors when users enter invalid database names.

Fixes #595

## Problem

When creating a new SQL database via the template-flow, an invalid database name (e.g., one starting with a number or containing invalid characters) was only validated AFTER the user submitted it, at the API level. This caused a confusing error:

```
✗ Provisioning New SQL Database: database name must start with a letter or underscore...
[ERROR] RegionResponseError: database name must start with a letter...
```

## Solution

- Import and use the existing `validateDatabaseName()` function from `@agentuity/server`
- Add a `validate` function to the database name prompt that:
  - Returns `true` for empty/whitespace input (allows auto-generation)
  - Validates non-empty input using `validateDatabaseName()`
  - Shows the error inline, allowing users to correct it immediately
- Update the hint to clarify naming rules: "lowercase letters, digits, underscores only"
- Normalize input with `trim()` to handle whitespace-only input

## Changes

- `packages/cli/src/cmd/project/template-flow.ts` - Added validation to database name prompt
- `packages/server/test/validation.test.ts` - Added 16 unit tests for `validateDatabaseName` and `validateBucketName`

## Testing

When creating a new project with a database, invalid names now show an inline error immediately:

- `123db` → shows "must start with a letter or underscore..."
- `MyDB` → shows "must be lowercase"
- `my-db` → shows "must start with a letter or underscore..."
- Press Enter → auto-generates (works as before)
- `valid_name` → proceeds successfully

## Verification

- ✅ Build passes
- ✅ Typecheck passes
- ✅ Lint passes
- ✅ All 116 tests pass (including 16 new validation tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced database name validation with stricter rules and clearer feedback during creation.
  * Input is now automatically trimmed and normalized for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->