### PR TITLE
task/org id not respecting preference

### DIFF
--- a/packages/cli/src/cmd/cloud/keyvalue/util.ts
+++ b/packages/cli/src/cmd/cloud/keyvalue/util.ts
@@ -1,6 +1,6 @@
 import { KeyValueStorageService, type Logger } from '@agentuity/core';
 import { createServerFetchAdapter, getServiceUrls } from '@agentuity/server';
-import type { AuthData, GlobalOptions, ProjectConfig } from '../../../types';
+import type { AuthData, Config, GlobalOptions, ProjectConfig } from '../../../types';
 import * as tui from '../../../tui';
 
 export function createStorageAdapter(ctx: {
@@ -8,9 +8,13 @@ export function createStorageAdapter(ctx: {
 	auth: AuthData;
 	region: string;
 	project?: ProjectConfig;
+	config: Config | null;
 	options: GlobalOptions;
 }) {
-	const orgId = ctx.project?.orgId ?? ctx.options.orgId;
+	const orgId =
+		ctx.project?.orgId ??
+		ctx.options.orgId ??
+		(process.env.AGENTUITY_CLOUD_ORG_ID || ctx.config?.preferences?.orgId);
 	if (!orgId) {
 		tui.fatal(
 			'Organization ID is required. Either run from a project directory or use --org-id flag.'

--- a/packages/cli/src/cmd/cloud/vector/util.ts
+++ b/packages/cli/src/cmd/cloud/vector/util.ts
@@ -1,6 +1,6 @@
 import { type Logger, VectorStorageService } from '@agentuity/core';
 import { createServerFetchAdapter, getServiceUrls } from '@agentuity/server';
-import type { AuthData, GlobalOptions, ProjectConfig } from '../../../types';
+import type { AuthData, Config, GlobalOptions, ProjectConfig } from '../../../types';
 import * as tui from '../../../tui';
 
 export function createStorageAdapter(ctx: {
@@ -8,9 +8,13 @@ export function createStorageAdapter(ctx: {
 	auth: AuthData;
 	region: string;
 	project?: ProjectConfig;
+	config: Config | null;
 	options: GlobalOptions;
 }) {
-	const orgId = ctx.project?.orgId ?? ctx.options.orgId;
+	const orgId =
+		ctx.project?.orgId ??
+		ctx.options.orgId ??
+		(process.env.AGENTUITY_CLOUD_ORG_ID || ctx.config?.preferences?.orgId);
 	if (!orgId) {
 		tui.fatal(
 			'Organization ID is required. Either run from a project directory or use --org-id flag.'


### PR DESCRIPTION
**org id should always respect the env and preferences**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced cloud operations configuration with flexible organization ID resolution, now supporting environment variables and configuration preferences as fallback options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->