### PR TITLE
feat: add deleted field to SnapshotLineageEntry schema

### DIFF
--- a/packages/server/src/api/sandbox/snapshot.ts
+++ b/packages/server/src/api/sandbox/snapshot.ts
@@ -110,6 +110,7 @@ const SnapshotLineageEntrySchema = z
 			.optional()
 			.describe('ID of the parent snapshot in the lineage'),
 		public: z.boolean().describe('Whether the snapshot is publicly accessible'),
+		deleted: z.boolean().optional().describe('Whether the snapshot has been deleted'),
 		org: SnapshotOrgInfoSchema.nullable()
 			.optional()
 			.describe('Organization details (for public snapshots)'),


### PR DESCRIPTION
## Summary

Adds optional `deleted` boolean field to the `SnapshotLineageEntry` schema in the snapshot lineage API.

## Why

The Catalyst API now returns deleted snapshots in lineage history (see agentuity/catalyst#420). The web console needs this field to display deleted snapshots appropriately (grayed out, non-clickable) in the snapshot history timeline.

## Changes

- `packages/server/src/api/sandbox/snapshot.ts`: Added `deleted` field to `SnapshotLineageEntrySchema`

## Related

- Catalyst PR: agentuity/catalyst#420

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking deletion status in snapshot lineage entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->