### PR TITLE
feat: Add DNS records to support boson test

### DIFF
--- a/packages/cli/src/cmd/cloud/deployment/show.ts
+++ b/packages/cli/src/cmd/cloud/deployment/show.ts
@@ -19,6 +19,7 @@ const DeploymentShowResponseSchema = z.object({
 	resourceStorage: z.string().nullable().optional().describe('the storage name'),
 	deploymentLogsURL: z.string().nullable().optional().describe('the url to the deployment logs'),
 	buildLogsURL: z.string().nullable().optional().describe('the url to the build logs'),
+	dnsRecords: z.array(z.string()).optional().describe('DNS records for custom domains'),
 	metadata: z
 		.object({
 			git: z
@@ -124,6 +125,9 @@ export const showSubcommand = createSubcommand({
 				if (deployment.buildLogsURL) {
 					tableData['Build Logs'] = tui.link(deployment.buildLogsURL);
 				}
+				if (deployment.dnsRecords && deployment.dnsRecords.length > 0) {
+					tableData['DNS Records'] = deployment.dnsRecords.join(', ');
+				}
 
 				tui.table([tableData], Object.keys(tableData), { layout: 'vertical', padStart: '  ' });
 
@@ -190,6 +194,7 @@ export const showSubcommand = createSubcommand({
 				resourceStorage: deployment.resourceStorage ?? undefined,
 				deploymentLogsURL: deployment.deploymentLogsURL ?? undefined,
 				buildLogsURL: deployment.buildLogsURL ?? undefined,
+				dnsRecords: deployment.dnsRecords ?? undefined,
 			};
 		} catch (ex) {
 			tui.fatal(`Failed to show deployment: ${ex}`);

--- a/packages/server/src/api/project/deployment.ts
+++ b/packages/server/src/api/project/deployment.ts
@@ -50,6 +50,7 @@ const DeploymentSchema = z.object({
 	resourceStorage: z.string().nullable().optional(),
 	deploymentLogsURL: z.string().nullable().optional(),
 	buildLogsURL: z.string().nullable().optional(),
+	dnsRecords: z.array(z.string()).optional(),
 });
 
 const DeploymentListResponseSchema = APIResponseSchema(z.array(DeploymentSchema));


### PR DESCRIPTION
Adds deployment DNS display in the show command for balance check billing feature.

## Changes
- Added DNS display to deployment show command
- Added deployment field to project API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DNS Records for Custom Domains: Deployments now display DNS records associated with custom domain configurations. When configured, DNS records appear as a comma-separated list in the deployment details view, providing enhanced visibility into your custom domain setup and making it easier to reference and manage domain configurations across all your deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->