### PR TITLE
Add snapshot encryption in CLI

### DIFF
--- a/packages/cli/src/cmd/cloud/sandbox/snapshot/build.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/snapshot/build.ts
@@ -576,6 +576,7 @@ export const buildSubcommand = createCommand({
 						description: finalDescription,
 						contentHash,
 						force: opts.force,
+						encrypt: true,
 						orgId,
 					});
 				},

--- a/packages/server/src/api/sandbox/snapshot.ts
+++ b/packages/server/src/api/sandbox/snapshot.ts
@@ -282,6 +282,7 @@ const _SnapshotBuildInitParamsSchema = z
 			.optional()
 			.describe('SHA-256 hash of snapshot content for change detection'),
 		force: z.boolean().optional().describe('Force rebuild even if content is unchanged'),
+		encrypt: z.boolean().optional().describe('Request encryption for the snapshot archive'),
 		orgId: z.string().optional().describe('Organization ID'),
 	})
 	.describe('Parameters for initializing a snapshot build');
@@ -339,7 +340,7 @@ export async function snapshotBuildInit(
 	client: APIClient,
 	params: SnapshotBuildInitParams
 ): Promise<SnapshotBuildInitResponse> {
-	const { runtime, name, description, tag, contentHash, force, orgId } = params;
+	const { runtime, name, description, tag, contentHash, force, encrypt, orgId } = params;
 	const queryString = buildQueryString({ orgId });
 	const url = `/sandbox/${API_VERSION}/snapshots/build${queryString}`;
 
@@ -349,6 +350,7 @@ export async function snapshotBuildInit(
 	if (tag) body.tag = tag;
 	if (contentHash) body.contentHash = contentHash;
 	if (force) body.force = force;
+	if (encrypt) body.encrypt = encrypt;
 
 	const resp = await client.post<z.infer<typeof SnapshotBuildInitAPIResponseSchema>>(
 		url,


### PR DESCRIPTION
## Summary

Add encryption support to the CLI snapshot build command, encrypting archives before upload when the server provides a public key.

## Changes

- Add `publicKey` field to `SnapshotBuildInitResponse` schema
- Encrypt snapshot archive using `encryptFIPSKEMDEMStream` when public key is provided
- Show "Encrypting snapshot..." spinner during encryption

## Testing

- ✅ Built encrypted snapshot - archive size increased from 246 to 403 bytes
- ✅ Snapshot uploaded and finalized successfully
- ✅ Created sandbox from encrypted snapshot - files restored correctly

## Related PRs

- Catalyst: https://github.com/agentuity/catalyst/pull/398
- Graviton: https://github.com/agentuity/graviton/pull/144
- App: https://github.com/agentuity/app/pull/new/task/add-snapshot-encryption-591

## Thread

https://ampcode.com/threads/T-019bbe78-38df-7199-9f60-7a40ff7da82c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Snapshot archives can now be optionally encrypted client-side when a public key is provided; uploads will use the encrypted artifact and report the appropriate size and content type for secure transmission.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->