### PR TITLE
fix: make KV and Vector commands work without project context

### DIFF
--- a/packages/cli/src/cmd/cloud/keyvalue/create-namespace.ts
+++ b/packages/cli/src/cmd/cloud/keyvalue/create-namespace.ts
@@ -9,7 +9,8 @@ export const createNamespaceSubcommand = createCommand({
 	description: 'Create a new keyvalue namespace',
 	tags: ['mutating', 'creates-resource', 'slow', 'requires-auth'],
 	idempotent: false,
-	requires: { auth: true },
+	requires: { auth: true, region: true },
+	optional: { project: true },
 	examples: [
 		{
 			command: getCommand('kv create-namespace production'),

--- a/packages/cli/src/cmd/cloud/keyvalue/delete-namespace.ts
+++ b/packages/cli/src/cmd/cloud/keyvalue/delete-namespace.ts
@@ -10,7 +10,8 @@ export const deleteNamespaceSubcommand = createCommand({
 	description: 'Delete a keyvalue namespace and all its keys',
 	tags: ['destructive', 'deletes-resource', 'slow', 'requires-auth'],
 	idempotent: true,
-	requires: { auth: true },
+	requires: { auth: true, region: true },
+	optional: { project: true },
 	examples: [
 		{
 			command: getCommand('kv delete-namespace staging'),

--- a/packages/cli/src/cmd/cloud/keyvalue/delete.ts
+++ b/packages/cli/src/cmd/cloud/keyvalue/delete.ts
@@ -16,7 +16,8 @@ export const deleteSubcommand = createCommand({
 	description: 'Delete a key from the keyvalue storage',
 	tags: ['destructive', 'deletes-resource', 'slow', 'requires-auth'],
 	idempotent: true,
-	requires: { auth: true },
+	requires: { auth: true, region: true },
+	optional: { project: true },
 	examples: [
 		{ command: getCommand('kv delete production user:123'), description: 'Delete user data' },
 		{ command: getCommand('kv delete cache session:abc'), description: 'Delete cached session' },

--- a/packages/cli/src/cmd/cloud/keyvalue/get.ts
+++ b/packages/cli/src/cmd/cloud/keyvalue/get.ts
@@ -14,7 +14,8 @@ export const getSubcommand = createCommand({
 	name: 'get',
 	description: 'Get a value from the keyvalue storage',
 	tags: ['read-only', 'fast', 'requires-auth'],
-	requires: { auth: true },
+	requires: { auth: true, region: true },
+	optional: { project: true },
 	examples: [
 		{ command: getCommand('kv get production user:123'), description: 'Get user data' },
 		{ command: getCommand('kv get cache session:abc'), description: 'Get cached session' },

--- a/packages/cli/src/cmd/cloud/keyvalue/keys.ts
+++ b/packages/cli/src/cmd/cloud/keyvalue/keys.ts
@@ -13,7 +13,8 @@ export const keysSubcommand = createCommand({
 	aliases: ['ls', 'list'],
 	description: 'List all keys in a keyvalue namespace',
 	tags: ['read-only', 'slow', 'requires-auth'],
-	requires: { auth: true },
+	requires: { auth: true, region: true },
+	optional: { project: true },
 	idempotent: true,
 	examples: [
 		{ command: getCommand('kv keys production'), description: 'List all keys in production' },

--- a/packages/cli/src/cmd/cloud/keyvalue/list-namespaces.ts
+++ b/packages/cli/src/cmd/cloud/keyvalue/list-namespaces.ts
@@ -10,7 +10,8 @@ export const listNamespacesSubcommand = createCommand({
 	aliases: ['namespaces', 'ns'],
 	description: 'List all keyvalue namespaces',
 	tags: ['read-only', 'fast', 'requires-auth'],
-	requires: { auth: true },
+	requires: { auth: true, region: true },
+	optional: { project: true },
 	examples: [
 		{ command: getCommand('kv list-namespaces'), description: 'List all namespaces' },
 		{ command: getCommand('kv namespaces'), description: 'List namespaces (using alias)' },

--- a/packages/cli/src/cmd/cloud/keyvalue/repl.ts
+++ b/packages/cli/src/cmd/cloud/keyvalue/repl.ts
@@ -11,7 +11,7 @@ export const replSubcommand = createCommand({
 	description: 'Start an interactive repl for working with keyvalue database',
 	tags: ['slow', 'requires-auth'],
 	idempotent: false,
-	requires: { auth: true },
+	requires: { auth: true, region: true },
 	optional: { project: true },
 	examples: [{ command: getCommand('kv repl'), description: 'Start interactive KV session' }],
 

--- a/packages/cli/src/cmd/cloud/keyvalue/search.ts
+++ b/packages/cli/src/cmd/cloud/keyvalue/search.ts
@@ -20,7 +20,8 @@ export const searchSubcommand = createCommand({
 	name: 'search',
 	description: 'Search for keys matching a keyword in a keyvalue namespace',
 	tags: ['read-only', 'slow', 'requires-auth'],
-	requires: { auth: true },
+	requires: { auth: true, region: true },
+	optional: { project: true },
 	idempotent: true,
 	examples: [
 		{

--- a/packages/cli/src/cmd/cloud/keyvalue/set.ts
+++ b/packages/cli/src/cmd/cloud/keyvalue/set.ts
@@ -19,7 +19,8 @@ export const setSubcommand = createCommand({
 	description: 'Set a key and value in the keyvalue storage',
 	tags: ['mutating', 'updates-resource', 'slow', 'requires-auth'],
 	idempotent: true,
-	requires: { auth: true },
+	requires: { auth: true, region: true },
+	optional: { project: true },
 	examples: [
 		{
 			command: getCommand(

--- a/packages/cli/src/cmd/cloud/keyvalue/stats.ts
+++ b/packages/cli/src/cmd/cloud/keyvalue/stats.ts
@@ -26,7 +26,8 @@ export const statsSubcommand = createCommand({
 	name: 'stats',
 	description: 'Get statistics for keyvalue storage',
 	tags: ['read-only', 'fast', 'requires-auth'],
-	requires: { auth: true },
+	requires: { auth: true, region: true },
+	optional: { project: true },
 	idempotent: true,
 	examples: [
 		{ command: getCommand('kv stats'), description: 'Show stats for all namespaces' },

--- a/packages/cli/src/cmd/cloud/keyvalue/util.ts
+++ b/packages/cli/src/cmd/cloud/keyvalue/util.ts
@@ -1,25 +1,33 @@
 import { KeyValueStorageService, type Logger } from '@agentuity/core';
 import { createServerFetchAdapter, getServiceUrls } from '@agentuity/server';
-import { getDefaultRegion } from '../../../config';
-import type { AuthData, Config } from '../../../types';
+import type { AuthData, GlobalOptions, ProjectConfig } from '../../../types';
+import * as tui from '../../../tui';
 
-export async function createStorageAdapter(ctx: {
+export function createStorageAdapter(ctx: {
 	logger: Logger;
-	config: Config | null;
 	auth: AuthData;
-	project?: { region: string };
+	region: string;
+	project?: ProjectConfig;
+	options: GlobalOptions;
 }) {
+	const orgId = ctx.project?.orgId ?? ctx.options.orgId;
+	if (!orgId) {
+		tui.fatal(
+			'Organization ID is required. Either run from a project directory or use --org-id flag.'
+		);
+	}
+
 	const adapter = createServerFetchAdapter(
 		{
 			headers: {
 				Authorization: `Bearer ${ctx.auth.apiKey}`,
+				'x-agentuity-orgid': orgId,
 			},
 		},
 		ctx.logger
 	);
 
-	const region = ctx.project?.region || (await getDefaultRegion(ctx.config?.name, ctx.config));
-	const urls = getServiceUrls(region);
+	const urls = getServiceUrls(ctx.region);
 	const baseUrl = urls.catalyst;
 	return new KeyValueStorageService(baseUrl, adapter);
 }

--- a/packages/cli/src/cmd/cloud/vector/delete-namespace.ts
+++ b/packages/cli/src/cmd/cloud/vector/delete-namespace.ts
@@ -11,7 +11,8 @@ export const deleteNamespaceSubcommand = createCommand({
 	description: 'Delete a vector namespace and all its vectors',
 	tags: ['destructive', 'deletes-resource', 'slow', 'requires-auth'],
 	idempotent: true,
-	requires: { auth: true, project: true },
+	requires: { auth: true, region: true },
+	optional: { project: true },
 	examples: [
 		{
 			command: getCommand('vector delete-namespace staging'),

--- a/packages/cli/src/cmd/cloud/vector/delete.ts
+++ b/packages/cli/src/cmd/cloud/vector/delete.ts
@@ -18,7 +18,8 @@ export const deleteSubcommand = createCommand({
 	aliases: ['del', 'rm'],
 	description: 'Delete one or more vectors by key',
 	tags: ['destructive', 'deletes-resource', 'slow', 'requires-auth'],
-	requires: { auth: true, project: true },
+	requires: { auth: true, region: true },
+	optional: { project: true },
 	idempotent: true,
 	examples: [
 		{

--- a/packages/cli/src/cmd/cloud/vector/get.ts
+++ b/packages/cli/src/cmd/cloud/vector/get.ts
@@ -16,7 +16,8 @@ export const getSubcommand = createCommand({
 	name: 'get',
 	description: 'Get a specific vector entry by key',
 	tags: ['read-only', 'fast', 'requires-auth'],
-	requires: { auth: true, project: true },
+	requires: { auth: true, region: true },
+	optional: { project: true },
 	idempotent: true,
 	examples: [
 		{

--- a/packages/cli/src/cmd/cloud/vector/index.ts
+++ b/packages/cli/src/cmd/cloud/vector/index.ts
@@ -34,7 +34,7 @@ export const vectorCommand = createCommand({
 		listNamespacesSubcommand,
 		deleteNamespaceSubcommand,
 	],
-	requires: { auth: true, project: true },
+	requires: { auth: true },
 });
 
 export default vectorCommand;

--- a/packages/cli/src/cmd/cloud/vector/list-namespaces.ts
+++ b/packages/cli/src/cmd/cloud/vector/list-namespaces.ts
@@ -11,7 +11,8 @@ export const listNamespacesSubcommand = createCommand({
 	aliases: ['namespaces', 'ns'],
 	description: 'List all vector namespaces',
 	tags: ['read-only', 'fast', 'requires-auth'],
-	requires: { auth: true, project: true },
+	requires: { auth: true, region: true },
+	optional: { project: true },
 	examples: [
 		{ command: getCommand('vector list-namespaces'), description: 'List all namespaces' },
 		{ command: getCommand('vector namespaces'), description: 'List namespaces (using alias)' },

--- a/packages/cli/src/cmd/cloud/vector/search.ts
+++ b/packages/cli/src/cmd/cloud/vector/search.ts
@@ -22,7 +22,8 @@ export const searchSubcommand = createCommand({
 	aliases: ['list', 'ls'],
 	description: 'Search for vectors using semantic similarity',
 	tags: ['read-only', 'slow', 'requires-auth'],
-	requires: { auth: true, project: true },
+	requires: { auth: true, region: true },
+	optional: { project: true },
 	idempotent: true,
 	examples: [
 		{

--- a/packages/cli/src/cmd/cloud/vector/stats.ts
+++ b/packages/cli/src/cmd/cloud/vector/stats.ts
@@ -42,7 +42,8 @@ export const statsSubcommand = createCommand({
 	name: 'stats',
 	description: 'Get statistics for vector storage',
 	tags: ['read-only', 'fast', 'requires-auth'],
-	requires: { auth: true, project: true },
+	requires: { auth: true, region: true },
+	optional: { project: true },
 	idempotent: true,
 	examples: [
 		{ command: getCommand('vector stats'), description: 'Show stats for all namespaces' },

--- a/packages/cli/src/cmd/cloud/vector/upsert.ts
+++ b/packages/cli/src/cmd/cloud/vector/upsert.ts
@@ -26,7 +26,8 @@ export const upsertSubcommand = createCommand({
 	description: 'Add or update vectors in the vector storage',
 	tags: ['mutating', 'updates-resource', 'slow', 'requires-auth'],
 	idempotent: true,
-	requires: { auth: true, project: true },
+	requires: { auth: true, region: true },
+	optional: { project: true },
 	examples: [
 		{
 			command: getCommand('vector upsert products doc1 --document "Comfortable office chair"'),

--- a/packages/cli/src/cmd/cloud/vector/util.ts
+++ b/packages/cli/src/cmd/cloud/vector/util.ts
@@ -1,30 +1,33 @@
-import { Logger, VectorStorageService } from '@agentuity/core';
+import { type Logger, VectorStorageService } from '@agentuity/core';
 import { createServerFetchAdapter, getServiceUrls } from '@agentuity/server';
-import { loadProjectSDKKey } from '../../../config';
-import type { Config } from '../../../types';
+import type { AuthData, GlobalOptions, ProjectConfig } from '../../../types';
 import * as tui from '../../../tui';
 
-export async function createStorageAdapter(ctx: {
+export function createStorageAdapter(ctx: {
 	logger: Logger;
-	projectDir: string;
-	config: Config | null;
-	project: { region: string };
+	auth: AuthData;
+	region: string;
+	project?: ProjectConfig;
+	options: GlobalOptions;
 }) {
-	const sdkKey = await loadProjectSDKKey(ctx.logger, ctx.projectDir);
-	if (!sdkKey) {
-		tui.fatal(`Couldn't find the AGENTUITY_SDK_KEY in ${ctx.projectDir} .env file`);
+	const orgId = ctx.project?.orgId ?? ctx.options.orgId;
+	if (!orgId) {
+		tui.fatal(
+			'Organization ID is required. Either run from a project directory or use --org-id flag.'
+		);
 	}
 
 	const adapter = createServerFetchAdapter(
 		{
 			headers: {
-				Authorization: `Bearer ${sdkKey}`,
+				Authorization: `Bearer ${ctx.auth.apiKey}`,
+				'x-agentuity-orgid': orgId,
 			},
 		},
 		ctx.logger
 	);
 
-	const urls = getServiceUrls(ctx.project.region);
+	const urls = getServiceUrls(ctx.region);
 	const baseUrl = urls.catalyst;
 	return new VectorStorageService(baseUrl, adapter);
 }


### PR DESCRIPTION
## Summary

Both KV and Vector CLI commands now work without requiring a project context. They can be run from any directory with `--org-id` and `--region` flags, or from a project directory where these are auto-detected.

## Problem

KV commands were using `getDefaultRegion()` which could return a different region than where the user's data was stored. Vector commands required a project context and SDK key from the project's .env file.

## Solution

Update both KV and Vector commands to:
1. Use `optional: { project: true }` and `requires: { region: true }`
2. Auto-detect region from project's `agentuity.json` if in a project directory
3. Prompt for region selection if not in a project (or use `--region` flag)
4. Get org ID from project or require `--org-id` flag
5. Send `x-agentuity-orgid` header for CLI key authentication

## Changes

### KV Commands (10 files)
- All subcommands now use `requires: { auth: true, region: true }` and `optional: { project: true }`
- `util.ts`: Use `ctx.region` directly and add `x-agentuity-orgid` header

### Vector Commands (8 files)
- Same pattern as KV
- `util.ts`: Updated to use CLI auth + org header (was using SDK key only)

## Testing

- Tested locally with `bun bin/cli.ts --org-id <org> cloud kv stats`
- Tested locally with `bun bin/cli.ts --org-id <org> cloud vector stats`
- Both typecheck and lint pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Region is now a required parameter for keyvalue and vector operations, replacing optional or inferred regional context
  * Project parameter is now optional for keyvalue and vector commands, enabling greater flexibility and reducing mandatory requirements
  
* **Bug Fixes**
  * Improved organization ID handling and validation in cloud storage operations with proper header propagation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->