### PR TITLE
fix(runtime): report session errors correctly when agent handler throws

### DIFF
--- a/packages/runtime/src/_standalone.ts
+++ b/packages/runtime/src/_standalone.ts
@@ -500,7 +500,12 @@ export class StandaloneAgentContext<
 														: undefined,
 											})
 											.then(() => {})
-											.catch((ex) => this.logger.error(ex));
+											.catch((ex) =>
+												this.logger.error(
+													'session complete failed: %s',
+													ex instanceof Error ? ex.message : ex
+												)
+											);
 									}
 								})
 								.catch(async (ex) => {
@@ -536,7 +541,12 @@ export class StandaloneAgentContext<
 														: undefined,
 											})
 											.then(() => {})
-											.catch((ex) => this.logger.error(ex));
+											.catch((ex) =>
+												this.logger.error(
+													'session complete failed: %s',
+													ex instanceof Error ? ex.message : ex
+												)
+											);
 									}
 								})
 								.finally(() => {
@@ -561,7 +571,12 @@ export class StandaloneAgentContext<
 												: undefined,
 									})
 									.then(() => {})
-									.catch((ex) => this.logger.error(ex));
+									.catch((ex) =>
+										this.logger.error(
+											'session complete failed: %s',
+											ex instanceof Error ? ex.message : ex
+										)
+									);
 							}
 						}
 
@@ -592,7 +607,12 @@ export class StandaloneAgentContext<
 											: undefined,
 								})
 								.then(() => {})
-								.catch((ex) => this.logger.error(ex));
+								.catch((ex) =>
+									this.logger.error(
+										'session complete failed: %s',
+										ex instanceof Error ? ex.message : ex
+									)
+								);
 						}
 						throw ex;
 					} finally {

--- a/packages/runtime/src/middleware.ts
+++ b/packages/runtime/src/middleware.ts
@@ -373,8 +373,13 @@ export function createOtelMiddleware() {
 					}
 
 					// Factor out finalization logic so it can run synchronously or deferred
-					const finalizeSession = async (statusCode?: number) => {
-						internal.info('[session] saving session %s (thread: %s)', sessionId, thread.id);
+					const finalizeSession = async (statusCode?: number, error?: string) => {
+						internal.info(
+							'[session] saving session %s (thread: %s) (error: %s)',
+							sessionId,
+							thread.id,
+							error
+						);
 						await sessionProvider.save(session);
 						internal.info('[session] session saved, now saving thread');
 						await threadProvider.save(thread);
@@ -397,12 +402,16 @@ export function createOtelMiddleware() {
 									id: sessionId,
 									threadId: isEmpty ? null : thread.id,
 									statusCode: statusCode ?? c.res?.status ?? 200,
+									error,
 									agentIds: agentIds?.length ? agentIds : undefined,
 									userData,
 								});
 								internal.info('[session] session complete event sent');
 							} catch (ex) {
-								internal.info('[session] session complete event failed: %s', ex);
+								internal.info(
+									'[session] session complete event failed: %s',
+									ex instanceof Error ? ex.message : ex
+								);
 								// Silently ignore session complete errors - don't block response
 							}
 						}
@@ -418,6 +427,13 @@ export function createOtelMiddleware() {
 							| undefined;
 						// eslint-disable-next-line @typescript-eslint/no-explicit-any
 						const isStreaming = Boolean((c as any).get(IS_STREAMING_RESPONSE_KEY));
+
+						// Check if Hono caught an error (c.error is set by Hono's error handler)
+						// or if the response status indicates an error
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						const honoError = (c as any).error as Error | undefined;
+						const responseStatus = c.res?.status ?? 200;
+						const isError = honoError || responseStatus >= 500;
 
 						if (isStreaming && streamDone) {
 							// Defer session/thread saving until stream completes
@@ -445,8 +461,21 @@ export function createOtelMiddleware() {
 							});
 
 							span.setStatus({ code: SpanStatusCode.OK });
+						} else if (isError) {
+							// Hono caught an error or response is 5xx - report as error
+							const errorMessage = honoError
+								? honoError.stack ?? honoError.message
+								: `HTTP ${responseStatus}`;
+							span.setStatus({
+								code: SpanStatusCode.ERROR,
+								message: honoError?.message ?? errorMessage,
+							});
+							if (honoError) {
+								span.recordException(honoError);
+							}
+							await finalizeSession(responseStatus, errorMessage);
 						} else {
-							// Non-streaming: save session/thread synchronously (existing behavior)
+							// Non-streaming success: save session/thread synchronously
 							await finalizeSession();
 							span.setStatus({ code: SpanStatusCode.OK });
 						}
@@ -454,10 +483,17 @@ export function createOtelMiddleware() {
 						if (ex instanceof Error) {
 							span.recordException(ex);
 						}
+						const errorMessage =
+							ex instanceof Error
+								? ex.stack ?? ex.message
+								: String(ex);
 						span.setStatus({
 							code: SpanStatusCode.ERROR,
-							message: (ex as Error).message ?? String(ex),
+							message: ex instanceof Error ? ex.message : String(ex),
 						});
+
+						await finalizeSession(500, errorMessage);
+
 						throw ex;
 					} finally {
 						const headers: Record<string, string> = {};


### PR DESCRIPTION
## Problem

When an agent handler throws an error:
1. The session was being reported as success instead of failure
2. Error logs showed empty objects (`{}`) instead of the actual error message

## Root Cause

1. **Session reported as success**: Hono catches unhandled errors internally and returns a 500 response, but `await next()` in the OTEL middleware resolves normally (doesn't throw). The middleware was only checking for thrown exceptions, not Hono-caught errors.

2. **Empty object logging**: Code was logging `this.logger.error(ex)` directly, but `JSON.stringify(new Error('test'))` returns `'{}'` because Error properties aren't enumerable.

## Solution

### middleware.ts
- Extended `finalizeSession` to accept an optional `error` parameter
- After `await next()`, check `c.error` (set by Hono's error handler) and response status >= 500
- Report session with error status and include full stack trace when available

### _standalone.ts
- Fixed 4 instances of `.catch((ex) => this.logger.error(ex))` to properly extract the error message before logging

## Testing

- `bun run build` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging and diagnostics for session completion failures with standardized, formatted error messages.
  * Enhanced error handling to properly capture and report error details during session finalization.
  * Better error tracking and messaging when session operations fail.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->