### PR TITLE
feat(server): add run() method to SandboxClient

### DIFF
--- a/packages/server/src/api/sandbox/client.ts
+++ b/packages/server/src/api/sandbox/client.ts
@@ -5,14 +5,17 @@ import type {
 	ExecuteOptions as CoreExecuteOptions,
 	Execution,
 	FileToWrite,
+	SandboxRunOptions,
+	SandboxRunResult,
 } from '@agentuity/core';
-import type { Writable } from 'node:stream';
+import type { Readable, Writable } from 'node:stream';
 import { APIClient } from '../api';
 import { sandboxCreate, type SandboxCreateResponse } from './create';
 import { sandboxDestroy } from './destroy';
 import { sandboxGet } from './get';
 import { sandboxExecute } from './execute';
 import { sandboxWriteFiles, sandboxReadFile } from './files';
+import { sandboxRun } from './run';
 import { executionGet, type ExecutionInfo } from './execution';
 import { ConsoleLogger } from '../../logger';
 import { getServiceUrls } from '../../config';
@@ -130,6 +133,36 @@ export interface SandboxClientOptions {
 }
 
 /**
+ * I/O options for one-shot sandbox execution via run()
+ */
+export interface SandboxClientRunIO {
+	/**
+	 * AbortSignal to cancel the execution
+	 */
+	signal?: AbortSignal;
+
+	/**
+	 * Readable stream for stdin input
+	 */
+	stdin?: Readable;
+
+	/**
+	 * Writable stream for stdout output
+	 */
+	stdout?: Writable;
+
+	/**
+	 * Writable stream for stderr output
+	 */
+	stderr?: Writable;
+
+	/**
+	 * Optional logger override for this run
+	 */
+	logger?: Logger;
+}
+
+/**
  * A sandbox instance returned by SandboxClient.create()
  */
 export interface SandboxInstance {
@@ -174,15 +207,25 @@ export interface SandboxInstance {
  *
  * @example
  * ```typescript
+ * // Interactive sandbox usage
  * const client = new SandboxClient();
  * const sandbox = await client.create();
  * const result = await sandbox.execute({ command: ['echo', 'hello'] });
  * await sandbox.destroy();
+ *
+ * // One-shot execution with streaming
+ * const result = await client.run(
+ *   { command: { exec: ['bun', 'run', 'script.ts'] } },
+ *   { stdout: process.stdout, stderr: process.stderr }
+ * );
  * ```
  */
 export class SandboxClient {
 	readonly #client: APIClient;
 	readonly #orgId?: string;
+	readonly #apiKey?: string;
+	readonly #region: string;
+	readonly #logger: Logger;
 
 	constructor(options: SandboxClientOptions = {}) {
 		const apiKey =
@@ -202,6 +245,48 @@ export class SandboxClient {
 
 		this.#client = new APIClient(url, logger, apiKey ?? '', {});
 		this.#orgId = options.orgId;
+		this.#apiKey = apiKey;
+		this.#region = region;
+		this.#logger = logger;
+	}
+
+	/**
+	 * Run a one-shot command in a new sandbox (creates, executes, destroys)
+	 *
+	 * This is a high-level convenience method that handles the full lifecycle:
+	 * creating a sandbox, streaming I/O, polling for completion, and cleanup.
+	 *
+	 * @param options - Execution options including command and configuration
+	 * @param io - Optional I/O streams and abort signal
+	 * @returns The run result including exit code and duration
+	 * @throws {Error} If stdin is provided without an API key
+	 *
+	 * @example
+	 * ```typescript
+	 * const client = new SandboxClient();
+	 * const result = await client.run(
+	 *   { command: { exec: ['bun', 'run', 'script.ts'] } },
+	 *   { stdout: process.stdout, stderr: process.stderr }
+	 * );
+	 * console.log('Exit code:', result.exitCode);
+	 * ```
+	 */
+	async run(options: SandboxRunOptions, io: SandboxClientRunIO = {}): Promise<SandboxRunResult> {
+		if (io.stdin && !this.#apiKey) {
+			throw new Error('SandboxClient.run(): stdin streaming requires an API key');
+		}
+
+		return sandboxRun(this.#client, {
+			options,
+			orgId: this.#orgId,
+			region: this.#region,
+			apiKey: this.#apiKey,
+			signal: io.signal,
+			stdin: io.stdin,
+			stdout: io.stdout,
+			stderr: io.stderr,
+			logger: io.logger ?? this.#logger,
+		});
 	}
 
 	/**

--- a/packages/server/src/api/sandbox/index.ts
+++ b/packages/server/src/api/sandbox/index.ts
@@ -21,7 +21,7 @@ export type {
 } from './execution';
 export { SandboxResponseError, writeAndDrain } from './util';
 export { SandboxClient } from './client';
-export type { SandboxClientOptions, SandboxInstance, ExecuteOptions } from './client';
+export type { SandboxClientOptions, SandboxClientRunIO, SandboxInstance, ExecuteOptions } from './client';
 export {
 	sandboxWriteFiles,
 	sandboxReadFile,

--- a/packages/server/test/sandbox-client.test.ts
+++ b/packages/server/test/sandbox-client.test.ts
@@ -296,6 +296,81 @@ describe('SandboxClient', () => {
 		});
 	});
 
+	describe('run', () => {
+		test('should have run method available', () => {
+			const client = new SandboxClient({ logger: createMockLogger() });
+			expect(typeof client.run).toBe('function');
+		});
+
+		test('should throw error when stdin provided without API key', async () => {
+			delete process.env.AGENTUITY_SDK_KEY;
+			delete process.env.AGENTUITY_CLI_KEY;
+
+			const client = new SandboxClient({ logger: createMockLogger() });
+			const { Readable } = await import('node:stream');
+			const stdin = new Readable({ read() {} });
+
+			await expect(
+				client.run({ command: { exec: ['cat'] } }, { stdin })
+			).rejects.toThrow('SandboxClient.run(): stdin streaming requires an API key');
+		});
+
+		test('should call sandbox create API with oneshot mode', async () => {
+			let createCalled = false;
+			let createBody: Record<string, unknown> | null = null;
+
+			mockFetch(async (url, opts) => {
+				if (opts?.method === 'POST' && url.includes('/sandbox/')) {
+					createCalled = true;
+					createBody = JSON.parse(opts.body as string);
+					return new Response(
+						JSON.stringify({
+							success: true,
+							data: {
+								sandboxId: 'sandbox-run-123',
+								status: 'running',
+							},
+						}),
+						{ status: 200, headers: { 'content-type': 'application/json' } }
+					);
+				}
+
+				if (opts?.method === 'GET' && url.includes('sandbox-run-123')) {
+					return new Response(
+						JSON.stringify({
+							success: true,
+							data: {
+								sandboxId: 'sandbox-run-123',
+								status: 'terminated',
+							},
+						}),
+						{ status: 200, headers: { 'content-type': 'application/json' } }
+					);
+				}
+
+				return new Response(null, { status: 404 });
+			});
+
+			const client = new SandboxClient({ logger: createMockLogger() });
+
+			const abortController = new AbortController();
+			setTimeout(() => abortController.abort(), 100);
+
+			try {
+				await client.run(
+					{ command: { exec: ['echo', 'hello'] } },
+					{ signal: abortController.signal }
+				);
+			} catch {
+				// Expected to be aborted
+			}
+
+			expect(createCalled).toBe(true);
+			expect((createBody?.command as Record<string, unknown>)?.mode).toBe('oneshot');
+			expect((createBody?.command as Record<string, unknown>)?.exec).toEqual(['echo', 'hello']);
+		});
+	});
+
 	describe('client direct methods', () => {
 		test('get should fetch sandbox by ID', async () => {
 			mockFetch(async (url, opts) => {


### PR DESCRIPTION
## Summary

Adds a `run()` method to `SandboxClient` that wraps `sandboxRun()` for one-shot sandbox execution with streaming support.

## Problem

For one-shot sandbox execution, there was a gap between the two available APIs:
- **`SandboxClient`**: Nice OO API, but requires manual polling for completion
- **`sandboxRun()`**: Handles polling + streaming, but needs raw `APIClient`

Using both together was awkward:
```typescript
const client = new SandboxClient();     // For create/destroy
const apiClient = new APIClient(...);   // For sandboxRun()
// Two clients for the same service
```

## Solution

Add `run()` to `SandboxClient` that delegates to `sandboxRun()`:

```typescript
const client = new SandboxClient();
const result = await client.run(
  { command: { exec: ['bun', 'run', 'script.ts'] } },
  { stdout: process.stdout, stderr: process.stderr }
);
console.log('Exit code:', result.exitCode);
```

## Changes

- Add `SandboxClientRunIO` interface for I/O options (stdin/stdout/stderr, signal, logger)
- Store `apiKey`, `region`, `logger` in `SandboxClient` for `run()` delegation
- Throw explicit error when stdin provided without API key
- Export `SandboxClientRunIO` type from sandbox index
- Add unit tests for the new method

## Testing

- ✅ `bun run typecheck` passes
- ✅ `bun run lint` passes
- ✅ `bun run build` passes
- ✅ `bun run test:packages` passes

Closes #621

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added one-shot sandbox execution capability with support for I/O streaming (stdin, stdout, stderr) and execution control via abort signals.
* Added API key validation for operations requiring stdin streaming.
* Expanded test coverage for sandbox execution scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->