### PR TITLE
feat: display organization info for resources in CLI

### DIFF
--- a/packages/cli/src/cmd/cloud/db/get.ts
+++ b/packages/cli/src/cmd/cloud/db/get.ts
@@ -12,6 +12,8 @@ const DBGetResponseSchema = z
 		name: z.string().describe('Database name'),
 		description: z.string().optional().describe('Database description'),
 		url: z.string().optional().describe('Database connection URL'),
+		org_id: z.string().optional().describe('Organization ID that owns this database'),
+		org_name: z.string().optional().describe('Organization name that owns this database'),
 	})
 	.or(
 		z.object({
@@ -175,6 +177,9 @@ export const getSubcommand = createSubcommand({
 			const tableData: Record<string, string> = {
 				Name: tui.bold(db.name),
 			};
+			if (db.org_name || db.org_id) {
+				tableData['Organization'] = db.org_name || db.org_id;
+			}
 			if (db.description) {
 				tableData['Description'] = db.description;
 			}
@@ -192,6 +197,8 @@ export const getSubcommand = createSubcommand({
 			name: db.name,
 			description: db.description ?? undefined,
 			url: db.url ?? undefined,
+			org_id: db.org_id,
+			org_name: db.org_name,
 		};
 	},
 });

--- a/packages/cli/src/cmd/cloud/db/list.ts
+++ b/packages/cli/src/cmd/cloud/db/list.ts
@@ -13,6 +13,8 @@ const DBListResponseSchema = z.object({
 				description: z.string().optional().describe('Database description'),
 				url: z.string().optional().describe('Database connection URL'),
 				cloud_region: z.string().optional().describe('Cloud region where database is hosted'),
+				org_id: z.string().optional().describe('Organization ID that owns this database'),
+				org_name: z.string().optional().describe('Organization name that owns this database'),
 			})
 		)
 		.describe('List of database resources'),
@@ -65,6 +67,10 @@ export const listSubcommand = createSubcommand({
 		const shouldShowCredentials = opts.showCredentials === true;
 		const shouldMask = !options.json && !shouldShowCredentials;
 
+		// Check if resources span multiple orgs
+		const uniqueOrgIds = new Set(resources.db.map((db) => db.org_id));
+		const showOrgColumn = uniqueOrgIds.size > 1;
+
 		if (!options.json) {
 			if (resources.db.length === 0) {
 				tui.info('No databases found');
@@ -73,12 +79,18 @@ export const listSubcommand = createSubcommand({
 					console.log(db.name);
 				}
 			} else {
-				const tableData = resources.db.map((db) => ({
-					Name: db.name,
-					Description: db.description ?? '',
-					Region: db.cloud_region,
-					URL: db.url ? (shouldMask ? tui.maskSecret(db.url) : db.url) : '',
-				}));
+				const tableData = resources.db.map((db) => {
+					const row: Record<string, string> = {
+						Name: db.name,
+					};
+					if (showOrgColumn) {
+						row.Organization = db.org_name || db.org_id;
+					}
+					row.Description = db.description ?? '';
+					row.Region = db.cloud_region;
+					row.URL = db.url ? (shouldMask ? tui.maskSecret(db.url) : db.url) : '';
+					return row;
+				});
 				tui.table(tableData);
 			}
 		}
@@ -89,6 +101,8 @@ export const listSubcommand = createSubcommand({
 				description: db.description ?? undefined,
 				url: db.url ?? undefined,
 				cloud_region: db.cloud_region,
+				org_id: db.org_id,
+				org_name: db.org_name,
 			})),
 		};
 	},

--- a/packages/cli/src/cmd/cloud/storage/get.ts
+++ b/packages/cli/src/cmd/cloud/storage/get.ts
@@ -13,6 +13,8 @@ const StorageGetResponseSchema = z.object({
 	secret_key: z.string().optional().describe('S3 secret key'),
 	region: z.string().optional().describe('S3 region'),
 	endpoint: z.string().optional().describe('S3 endpoint URL'),
+	org_id: z.string().optional().describe('Organization ID that owns this bucket'),
+	org_name: z.string().optional().describe('Organization name that owns this bucket'),
 });
 
 export const getSubcommand = createSubcommand({
@@ -100,24 +102,27 @@ export const getSubcommand = createSubcommand({
 		const shouldMask = !options.json && !shouldShowCredentials;
 
 		if (!options.json) {
-			console.log(tui.bold('Bucket Name: ') + bucket.bucket_name);
+			console.log(tui.bold('Bucket Name:  ') + bucket.bucket_name);
+			if (bucket.org_name || bucket.org_id) {
+				console.log(tui.bold('Organization: ') + (bucket.org_name || bucket.org_id));
+			}
 			if (bucket.access_key) {
 				const displayAccessKey = shouldMask
 					? tui.maskSecret(bucket.access_key)
 					: bucket.access_key;
-				console.log(tui.bold('Access Key:  ') + displayAccessKey);
+				console.log(tui.bold('Access Key:   ') + displayAccessKey);
 			}
 			if (bucket.secret_key) {
 				const displaySecretKey = shouldMask
 					? tui.maskSecret(bucket.secret_key)
 					: bucket.secret_key;
-				console.log(tui.bold('Secret Key:  ') + displaySecretKey);
+				console.log(tui.bold('Secret Key:   ') + displaySecretKey);
 			}
 			if (bucket.region) {
-				console.log(tui.bold('Region:      ') + bucket.region);
+				console.log(tui.bold('Region:       ') + bucket.region);
 			}
 			if (bucket.endpoint) {
-				console.log(tui.bold('Endpoint:    ') + bucket.endpoint);
+				console.log(tui.bold('Endpoint:     ') + bucket.endpoint);
 			}
 		}
 
@@ -127,6 +132,8 @@ export const getSubcommand = createSubcommand({
 			secret_key: bucket.secret_key ?? undefined,
 			region: bucket.region ?? undefined,
 			endpoint: bucket.endpoint ?? undefined,
+			org_id: bucket.org_id,
+			org_name: bucket.org_name,
 		};
 	},
 });

--- a/packages/cli/src/cmd/cloud/storage/list.ts
+++ b/packages/cli/src/cmd/cloud/storage/list.ts
@@ -18,6 +18,8 @@ const StorageListResponseSchema = z.object({
 				region: z.string().optional().describe('S3 region'),
 				endpoint: z.string().optional().describe('S3 endpoint URL'),
 				cloud_region: z.string().optional().describe('Cloud region where bucket is hosted'),
+				org_id: z.string().optional().describe('Organization ID that owns this bucket'),
+				org_name: z.string().optional().describe('Organization name that owns this bucket'),
 			})
 		)
 		.optional()
@@ -189,6 +191,10 @@ export const listSubcommand = createSubcommand({
 		const shouldShowCredentials = opts.showCredentials === true;
 		const shouldMask = !options.json && !shouldShowCredentials;
 
+		// Check if resources span multiple orgs
+		const uniqueOrgIds = new Set(resources.s3.map((s3) => s3.org_id));
+		const showOrgColumn = uniqueOrgIds.size > 1;
+
 		if (!options.json) {
 			if (resources.s3.length === 0) {
 				tui.info('No storage buckets found');
@@ -203,6 +209,9 @@ export const listSubcommand = createSubcommand({
 						continue;
 					}
 					console.log(tui.bold(s3.bucket_name));
+					if (showOrgColumn) {
+						console.log(` Organization: ${tui.muted(s3.org_name || s3.org_id)}`);
+					}
 					if (s3.access_key) {
 						const displayAccessKey = shouldMask
 							? tui.maskSecret(s3.access_key)
@@ -230,6 +239,8 @@ export const listSubcommand = createSubcommand({
 				region: s3.region ?? undefined,
 				endpoint: s3.endpoint ?? undefined,
 				cloud_region: s3.cloud_region,
+				org_id: s3.org_id,
+				org_name: s3.org_name,
 			})),
 		};
 	},

--- a/packages/server/src/api/org/resources.ts
+++ b/packages/server/src/api/org/resources.ts
@@ -9,6 +9,8 @@ const OrgS3Resource = z.object({
 	region: z.string().nullable().optional().describe('the S3 region'),
 	endpoint: z.string().nullable().optional().describe('the S3 endpoint'),
 	cloud_region: z.string().describe('the cloud region where this resource is provisioned'),
+	org_id: z.string().describe('the organization ID that owns this resource'),
+	org_name: z.string().describe('the organization name that owns this resource'),
 });
 
 const OrgDBResource = z.object({
@@ -18,6 +20,8 @@ const OrgDBResource = z.object({
 	password: z.string().nullable().optional().describe('the database password'),
 	url: z.string().nullable().optional().describe('the full database connection URL'),
 	cloud_region: z.string().describe('the cloud region where this resource is provisioned'),
+	org_id: z.string().describe('the organization ID that owns this resource'),
+	org_name: z.string().describe('the organization name that owns this resource'),
 });
 
 const OrgResourceListResponse = z.object({


### PR DESCRIPTION
## Summary

Add organization identification to CLI resource commands so users can see which organization each resource belongs to.

## Problem

Users in multiple organizations were confused when `agentuity cloud db list` showed databases that didn't appear in the web app. The web app is scoped to the active organization, while CLI shows all organizations.

See: https://github.com/agentuity/sdk/issues/594

## Solution

### SDK Types
- Add `org_id` and `org_name` fields to `OrgDBResource` and `OrgS3Resource` Zod schemas

### CLI Commands
- **db list / storage list**: Conditionally display "Organization" column only when resources span multiple orgs (hidden for single-org users to avoid noise)
- **db get / storage get**: Always display organization in detail view
- **JSON output**: Always include `org_id` and `org_name` fields

### Example Output

**Single-org user (unchanged):**
```
Name           Region  URL
loren_ryther   usc     postgresql://...
```

**Multi-org user (shows org column):**
```
Name           Organization    Region  URL
loren_ryther   My Org          usc     postgresql://...
alma_sitterud  Other Org       usc     postgresql://...
```

## Testing
- `bun run typecheck` passes
- `bun run build` passes  
- `bun run lint` passes
- Manual testing with local CLI verified org fields appear

## Related
- Fixes: #594
- Related Catalyst PR: https://github.com/agentuity/catalyst/pull/396

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database and storage bucket commands now display organization ownership information (including organization name and ID) in API responses and CLI output.
  * List views automatically include an Organization column when resources span multiple organizations, improving visibility and management of multi-organization resources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->