### PR TITLE
fix machine delete response schema validation

### DIFF
--- a/packages/server/src/api/machine/machine.ts
+++ b/packages/server/src/api/machine/machine.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { APIResponseSchema, APIClient } from '../api';
+import { APIResponseSchema, APIResponseSchemaNoData, APIClient } from '../api';
 import { MachineResponseError } from './util';
 
 const MachineSchema = z.object({
@@ -25,7 +25,7 @@ const MachineSchema = z.object({
 
 const MachineListResponseSchema = APIResponseSchema(z.array(MachineSchema));
 const MachineGetResponseSchema = APIResponseSchema(MachineSchema);
-const MachineDeleteResponseSchema = APIResponseSchema(z.boolean());
+const MachineDeleteResponseSchema = APIResponseSchemaNoData();
 
 export type Machine = z.infer<typeof MachineSchema>;
 
@@ -45,12 +45,11 @@ export async function machineGet(client: APIClient, machineId: string): Promise<
 	throw new MachineResponseError({ message: resp.message });
 }
 
-export async function machineDelete(client: APIClient, machineId: string): Promise<boolean> {
+export async function machineDelete(client: APIClient, machineId: string): Promise<void> {
 	const resp = await client.delete(`/machine/${machineId}`, MachineDeleteResponseSchema);
-	if (resp.success) {
-		return resp.data;
+	if (!resp.success) {
+		throw new MachineResponseError({ message: resp.message });
 	}
-	throw new MachineResponseError({ message: resp.message });
 }
 
 const MachineDeploymentProjectSchema = z.object({


### PR DESCRIPTION
## Overview

Fixes validation error when running `machine delete` command. The command worked correctly (machine was deleted) but threw a `ValidationOutputError` because the SDK expected a `data` field in the response that the server doesn't return.

## Root Cause

- **Server** (`catalyst/server/apis/machine/machine_2025_03_17.go:1016-1018`): Returns `{"success": true}` with no `data` field
- **SDK** (`packages/server/src/api/machine/machine.ts:28`): Used `APIResponseSchema(z.boolean())` which expects `{success: true, data: boolean}`

The mismatch caused Zod validation to fail with:
```
Invalid input: expected boolean, received undefined at path ['data']
```

## Changes

- Added `APIResponseSchemaNoData` import
- Changed `MachineDeleteResponseSchema` from `APIResponseSchema(z.boolean())` to `APIResponseSchemaNoData()`
- Updated `machineDelete()` return type from `Promise<boolean>` to `Promise<void>`

## Testing

- [x] Build passes
- [x] Typecheck passes
- [x] Lint passes
- [x] Unit tests pass

## Notes

- The CLI command already ignores the return value from `machineDelete()`, so no CLI changes needed
- This follows the same pattern as other delete operations: `threadDelete`, `deleteQueue`, `deleteDestination`, `deleteSource`, etc.

Fixes #669

## Repository-Specific Changes

- Added `APIResponseSchemaNoData` import to `packages/server/src/api/machine/machine.ts`
- Changed `MachineDeleteResponseSchema` from `APIResponseSchema(z.boolean())` to `APIResponseSchemaNoData()`
- Updated `machineDelete()` return type from `Promise<boolean>` to `Promise<void>`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated machine deletion API response handling to use a standardized no-data response schema for improved consistency in error management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->