### PR TITLE
fix(cli): use process.execPath for compiled binaries in setup command

### DIFF
--- a/packages/cli/src/cmd/setup/index.ts
+++ b/packages/cli/src/cmd/setup/index.ts
@@ -37,9 +37,14 @@ export const command = createCommand({
 						message: 'Validating your identity',
 						clearOnSuccess: true,
 						callback: async () => {
-							const newargs = process.argv.map((x) => (x === 'setup' ? 'login' : x));
+							// For compiled binaries, process.argv contains virtual paths (/$bunfs/root/...)
+							// Use process.execPath which has the actual binary path
+							const isCompiledBinary = process.argv[1]?.startsWith('/$bunfs/');
+							const cmd = isCompiledBinary
+								? [process.execPath, ...process.argv.slice(2).map((x) => (x === 'setup' ? 'login' : x))]
+								: process.argv.map((x) => (x === 'setup' ? 'login' : x));
 							const r = Bun.spawn({
-								cmd: newargs.concat('--json'),
+								cmd: cmd.concat('--json'),
 								stdout: 'pipe',
 								stderr: 'inherit',
 							});


### PR DESCRIPTION
## Problem

When the CLI is run as a compiled executable, the `setup` command fails to spawn the `login` subcommand because `process.argv` contains virtual Bun filesystem paths (`/$bunfs/root/...`) instead of the actual executable path.

**Compiled binary `process.argv`:**
```
[ "bun", "/$bunfs/root/agentuity-darwin-arm64", "setup", "--setup-token", "..." ]
```

**Running from `bun` directly (works):**
```
[ "/Users/.../bun", "/Users/.../cli.ts", "setup", "--setup-token", "..." ]
```

## Solution

Detect compiled binaries by checking if `process.argv[1]` starts with `/$bunfs/`, and use `process.execPath` (which contains the real binary path) instead of the virtual paths in `process.argv`.

## Testing

Tested both:
- ✅ Compiled executable: correctly uses `process.execPath`
- ✅ Running via `bun cli.ts`: continues to use `process.argv`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI setup command handling for compiled Bun binaries to ensure proper argument processing and command execution in compiled environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->