### PR TITLE
feat(cli): add instanceType, instanceTags, privateIPv4, availabilityZone to machine list

### DIFF
--- a/packages/cli/src/cmd/cloud/machine/list.ts
+++ b/packages/cli/src/cmd/cloud/machine/list.ts
@@ -14,6 +14,10 @@ const MachineListResponseSchema = z.array(
 		region: z.string().describe('Region'),
 		orgName: z.string().nullable().optional().describe('Organization name'),
 		createdAt: z.string().describe('Creation timestamp'),
+		privateIPv4: z.string().nullable().optional().describe('Private IPv4 address'),
+		availabilityZone: z.string().nullable().optional().describe('Availability zone'),
+		instanceType: z.string().nullable().optional().describe('Instance type'),
+		instanceTags: z.array(z.string()).nullable().optional().describe('Instance tags'),
 	})
 );
 
@@ -48,6 +52,10 @@ export const listSubcommand = createSubcommand({
 				region: m.region,
 				orgName: m.orgName ?? undefined,
 				createdAt: m.createdAt,
+				privateIPv4: m.privateIPv4 ?? undefined,
+				availabilityZone: m.availabilityZone ?? undefined,
+				instanceType: m.instanceType ?? undefined,
+				instanceTags: m.instanceTags ?? undefined,
 			}));
 
 			if (!options.json) {
@@ -59,6 +67,10 @@ export const listSubcommand = createSubcommand({
 						Status: m.status,
 						Provider: m.provider,
 						Region: m.region,
+						AZ: m.availabilityZone ?? '-',
+						Type: m.instanceType ?? '-',
+						'Private IP': m.privateIPv4 ?? '-',
+						Tags: m.instanceTags?.join(', ') || '-',
 						Created: new Date(m.createdAt).toLocaleString(),
 					}));
 
@@ -67,6 +79,10 @@ export const listSubcommand = createSubcommand({
 						{ name: 'Status', alignment: 'left' },
 						{ name: 'Provider', alignment: 'left' },
 						{ name: 'Region', alignment: 'left' },
+						{ name: 'AZ', alignment: 'left' },
+						{ name: 'Type', alignment: 'left' },
+						{ name: 'Private IP', alignment: 'left' },
+						{ name: 'Tags', alignment: 'left' },
 						{ name: 'Created', alignment: 'left' },
 					]);
 				}

--- a/packages/server/src/api/machine/machine.ts
+++ b/packages/server/src/api/machine/machine.ts
@@ -7,6 +7,8 @@ const MachineSchema = z.object({
 	instanceId: z.string().nullable().optional(),
 	privateIPv4: z.string().nullable().optional(),
 	availabilityZone: z.string().nullable().optional(),
+	instanceType: z.string().nullable().optional(),
+	instanceTags: z.array(z.string()).nullable().optional(),
 	deploymentCount: z.number().optional(),
 	status: z.string(),
 	provider: z.string(),


### PR DESCRIPTION
Adds new fields returned by GET /machine from catalyst to the `cloud machine ls` output:

- **privateIPv4** - Private IPv4 address
- **availabilityZone** - Availability zone (displayed as AZ)
- **instanceType** - Instance type (displayed as Type)
- **instanceTags** - Instance tags (comma-separated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Machine list command now includes four new information fields: Private IP address, Availability Zone, Instance Type, and Tags. These details are displayed in both human-readable table format and JSON output, providing enhanced visibility and enabling better management of cloud infrastructure resources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->