### PR TITLE
feat: add AGENTUITY_HIDE_BANNER env var to hide beta banner

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -789,7 +789,7 @@ if [ "${AGENTUITY_HIDE_BANNER:-}" != "true" ]; then
   printf "${RED}│${NC}  ${RED}⚠  v1 BETA BUILD - READY FOR PRODUCTION TESTING${NC}                    ${RED}│${NC}\n"
   printf "${RED}├─────────────────────────────────────────────────────────────────────┤${NC}\n"
   printf "${RED}│${NC}                                                                     ${RED}│${NC}\n"
-  printf "${RED}│${NC}  This is an Beta build of the upcoming v1 production release.       ${RED}│${NC}\n"
+  printf "${RED}│${NC}  This is a Beta build of the upcoming v1 production release.       ${RED}│${NC}\n"
   printf "${RED}│${NC}  This build is ${RED}ready for production testing${NC}.                        ${RED}│${NC}\n"
   printf "${RED}│${NC}                                                                     ${RED}│${NC}\n"
   printf "${RED}│${NC}  Please report any issues:                                          ${RED}│${NC}\n"


### PR DESCRIPTION
Adds an environment variable `AGENTUITY_HIDE_BANNER` that when set to `true` will hide the beta banner during installation.

**Usage:**
```bash
AGENTUITY_HIDE_BANNER=true ./install.sh
```

By default, the banner is shown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installation script now supports optional banner suppression via an environment variable, producing cleaner, non-interactive output for automated runs and CI pipelines. This prevents the production banner from being printed when suppression is enabled while leaving installation and progress behavior unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->