### PR TITLE
fix: remove project requirement from KV commands

### DIFF
--- a/packages/cli/src/cmd/cloud/keyvalue/create-namespace.ts
+++ b/packages/cli/src/cmd/cloud/keyvalue/create-namespace.ts
@@ -9,7 +9,7 @@ export const createNamespaceSubcommand = createCommand({
 	description: 'Create a new keyvalue namespace',
 	tags: ['mutating', 'creates-resource', 'slow', 'requires-auth'],
 	idempotent: false,
-	requires: { auth: true, project: true },
+	requires: { auth: true },
 	examples: [
 		{
 			command: getCommand('kv create-namespace production'),

--- a/packages/cli/src/cmd/cloud/keyvalue/delete-namespace.ts
+++ b/packages/cli/src/cmd/cloud/keyvalue/delete-namespace.ts
@@ -8,9 +8,9 @@ export const deleteNamespaceSubcommand = createCommand({
 	name: 'delete-namespace',
 	aliases: ['rm-namespace'],
 	description: 'Delete a keyvalue namespace and all its keys',
-	tags: ['destructive', 'deletes-resource', 'slow', 'requires-auth', 'requires-project'],
+	tags: ['destructive', 'deletes-resource', 'slow', 'requires-auth'],
 	idempotent: true,
-	requires: { auth: true, project: true },
+	requires: { auth: true },
 	examples: [
 		{
 			command: getCommand('kv delete-namespace staging'),

--- a/packages/cli/src/cmd/cloud/keyvalue/delete.ts
+++ b/packages/cli/src/cmd/cloud/keyvalue/delete.ts
@@ -16,7 +16,7 @@ export const deleteSubcommand = createCommand({
 	description: 'Delete a key from the keyvalue storage',
 	tags: ['destructive', 'deletes-resource', 'slow', 'requires-auth'],
 	idempotent: true,
-	requires: { auth: true, project: true },
+	requires: { auth: true },
 	examples: [
 		{ command: getCommand('kv delete production user:123'), description: 'Delete user data' },
 		{ command: getCommand('kv delete cache session:abc'), description: 'Delete cached session' },

--- a/packages/cli/src/cmd/cloud/keyvalue/get.ts
+++ b/packages/cli/src/cmd/cloud/keyvalue/get.ts
@@ -14,7 +14,7 @@ export const getSubcommand = createCommand({
 	name: 'get',
 	description: 'Get a value from the keyvalue storage',
 	tags: ['read-only', 'fast', 'requires-auth'],
-	requires: { auth: true, project: true },
+	requires: { auth: true },
 	examples: [
 		{ command: getCommand('kv get production user:123'), description: 'Get user data' },
 		{ command: getCommand('kv get cache session:abc'), description: 'Get cached session' },

--- a/packages/cli/src/cmd/cloud/keyvalue/index.ts
+++ b/packages/cli/src/cmd/cloud/keyvalue/index.ts
@@ -35,6 +35,6 @@ export const command = createCommand({
 		createNamespaceSubcommand,
 		deleteNamespaceSubcommand,
 	],
-	requires: { auth: true, project: true },
+	requires: { auth: true },
 });
 export default command;

--- a/packages/cli/src/cmd/cloud/keyvalue/keys.ts
+++ b/packages/cli/src/cmd/cloud/keyvalue/keys.ts
@@ -13,7 +13,7 @@ export const keysSubcommand = createCommand({
 	aliases: ['ls', 'list'],
 	description: 'List all keys in a keyvalue namespace',
 	tags: ['read-only', 'slow', 'requires-auth'],
-	requires: { auth: true, project: true },
+	requires: { auth: true },
 	idempotent: true,
 	examples: [
 		{ command: getCommand('kv keys production'), description: 'List all keys in production' },

--- a/packages/cli/src/cmd/cloud/keyvalue/list-namespaces.ts
+++ b/packages/cli/src/cmd/cloud/keyvalue/list-namespaces.ts
@@ -10,7 +10,7 @@ export const listNamespacesSubcommand = createCommand({
 	aliases: ['namespaces', 'ns'],
 	description: 'List all keyvalue namespaces',
 	tags: ['read-only', 'fast', 'requires-auth'],
-	requires: { auth: true, project: true },
+	requires: { auth: true },
 	examples: [
 		{ command: getCommand('kv list-namespaces'), description: 'List all namespaces' },
 		{ command: getCommand('kv namespaces'), description: 'List namespaces (using alias)' },

--- a/packages/cli/src/cmd/cloud/keyvalue/repl.ts
+++ b/packages/cli/src/cmd/cloud/keyvalue/repl.ts
@@ -11,16 +11,19 @@ export const replSubcommand = createCommand({
 	description: 'Start an interactive repl for working with keyvalue database',
 	tags: ['slow', 'requires-auth'],
 	idempotent: false,
-	requires: { auth: true, project: true },
+	requires: { auth: true },
+	optional: { project: true },
 	examples: [{ command: getCommand('kv repl'), description: 'Start interactive KV session' }],
 
 	async handler(ctx) {
 		showBanner(undefined, true);
-		tui.info('Managing keyvalue store for project');
+		tui.info('Managing keyvalue store');
 		tui.newline();
-		console.log(tui.bold('Org:'.padEnd(10, ' ')), ' ', tui.muted(ctx.project.orgId));
-		console.log(tui.bold('Project:'.padEnd(10, ' ')), ' ', tui.muted(ctx.project.projectId));
-		tui.newline();
+		if (ctx.project) {
+			console.log(tui.bold('Org:'.padEnd(10, ' ')), ' ', tui.muted(ctx.project.orgId));
+			console.log(tui.bold('Project:'.padEnd(10, ' ')), ' ', tui.muted(ctx.project.projectId));
+			tui.newline();
+		}
 
 		const storage = await createStorageAdapter(ctx);
 

--- a/packages/cli/src/cmd/cloud/keyvalue/search.ts
+++ b/packages/cli/src/cmd/cloud/keyvalue/search.ts
@@ -20,7 +20,7 @@ export const searchSubcommand = createCommand({
 	name: 'search',
 	description: 'Search for keys matching a keyword in a keyvalue namespace',
 	tags: ['read-only', 'slow', 'requires-auth'],
-	requires: { auth: true, project: true },
+	requires: { auth: true },
 	idempotent: true,
 	examples: [
 		{

--- a/packages/cli/src/cmd/cloud/keyvalue/set.ts
+++ b/packages/cli/src/cmd/cloud/keyvalue/set.ts
@@ -19,7 +19,7 @@ export const setSubcommand = createCommand({
 	description: 'Set a key and value in the keyvalue storage',
 	tags: ['mutating', 'updates-resource', 'slow', 'requires-auth'],
 	idempotent: true,
-	requires: { auth: true, project: true },
+	requires: { auth: true },
 	examples: [
 		{
 			command: getCommand(

--- a/packages/cli/src/cmd/cloud/keyvalue/stats.ts
+++ b/packages/cli/src/cmd/cloud/keyvalue/stats.ts
@@ -26,7 +26,7 @@ export const statsSubcommand = createCommand({
 	name: 'stats',
 	description: 'Get statistics for keyvalue storage',
 	tags: ['read-only', 'fast', 'requires-auth'],
-	requires: { auth: true, project: true },
+	requires: { auth: true },
 	idempotent: true,
 	examples: [
 		{ command: getCommand('kv stats'), description: 'Show stats for all namespaces' },

--- a/packages/cli/src/cmd/cloud/keyvalue/util.ts
+++ b/packages/cli/src/cmd/cloud/keyvalue/util.ts
@@ -1,34 +1,25 @@
-import { KeyValueStorageService, Logger } from '@agentuity/core';
+import { KeyValueStorageService, type Logger } from '@agentuity/core';
 import { createServerFetchAdapter, getServiceUrls } from '@agentuity/server';
-import { loadProjectSDKKey } from '../../../config';
-import { ErrorCode } from '../../../errors';
-import type { Config } from '../../../types';
-import * as tui from '../../../tui';
+import { getDefaultRegion } from '../../../config';
+import type { AuthData, Config } from '../../../types';
 
 export async function createStorageAdapter(ctx: {
 	logger: Logger;
-	projectDir: string;
 	config: Config | null;
-	project: { region: string };
+	auth: AuthData;
+	project?: { region: string };
 }) {
-	const sdkKey = await loadProjectSDKKey(ctx.logger, ctx.projectDir);
-	if (!sdkKey) {
-		tui.fatal(
-			`Couldn't find the AGENTUITY_SDK_KEY in ${ctx.projectDir} .env file`,
-			ErrorCode.CONFIG_NOT_FOUND
-		);
-	}
-
 	const adapter = createServerFetchAdapter(
 		{
 			headers: {
-				Authorization: `Bearer ${sdkKey}`,
+				Authorization: `Bearer ${ctx.auth.apiKey}`,
 			},
 		},
 		ctx.logger
 	);
 
-	const urls = getServiceUrls(ctx.project.region);
+	const region = ctx.project?.region || (await getDefaultRegion(ctx.config?.name, ctx.config));
+	const urls = getServiceUrls(region);
 	const baseUrl = urls.catalyst;
 	return new KeyValueStorageService(baseUrl, adapter);
 }


### PR DESCRIPTION
## Summary

KV resources are org-scoped, not project-scoped, so there's no need to require a project context to use KV CLI commands.

## Changes

- **util.ts**: Refactored `createStorageAdapter` to use `auth.apiKey` instead of SDK key from project `.env` file. Uses `getDefaultRegion()` when project context is not available.
- **All KV subcommands**: Changed from `requires: { auth: true, project: true }` to `requires: { auth: true }`
- **repl.ts**: Added `optional: { project: true }` and conditionally displays project info

## Testing

- `bun run typecheck` ✅
- `bun run lint` ✅  
- `bun run build` ✅
- `bun run test` ✅

KV commands now work from anywhere as long as the user is authenticated (`agentuity auth login`).

Fixes #617

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **CLI Updates**
  * Key-value commands now require only authentication; project context is optional
  * REPL command accepts project context as an optional parameter
  * Users can execute key-value operations without an active project context

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->