### PR TITLE
feat(runtime): add waitUntil() directly on route context

### DIFF
--- a/apps/docs/src/api/agent-calls/route.ts
+++ b/apps/docs/src/api/agent-calls/route.ts
@@ -61,18 +61,16 @@ router.post('/background', async (c) => {
 	c.var.logger?.info('Background agent call starting', { taskId, operation });
 
 	// waitUntil() allows response to return immediately while agent runs in background
-	c.executionCtx?.waitUntil(
-		(async () => {
-			const result = await textProcessorAgent.run({
-				text: AGENT_CALLS_SAMPLE_TEXT,
-				operation,
-			});
-			c.var.logger?.info('Background task completed', {
-				taskId,
-				result: result.result,
-			});
-		})()
-	);
+	c.waitUntil(async () => {
+		const result = await textProcessorAgent.run({
+			text: AGENT_CALLS_SAMPLE_TEXT,
+			operation,
+		});
+		c.var.logger?.info('Background task completed', {
+			taskId,
+			result: result.result,
+		});
+	});
 
 	return c.json({
 		pattern: 'background',

--- a/apps/docs/src/api/context/route.ts
+++ b/apps/docs/src/api/context/route.ts
@@ -72,12 +72,10 @@ router.get('/logger', async (c) => {
 
 // waitUntil() allows response to return immediately while task runs in background
 router.get('/background', async (c) => {
-	c.executionCtx?.waitUntil(
-		(async () => {
-			await new Promise((resolve) => setTimeout(resolve, 5000));
-			c.var.logger?.info('Background task completed after 5 seconds!');
-		})()
-	);
+	c.waitUntil(async () => {
+		await new Promise((resolve) => setTimeout(resolve, 5000));
+		c.var.logger?.info('Background task completed after 5 seconds!');
+	});
 
 	return c.json({
 		message: 'Background task started',

--- a/apps/docs/src/api/durable-stream/route.ts
+++ b/apps/docs/src/api/durable-stream/route.ts
@@ -94,7 +94,7 @@ router.post('/create', async (c) => {
 	};
 
 	// Start generation in background
-	c.executionCtx?.waitUntil(generateInBackground());
+	c.waitUntil(generateInBackground());
 
 	// Return immediately - URL will return content once stream is closed
 	return c.json({

--- a/apps/docs/src/web/App.tsx
+++ b/apps/docs/src/web/App.tsx
@@ -419,7 +419,7 @@ router.post("/generate", async (c) => {
   });
 
   // Write content in background
-  c.executionCtx?.waitUntil((async () => {
+  c.waitUntil(async () => {
     const { textStream } = streamText({
       model: openai("gpt-4"),
       prompt: "Generate a weekly report...",
@@ -429,7 +429,7 @@ router.post("/generate", async (c) => {
       await stream.write(chunk);
     }
     await stream.close();
-  })());
+  });
 
   // Return URL immediately - shareable with anyone
   return c.json({

--- a/packages/runtime/src/_context.ts
+++ b/packages/runtime/src/_context.ts
@@ -196,6 +196,16 @@ export const setupRequestAgentContext = <
 	// RequestAgentContext is only used within agents via AsyncLocalStorage.
 	// No properties need to be copied between them.
 
+	// Provide c.waitUntil() directly on route context for consistency with AgentContext
+	if (!('waitUntil' in ctxObject)) {
+		Object.defineProperty(ctxObject, 'waitUntil', {
+			value: (callback: Promise<void> | (() => void | Promise<void>)) => {
+				args.handler.waitUntil(callback);
+			},
+			configurable: true,
+		});
+	}
+
 	// Provide executionCtx.waitUntil for compatibility with Cloudflare Workers API
 	Object.defineProperty(ctxObject, 'executionCtx', {
 		get() {

--- a/packages/runtime/src/router.ts
+++ b/packages/runtime/src/router.ts
@@ -10,9 +10,29 @@ export type { HonoEnv };
 // Re-export WebSocketConnection from handlers
 export type { WebSocketConnection } from './handlers/websocket';
 
-// Module augmentation to add deprecated methods to Hono
-// These stubs throw errors with migration instructions
+// Module augmentation to extend Hono types for Agentuity runtime
 declare module 'hono' {
+	// Extend Context with waitUntil for route handlers
+	// Note: executionCtx is already provided by Hono's Context class
+	interface Context {
+		/**
+		 * Schedule a background task that runs after the response is sent.
+		 * Works the same as `ctx.waitUntil()` in agent handlers.
+		 *
+		 * @example
+		 * ```typescript
+		 * router.post('/data', async (c) => {
+		 *   c.waitUntil(async () => {
+		 *     await sendAnalytics(c.req.url);
+		 *   });
+		 *   return c.json({ success: true });
+		 * });
+		 * ```
+		 */
+		waitUntil(callback: Promise<void> | (() => void | Promise<void>)): void;
+	}
+
+	// Deprecated router methods (stubs that throw errors with migration instructions)
 	interface Hono {
 		/**
 		 * @deprecated Use the `websocket` middleware instead:


### PR DESCRIPTION
## Summary

Adds `c.waitUntil()` method directly to Hono route context for consistency with `ctx.waitUntil()` in agent handlers.

## Problem

Users expected to use `c.waitUntil()` in routes (like they do with `ctx.waitUntil()` in agents), but the SDK only provided `c.executionCtx?.waitUntil()` which required verbose optional chaining and was not discoverable.

**Before:**
```typescript
router.post('/', async (c) => {
    c.executionCtx?.waitUntil((async () => {
        await someLongRunningOperation();
    })());
    return c.json({ success: true });
});
```

**After:**
```typescript
router.post('/', async (c) => {
    c.waitUntil(async () => {
        await someLongRunningOperation();
    });
    return c.json({ success: true });
});
```

## Changes

- **packages/runtime/src/_context.ts**: Add `waitUntil` property to route context in `setupRequestAgentContext`
- **packages/runtime/src/router.ts**: Add TypeScript module augmentation for Hono `Context` interface with JSDoc
- **apps/docs/**: Update all documentation examples to use the simpler `c.waitUntil()` syntax

## Verification

- ✅ Build passes
- ✅ Typecheck passes
- ✅ Lint passes
- ✅ 569 runtime tests pass

Fixes #628