### PR TITLE
fix(cli): use saved org preference for sandbox SSH/SCP

### DIFF
--- a/packages/cli/src/cmd/cloud/scp/download.ts
+++ b/packages/cli/src/cmd/cloud/scp/download.ts
@@ -52,7 +52,7 @@ export const downloadCommand = createSubcommand({
 	},
 
 	async handler(ctx) {
-		const { apiClient, args, opts, project, projectDir, config, logger, auth, orgId } = ctx;
+		const { apiClient, args, opts, project, projectDir, config, logger, auth } = ctx;
 
 		let identifier = opts?.identifier ?? project?.projectId;
 
@@ -60,8 +60,12 @@ export const downloadCommand = createSubcommand({
 			identifier = await tui.showProjectList(apiClient, true);
 		}
 
-		// Look up region from identifier (project/deployment)
+		// Look up region from identifier (project/deployment/sandbox)
 		const profileName = config?.name;
+
+		// For sandbox identifiers, use saved org preference (no prompting)
+		const orgId = identifier.startsWith('sbx_') ? config?.preferences?.orgId : undefined;
+
 		const region = await getIdentifierRegion(
 			logger,
 			auth,

--- a/packages/cli/src/cmd/cloud/scp/upload.ts
+++ b/packages/cli/src/cmd/cloud/scp/upload.ts
@@ -55,7 +55,7 @@ export const uploadCommand = createSubcommand({
 	prerequisites: ['cloud deploy'],
 
 	async handler(ctx) {
-		const { apiClient, args, opts, project, projectDir, config, logger, auth, orgId } = ctx;
+		const { apiClient, args, opts, project, projectDir, config, logger, auth } = ctx;
 
 		let identifier = opts?.identifier ?? project?.projectId;
 
@@ -63,8 +63,12 @@ export const uploadCommand = createSubcommand({
 			identifier = await tui.showProjectList(apiClient, true);
 		}
 
-		// Look up region from identifier (project/deployment)
+		// Look up region from identifier (project/deployment/sandbox)
 		const profileName = config?.name;
+
+		// For sandbox identifiers, use saved org preference (no prompting)
+		const orgId = identifier.startsWith('sbx_') ? config?.preferences?.orgId : undefined;
+
 		const region = await getIdentifierRegion(
 			logger,
 			auth,

--- a/packages/cli/src/cmd/cloud/ssh.ts
+++ b/packages/cli/src/cmd/cloud/ssh.ts
@@ -46,7 +46,7 @@ export const sshSubcommand = createSubcommand({
 	schema: { args, options },
 
 	async handler(ctx) {
-		const { apiClient, project, projectDir, args, config, opts, logger, auth, orgId } = ctx;
+		const { apiClient, project, projectDir, args, config, opts, logger, auth } = ctx;
 
 		let projectId = project?.projectId;
 		let identifier = args?.identifier;
@@ -70,6 +70,10 @@ export const sshSubcommand = createSubcommand({
 		// Look up region from identifier (project/deployment/sandbox)
 		const profileName = config?.name;
 		const targetIdentifier = identifier ?? projectId!;
+
+		// For sandbox identifiers, use saved org preference (no prompting)
+		const orgId = targetIdentifier.startsWith('sbx_') ? config?.preferences?.orgId : undefined;
+
 		const region = await getIdentifierRegion(
 			logger,
 			auth,


### PR DESCRIPTION
## Summary

When SSHing or using SCP with sandbox identifiers (`sbx_*`), the command was failing with:
```
[ERROR] APIErrorResponse: orgId is required
```

This PR fixes the issue by using the saved org preference from config (`config.preferences.orgId`) instead of prompting for org selection.

## Changes

- `ssh.ts`: Use saved org preference for sandbox identifiers
- `scp/upload.ts`: Use saved org preference for sandbox identifiers  
- `scp/download.ts`: Use saved org preference for sandbox identifiers

## Testing

1. Created a sandbox: `agentuity cloud sandbox create --name ssh-test --runtime bun:1`
2. Verified SSH works without prompt: `agentuity cloud ssh sbx_<id> --show`
3. Confirmed project SSH still works: `agentuity cloud ssh proj_<id> --show`
4. Typecheck, lint, and tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox identifier handling in cloud operations. SCP download, SCP upload, and SSH commands now automatically use saved organization preferences for sandbox identifiers (prefixed with "sbx_"), eliminating unnecessary prompts for organization selection. This streamlines the workflow when managing sandbox environments without requiring repeated user input.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->