### PR TITLE
fix: generate correct import paths for shared schema types

### DIFF
--- a/packages/cli/src/cmd/build/ast.ts
+++ b/packages/cli/src/cmd/build/ast.ts
@@ -1362,8 +1362,16 @@ export async function parseRoute(
 	let exportName: string | undefined;
 	let variableName: string | undefined;
 
+	// Import info structure for tracking where identifiers come from
+	interface ImportInfo {
+		modulePath: string;
+		importedName: string; // The exported name from the source module
+		importKind: 'named' | 'default';
+	}
+
 	// Extract import statements to map variable names to their import sources
-	const importMap = new Map<string, string>(); // Maps variable name to import path
+	const importMap = new Map<string, string>(); // Maps variable name to import path (for backwards compat)
+	const importInfoMap = new Map<string, ImportInfo>(); // Maps variable name to full import info
 	for (const body of ast.body) {
 		if (body.type === 'ImportDeclaration') {
 			const importDecl = body as {
@@ -1371,6 +1379,7 @@ export async function parseRoute(
 				specifiers?: Array<{
 					type: string;
 					local?: { name?: string };
+					imported?: { name?: string }; // For named imports: the exported name
 				}>;
 			};
 			const importPath = importDecl.source?.value;
@@ -1379,9 +1388,20 @@ export async function parseRoute(
 					if (spec.type === 'ImportDefaultSpecifier' && spec.local?.name) {
 						// import hello from '@agent/hello'
 						importMap.set(spec.local.name, importPath);
+						importInfoMap.set(spec.local.name, {
+							modulePath: importPath,
+							importedName: 'default',
+							importKind: 'default',
+						});
 					} else if (spec.type === 'ImportSpecifier' && spec.local?.name) {
-						// import { hello } from './shared'
+						// import { hello } from './shared' or import { hello as h } from './shared'
+						const importedName = spec.imported?.name ?? spec.local.name;
 						importMap.set(spec.local.name, importPath);
+						importInfoMap.set(spec.local.name, {
+							modulePath: importPath,
+							importedName,
+							importKind: 'named',
+						});
 					}
 				}
 			}
@@ -1620,10 +1640,29 @@ export async function parseRoute(
 										if (validatorInfo.inputSchemaVariable) {
 											routeConfig.inputSchemaVariable =
 												validatorInfo.inputSchemaVariable;
+											// Track where the schema is imported from (if imported)
+											const inputImportInfo = importInfoMap.get(
+												validatorInfo.inputSchemaVariable
+											);
+											if (inputImportInfo) {
+												routeConfig.inputSchemaImportPath = inputImportInfo.modulePath;
+												routeConfig.inputSchemaImportedName =
+													inputImportInfo.importedName;
+											}
 										}
 										if (validatorInfo.outputSchemaVariable) {
 											routeConfig.outputSchemaVariable =
 												validatorInfo.outputSchemaVariable;
+											// Track where the schema is imported from (if imported)
+											const outputImportInfo = importInfoMap.get(
+												validatorInfo.outputSchemaVariable
+											);
+											if (outputImportInfo) {
+												routeConfig.outputSchemaImportPath =
+													outputImportInfo.modulePath;
+												routeConfig.outputSchemaImportedName =
+													outputImportInfo.importedName;
+											}
 										}
 										if (validatorInfo.stream !== undefined) {
 											routeConfig.stream = validatorInfo.stream;
@@ -1700,10 +1739,29 @@ export async function parseRoute(
 										if (validatorInfo.inputSchemaVariable) {
 											routeConfig.inputSchemaVariable =
 												validatorInfo.inputSchemaVariable;
+											// Track where the schema is imported from (if imported)
+											const inputImportInfo = importInfoMap.get(
+												validatorInfo.inputSchemaVariable
+											);
+											if (inputImportInfo) {
+												routeConfig.inputSchemaImportPath = inputImportInfo.modulePath;
+												routeConfig.inputSchemaImportedName =
+													inputImportInfo.importedName;
+											}
 										}
 										if (validatorInfo.outputSchemaVariable) {
 											routeConfig.outputSchemaVariable =
 												validatorInfo.outputSchemaVariable;
+											// Track where the schema is imported from (if imported)
+											const outputImportInfo = importInfoMap.get(
+												validatorInfo.outputSchemaVariable
+											);
+											if (outputImportInfo) {
+												routeConfig.outputSchemaImportPath =
+													outputImportInfo.modulePath;
+												routeConfig.outputSchemaImportedName =
+													outputImportInfo.importedName;
+											}
 										}
 										if (validatorInfo.stream !== undefined) {
 											routeConfig.stream = validatorInfo.stream;
@@ -1879,9 +1937,25 @@ export async function parseRoute(
 							);
 							if (validatorInfo.inputSchemaVariable) {
 								routeConfig.inputSchemaVariable = validatorInfo.inputSchemaVariable;
+								// Track where the schema is imported from (if imported)
+								const inputImportInfo = importInfoMap.get(
+									validatorInfo.inputSchemaVariable
+								);
+								if (inputImportInfo) {
+									routeConfig.inputSchemaImportPath = inputImportInfo.modulePath;
+									routeConfig.inputSchemaImportedName = inputImportInfo.importedName;
+								}
 							}
 							if (validatorInfo.outputSchemaVariable) {
 								routeConfig.outputSchemaVariable = validatorInfo.outputSchemaVariable;
+								// Track where the schema is imported from (if imported)
+								const outputImportInfo = importInfoMap.get(
+									validatorInfo.outputSchemaVariable
+								);
+								if (outputImportInfo) {
+									routeConfig.outputSchemaImportPath = outputImportInfo.modulePath;
+									routeConfig.outputSchemaImportedName = outputImportInfo.importedName;
+								}
 							}
 							if (validatorInfo.stream !== undefined) {
 								routeConfig.stream = validatorInfo.stream;
@@ -1894,9 +1968,21 @@ export async function parseRoute(
 						// which is useful when using zValidator (input-only) but needing typed outputs
 						if (!routeConfig.inputSchemaVariable && exportedInputSchemaName) {
 							routeConfig.inputSchemaVariable = exportedInputSchemaName;
+							// Check if exported schema name is also imported
+							const inputImportInfo = importInfoMap.get(exportedInputSchemaName);
+							if (inputImportInfo) {
+								routeConfig.inputSchemaImportPath = inputImportInfo.modulePath;
+								routeConfig.inputSchemaImportedName = inputImportInfo.importedName;
+							}
 						}
 						if (!routeConfig.outputSchemaVariable && exportedOutputSchemaName) {
 							routeConfig.outputSchemaVariable = exportedOutputSchemaName;
+							// Check if exported schema name is also imported
+							const outputImportInfo = importInfoMap.get(exportedOutputSchemaName);
+							if (outputImportInfo) {
+								routeConfig.outputSchemaImportPath = outputImportInfo.modulePath;
+								routeConfig.outputSchemaImportedName = outputImportInfo.importedName;
+							}
 						}
 
 						routes.push({

--- a/packages/cli/src/cmd/build/vite/registry-generator.ts
+++ b/packages/cli/src/cmd/build/vite/registry-generator.ts
@@ -4,13 +4,52 @@
  * Generates src/generated/registry.ts from discovered agents
  */
 
-import { join } from 'node:path';
+import { join, dirname, relative, resolve } from 'node:path';
 import { writeFileSync, mkdirSync, existsSync, unlinkSync, readFileSync } from 'node:fs';
 import { stat } from 'node:fs/promises';
 import { StructuredError } from '@agentuity/core';
 import { toCamelCase, toPascalCase } from '../../../utils/string';
 import type { AgentMetadata } from './agent-discovery';
 import type { RouteInfo } from './route-discovery';
+
+/**
+ * Rebase a relative import path from the route file's location to the generated file's location.
+ * @param routeFilename - The route file path (e.g., 'api/example/route.ts' or './api/example/route.ts')
+ * @param schemaImportPath - The import path as written in the route file (e.g., '../../utils/schemas')
+ * @param srcDir - The src directory path
+ * @returns The rebased import path relative to src/generated/
+ */
+function rebaseImportPath(routeFilename: string, schemaImportPath: string, srcDir: string): string {
+	// Non-relative imports (bare modules like '@company/schemas') should be used as-is
+	if (!schemaImportPath.startsWith('.') && !schemaImportPath.startsWith('/')) {
+		return schemaImportPath;
+	}
+
+	// Normalize route filename to get its directory relative to srcDir
+	let routeDir: string;
+	const cleanFilename = routeFilename.replace(/\\/g, '/');
+	if (cleanFilename.startsWith('./')) {
+		routeDir = dirname(join(srcDir, cleanFilename.substring(2)));
+	} else if (cleanFilename.startsWith('src/')) {
+		routeDir = dirname(join(srcDir, '..', cleanFilename));
+	} else {
+		routeDir = dirname(join(srcDir, cleanFilename));
+	}
+
+	// Resolve the schema module path from the route file's directory
+	const resolvedSchemaPath = resolve(routeDir, schemaImportPath);
+
+	// Calculate the relative path from src/generated/ to the resolved schema path
+	const generatedDir = join(srcDir, 'generated');
+	let rebasedPath = relative(generatedDir, resolvedSchemaPath).replace(/\\/g, '/');
+
+	// Ensure it starts with './' or '../'
+	if (!rebasedPath.startsWith('.') && !rebasedPath.startsWith('/')) {
+		rebasedPath = './' + rebasedPath;
+	}
+
+	return rebasedPath;
+}
 
 const AgentIdentifierCollisionError = StructuredError('AgentIdentifierCollisionError');
 
@@ -617,6 +656,8 @@ export async function generateRouteRegistry(
 	const imports: string[] = [];
 	const agentImports = new Map<string, string>();
 	const routeFileImports = new Map<string, Set<string>>();
+	// Track per-route which import path and schema name to use for alias lookup
+	const routeSchemaImportInfo = new Map<string, { importPath: string; schemaName: string }>();
 
 	// Collect agent and schema imports from routes with validators or exported schemas
 	allRoutes.forEach((route) => {
@@ -690,25 +731,76 @@ export async function generateRouteRegistry(
 		}
 
 		// Collect schema variable imports
-		if (route.inputSchemaVariable || route.outputSchemaVariable) {
-			const filename = route.filename.replace(/\\/g, '/');
-			// Remove 'src/' prefix if present (routes.filename might be './api/...' or 'src/api/...')
-			const withoutSrc = filename.startsWith('src/') ? filename.substring(4) : filename;
-			const withoutLeadingDot = withoutSrc.startsWith('./')
-				? withoutSrc.substring(2)
-				: withoutSrc;
-			const importPath = `../${withoutLeadingDot.replace(/\.ts$/, '')}`;
+		// If the schema is imported from another file, use that file's path (rebased)
+		// Otherwise fall back to the route file path (for locally defined schemas)
+		if (route.inputSchemaVariable) {
+			let importPath: string;
+			let schemaNameToImport: string;
+
+			if (route.inputSchemaImportPath) {
+				// Schema is imported - rebase the import path from route file to generated file
+				importPath = rebaseImportPath(route.filename, route.inputSchemaImportPath, srcDir);
+				// Use the actual exported name (handles aliased imports like `import { A as B }`)
+				schemaNameToImport =
+					route.inputSchemaImportedName === 'default'
+						? route.inputSchemaVariable
+						: (route.inputSchemaImportedName ?? route.inputSchemaVariable);
+			} else {
+				// Schema is locally defined - import from the route file
+				const filename = route.filename.replace(/\\/g, '/');
+				const withoutSrc = filename.startsWith('src/') ? filename.substring(4) : filename;
+				const withoutLeadingDot = withoutSrc.startsWith('./')
+					? withoutSrc.substring(2)
+					: withoutSrc;
+				importPath = `../${withoutLeadingDot.replace(/\.ts$/, '')}`;
+				schemaNameToImport = route.inputSchemaVariable;
+			}
 
 			if (!routeFileImports.has(importPath)) {
 				routeFileImports.set(importPath, new Set());
 			}
+			routeFileImports.get(importPath)!.add(schemaNameToImport);
 
-			if (route.inputSchemaVariable) {
-				routeFileImports.get(importPath)!.add(route.inputSchemaVariable);
+			// Store the resolved import info for later alias lookup
+			routeSchemaImportInfo.set(`input:${route.path}:${route.method}`, {
+				importPath,
+				schemaName: schemaNameToImport,
+			});
+		}
+
+		if (route.outputSchemaVariable) {
+			let importPath: string;
+			let schemaNameToImport: string;
+
+			if (route.outputSchemaImportPath) {
+				// Schema is imported - rebase the import path from route file to generated file
+				importPath = rebaseImportPath(route.filename, route.outputSchemaImportPath, srcDir);
+				// Use the actual exported name (handles aliased imports like `import { A as B }`)
+				schemaNameToImport =
+					route.outputSchemaImportedName === 'default'
+						? route.outputSchemaVariable
+						: (route.outputSchemaImportedName ?? route.outputSchemaVariable);
+			} else {
+				// Schema is locally defined - import from the route file
+				const filename = route.filename.replace(/\\/g, '/');
+				const withoutSrc = filename.startsWith('src/') ? filename.substring(4) : filename;
+				const withoutLeadingDot = withoutSrc.startsWith('./')
+					? withoutSrc.substring(2)
+					: withoutSrc;
+				importPath = `../${withoutLeadingDot.replace(/\.ts$/, '')}`;
+				schemaNameToImport = route.outputSchemaVariable;
 			}
-			if (route.outputSchemaVariable) {
-				routeFileImports.get(importPath)!.add(route.outputSchemaVariable);
+
+			if (!routeFileImports.has(importPath)) {
+				routeFileImports.set(importPath, new Set());
 			}
+			routeFileImports.get(importPath)!.add(schemaNameToImport);
+
+			// Store the resolved import info for later alias lookup
+			routeSchemaImportInfo.set(`output:${route.path}:${route.method}`, {
+				importPath,
+				schemaName: schemaNameToImport,
+			});
 		}
 	});
 
@@ -774,18 +866,22 @@ export async function generateRouteRegistry(
 				inputSchemaType = `typeof ${importName} extends { inputSchema?: infer I } ? I : never`;
 				outputSchemaType = `typeof ${importName} extends { outputSchema?: infer O } ? O : never`;
 			} else if (route.inputSchemaVariable || route.outputSchemaVariable) {
-				// Get the aliased schema names for this route's file
-				const filename = route.filename.replace(/\\/g, '/');
-				const withoutSrc = filename.startsWith('src/') ? filename.substring(4) : filename;
-				const withoutLeadingDot = withoutSrc.startsWith('./')
-					? withoutSrc.substring(2)
-					: withoutSrc;
-				const importPath = `../${withoutLeadingDot.replace(/\.ts$/, '')}`;
-				const aliases = schemaImportAliases.get(importPath);
+				// Get the aliased schema names using the stored import info
+				// (which correctly handles schemas imported from shared files)
+				const inputInfo = routeSchemaImportInfo.get(`input:${route.path}:${route.method}`);
+				const outputInfo = routeSchemaImportInfo.get(`output:${route.path}:${route.method}`);
 
-				const inputAlias = route.inputSchemaVariable && aliases?.get(route.inputSchemaVariable);
-				const outputAlias =
-					route.outputSchemaVariable && aliases?.get(route.outputSchemaVariable);
+				let inputAlias: string | undefined;
+				let outputAlias: string | undefined;
+
+				if (inputInfo) {
+					const aliases = schemaImportAliases.get(inputInfo.importPath);
+					inputAlias = aliases?.get(inputInfo.schemaName);
+				}
+				if (outputInfo) {
+					const aliases = schemaImportAliases.get(outputInfo.importPath);
+					outputAlias = aliases?.get(outputInfo.schemaName);
+				}
 
 				inputType = inputAlias ? `InferInput<typeof ${inputAlias}>` : 'never';
 				outputType = outputAlias ? `InferOutput<typeof ${outputAlias}>` : 'never';

--- a/packages/cli/src/cmd/build/vite/route-discovery.ts
+++ b/packages/cli/src/cmd/build/vite/route-discovery.ts
@@ -37,6 +37,10 @@ export interface RouteInfo {
 	agentDescription?: string;
 	inputSchemaVariable?: string;
 	outputSchemaVariable?: string;
+	inputSchemaImportPath?: string;
+	inputSchemaImportedName?: string;
+	outputSchemaImportPath?: string;
+	outputSchemaImportedName?: string;
 	inputSchemaCode?: string;
 	outputSchemaCode?: string;
 	stream?: boolean;
@@ -119,6 +123,18 @@ export async function discoverRoutes(
 							agentImportPath: route.config?.agentImportPath as string | undefined,
 							inputSchemaVariable: route.config?.inputSchemaVariable as string | undefined,
 							outputSchemaVariable: route.config?.outputSchemaVariable as string | undefined,
+							inputSchemaImportPath: route.config?.inputSchemaImportPath as
+								| string
+								| undefined,
+							inputSchemaImportedName: route.config?.inputSchemaImportedName as
+								| string
+								| undefined,
+							outputSchemaImportPath: route.config?.outputSchemaImportPath as
+								| string
+								| undefined,
+							outputSchemaImportedName: route.config?.outputSchemaImportedName as
+								| string
+								| undefined,
 							stream:
 								route.config?.stream !== undefined && route.config.stream !== null
 									? Boolean(route.config.stream)

--- a/packages/cli/test/cmd/build/vite/registry-generator.test.ts
+++ b/packages/cli/test/cmd/build/vite/registry-generator.test.ts
@@ -1820,5 +1820,139 @@ describe('registry-generator', () => {
 			expect(content).toContain('"pathParams": [');
 			expect(content).toContain('"userId"');
 		});
+
+		test('should import schemas from shared files when inputSchemaImportPath is provided (issue #629)', async () => {
+			// Simulate a route that imports UserSchema from a shared utils file
+			// Route is at src/api/example/route.ts
+			// Schema is at src/utils/schemas.ts
+			// Import in route: import { UserSchema } from '../../utils/schemas'
+			const routes: RouteInfo[] = [
+				{
+					method: 'POST',
+					path: '/api/example',
+					filename: './api/example/route.ts',
+					hasValidator: true,
+					routeType: 'api',
+					inputSchemaVariable: 'UserSchema',
+					inputSchemaImportPath: '../../utils/schemas', // as written in the route file
+					inputSchemaImportedName: 'UserSchema', // the exported name
+				},
+			];
+
+			await generateRouteRegistry(srcDir, routes);
+
+			const routesPath = join(generatedDir, 'routes.ts');
+			expect(existsSync(routesPath)).toBe(true);
+			const content = await Bun.file(routesPath).text();
+
+			// Should import from the utils/schemas file, NOT from the route file
+			expect(content).toContain("from '../utils/schemas'");
+			// Should NOT import from the route file
+			expect(content).not.toContain("from '../api/example/route'");
+			// Should have the schema type export
+			expect(content).toContain('export type POSTApiExampleInput');
+		});
+
+		test('should handle aliased imports correctly (import { A as B })', async () => {
+			// Simulate: import { UserSchema as US } from '../../utils/schemas'
+			// then using US in validator({ input: US })
+			const routes: RouteInfo[] = [
+				{
+					method: 'POST',
+					path: '/api/users',
+					filename: './api/users/route.ts',
+					hasValidator: true,
+					routeType: 'api',
+					inputSchemaVariable: 'US', // local name used in the route file
+					inputSchemaImportPath: '../../utils/schemas',
+					inputSchemaImportedName: 'UserSchema', // the actual exported name
+				},
+			];
+
+			await generateRouteRegistry(srcDir, routes);
+
+			const routesPath = join(generatedDir, 'routes.ts');
+			const content = await Bun.file(routesPath).text();
+
+			// Should import the actual exported name (UserSchema), not the local alias (US)
+			expect(content).toContain('UserSchema as UserSchema_');
+			expect(content).toContain("from '../utils/schemas'");
+		});
+
+		test('should handle bare module imports (non-relative) as-is', async () => {
+			// Simulate: import { SharedSchema } from '@company/schemas'
+			const routes: RouteInfo[] = [
+				{
+					method: 'POST',
+					path: '/api/data',
+					filename: './api/data/route.ts',
+					hasValidator: true,
+					routeType: 'api',
+					inputSchemaVariable: 'SharedSchema',
+					inputSchemaImportPath: '@company/schemas', // bare module, not relative
+					inputSchemaImportedName: 'SharedSchema',
+				},
+			];
+
+			await generateRouteRegistry(srcDir, routes);
+
+			const routesPath = join(generatedDir, 'routes.ts');
+			const content = await Bun.file(routesPath).text();
+
+			// Should use the bare module path as-is
+			expect(content).toContain("from '@company/schemas'");
+		});
+
+		test('should fall back to route file for locally defined schemas', async () => {
+			// Simulate a schema defined directly in the route file (no import path)
+			const routes: RouteInfo[] = [
+				{
+					method: 'POST',
+					path: '/api/local',
+					filename: './api/local/route.ts',
+					hasValidator: true,
+					routeType: 'api',
+					inputSchemaVariable: 'LocalSchema',
+					// No inputSchemaImportPath - schema is defined locally
+				},
+			];
+
+			await generateRouteRegistry(srcDir, routes);
+
+			const routesPath = join(generatedDir, 'routes.ts');
+			const content = await Bun.file(routesPath).text();
+
+			// Should import from the route file itself
+			expect(content).toContain("from '../api/local/route'");
+		});
+
+		test('should handle both input and output schemas from different files', async () => {
+			const routes: RouteInfo[] = [
+				{
+					method: 'POST',
+					path: '/api/mixed',
+					filename: './api/mixed/route.ts',
+					hasValidator: true,
+					routeType: 'api',
+					inputSchemaVariable: 'InputSchema',
+					inputSchemaImportPath: '../../schemas/input',
+					inputSchemaImportedName: 'InputSchema',
+					outputSchemaVariable: 'OutputSchema',
+					outputSchemaImportPath: '../../schemas/output',
+					outputSchemaImportedName: 'OutputSchema',
+				},
+			];
+
+			await generateRouteRegistry(srcDir, routes);
+
+			const routesPath = join(generatedDir, 'routes.ts');
+			const content = await Bun.file(routesPath).text();
+
+			// Should have imports from both schema files
+			expect(content).toContain("from '../schemas/input'");
+			expect(content).toContain("from '../schemas/output'");
+			expect(content).toContain('InputSchema as InputSchema_');
+			expect(content).toContain('OutputSchema as OutputSchema_');
+		});
 	});
 });

--- a/packages/cli/test/route-schema-extraction.test.ts
+++ b/packages/cli/test/route-schema-extraction.test.ts
@@ -890,4 +890,142 @@ export default router;
 			cleanup();
 		}
 	});
+
+	test('should track import path for imported schemas (issue #629)', async () => {
+		const content = `
+import { createRouter, validator } from '@agentuity/runtime';
+import { UserSchema } from '../../utils/schemas';
+
+const router = createRouter();
+router.post('/test', validator({ input: UserSchema }), async (c) => {
+	return c.json({ ok: true });
+});
+
+export default router;
+		`;
+
+		const { tempDir, path, cleanup } = createTempFile(content);
+		try {
+			const routes = await parseRoute(tempDir, path, projectId, deploymentId);
+			expect(routes).toHaveLength(1);
+			expect(routes[0].config?.hasValidator).toBe(true);
+			expect(routes[0].config?.inputSchemaVariable).toBe('UserSchema');
+			expect(routes[0].config?.inputSchemaImportPath).toBe('../../utils/schemas');
+			expect(routes[0].config?.inputSchemaImportedName).toBe('UserSchema');
+		} finally {
+			cleanup();
+		}
+	});
+
+	test('should track aliased import for schemas (issue #629)', async () => {
+		const content = `
+import { createRouter, validator } from '@agentuity/runtime';
+import { UserSchema as US } from '../../utils/schemas';
+
+const router = createRouter();
+router.post('/test', validator({ input: US }), async (c) => {
+	return c.json({ ok: true });
+});
+
+export default router;
+		`;
+
+		const { tempDir, path, cleanup } = createTempFile(content);
+		try {
+			const routes = await parseRoute(tempDir, path, projectId, deploymentId);
+			expect(routes).toHaveLength(1);
+			expect(routes[0].config?.hasValidator).toBe(true);
+			expect(routes[0].config?.inputSchemaVariable).toBe('US');
+			expect(routes[0].config?.inputSchemaImportPath).toBe('../../utils/schemas');
+			// The importedName should be the original exported name, not the local alias
+			expect(routes[0].config?.inputSchemaImportedName).toBe('UserSchema');
+		} finally {
+			cleanup();
+		}
+	});
+
+	test('should track import paths for both input and output schemas (issue #629)', async () => {
+		const content = `
+import { createRouter, validator } from '@agentuity/runtime';
+import { InputSchema } from '../schemas/input';
+import { OutputSchema } from '../schemas/output';
+
+const router = createRouter();
+router.post('/test', validator({ input: InputSchema, output: OutputSchema }), async (c) => {
+	return c.json({ ok: true });
+});
+
+export default router;
+		`;
+
+		const { tempDir, path, cleanup } = createTempFile(content);
+		try {
+			const routes = await parseRoute(tempDir, path, projectId, deploymentId);
+			expect(routes).toHaveLength(1);
+			expect(routes[0].config?.hasValidator).toBe(true);
+			expect(routes[0].config?.inputSchemaVariable).toBe('InputSchema');
+			expect(routes[0].config?.inputSchemaImportPath).toBe('../schemas/input');
+			expect(routes[0].config?.inputSchemaImportedName).toBe('InputSchema');
+			expect(routes[0].config?.outputSchemaVariable).toBe('OutputSchema');
+			expect(routes[0].config?.outputSchemaImportPath).toBe('../schemas/output');
+			expect(routes[0].config?.outputSchemaImportedName).toBe('OutputSchema');
+		} finally {
+			cleanup();
+		}
+	});
+
+	test('should not set import path for locally defined schemas (issue #629)', async () => {
+		const content = `
+import { createRouter, validator } from '@agentuity/runtime';
+import { s } from '@agentuity/schema';
+
+export const LocalSchema = s.object({ name: s.string() });
+
+const router = createRouter();
+router.post('/test', validator({ input: LocalSchema }), async (c) => {
+	return c.json({ ok: true });
+});
+
+export default router;
+		`;
+
+		const { tempDir, path, cleanup } = createTempFile(content);
+		try {
+			const routes = await parseRoute(tempDir, path, projectId, deploymentId);
+			expect(routes).toHaveLength(1);
+			expect(routes[0].config?.hasValidator).toBe(true);
+			expect(routes[0].config?.inputSchemaVariable).toBe('LocalSchema');
+			// Should not have import path since schema is defined locally
+			expect(routes[0].config?.inputSchemaImportPath).toBeUndefined();
+			expect(routes[0].config?.inputSchemaImportedName).toBeUndefined();
+		} finally {
+			cleanup();
+		}
+	});
+
+	test('should handle bare module imports for schemas (issue #629)', async () => {
+		const content = `
+import { createRouter, validator } from '@agentuity/runtime';
+import { SharedSchema } from '@company/schemas';
+
+const router = createRouter();
+router.post('/test', validator({ input: SharedSchema }), async (c) => {
+	return c.json({ ok: true });
+});
+
+export default router;
+		`;
+
+		const { tempDir, path, cleanup } = createTempFile(content);
+		try {
+			const routes = await parseRoute(tempDir, path, projectId, deploymentId);
+			expect(routes).toHaveLength(1);
+			expect(routes[0].config?.hasValidator).toBe(true);
+			expect(routes[0].config?.inputSchemaVariable).toBe('SharedSchema');
+			expect(routes[0].config?.inputSchemaImportPath).toBe('@company/schemas');
+			expect(routes[0].config?.inputSchemaImportedName).toBe('SharedSchema');
+		} finally {
+			cleanup();
+		}
+	});
 });


### PR DESCRIPTION
## Problem

When a schema type is defined in a shared utility file and imported into a route file for use in a validator, the CLI's code generator incorrectly tried to import the type from the route file instead of following the import chain to the original source.

For example:
```typescript
// src/utils/schemas.ts
export const UserSchema = s.object({ ... });

// src/api/example/route.ts
import { UserSchema } from '../../utils/schemas';
router.post('/', validator({ input: UserSchema }), ...);

// src/generated/routes.ts (BEFORE - incorrect)
import type { UserSchema } from '../api/example/route';  // ❌ ERROR: not exported from route.ts
```

## Solution

Enhanced the CLI to track where schema variables are imported from and generate the correct import paths:

1. **Enhanced import tracking** in `ast.ts`:
   - Track the import path for each schema variable
   - Track the original exported name (handles aliased imports like `import { A as B }`)
   
2. **Extended `RouteInfo` interface** with new fields:
   - `inputSchemaImportPath` / `outputSchemaImportPath`
   - `inputSchemaImportedName` / `outputSchemaImportedName`

3. **Added `rebaseImportPath()` helper** to correctly calculate relative paths from `src/generated/routes.ts` to the schema's actual location

4. **Updated `registry-generator.ts`** to use schema import paths when available, falling back to route file path for locally-defined schemas

```typescript
// src/generated/routes.ts (AFTER - correct)
import type { UserSchema } from '../utils/schemas';  // ✅ Correct!
```

## Edge Cases Handled

- **Aliased imports**: `import { UserSchema as US }` → correctly imports `UserSchema`
- **Bare module imports**: `import { X } from '@company/schemas'` → kept as-is
- **Locally defined schemas**: Falls back to importing from route file
- **Multiple schemas from different files**: Each imports from the correct source

## Testing

Added 10 new tests covering all scenarios:
- 5 tests in `registry-generator.test.ts` for import generation
- 5 tests in `route-schema-extraction.test.ts` for AST extraction

All 768 CLI tests pass.

Fixes #629

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced schema import tracking and resolution in route configurations
  * Added support for importing schemas from shared files with proper aliasing
  * Improved type generation accuracy for routes using imported schemas

* **Tests**
  * Added comprehensive test coverage for schema import scenarios including aliases, cross-file imports, and local definitions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->