### PR TITLE
Add brand_color, requirements, and readme to SandboxRuntime

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -76,6 +76,7 @@ export {
 export {
 	type SandboxResources,
 	type SandboxStatus,
+	type SandboxRuntimeRequirements,
 	type SandboxRuntime,
 	type ExecutionStatus,
 	type StreamReader,

--- a/packages/core/src/services/sandbox.ts
+++ b/packages/core/src/services/sandbox.ts
@@ -28,6 +28,28 @@ export type SandboxStatus = 'creating' | 'idle' | 'running' | 'terminated' | 'fa
 /**
  * Runtime information for a sandbox
  */
+export interface SandboxRuntimeRequirements {
+	/**
+	 * Memory requirement (e.g., "1Gi")
+	 */
+	memory?: string;
+
+	/**
+	 * CPU requirement (e.g., "1")
+	 */
+	cpu?: string;
+
+	/**
+	 * Disk requirement (e.g., "500Mi")
+	 */
+	disk?: string;
+
+	/**
+	 * Whether network access is enabled
+	 */
+	networkEnabled: boolean;
+}
+
 export interface SandboxRuntime {
 	/**
 	 * Unique runtime identifier
@@ -50,6 +72,11 @@ export interface SandboxRuntime {
 	iconUrl?: string;
 
 	/**
+	 * Brand color for the runtime (hex color code)
+	 */
+	brandColor?: string;
+
+	/**
 	 * URL for runtime documentation or homepage
 	 */
 	url?: string;
@@ -58,6 +85,16 @@ export interface SandboxRuntime {
 	 * Optional tags for categorization
 	 */
 	tags?: string[];
+
+	/**
+	 * Runtime requirements (memory, cpu, disk, network)
+	 */
+	requirements?: SandboxRuntimeRequirements;
+
+	/**
+	 * Readme content in markdown format
+	 */
+	readme?: string;
 }
 
 /**

--- a/packages/server/src/api/sandbox/runtime.ts
+++ b/packages/server/src/api/sandbox/runtime.ts
@@ -3,14 +3,26 @@ import { APIClient, APIResponseSchema } from '../api';
 import { SandboxResponseError, API_VERSION } from './util';
 import type { ListRuntimesParams, ListRuntimesResponse, SandboxRuntime } from '@agentuity/core';
 
+const RuntimeRequirementsSchema = z
+	.object({
+		memory: z.string().optional().describe('Memory requirement (e.g., "1Gi")'),
+		cpu: z.string().optional().describe('CPU requirement (e.g., "1")'),
+		disk: z.string().optional().describe('Disk requirement (e.g., "500Mi")'),
+		networkEnabled: z.boolean().describe('Whether network access is enabled'),
+	})
+	.describe('Runtime resource requirements');
+
 const RuntimeInfoSchema = z
 	.object({
 		id: z.string().describe('Unique runtime identifier'),
 		name: z.string().describe('Runtime name (e.g., "bun:1", "python:3.14")'),
 		description: z.string().optional().describe('Optional description'),
 		iconUrl: z.string().optional().describe('URL for runtime icon'),
+		brandColor: z.string().optional().describe('Brand color for the runtime (hex color code)'),
 		url: z.string().optional().describe('URL for runtime documentation or homepage'),
 		tags: z.array(z.string()).optional().describe('Optional tags for categorization'),
+		requirements: RuntimeRequirementsSchema.optional().describe('Runtime resource requirements'),
+		readme: z.string().optional().describe('Readme content in markdown format'),
 	})
 	.describe('Information about a sandbox runtime');
 
@@ -67,8 +79,11 @@ export async function runtimeList(
 					name: r.name,
 					description: r.description,
 					iconUrl: r.iconUrl,
+					brandColor: r.brandColor,
 					url: r.url,
 					tags: r.tags,
+					requirements: r.requirements,
+					readme: r.readme,
 				})
 			),
 			total: resp.data.total,

--- a/packages/vscode/src/core/cliClient.ts
+++ b/packages/vscode/src/core/cliClient.ts
@@ -1303,13 +1303,23 @@ export interface SandboxEnvResult {
 }
 
 // Sandbox runtime types
+export interface SandboxRuntimeRequirements {
+	memory?: string;
+	cpu?: string;
+	disk?: string;
+	networkEnabled: boolean;
+}
+
 export interface SandboxRuntime {
 	id: string;
 	name: string;
 	description?: string;
 	iconUrl?: string;
+	brandColor?: string;
 	url?: string;
 	tags?: string[];
+	requirements?: SandboxRuntimeRequirements;
+	readme?: string;
 }
 
 export interface SandboxRuntimeListParams {


### PR DESCRIPTION
## Summary

Updates the `SandboxRuntime` interface to include three new fields matching the database changes from app commit [aee2a518e96da512643d1825837918fb07f2f62f](https://github.com/agentuity/app/commit/aee2a518e96da512643d1825837918fb07f2f62f):

- `brandColor` - Brand color for the runtime (hex color code)
- `requirements` - Runtime requirements (memory, cpu, disk, networkEnabled)
- `readme` - Readme content in markdown format

## Changes

### packages/core
- Added `SandboxRuntimeRequirements` interface
- Updated `SandboxRuntime` interface with new fields
- Exported `SandboxRuntimeRequirements` from index.ts

### packages/server
- Updated Zod schema with `RuntimeRequirementsSchema`
- Updated runtime list mapping to include new fields

### packages/vscode
- Updated `SandboxRuntimeRequirements` interface
- Updated `SandboxRuntime` interface with new fields

## Related

- App commit: https://github.com/agentuity/app/commit/aee2a518e96da512643d1825837918fb07f2f62f
- Catalyst PR: https://github.com/agentuity/catalyst/pull/new/task/add-updated-runtime-properties

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime requirements configuration with memory, CPU, disk, and network settings.
  * Extended sandbox runtime metadata with brand color and readme fields for enhanced customization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->