### PR TITLE
fix: expand exclusion patterns to match nested directories in snapshot build

### DIFF
--- a/packages/cli/src/cmd/cloud/sandbox/snapshot/build.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/snapshot/build.ts
@@ -165,7 +165,7 @@ function substituteVariables(
 }
 
 // Default patterns that are always excluded from snapshot builds
-const DEFAULT_EXCLUSIONS = ['.git/**', 'node_modules/**', '.agentuity/**', '.env*'];
+const DEFAULT_EXCLUSIONS = ['.git', '.git/**', 'node_modules/**', '.agentuity/**', '.env*'];
 
 async function resolveFileGlobs(
 	directory: string,
@@ -203,6 +203,8 @@ async function resolveFileGlobs(
 		}
 	}
 
+	// Expand exclusion patterns to include nested variants
+	const expandedExclusions: string[] = [];
 	for (let pattern of exclusions) {
 		// If pattern already contains glob wildcards, use it as-is
 		// Otherwise, check if it refers to a directory and auto-append /** to exclude all contents
@@ -219,6 +221,16 @@ async function resolveFileGlobs(
 			}
 		}
 
+		expandedExclusions.push(pattern);
+
+		// Add **/ prefix variant to match nested occurrences (e.g., .agentuity/** -> **/.agentuity/**)
+		// Skip if pattern already starts with **/ or is just a wildcard pattern
+		if (!pattern.startsWith('**/')) {
+			expandedExclusions.push(`**/${pattern}`);
+		}
+	}
+
+	for (const pattern of expandedExclusions) {
 		const glob = new Bun.Glob(pattern);
 		for await (const file of glob.scan({ cwd: directory, dot: true })) {
 			files.delete(file);


### PR DESCRIPTION
## Problem

The snapshot build command was not properly excluding nested `node_modules`, `.git`, `.agentuity`, and `.env` files. This was happening because `Bun.Glob.scan()` patterns like `.agentuity/**` only match at the root level, not nested occurrences like `apps/testing/.agentuity/`.

Reference: https://github.com/agentuity/sdk/actions/runs/21268291508/job/61212661825

## Solution

Automatically expand all exclusion patterns (both default and user-provided) to include a `**/` prefix variant. This ensures nested occurrences are also excluded.

For example:
- `.agentuity/**` → also adds `**/.agentuity/**`
- `node_modules/**` → also adds `**/node_modules/**`
- User pattern `!mydir/**` → also adds `**/mydir/**`

## Testing

Verified locally that problematic files dropped from 33 to 0 after the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file exclusion pattern matching during snapshot building to correctly handle nested directory structures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->