### PR TITLE
feat(cli): add commands for setting default org and region preferences

### DIFF
--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -1,11 +1,5 @@
 import enquirer from 'enquirer';
-import {
-	getDefaultConfigPath,
-	getAuth,
-	saveConfig,
-	loadConfig,
-	saveOrgId,
-} from './config';
+import { getDefaultConfigPath, getAuth, saveConfig, loadConfig, saveOrgId } from './config';
 import { getCommand } from './command-prefix';
 import type { CommandContext, AuthData } from './types';
 import * as tui from './tui';

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1242,7 +1242,12 @@ async function registerSubcommand(
 							ctx as CommandContext & { apiClient: APIClientType }
 						);
 					}
-					if ((normalized.requiresRegion || normalized.optionalRegion) && ctx.apiClient) {
+					if (
+						(normalized.requiresRegion ||
+							normalized.optionalRegion ||
+							normalized.requiresRegions) &&
+						ctx.apiClient
+					) {
 						const apiClient: APIClientType = ctx.apiClient as APIClientType;
 						const regions = await tui.spinner({
 							message: 'Fetching cloud regions',
@@ -1255,15 +1260,20 @@ async function registerSubcommand(
 								);
 							},
 						});
-						const region = await resolveRegion({
-							options: options as Record<string, unknown>,
-							regions,
-							logger: baseCtx.logger,
-							required: !!normalized.requiresRegion,
-							region: project?.region,
-						});
-						if (region) {
-							ctx.region = region;
+						if (normalized.requiresRegions) {
+							ctx.regions = regions;
+						}
+						if (normalized.requiresRegion || normalized.optionalRegion) {
+							const region = await resolveRegion({
+								options: options as Record<string, unknown>,
+								regions,
+								logger: baseCtx.logger,
+								required: !!normalized.requiresRegion,
+								region: project?.region,
+							});
+							if (region) {
+								ctx.region = region;
+							}
 						}
 					}
 					await executeOrValidate(
@@ -1318,7 +1328,12 @@ async function registerSubcommand(
 						ctx as CommandContext & { apiClient: APIClientType }
 					);
 				}
-				if ((normalized.requiresRegion || normalized.optionalRegion) && ctx.apiClient) {
+				if (
+					(normalized.requiresRegion ||
+						normalized.optionalRegion ||
+						normalized.requiresRegions) &&
+					ctx.apiClient
+				) {
 					const apiClient: APIClientType = ctx.apiClient as APIClientType;
 					const regions = await tui.spinner({
 						message: 'Fetching cloud regions',
@@ -1331,15 +1346,20 @@ async function registerSubcommand(
 							);
 						},
 					});
-					const region = await resolveRegion({
-						options: options as Record<string, unknown>,
-						regions,
-						logger: baseCtx.logger,
-						required: !!normalized.requiresRegion,
-						region: project?.region,
-					});
-					if (region) {
-						ctx.region = region;
+					if (normalized.requiresRegions) {
+						ctx.regions = regions;
+					}
+					if (normalized.requiresRegion || normalized.optionalRegion) {
+						const region = await resolveRegion({
+							options: options as Record<string, unknown>,
+							regions,
+							logger: baseCtx.logger,
+							required: !!normalized.requiresRegion,
+							region: project?.region,
+						});
+						if (region) {
+							ctx.region = region;
+						}
 					}
 				}
 				if (subcommand.handler) {

--- a/packages/cli/src/cmd/auth/index.ts
+++ b/packages/cli/src/cmd/auth/index.ts
@@ -5,6 +5,7 @@ import { logoutCommand } from './logout';
 import { signupCommand } from './signup';
 import { whoamiCommand } from './whoami';
 import { sshSubcommand } from './ssh';
+import { orgSubcommand } from './org';
 import { getCommand } from '../../command-prefix';
 
 export const command = createCommand({
@@ -14,6 +15,7 @@ export const command = createCommand({
 	examples: [
 		{ command: getCommand('auth login'), description: 'Login to your account' },
 		{ command: getCommand('auth whoami'), description: 'Show current user info' },
+		{ command: getCommand('auth org select'), description: 'Set default organization' },
 	],
 	subcommands: [
 		apikeyCommand,
@@ -22,5 +24,6 @@ export const command = createCommand({
 		signupCommand,
 		whoamiCommand,
 		sshSubcommand,
+		orgSubcommand,
 	],
 });

--- a/packages/cli/src/cmd/auth/org/index.ts
+++ b/packages/cli/src/cmd/auth/org/index.ts
@@ -1,0 +1,142 @@
+import { z } from 'zod';
+import { createSubcommand, createCommand } from '../../../types';
+import { getCommand } from '../../../command-prefix';
+import { saveOrgId, clearOrgId } from '../../../config';
+import * as tui from '../../../tui';
+import { listOrganizations } from '@agentuity/server';
+
+const selectCommand = createSubcommand({
+	name: 'select',
+	description: 'Set the default organization for all commands',
+	tags: ['fast', 'requires-auth'],
+	requires: { auth: true, apiClient: true },
+	examples: [
+		{ command: getCommand('auth org select'), description: 'Select default organization' },
+		{
+			command: getCommand('auth org select org_abc123'),
+			description: 'Set specific organization as default',
+		},
+	],
+	schema: {
+		args: z.object({
+			org_id: z.string().optional().describe('Organization ID to set as default'),
+		}),
+		response: z.object({
+			orgId: z.string().describe('The selected organization ID'),
+			name: z.string().describe('The organization name'),
+		}),
+	},
+
+	async handler(ctx) {
+		const { apiClient, args, options } = ctx;
+		const argOrgId = args.org_id;
+
+		const orgs = await tui.spinner({
+			message: 'Fetching organizations',
+			clearOnSuccess: true,
+			callback: () => listOrganizations(apiClient),
+		});
+
+		if (orgs.length === 0) {
+			tui.fatal('No organizations found for your account');
+		}
+
+		let selectedOrgId = argOrgId;
+
+		if (selectedOrgId) {
+			const org = orgs.find((o) => o.id === selectedOrgId);
+			if (!org) {
+				tui.fatal(
+					`Organization '${selectedOrgId}' not found. Use '${getCommand('auth org select')}' to see available organizations.`
+				);
+			}
+		} else {
+			if (!process.stdin.isTTY) {
+				tui.fatal(
+					'Organization ID required in non-interactive mode. Usage: ' +
+						getCommand('auth org select <org_id>')
+				);
+			}
+			selectedOrgId = await tui.selectOrganization(orgs);
+		}
+
+		await saveOrgId(selectedOrgId);
+
+		const selectedOrg = orgs.find((o) => o.id === selectedOrgId)!;
+
+		if (!options.json) {
+			tui.success(`Default organization set to ${tui.bold(selectedOrg.name)}`);
+		}
+
+		return { orgId: selectedOrgId, name: selectedOrg.name };
+	},
+});
+
+const unselectCommand = createSubcommand({
+	name: 'unselect',
+	description: 'Clear the default organization preference',
+	tags: ['fast'],
+	examples: [
+		{ command: getCommand('auth org unselect'), description: 'Clear default organization' },
+	],
+	schema: {
+		response: z.object({
+			cleared: z.boolean().describe('Whether the preference was cleared'),
+		}),
+	},
+
+	async handler(ctx) {
+		const { options, config } = ctx;
+
+		const hadOrg = !!config?.preferences?.orgId;
+		await clearOrgId();
+
+		if (!options.json) {
+			if (hadOrg) {
+				tui.success('Default organization cleared');
+			} else {
+				tui.info('No default organization was set');
+			}
+		}
+
+		return { cleared: hadOrg };
+	},
+});
+
+const currentCommand = createSubcommand({
+	name: 'current',
+	description: 'Show the current default organization',
+	tags: ['read-only', 'fast'],
+	idempotent: true,
+	examples: [
+		{ command: getCommand('auth org current'), description: 'Show default organization' },
+		{ command: getCommand('auth org current --json'), description: 'Show output in JSON format' },
+	],
+	schema: {
+		response: z.string().nullable().describe('The current organization ID or null if not set'),
+	},
+
+	async handler(ctx) {
+		const { options, config } = ctx;
+		const orgId = config?.preferences?.orgId || null;
+
+		if (!options.json) {
+			if (orgId) {
+				console.log(orgId);
+			}
+		}
+
+		return orgId;
+	},
+});
+
+export const orgSubcommand = createCommand({
+	name: 'org',
+	description: 'Manage default organization preference',
+	tags: ['fast'],
+	examples: [
+		{ command: getCommand('auth org select'), description: 'Set default organization' },
+		{ command: getCommand('auth org current'), description: 'Show current default' },
+	],
+	subcommands: [selectCommand, unselectCommand, currentCommand],
+});

--- a/packages/cli/src/cmd/cloud/index.ts
+++ b/packages/cli/src/cmd/cloud/index.ts
@@ -15,6 +15,7 @@ import apikeyCommand from './apikey';
 import streamCommand from './stream';
 import vectorCommand from './vector';
 import sandboxCommand from './sandbox';
+import { regionSubcommand } from './region';
 import { getCommand } from '../../command-prefix';
 
 export const command = createCommand({
@@ -24,6 +25,7 @@ export const command = createCommand({
 	examples: [
 		{ command: getCommand('cloud deploy'), description: 'Deploy your agent to the cloud' },
 		{ command: getCommand('cloud deployment list'), description: 'List all deployments' },
+		{ command: getCommand('cloud region select'), description: 'Set default region' },
 	],
 	subcommands: [
 		apikeyCommand,
@@ -42,5 +44,6 @@ export const command = createCommand({
 		sshSubcommand,
 		scpSubcommand,
 		deploymentCommand,
+		regionSubcommand,
 	],
 });

--- a/packages/cli/src/cmd/cloud/region/index.ts
+++ b/packages/cli/src/cmd/cloud/region/index.ts
@@ -1,0 +1,157 @@
+import { z } from 'zod';
+import { createSubcommand, createCommand } from '../../../types';
+import { getCommand } from '../../../command-prefix';
+import { saveRegion, clearRegion } from '../../../config';
+import * as tui from '../../../tui';
+
+const selectCommand = createSubcommand({
+	name: 'select',
+	description: 'Set the default cloud region for all commands',
+	tags: ['fast', 'requires-auth'],
+	requires: { auth: true, regions: true },
+	examples: [
+		{ command: getCommand('cloud region select'), description: 'Select default region' },
+		{
+			command: getCommand('cloud region select usc'),
+			description: 'Set specific region as default',
+		},
+	],
+	schema: {
+		args: z.object({
+			region: z.string().optional().describe('Region code to set as default'),
+		}),
+		response: z.object({
+			region: z.string().describe('The selected region code'),
+			description: z.string().describe('The region description'),
+		}),
+	},
+
+	async handler(ctx) {
+		const { regions, args, options } = ctx;
+
+		let selectedRegion = args.region;
+
+		if (selectedRegion) {
+			const region = regions.find((r) => r.region === selectedRegion);
+			if (!region) {
+				const available = regions.map((r) => r.region).join(', ');
+				tui.fatal(`Region '${selectedRegion}' not found. Available regions: ${available}`);
+			}
+		} else {
+			if (!process.stdin.isTTY) {
+				tui.fatal(
+					'Region code required in non-interactive mode. Usage: ' +
+						getCommand('cloud region select <region>')
+				);
+			}
+
+			if (regions.length === 1) {
+				selectedRegion = regions[0].region;
+			} else {
+				const response = await tui.createPrompt().select<string>({
+					message: 'Select a default region',
+					options: regions.map((r) => ({
+						value: r.region,
+						label: `${r.description} ${tui.muted(`(${r.region})`)}`,
+					})),
+				});
+				selectedRegion = response;
+			}
+		}
+
+		await saveRegion(selectedRegion);
+
+		const selectedRegionInfo = regions.find((r) => r.region === selectedRegion)!;
+
+		if (!options.json) {
+			tui.success(
+				`Default region set to ${tui.bold(selectedRegionInfo.description)} (${selectedRegion})`
+			);
+		}
+
+		return { region: selectedRegion, description: selectedRegionInfo.description };
+	},
+});
+
+const unselectCommand = createSubcommand({
+	name: 'unselect',
+	description: 'Clear the default region preference',
+	tags: ['fast'],
+	examples: [
+		{ command: getCommand('cloud region unselect'), description: 'Clear default region' },
+	],
+	schema: {
+		response: z.object({
+			cleared: z.boolean().describe('Whether the preference was cleared'),
+		}),
+	},
+
+	async handler(ctx) {
+		const { options, config } = ctx;
+
+		const hadRegion = !!config?.preferences?.region;
+
+		if (hadRegion && process.stdin.isTTY) {
+			const confirmed = await tui.confirm('Clear default region preference?', true);
+			if (!confirmed) {
+				if (!options.json) {
+					tui.info('Cancelled');
+				}
+				return { cleared: false };
+			}
+		}
+
+		await clearRegion();
+
+		if (!options.json) {
+			if (hadRegion) {
+				tui.success('Default region cleared');
+			} else {
+				tui.info('No default region was set');
+			}
+		}
+
+		return { cleared: hadRegion };
+	},
+});
+
+const currentCommand = createSubcommand({
+	name: 'current',
+	description: 'Show the current default region',
+	tags: ['read-only', 'fast'],
+	idempotent: true,
+	examples: [
+		{ command: getCommand('cloud region current'), description: 'Show default region' },
+		{
+			command: getCommand('cloud region current --json'),
+			description: 'Show output in JSON format',
+		},
+	],
+	schema: {
+		response: z.string().nullable().describe('The current region code or null if not set'),
+	},
+
+	async handler(ctx) {
+		const { options, config } = ctx;
+		const region = config?.preferences?.region || null;
+
+		if (!options.json) {
+			if (region) {
+				console.log(region);
+			}
+		}
+
+		return region;
+	},
+});
+
+export const regionSubcommand = createCommand({
+	name: 'region',
+	description: 'Manage default cloud region preference',
+	tags: ['fast'],
+	examples: [
+		{ command: getCommand('cloud region select'), description: 'Set default region' },
+		{ command: getCommand('cloud region current'), description: 'Show current default' },
+	],
+	subcommands: [selectCommand, unselectCommand, currentCommand],
+});

--- a/packages/cli/src/cmd/dev/index.ts
+++ b/packages/cli/src/cmd/dev/index.ts
@@ -227,7 +227,9 @@ export const command = createCommand({
 					tui.newline();
 
 					const shouldLogin = await tui.confirm(
-						hasProfile ? 'Would you like to login now?' : 'Would you like to login or create an account?',
+						hasProfile
+							? 'Would you like to login now?'
+							: 'Would you like to login or create an account?',
 						true
 					);
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -359,6 +359,29 @@ export async function saveOrgId(orgId: string): Promise<void> {
 	await saveConfig(config);
 }
 
+export async function clearOrgId(): Promise<void> {
+	const config = await getOrInitConfig();
+	if (config.preferences) {
+		delete (config.preferences as Record<string, unknown>).orgId;
+		await saveConfig(config);
+	}
+}
+
+export async function saveRegion(region: string): Promise<void> {
+	const config = await getOrInitConfig();
+	config.preferences = config.preferences || {};
+	(config.preferences as Record<string, unknown>).region = region;
+	await saveConfig(config);
+}
+
+export async function clearRegion(): Promise<void> {
+	const config = await getOrInitConfig();
+	if (config.preferences) {
+		delete (config.preferences as Record<string, unknown>).region;
+		await saveConfig(config);
+	}
+}
+
 export async function getAuth(): Promise<AuthData | null> {
 	const config = await loadConfig();
 	const profileName = config?.name || defaultProfileName;
@@ -721,13 +744,18 @@ interface RegionsCacheData {
 /**
  * Get the default region using priority ordering:
  * 1. AGENTUITY_REGION environment variable
- * 2. First entry in region-{profile}.json (nearest region, sorted by distance)
- * 3. 'local' for local profile, 'usc' otherwise
+ * 2. 'local' for local profile
+ * 3. Saved region preference (config.preferences.region)
+ * 4. First entry in region-{profile}.json (nearest region, sorted by distance)
+ * 5. 'usc' fallback
  *
  * Used for API calls that can hit any Catalyst instance (global database operations).
  * Note: This is NOT called when --region flag is provided (handled at command level).
  */
-export async function getDefaultRegion(profileName = 'production'): Promise<string> {
+export async function getDefaultRegion(
+	profileName = 'production',
+	config?: Config | null
+): Promise<string> {
 	// 1. Check environment variable first
 	if (process.env.AGENTUITY_REGION) {
 		return process.env.AGENTUITY_REGION;
@@ -738,7 +766,12 @@ export async function getDefaultRegion(profileName = 'production'): Promise<stri
 		return 'local';
 	}
 
-	// 3. Check cached regions file (sorted by distance)
+	// 3. Check saved region preference
+	if (config?.preferences?.region) {
+		return config.preferences.region;
+	}
+
+	// 4. Check cached regions file (sorted by distance)
 	try {
 		const cachePath = join(getDefaultConfigDir(), `regions-${profileName}.json`);
 		const file = Bun.file(cachePath);
@@ -752,7 +785,7 @@ export async function getDefaultRegion(profileName = 'production'): Promise<stri
 		// Fall through to default
 	}
 
-	// 4. Final fallback
+	// 5. Final fallback
 	return 'usc';
 }
 

--- a/packages/cli/src/tui.ts
+++ b/packages/cli/src/tui.ts
@@ -816,9 +816,7 @@ export function showLoggedOutMessage(appBaseUrl: string, hasProfile = false): vo
 	const RESET = '\x1b[0m';
 
 	const signupTitle = hasProfile ? 'Login' : 'Sign up / Login';
-	const signupURL = hasProfile
-		? `${appBaseUrl}/sign-in`
-		: `${appBaseUrl}/sign-up`;
+	const signupURL = hasProfile ? `${appBaseUrl}/sign-in` : `${appBaseUrl}/sign-up`;
 	const showInline = supportsHyperlinks();
 	const signupLink = showInline
 		? link(signupURL, signupTitle)

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -50,6 +50,7 @@ export const ConfigSchema = zod.object({
 			last_legacy_warning: zod.number().optional().describe('Last legacy CLI warning timestamp'),
 			signup_banner_shown: zod.boolean().optional().describe('If the signup banner was shown'),
 			orgId: zod.string().optional().describe('Default organization ID'),
+			region: zod.string().optional().describe('Default cloud region'),
 			project_dir: zod.string().optional().describe('Last used project directory'),
 		})
 		.optional()

--- a/packages/cli/test/cmd/auth/org.test.ts
+++ b/packages/cli/test/cmd/auth/org.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'bun:test';
+import { orgSubcommand } from '../../../src/cmd/auth/org';
+
+describe('auth org commands', () => {
+	describe('orgSubcommand definition', () => {
+		test('should have correct name', () => {
+			expect(orgSubcommand.name).toBe('org');
+		});
+
+		test('should have description', () => {
+			expect(orgSubcommand.description).toBe('Manage default organization preference');
+		});
+
+		test('should have subcommands', () => {
+			expect(orgSubcommand.subcommands).toBeDefined();
+			expect(orgSubcommand.subcommands?.length).toBe(3);
+		});
+
+		test('should have examples', () => {
+			expect(orgSubcommand.examples).toBeDefined();
+			expect(orgSubcommand.examples?.length).toBeGreaterThan(0);
+		});
+	});
+
+	describe('select subcommand', () => {
+		const selectCommand = orgSubcommand.subcommands?.find((c) => c.name === 'select');
+
+		test('should exist', () => {
+			expect(selectCommand).toBeDefined();
+		});
+
+		test('should require auth', () => {
+			expect(selectCommand?.requires?.auth).toBe(true);
+		});
+
+		test('should require apiClient', () => {
+			expect(selectCommand?.requires?.apiClient).toBe(true);
+		});
+
+		test('should have response schema', () => {
+			expect(selectCommand?.schema?.response).toBeDefined();
+		});
+
+		test('should have args schema for org_id', () => {
+			expect(selectCommand?.schema?.args).toBeDefined();
+		});
+	});
+
+	describe('unselect subcommand', () => {
+		const unselectCommand = orgSubcommand.subcommands?.find((c) => c.name === 'unselect');
+
+		test('should exist', () => {
+			expect(unselectCommand).toBeDefined();
+		});
+
+		test('should not require auth', () => {
+			expect(unselectCommand?.requires?.auth).toBeUndefined();
+		});
+
+		test('should have response schema', () => {
+			expect(unselectCommand?.schema?.response).toBeDefined();
+		});
+	});
+
+	describe('current subcommand', () => {
+		const currentCommand = orgSubcommand.subcommands?.find((c) => c.name === 'current');
+
+		test('should exist', () => {
+			expect(currentCommand).toBeDefined();
+		});
+
+		test('should not require auth', () => {
+			expect(currentCommand?.requires?.auth).toBeUndefined();
+		});
+
+		test('should be idempotent', () => {
+			expect(currentCommand?.idempotent).toBe(true);
+		});
+
+		test('should have read-only tag', () => {
+			expect(currentCommand?.tags).toContain('read-only');
+		});
+
+		test('should have response schema', () => {
+			expect(currentCommand?.schema?.response).toBeDefined();
+		});
+	});
+});

--- a/packages/cli/test/cmd/cloud/region.test.ts
+++ b/packages/cli/test/cmd/cloud/region.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'bun:test';
+import { regionSubcommand } from '../../../src/cmd/cloud/region';
+
+describe('cloud region commands', () => {
+	describe('regionSubcommand definition', () => {
+		test('should have correct name', () => {
+			expect(regionSubcommand.name).toBe('region');
+		});
+
+		test('should have description', () => {
+			expect(regionSubcommand.description).toBe('Manage default cloud region preference');
+		});
+
+		test('should have subcommands', () => {
+			expect(regionSubcommand.subcommands).toBeDefined();
+			expect(regionSubcommand.subcommands?.length).toBe(3);
+		});
+
+		test('should have examples', () => {
+			expect(regionSubcommand.examples).toBeDefined();
+			expect(regionSubcommand.examples?.length).toBeGreaterThan(0);
+		});
+	});
+
+	describe('select subcommand', () => {
+		const selectCommand = regionSubcommand.subcommands?.find((c) => c.name === 'select');
+
+		test('should exist', () => {
+			expect(selectCommand).toBeDefined();
+		});
+
+		test('should require auth', () => {
+			expect(selectCommand?.requires?.auth).toBe(true);
+		});
+
+		test('should require regions', () => {
+			expect(selectCommand?.requires?.regions).toBe(true);
+		});
+
+		test('should have response schema', () => {
+			expect(selectCommand?.schema?.response).toBeDefined();
+		});
+
+		test('should have args schema for region', () => {
+			expect(selectCommand?.schema?.args).toBeDefined();
+		});
+	});
+
+	describe('unselect subcommand', () => {
+		const unselectCommand = regionSubcommand.subcommands?.find((c) => c.name === 'unselect');
+
+		test('should exist', () => {
+			expect(unselectCommand).toBeDefined();
+		});
+
+		test('should not require auth', () => {
+			expect(unselectCommand?.requires?.auth).toBeUndefined();
+		});
+
+		test('should have response schema', () => {
+			expect(unselectCommand?.schema?.response).toBeDefined();
+		});
+	});
+
+	describe('current subcommand', () => {
+		const currentCommand = regionSubcommand.subcommands?.find((c) => c.name === 'current');
+
+		test('should exist', () => {
+			expect(currentCommand).toBeDefined();
+		});
+
+		test('should not require auth', () => {
+			expect(currentCommand?.requires?.auth).toBeUndefined();
+		});
+
+		test('should be idempotent', () => {
+			expect(currentCommand?.idempotent).toBe(true);
+		});
+
+		test('should have read-only tag', () => {
+			expect(currentCommand?.tags).toContain('read-only');
+		});
+
+		test('should have response schema', () => {
+			expect(currentCommand?.schema?.response).toBeDefined();
+		});
+	});
+});

--- a/packages/cli/test/config/preferences.test.ts
+++ b/packages/cli/test/config/preferences.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { join } from 'node:path';
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+describe('config preferences', () => {
+	describe('getDefaultRegion with saved preference', () => {
+		let testDir: string;
+		let originalConfigDir: string | undefined;
+
+		beforeEach(() => {
+			testDir = join(tmpdir(), `agentuity-test-${Date.now()}`);
+			mkdirSync(testDir, { recursive: true });
+			originalConfigDir = process.env.AGENTUITY_CONFIG_DIR;
+		});
+
+		afterEach(() => {
+			if (originalConfigDir !== undefined) {
+				process.env.AGENTUITY_CONFIG_DIR = originalConfigDir;
+			} else {
+				delete process.env.AGENTUITY_CONFIG_DIR;
+			}
+			try {
+				rmSync(testDir, { recursive: true, force: true });
+			} catch {
+				// Ignore cleanup errors
+			}
+		});
+
+		test('should return saved region preference when config has it', async () => {
+			const { getDefaultRegion } = await import('../../src/config');
+
+			const config = {
+				name: 'production',
+				preferences: {
+					region: 'euw',
+				},
+			};
+
+			const result = await getDefaultRegion('production', config);
+			expect(result).toBe('euw');
+		});
+
+		test('should return fallback when no preference is set', async () => {
+			const { getDefaultRegion } = await import('../../src/config');
+
+			const config = {
+				name: 'production',
+				preferences: {},
+			};
+
+			// Note: This may return 'usc' or a cached region depending on environment
+			const result = await getDefaultRegion('production', config);
+			expect(typeof result).toBe('string');
+		});
+
+		test('should prioritize env var over saved preference', async () => {
+			const { getDefaultRegion } = await import('../../src/config');
+
+			const originalEnv = process.env.AGENTUITY_REGION;
+			process.env.AGENTUITY_REGION = 'apse';
+
+			try {
+				const config = {
+					name: 'production',
+					preferences: {
+						region: 'euw',
+					},
+				};
+
+				const result = await getDefaultRegion('production', config);
+				expect(result).toBe('apse');
+			} finally {
+				if (originalEnv !== undefined) {
+					process.env.AGENTUITY_REGION = originalEnv;
+				} else {
+					delete process.env.AGENTUITY_REGION;
+				}
+			}
+		});
+
+		test('should return local for local profile regardless of preference', async () => {
+			const { getDefaultRegion } = await import('../../src/config');
+
+			const config = {
+				name: 'local',
+				preferences: {
+					region: 'euw',
+				},
+			};
+
+			const result = await getDefaultRegion('local', config);
+			expect(result).toBe('local');
+		});
+	});
+});

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -754,7 +754,9 @@ async function main() {
 					const isTransient = errStr.includes('404') || errStr.includes('Not Found');
 					if (isTransient && attempt < maxRetries) {
 						const delay = attempt * 5;
-						console.log(`   ⚠ Transient error, retrying in ${delay}s (attempt ${attempt}/${maxRetries})...`);
+						console.log(
+							`   ⚠ Transient error, retrying in ${delay}s (attempt ${attempt}/${maxRetries})...`
+						);
 						await new Promise((r) => setTimeout(r, delay * 1000));
 					} else {
 						break;


### PR DESCRIPTION
## Summary

Implements #580 - Add commands to set default organization and region so users don't have to select them for every command.

## New Commands

| Command | Description |
|---------|-------------|
| `agentuity auth org select [org_id]` | Set default organization (prompts if no arg in TTY) |
| `agentuity auth org unselect` | Clear default organization preference |
| `agentuity auth org current` | Print current org_id (empty if not set) |
| `agentuity cloud region select [region]` | Set default region (prompts if no arg in TTY) |
| `agentuity cloud region unselect` | Clear default region (with confirmation) |
| `agentuity cloud region current` | Print current region (empty if not set) |

## Changes

### New Files
- `packages/cli/src/cmd/auth/org/index.ts` - Org subcommand group
- `packages/cli/src/cmd/cloud/region/index.ts` - Region subcommand group
- `packages/cli/test/cmd/auth/org.test.ts` - Tests for org commands
- `packages/cli/test/cmd/cloud/region.test.ts` - Tests for region commands
- `packages/cli/test/config/preferences.test.ts` - Tests for config helpers

### Modified Files
- `packages/cli/src/types.ts` - Add `region` to preferences schema
- `packages/cli/src/config.ts` - Add `clearOrgId()`, `saveRegion()`, `clearRegion()` helpers; update `getDefaultRegion()` to check saved preference
- `packages/cli/src/cli.ts` - Fix to inject `regions` array when `requires: { regions: true }` is set
- `packages/cli/src/cmd/auth/index.ts` - Register org subcommand
- `packages/cli/src/cmd/cloud/index.ts` - Register region subcommand

## Region Resolution Priority (updated)

1. `AGENTUITY_REGION` env var
2. `local` profile → `'local'`
3. **`config.preferences.region`** (NEW - saved preference)
4. Regions cache file
5. Fallback `'usc'`

## Testing

- ✅ 38 new tests added and passing
- ✅ Typecheck passes
- ✅ Lint passes
- ✅ Manual testing completed for all commands

Closes #580

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization preference management commands (select, unselect, view current organization).
  * Added region preference management commands (select, unselect, view current region).
  * Enhanced region handling across CLI operations.

* **Tests**
  * Added comprehensive test coverage for organization and region management.
  * Added preference configuration tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->