### PR TITLE
fix(cli): return actual project data in JSON output and fix banner overflow

### DIFF
--- a/packages/cli/src/cmd/project/create.ts
+++ b/packages/cli/src/cmd/project/create.ts
@@ -9,6 +9,7 @@ const ProjectCreateResponseSchema = z.object({
 	name: z.string().describe('Project name'),
 	path: z.string().describe('Project directory path'),
 	projectId: z.string().optional().describe('Project ID if registered'),
+	orgId: z.string().optional().describe('Organization ID if registered'),
 	template: z.string().describe('Template used'),
 	installed: z.boolean().describe('Whether dependencies were installed'),
 	built: z.boolean().describe('Whether the project was built'),
@@ -83,7 +84,7 @@ export const createProjectSubcommand = createSubcommand({
 			);
 		}
 
-		await runCreateFlow({
+		const result = await runCreateFlow({
 			projectName: opts.name,
 			dir: opts.dir,
 			domains: opts.domains,
@@ -101,14 +102,16 @@ export const createProjectSubcommand = createSubcommand({
 			region,
 		});
 
-		// Return best-effort response (runCreateFlow doesn't return values)
 		return {
 			success: true,
-			name: opts.name || 'project',
-			path: opts.dir || process.cwd(),
-			template: opts.template || 'default',
-			installed: opts.install !== false,
-			built: opts.build !== false,
+			name: result.name,
+			path: result.path,
+			projectId: result.projectId,
+			orgId: result.orgId,
+			template: result.template,
+			installed: result.installed,
+			built: result.built,
+			domains: result.domains,
 		};
 	},
 });

--- a/packages/cli/src/cmd/project/template-flow.ts
+++ b/packages/cli/src/cmd/project/template-flow.ts
@@ -57,7 +57,18 @@ interface CreateFlowOptions {
 	apiClient?: APIClient;
 }
 
-export async function runCreateFlow(options: CreateFlowOptions): Promise<void> {
+export interface CreateFlowResult {
+	projectId?: string;
+	orgId?: string;
+	name: string;
+	path: string;
+	template: string;
+	installed: boolean;
+	built: boolean;
+	domains?: string[];
+}
+
+export async function runCreateFlow(options: CreateFlowOptions): Promise<CreateFlowResult> {
 	const {
 		projectName: initialProjectName,
 		dir: targetDir,
@@ -169,7 +180,7 @@ export async function runCreateFlow(options: CreateFlowOptions): Promise<void> {
 			const home = homedir();
 			if (dest === '/' || dest === home) {
 				logger.fatal(`Refusing to delete protected path: ${dest}`, ErrorCode.VALIDATION_FAILED);
-				return;
+				return undefined as never;
 			}
 			rmSync(dest, { recursive: true, force: true });
 			tui.success(`Deleted ${dest}`);
@@ -194,7 +205,7 @@ export async function runCreateFlow(options: CreateFlowOptions): Promise<void> {
 				`Template "${initialTemplate}" not found\n\nAvailable templates:\n${availableTemplates}`,
 				ErrorCode.RESOURCE_NOT_FOUND
 			);
-			return;
+			return undefined as never;
 		}
 		selectedTemplate = found;
 	} else if (skipPrompts || templates.length === 1) {
@@ -223,7 +234,7 @@ export async function runCreateFlow(options: CreateFlowOptions): Promise<void> {
 		const found = templates.find((t) => t.id === templateId);
 		if (!found) {
 			logger.fatal('Template selection failed', ErrorCode.USER_CANCELLED);
-			return;
+			return undefined as never;
 		}
 		selectedTemplate = found;
 	}
@@ -624,6 +635,17 @@ export async function runCreateFlow(options: CreateFlowOptions): Promise<void> {
 	if (authEnabled && !templateHasAuth) {
 		printIntegrationExamples();
 	}
+
+	return {
+		projectId,
+		orgId,
+		name: projectName,
+		path: dest,
+		template: selectedTemplate.id,
+		installed: !options.noInstall,
+		built: !options.noBuild,
+		domains: _domains,
+	};
 }
 
 /**

--- a/packages/cli/src/tui.ts
+++ b/packages/cli/src/tui.ts
@@ -348,6 +348,11 @@ export function link(url: string, title?: string, color = getColor('link')): str
  * Check if terminal supports OSC 8 hyperlinks
  */
 export function supportsHyperlinks(): boolean {
+	// No hyperlink support without a TTY
+	if (!process.stdout.isTTY) {
+		return false;
+	}
+
 	const term = process.env.TERM || '';
 	const termProgram = process.env.TERM_PROGRAM || '';
 	const wtSession = process.env.WT_SESSION || '';
@@ -360,7 +365,6 @@ export function supportsHyperlinks(): boolean {
 		termProgram.includes('Apple_Terminal') ||
 		termProgram.includes('Hyper') ||
 		term.includes('xterm-kitty') ||
-		term.includes('xterm-256color') ||
 		wtSession !== '' // Windows Terminal
 	);
 }


### PR DESCRIPTION
## Summary

This PR fixes two issues with the CLI:

### 1. Project create `--json` output now returns actual data

Previously, `agentuity project create --json` returned placeholder values instead of the actual project information. Now it properly returns:
- `projectId` - The ID of the registered project (when authenticated)
- `orgId` - The organization ID (when authenticated)
- `name` - The actual project name
- `path` - The actual project path
- `template` - The template used
- `domains` - Any configured domains

### 2. Banner version overflow in non-TTY mode

When running the CLI without a TTY (e.g., in CI or piped), the version was showing as a full URL which overflowed the banner box:

```
│ Version:        https://github.com/agentuity/sdk/releases/tag/v0.1.13 │
```

Now it correctly shows just the version number:

```
│ Version:        0.1.13                             │
```

## Changes

- `template-flow.ts`: Added `CreateFlowResult` interface and updated `runCreateFlow` to return actual values
- `create.ts`: Updated handler to use returned values and added `orgId` to response schema
- `tui.ts`: Fixed `supportsHyperlinks()` to return `false` when no TTY, removed overly broad `xterm-256color` check

## Testing

```bash
# Non-TTY mode shows version correctly
echo "" | bun packages/cli/bin/cli.ts --help
# Version:        0.1.13

# JSON output includes actual values
bun packages/cli/bin/cli.ts project create --name test --template default --no-install --no-build --no-register --confirm --json
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced project creation response to include organization ID and domain information when applicable.
  * Improved terminal capability detection for better hyperlink support across different terminal environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->