### PR TITLE
feat(server): add specific error types for sandbox operations

### DIFF
--- a/packages/server/src/api/api.ts
+++ b/packages/server/src/api/api.ts
@@ -714,6 +714,7 @@ export const APIResponseSchema = <T extends z.ZodType>(dataSchema: T) =>
 		z.object({
 			success: z.literal<false>(false),
 			message: z.string().describe('the error message'),
+			code: z.string().optional().describe('machine-readable error code'),
 		}),
 		z.object({
 			success: z.literal<true>(true),
@@ -726,6 +727,7 @@ export const APIResponseSchemaOptionalData = <T extends z.ZodType>(dataSchema: T
 		z.object({
 			success: z.literal<false>(false),
 			message: z.string().describe('the error message'),
+			code: z.string().optional().describe('machine-readable error code'),
 		}),
 		z.object({
 			success: z.literal<true>(true),
@@ -738,6 +740,7 @@ export const APIResponseSchemaNoData = () =>
 		z.object({
 			success: z.literal<false>(false),
 			message: z.string().describe('the error message'),
+			code: z.string().optional().describe('machine-readable error code'),
 		}),
 		z.object({
 			success: z.literal<true>(true),

--- a/packages/server/src/api/sandbox/create.ts
+++ b/packages/server/src/api/sandbox/create.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { APIClient, APIResponseSchema } from '../api';
-import { SandboxResponseError, API_VERSION } from './util';
+import { throwSandboxError, API_VERSION } from './util';
 import type { SandboxCreateOptions, SandboxStatus } from '@agentuity/core';
 
 const SandboxCreateRequestSchema = z
@@ -196,5 +196,5 @@ export async function sandboxCreate(
 		return resp.data;
 	}
 
-	throw new SandboxResponseError({ message: resp.message });
+	throwSandboxError(resp, {});
 }

--- a/packages/server/src/api/sandbox/destroy.ts
+++ b/packages/server/src/api/sandbox/destroy.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { APIClient, APIResponseSchemaNoData } from '../api';
-import { SandboxResponseError, API_VERSION } from './util';
+import { throwSandboxError, API_VERSION } from './util';
 
 const DestroyResponseSchema = APIResponseSchemaNoData();
 
@@ -37,5 +37,5 @@ export async function sandboxDestroy(
 		return;
 	}
 
-	throw new SandboxResponseError({ message: resp.message, sandboxId });
+	throwSandboxError(resp, { sandboxId });
 }

--- a/packages/server/src/api/sandbox/execute.ts
+++ b/packages/server/src/api/sandbox/execute.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { APIClient, APIResponseSchema } from '../api';
-import { SandboxResponseError, API_VERSION } from './util';
+import { throwSandboxError, API_VERSION } from './util';
 import { FileToWriteSchema } from './files';
 import type { ExecuteOptions, Execution, ExecutionStatus } from '@agentuity/core';
 
@@ -98,5 +98,5 @@ export async function sandboxExecute(
 		};
 	}
 
-	throw new SandboxResponseError({ message: resp.message, sandboxId });
+	throwSandboxError(resp, { sandboxId });
 }

--- a/packages/server/src/api/sandbox/execution.ts
+++ b/packages/server/src/api/sandbox/execution.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { APIClient, APIResponseSchema } from '../api';
-import { SandboxResponseError, API_VERSION } from './util';
+import { throwSandboxError, API_VERSION } from './util';
 import type { ExecutionStatus } from '@agentuity/core';
 
 const ExecutionInfoSchema = z
@@ -97,7 +97,7 @@ export async function executionGet(
 		};
 	}
 
-	throw new SandboxResponseError({ message: resp.message, executionId });
+	throwSandboxError(resp, { executionId });
 }
 
 export interface ExecutionListParams {
@@ -157,5 +157,5 @@ export async function executionList(
 		};
 	}
 
-	throw new SandboxResponseError({ message: resp.message, sandboxId });
+	throwSandboxError(resp, { sandboxId });
 }

--- a/packages/server/src/api/sandbox/files.ts
+++ b/packages/server/src/api/sandbox/files.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { APIClient } from '../api';
-import { SandboxResponseError, API_VERSION } from './util';
+import { SandboxResponseError, throwSandboxError, API_VERSION } from './util';
 import type { FileToWrite } from '@agentuity/core';
 
 export const FileToWriteSchema = z.object({
@@ -85,7 +85,7 @@ export async function sandboxWriteFiles(
 		};
 	}
 
-	throw new SandboxResponseError({ message: resp.message, sandboxId });
+	throwSandboxError(resp, { sandboxId });
 }
 
 export interface ReadFileParams {
@@ -196,7 +196,7 @@ export async function sandboxMkDir(client: APIClient, params: MkDirParams): Prom
 	);
 
 	if (!resp.success) {
-		throw new SandboxResponseError({ message: resp.message, sandboxId });
+		throwSandboxError(resp, { sandboxId });
 	}
 }
 
@@ -256,7 +256,7 @@ export async function sandboxRmDir(client: APIClient, params: RmDirParams): Prom
 	);
 
 	if (!resp.success) {
-		throw new SandboxResponseError({ message: resp.message, sandboxId });
+		throwSandboxError(resp, { sandboxId });
 	}
 }
 
@@ -313,7 +313,7 @@ export async function sandboxRmFile(client: APIClient, params: RmFileParams): Pr
 	);
 
 	if (!resp.success) {
-		throw new SandboxResponseError({ message: resp.message, sandboxId });
+		throwSandboxError(resp, { sandboxId });
 	}
 }
 
@@ -395,7 +395,7 @@ export async function sandboxListFiles(
 		};
 	}
 
-	throw new SandboxResponseError({ message: resp.message, sandboxId });
+	throwSandboxError(resp, { sandboxId });
 }
 
 export type ArchiveFormat = 'zip' | 'tar.gz';
@@ -519,7 +519,7 @@ export async function sandboxUploadArchive(
 	const result = UploadArchiveResponseSchema.parse(body);
 
 	if (!result.success) {
-		throw new SandboxResponseError({ message: result.message, sandboxId, sessionId });
+		throwSandboxError(result, { sandboxId, sessionId });
 	}
 }
 
@@ -592,5 +592,5 @@ export async function sandboxSetEnv(
 		};
 	}
 
-	throw new SandboxResponseError({ message: resp.message, sandboxId });
+	throwSandboxError(resp, { sandboxId });
 }

--- a/packages/server/src/api/sandbox/get.ts
+++ b/packages/server/src/api/sandbox/get.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { APIClient, APIResponseSchema } from '../api';
-import { SandboxResponseError, API_VERSION } from './util';
+import { throwSandboxError, API_VERSION } from './util';
 import type {
 	SandboxInfo,
 	SandboxStatus,
@@ -212,5 +212,5 @@ export async function sandboxGet(
 		};
 	}
 
-	throw new SandboxResponseError({ message: resp.message, sandboxId });
+	throwSandboxError(resp, { sandboxId });
 }

--- a/packages/server/src/api/sandbox/index.ts
+++ b/packages/server/src/api/sandbox/index.ts
@@ -19,7 +19,18 @@ export type {
 	ExecutionListParams,
 	ExecutionListResponse,
 } from './execution';
-export { SandboxResponseError, writeAndDrain } from './util';
+export {
+	SandboxResponseError,
+	SandboxNotFoundError,
+	SandboxTerminatedError,
+	ExecutionNotFoundError,
+	ExecutionTimeoutError,
+	ExecutionCancelledError,
+	SnapshotNotFoundError,
+	throwSandboxError,
+	writeAndDrain,
+} from './util';
+export type { SandboxErrorCode, SandboxErrorContext } from './util';
 export { SandboxClient } from './client';
 export type {
 	SandboxClientOptions,

--- a/packages/server/src/api/sandbox/list.ts
+++ b/packages/server/src/api/sandbox/list.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { APIClient, APIResponseSchema } from '../api';
-import { SandboxResponseError, API_VERSION } from './util';
+import { throwSandboxError, API_VERSION } from './util';
 import type {
 	ListSandboxesParams,
 	ListSandboxesResponse,
@@ -182,5 +182,5 @@ export async function sandboxList(
 		};
 	}
 
-	throw new SandboxResponseError({ message: resp.message });
+	throwSandboxError(resp, {});
 }

--- a/packages/server/src/api/sandbox/run.ts
+++ b/packages/server/src/api/sandbox/run.ts
@@ -4,7 +4,7 @@ import { APIClient } from '../api';
 import { sandboxCreate } from './create';
 import { sandboxDestroy } from './destroy';
 import { sandboxGet } from './get';
-import { SandboxResponseError, writeAndDrain } from './util';
+import { ExecutionCancelledError, ExecutionTimeoutError, writeAndDrain } from './util';
 import type { SandboxRunOptions, SandboxRunResult } from '@agentuity/core';
 import { getServiceUrls } from '../../config';
 
@@ -143,7 +143,7 @@ export async function sandboxRun(
 		while (attempts < MAX_POLL_ATTEMPTS) {
 			if (signal?.aborted) {
 				abortController.abort();
-				throw new SandboxResponseError({
+				throw new ExecutionCancelledError({
 					message: 'Sandbox execution cancelled',
 					sandboxId,
 				});
@@ -195,7 +195,7 @@ export async function sandboxRun(
 			};
 		}
 
-		throw new SandboxResponseError({
+		throw new ExecutionTimeoutError({
 			message: 'Sandbox execution polling timed out',
 			sandboxId,
 		});

--- a/packages/server/src/api/sandbox/runtime.ts
+++ b/packages/server/src/api/sandbox/runtime.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { APIClient, APIResponseSchema } from '../api';
-import { SandboxResponseError, API_VERSION } from './util';
+import { throwSandboxError, API_VERSION } from './util';
 import type { ListRuntimesParams, ListRuntimesResponse, SandboxRuntime } from '@agentuity/core';
 
 const RuntimeRequirementsSchema = z
@@ -90,5 +90,5 @@ export async function runtimeList(
 		};
 	}
 
-	throw new SandboxResponseError({ message: resp.message });
+	throwSandboxError(resp, {});
 }

--- a/packages/server/src/api/sandbox/snapshot.ts
+++ b/packages/server/src/api/sandbox/snapshot.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { APIClient, APIResponseSchema, APIResponseSchemaNoData } from '../api';
-import { SandboxResponseError, API_VERSION } from './util';
+import { SandboxResponseError, throwSandboxError, API_VERSION } from './util';
 
 const SnapshotFileInfoSchema = z
 	.object({
@@ -260,7 +260,7 @@ export async function snapshotCreate(
 		return resp.data;
 	}
 
-	throw new SandboxResponseError({ message: resp.message });
+	throwSandboxError(resp, {});
 }
 
 /**
@@ -288,7 +288,7 @@ export async function snapshotGet(
 		return resp.data;
 	}
 
-	throw new SandboxResponseError({ message: resp.message });
+	throwSandboxError(resp, {});
 }
 
 /**
@@ -316,7 +316,7 @@ export async function snapshotList(
 		return resp.data;
 	}
 
-	throw new SandboxResponseError({ message: resp.message });
+	throwSandboxError(resp, {});
 }
 
 /**
@@ -340,7 +340,7 @@ export async function snapshotDelete(
 	);
 
 	if (!resp.success) {
-		throw new SandboxResponseError({ message: resp.message });
+		throwSandboxError(resp, {});
 	}
 }
 
@@ -370,7 +370,7 @@ export async function snapshotTag(
 		return resp.data;
 	}
 
-	throw new SandboxResponseError({ message: resp.message });
+	throwSandboxError(resp, {});
 }
 
 /**
@@ -413,7 +413,7 @@ export async function snapshotLineage(
 		return resp.data;
 	}
 
-	throw new SandboxResponseError({ message: resp.message });
+	throwSandboxError(resp, {});
 }
 
 // ===== Public Snapshot API =====
@@ -469,7 +469,7 @@ export async function snapshotPublicGet(
 		return resp.data;
 	}
 
-	throw new SandboxResponseError({ message: resp.message });
+	throwSandboxError(resp, {});
 }
 
 // ===== Snapshot Build API =====
@@ -600,7 +600,7 @@ export async function snapshotBuildInit(
 		return resp.data;
 	}
 
-	throw new SandboxResponseError({ message: resp.message });
+	throwSandboxError(resp, {});
 }
 
 /**
@@ -638,7 +638,7 @@ export async function snapshotBuildFinalize(
 		return resp.data;
 	}
 
-	throw new SandboxResponseError({ message: resp.message });
+	throwSandboxError(resp, {});
 }
 
 // ===== Snapshot Upload API (for public snapshots) =====
@@ -707,5 +707,5 @@ export async function snapshotUpload(
 		return data.data;
 	}
 
-	throw new SandboxResponseError({ message: data.message });
+	throwSandboxError(data, {});
 }

--- a/packages/server/src/api/sandbox/util.ts
+++ b/packages/server/src/api/sandbox/util.ts
@@ -6,6 +6,18 @@ interface WritableWithDrain extends EventEmitter {
 }
 
 /**
+ * Machine-readable error codes for sandbox operations.
+ * These codes allow programmatic error handling without fragile string matching.
+ */
+export type SandboxErrorCode =
+	| 'SANDBOX_NOT_FOUND'
+	| 'SANDBOX_TERMINATED'
+	| 'EXECUTION_NOT_FOUND'
+	| 'EXECUTION_TIMEOUT'
+	| 'EXECUTION_CANCELLED'
+	| 'SNAPSHOT_NOT_FOUND';
+
+/**
  * Error thrown when a sandbox API request fails.
  *
  * Includes optional context about which sandbox or execution caused the error.
@@ -17,7 +29,175 @@ export const SandboxResponseError = StructuredError('SandboxResponseError')<{
 	executionId?: string;
 	/** The session ID (trace ID) from the x-session-id response header for OTel correlation */
 	sessionId?: string | null;
+	/** Machine-readable error code for programmatic error handling */
+	code?: SandboxErrorCode;
 }>();
+
+/**
+ * Error thrown when a sandbox is not found.
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await sandboxGet(client, { sandboxId: 'non-existent' });
+ * } catch (error) {
+ *   if (error._tag === 'SandboxNotFoundError') {
+ *     console.error(`Sandbox not found: ${error.sandboxId}`);
+ *   }
+ * }
+ * ```
+ */
+export const SandboxNotFoundError = StructuredError('SandboxNotFoundError')<{
+	sandboxId: string;
+}>();
+
+/**
+ * Error thrown when a sandbox has already terminated.
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await sandboxExecute(client, { sandboxId: 'terminated-sandbox', command: ['ls'] });
+ * } catch (error) {
+ *   if (error._tag === 'SandboxTerminatedError') {
+ *     console.error(`Sandbox terminated: ${error.sandboxId}`);
+ *   }
+ * }
+ * ```
+ */
+export const SandboxTerminatedError = StructuredError('SandboxTerminatedError')<{
+	sandboxId: string;
+}>();
+
+/**
+ * Error thrown when an execution is not found.
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await executionGet(client, { executionId: 'non-existent' });
+ * } catch (error) {
+ *   if (error._tag === 'ExecutionNotFoundError') {
+ *     console.error(`Execution not found: ${error.executionId}`);
+ *   }
+ * }
+ * ```
+ */
+export const ExecutionNotFoundError = StructuredError('ExecutionNotFoundError')<{
+	executionId: string;
+	sandboxId?: string;
+}>();
+
+/**
+ * Error thrown when an execution times out.
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await sandboxExecute(client, { sandboxId, command: ['long-running'], timeout: '30s' });
+ * } catch (error) {
+ *   if (error._tag === 'ExecutionTimeoutError') {
+ *     console.error('Execution timed out');
+ *   }
+ * }
+ * ```
+ */
+export const ExecutionTimeoutError = StructuredError('ExecutionTimeoutError')<{
+	executionId?: string;
+	sandboxId?: string;
+}>();
+
+/**
+ * Error thrown when an execution is cancelled.
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await sandboxRun(client, params, { signal: controller.signal });
+ * } catch (error) {
+ *   if (error._tag === 'ExecutionCancelledError') {
+ *     console.error('Execution was cancelled');
+ *   }
+ * }
+ * ```
+ */
+export const ExecutionCancelledError = StructuredError('ExecutionCancelledError')<{
+	sandboxId?: string;
+}>();
+
+/**
+ * Error thrown when a snapshot is not found.
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await snapshotGet(client, { snapshotId: 'non-existent' });
+ * } catch (error) {
+ *   if (error._tag === 'SnapshotNotFoundError') {
+ *     console.error(`Snapshot not found: ${error.snapshotId}`);
+ *   }
+ * }
+ * ```
+ */
+export const SnapshotNotFoundError = StructuredError('SnapshotNotFoundError')<{
+	snapshotId?: string;
+}>();
+
+/**
+ * Context for throwing sandbox errors.
+ */
+export interface SandboxErrorContext {
+	sandboxId?: string;
+	executionId?: string;
+	sessionId?: string | null;
+	snapshotId?: string;
+}
+
+/**
+ * Throws the appropriate sandbox error based on the response code.
+ *
+ * This helper centralizes error mapping logic, throwing specific error types
+ * when the backend returns a known error code, and falling back to
+ * SandboxResponseError for unknown codes.
+ *
+ * @param resp - The API response containing message and optional code
+ * @param context - Context about the operation (sandbox ID, execution ID, etc.)
+ * @throws {SandboxNotFoundError} When code is 'SANDBOX_NOT_FOUND'
+ * @throws {SandboxTerminatedError} When code is 'SANDBOX_TERMINATED'
+ * @throws {ExecutionNotFoundError} When code is 'EXECUTION_NOT_FOUND'
+ * @throws {ExecutionTimeoutError} When code is 'EXECUTION_TIMEOUT'
+ * @throws {ExecutionCancelledError} When code is 'EXECUTION_CANCELLED'
+ * @throws {SnapshotNotFoundError} When code is 'SNAPSHOT_NOT_FOUND'
+ * @throws {SandboxResponseError} For unknown codes or when no code is provided
+ */
+export function throwSandboxError(
+	resp: { message?: string; code?: string },
+	context: SandboxErrorContext
+): never {
+	const { sandboxId, executionId, sessionId, snapshotId } = context;
+	const code = resp.code as SandboxErrorCode | undefined;
+
+	switch (code) {
+		case 'SANDBOX_NOT_FOUND':
+			throw new SandboxNotFoundError({ message: resp.message, sandboxId: sandboxId ?? '' });
+		case 'SANDBOX_TERMINATED':
+			throw new SandboxTerminatedError({ message: resp.message, sandboxId: sandboxId ?? '' });
+		case 'EXECUTION_NOT_FOUND':
+			throw new ExecutionNotFoundError({
+				message: resp.message,
+				executionId: executionId ?? '',
+				sandboxId,
+			});
+		case 'EXECUTION_TIMEOUT':
+			throw new ExecutionTimeoutError({ message: resp.message, executionId, sandboxId });
+		case 'EXECUTION_CANCELLED':
+			throw new ExecutionCancelledError({ message: resp.message, sandboxId });
+		case 'SNAPSHOT_NOT_FOUND':
+			throw new SnapshotNotFoundError({ message: resp.message, snapshotId });
+		default:
+			throw new SandboxResponseError({ message: resp.message, sandboxId, executionId, sessionId, code });
+	}
+}
 
 /** Current sandbox API version */
 export const API_VERSION = '2025-03-17';

--- a/packages/server/test/sandbox-errors.test.ts
+++ b/packages/server/test/sandbox-errors.test.ts
@@ -1,0 +1,308 @@
+import { describe, test, expect } from 'bun:test';
+import {
+	SandboxResponseError,
+	SandboxNotFoundError,
+	SandboxTerminatedError,
+	ExecutionNotFoundError,
+	ExecutionTimeoutError,
+	ExecutionCancelledError,
+	SnapshotNotFoundError,
+	throwSandboxError,
+} from '../src/api/sandbox/util';
+
+describe('Sandbox Error Types', () => {
+	describe('SandboxResponseError', () => {
+		test('should have correct _tag', () => {
+			const error = new SandboxResponseError({ message: 'test error' });
+			expect(error._tag).toBe('SandboxResponseError');
+		});
+
+		test('should include context fields', () => {
+			const error = new SandboxResponseError({
+				message: 'test error',
+				sandboxId: 'sandbox-123',
+				executionId: 'exec-456',
+				sessionId: 'session-789',
+				code: 'SANDBOX_NOT_FOUND',
+			});
+			expect(error.sandboxId).toBe('sandbox-123');
+			expect(error.executionId).toBe('exec-456');
+			expect(error.sessionId).toBe('session-789');
+			expect(error.code).toBe('SANDBOX_NOT_FOUND');
+		});
+	});
+
+	describe('SandboxNotFoundError', () => {
+		test('should have correct _tag', () => {
+			const error = new SandboxNotFoundError({
+				message: 'Sandbox not found',
+				sandboxId: 'sandbox-123',
+			});
+			expect(error._tag).toBe('SandboxNotFoundError');
+		});
+
+		test('should include sandboxId', () => {
+			const error = new SandboxNotFoundError({
+				message: 'Sandbox not found',
+				sandboxId: 'sandbox-123',
+			});
+			expect(error.sandboxId).toBe('sandbox-123');
+		});
+	});
+
+	describe('SandboxTerminatedError', () => {
+		test('should have correct _tag', () => {
+			const error = new SandboxTerminatedError({
+				message: 'Sandbox terminated',
+				sandboxId: 'sandbox-123',
+			});
+			expect(error._tag).toBe('SandboxTerminatedError');
+		});
+
+		test('should include sandboxId', () => {
+			const error = new SandboxTerminatedError({
+				message: 'Sandbox terminated',
+				sandboxId: 'sandbox-123',
+			});
+			expect(error.sandboxId).toBe('sandbox-123');
+		});
+	});
+
+	describe('ExecutionNotFoundError', () => {
+		test('should have correct _tag', () => {
+			const error = new ExecutionNotFoundError({
+				message: 'Execution not found',
+				executionId: 'exec-123',
+			});
+			expect(error._tag).toBe('ExecutionNotFoundError');
+		});
+
+		test('should include context fields', () => {
+			const error = new ExecutionNotFoundError({
+				message: 'Execution not found',
+				executionId: 'exec-123',
+				sandboxId: 'sandbox-456',
+			});
+			expect(error.executionId).toBe('exec-123');
+			expect(error.sandboxId).toBe('sandbox-456');
+		});
+	});
+
+	describe('ExecutionTimeoutError', () => {
+		test('should have correct _tag', () => {
+			const error = new ExecutionTimeoutError({
+				message: 'Execution timed out',
+			});
+			expect(error._tag).toBe('ExecutionTimeoutError');
+		});
+
+		test('should include optional context fields', () => {
+			const error = new ExecutionTimeoutError({
+				message: 'Execution timed out',
+				executionId: 'exec-123',
+				sandboxId: 'sandbox-456',
+			});
+			expect(error.executionId).toBe('exec-123');
+			expect(error.sandboxId).toBe('sandbox-456');
+		});
+	});
+
+	describe('ExecutionCancelledError', () => {
+		test('should have correct _tag', () => {
+			const error = new ExecutionCancelledError({
+				message: 'Execution cancelled',
+			});
+			expect(error._tag).toBe('ExecutionCancelledError');
+		});
+
+		test('should include optional sandboxId', () => {
+			const error = new ExecutionCancelledError({
+				message: 'Execution cancelled',
+				sandboxId: 'sandbox-123',
+			});
+			expect(error.sandboxId).toBe('sandbox-123');
+		});
+	});
+
+	describe('SnapshotNotFoundError', () => {
+		test('should have correct _tag', () => {
+			const error = new SnapshotNotFoundError({
+				message: 'Snapshot not found',
+			});
+			expect(error._tag).toBe('SnapshotNotFoundError');
+		});
+
+		test('should include optional snapshotId', () => {
+			const error = new SnapshotNotFoundError({
+				message: 'Snapshot not found',
+				snapshotId: 'snap-123',
+			});
+			expect(error.snapshotId).toBe('snap-123');
+		});
+	});
+});
+
+describe('throwSandboxError', () => {
+	test('should throw SandboxNotFoundError when code is SANDBOX_NOT_FOUND', () => {
+		expect(() =>
+			throwSandboxError(
+				{ message: 'Sandbox not found', code: 'SANDBOX_NOT_FOUND' },
+				{ sandboxId: 'sandbox-123' }
+			)
+		).toThrow(SandboxNotFoundError);
+
+		try {
+			throwSandboxError(
+				{ message: 'Sandbox not found', code: 'SANDBOX_NOT_FOUND' },
+				{ sandboxId: 'sandbox-123' }
+			);
+		} catch (error) {
+			expect((error as SandboxNotFoundError)._tag).toBe('SandboxNotFoundError');
+			expect((error as SandboxNotFoundError).sandboxId).toBe('sandbox-123');
+		}
+	});
+
+	test('should throw SandboxTerminatedError when code is SANDBOX_TERMINATED', () => {
+		expect(() =>
+			throwSandboxError(
+				{ message: 'Sandbox terminated', code: 'SANDBOX_TERMINATED' },
+				{ sandboxId: 'sandbox-123' }
+			)
+		).toThrow(SandboxTerminatedError);
+	});
+
+	test('should throw ExecutionNotFoundError when code is EXECUTION_NOT_FOUND', () => {
+		expect(() =>
+			throwSandboxError(
+				{ message: 'Execution not found', code: 'EXECUTION_NOT_FOUND' },
+				{ executionId: 'exec-123', sandboxId: 'sandbox-456' }
+			)
+		).toThrow(ExecutionNotFoundError);
+
+		try {
+			throwSandboxError(
+				{ message: 'Execution not found', code: 'EXECUTION_NOT_FOUND' },
+				{ executionId: 'exec-123', sandboxId: 'sandbox-456' }
+			);
+		} catch (error) {
+			expect((error as ExecutionNotFoundError).executionId).toBe('exec-123');
+			expect((error as ExecutionNotFoundError).sandboxId).toBe('sandbox-456');
+		}
+	});
+
+	test('should throw ExecutionTimeoutError when code is EXECUTION_TIMEOUT', () => {
+		expect(() =>
+			throwSandboxError(
+				{ message: 'Execution timed out', code: 'EXECUTION_TIMEOUT' },
+				{ sandboxId: 'sandbox-123' }
+			)
+		).toThrow(ExecutionTimeoutError);
+	});
+
+	test('should throw ExecutionCancelledError when code is EXECUTION_CANCELLED', () => {
+		expect(() =>
+			throwSandboxError(
+				{ message: 'Execution cancelled', code: 'EXECUTION_CANCELLED' },
+				{ sandboxId: 'sandbox-123' }
+			)
+		).toThrow(ExecutionCancelledError);
+	});
+
+	test('should throw SnapshotNotFoundError when code is SNAPSHOT_NOT_FOUND', () => {
+		expect(() =>
+			throwSandboxError(
+				{ message: 'Snapshot not found', code: 'SNAPSHOT_NOT_FOUND' },
+				{ snapshotId: 'snap-123' }
+			)
+		).toThrow(SnapshotNotFoundError);
+	});
+
+	test('should throw SandboxResponseError for unknown codes', () => {
+		expect(() =>
+			throwSandboxError(
+				{ message: 'Unknown error', code: 'UNKNOWN_CODE' },
+				{ sandboxId: 'sandbox-123' }
+			)
+		).toThrow(SandboxResponseError);
+
+		try {
+			throwSandboxError(
+				{ message: 'Unknown error', code: 'UNKNOWN_CODE' },
+				{ sandboxId: 'sandbox-123' }
+			);
+		} catch (error) {
+			expect((error as SandboxResponseError)._tag).toBe('SandboxResponseError');
+			expect((error as SandboxResponseError).code).toBe('UNKNOWN_CODE');
+		}
+	});
+
+	test('should throw SandboxResponseError when no code is provided', () => {
+		expect(() =>
+			throwSandboxError({ message: 'Generic error' }, { sandboxId: 'sandbox-123' })
+		).toThrow(SandboxResponseError);
+
+		try {
+			throwSandboxError({ message: 'Generic error' }, { sandboxId: 'sandbox-123' });
+		} catch (error) {
+			expect((error as SandboxResponseError)._tag).toBe('SandboxResponseError');
+			expect((error as SandboxResponseError).sandboxId).toBe('sandbox-123');
+		}
+	});
+
+	test('should preserve message in thrown errors', () => {
+		try {
+			throwSandboxError(
+				{ message: 'Custom error message', code: 'SANDBOX_NOT_FOUND' },
+				{ sandboxId: 'sandbox-123' }
+			);
+		} catch (error) {
+			expect((error as Error).message).toBe('Custom error message');
+		}
+	});
+
+	test('should preserve sessionId in SandboxResponseError fallback', () => {
+		try {
+			throwSandboxError(
+				{ message: 'Error with session' },
+				{ sandboxId: 'sandbox-123', sessionId: 'session-456' }
+			);
+		} catch (error) {
+			expect((error as SandboxResponseError).sessionId).toBe('session-456');
+		}
+	});
+});
+
+describe('Error discrimination patterns', () => {
+	test('should allow discrimination by _tag property', () => {
+		const errors = [
+			new SandboxNotFoundError({ message: 'not found', sandboxId: 'sb-1' }),
+			new SandboxTerminatedError({ message: 'terminated', sandboxId: 'sb-2' }),
+			new ExecutionNotFoundError({ message: 'exec not found', executionId: 'ex-1' }),
+			new SandboxResponseError({ message: 'generic' }),
+		];
+
+		for (const error of errors) {
+			switch (error._tag) {
+				case 'SandboxNotFoundError':
+					expect(error.sandboxId).toBe('sb-1');
+					break;
+				case 'SandboxTerminatedError':
+					expect(error.sandboxId).toBe('sb-2');
+					break;
+				case 'ExecutionNotFoundError':
+					expect(error.executionId).toBe('ex-1');
+					break;
+				case 'SandboxResponseError':
+					expect(error.message).toBe('generic');
+					break;
+			}
+		}
+	});
+
+	test('should work with instanceof checks', () => {
+		const error = new SandboxNotFoundError({ message: 'not found', sandboxId: 'sb-1' });
+
+		expect(error instanceof Error).toBe(true);
+		expect(error instanceof SandboxNotFoundError).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

Add specific error types for sandbox API operations to enable programmatic error handling without fragile string matching on error messages.

Closes #677

## Problem

Currently, detecting why a sandbox operation failed requires fragile string matching:

```typescript
try {
  await sandbox.execute({ command: [...] });
} catch (error) {
  if (error.message.includes('not found') || error.message.includes('terminated')) {
    // Recreate sandbox
  }
}
```

## Solution (Option B)

Following @jhaynie's direction, this PR implements Option B from the issue - creating specific error types that match the Queue API pattern (`QueueNotFoundError`, `MessageNotFoundError`, etc.).

### New Error Types

| Error Type | When Thrown |
|------------|-------------|
| `SandboxNotFoundError` | Sandbox doesn't exist |
| `SandboxTerminatedError` | Sandbox already terminated |
| `ExecutionNotFoundError` | Execution doesn't exist |
| `ExecutionTimeoutError` | Execution times out |
| `ExecutionCancelledError` | Execution is cancelled |
| `SnapshotNotFoundError` | Snapshot doesn't exist |

### Usage

```typescript
import { SandboxNotFoundError, ExecutionTimeoutError } from '@agentuity/server';

try {
  await sandboxGet(client, { sandboxId: 'non-existent' });
} catch (error) {
  if (error._tag === 'SandboxNotFoundError') {
    console.log(`Sandbox not found: ${error.sandboxId}`);
  } else if (error._tag === 'ExecutionTimeoutError') {
    console.log('Execution timed out');
  }
}
```

## Changes

- **packages/server/src/api/api.ts**: Added `code?: string` to API error response schemas
- **packages/server/src/api/sandbox/util.ts**: Added 6 new error types, `SandboxErrorCode` type, and `throwSandboxError` helper
- **packages/server/src/api/sandbox/index.ts**: Exported new error types
- **10 sandbox API files**: Updated to use `throwSandboxError` helper
- **packages/server/test/sandbox-errors.test.ts**: Added 26 comprehensive tests

## Backend Integration

The API response schemas now support an optional `code` field. When the backend returns error codes like `SANDBOX_NOT_FOUND`, the SDK will throw the corresponding specific error type. For unknown codes or when no code is provided, `SandboxResponseError` is thrown as a fallback.

## Verification

- ✅ `bun run typecheck` - All packages pass
- ✅ `bun run lint` - No errors  
- ✅ `bun run build` - All packages build successfully
- ✅ `bun run test` (server) - 160 tests pass (including 26 new tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API responses now include optional machine-readable error codes in failure cases to help identify specific error conditions
  * Introduced structured error types for sandbox operations, including scenarios such as sandbox not found, sandbox terminated, execution timeout, execution cancelled, and snapshot not found

* **Tests**
  * Added comprehensive test coverage for error handling and error type discrimination

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->