### PR TITLE
fix: add queue service to Hono context Variables

### DIFF
--- a/packages/runtime/src/_server.ts
+++ b/packages/runtime/src/_server.ts
@@ -30,6 +30,7 @@ export const AGENT_CONTEXT_PROPERTIES = [
 	'stream',
 	'vector',
 	'sandbox',
+	'queue',
 	'state',
 	'thread',
 	'session',

--- a/packages/runtime/src/app.ts
+++ b/packages/runtime/src/app.ts
@@ -11,6 +11,7 @@ import type {
 	StreamStorage,
 	VectorStorage,
 	SandboxService,
+	QueueService,
 	SessionStartEvent,
 } from '@agentuity/core';
 
@@ -227,6 +228,7 @@ export interface Variables<TAppState = Record<string, never>> {
 	stream: StreamStorage;
 	vector: VectorStorage;
 	sandbox: SandboxService;
+	queue: QueueService;
 	app: TAppState;
 	// Web analytics context (set by createWebSessionMiddleware, thread-only tracking)
 	_webThreadId?: string;

--- a/packages/runtime/src/middleware.ts
+++ b/packages/runtime/src/middleware.ts
@@ -55,6 +55,7 @@ export const AGENT_CONTEXT_PROPERTIES = [
 	'stream',
 	'vector',
 	'sandbox',
+	'queue',
 	'state',
 	'thread',
 	'session',
@@ -112,6 +113,7 @@ export function createBaseMiddleware(config: MiddlewareConfig) {
 		c.set('stream', services.stream);
 		c.set('vector', services.vector);
 		c.set('sandbox', services.sandbox);
+		c.set('queue', services.queue);
 
 		installContextPropertyHelpers(c);
 


### PR DESCRIPTION
## Summary

Fixes #700 - The `queue` service was available on `AgentContext` (for agent handlers) but missing from the Hono context's `Variables` type (`c.var.queue`).

## Problem

Users could access `ctx.queue` in agent handlers but not `c.var.queue` in route handlers, causing a type mismatch.

## Changes

| File | Change |
|------|--------|
| `packages/runtime/src/app.ts` | Added `QueueService` import and `queue: QueueService` to `Variables` interface |
| `packages/runtime/src/middleware.ts` | Added `'queue'` to `AGENT_CONTEXT_PROPERTIES` array |
| `packages/runtime/src/middleware.ts` | Added `c.set('queue', services.queue)` in `createBaseMiddleware` |
| `packages/runtime/src/_server.ts` | Added `'queue'` to exported `AGENT_CONTEXT_PROPERTIES` array |

## Verification

- ✅ `bun run build` passes
- ✅ `bun run typecheck` passes
- ✅ `bun run lint` passes
- ✅ `bun run test` passes (591 tests, including auto-generated test for `queue` in context-property-errors.test.ts)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Queue service is now accessible within the application context, enabling developers to utilize queue functionality in their agent applications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->