### PR TITLE
Add AGENTUITY_CLOUD_BASE_URL to allowed env vars

### DIFF
--- a/packages/cli/src/env-util.ts
+++ b/packages/cli/src/env-util.ts
@@ -17,7 +17,7 @@ export const PUBLIC_VAR_PREFIXES = ['VITE_', 'AGENTUITY_PUBLIC_', 'PUBLIC_'] as 
  * Specific AGENTUITY_ keys that are allowed to be set by users.
  * Note: There is also a whitelist in the API that must be kept in sync.
  */
-export const AGENTUITY_ALLOWED_KEYS = ['AGENTUITY_AUTH_SECRET'] as const;
+export const AGENTUITY_ALLOWED_KEYS = ['AGENTUITY_AUTH_SECRET', 'AGENTUITY_CLOUD_BASE_URL'] as const;
 
 /**
  * Check if a key is a public variable (exposed to frontend)


### PR DESCRIPTION
Adds AGENTUITY_CLOUD_BASE_URL to the AGENTUITY_ALLOWED_KEYS allowlist so users can set this environment variable.

Companion PR in app repo: https://github.com/agentuity/app/pull/1032

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now configure the Agentuity cloud base URL through environment variables, enabling customization of cloud endpoint connections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->