### PR TITLE
fix: CLI error when trying to log in from the auth section

### DIFF
--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -72,12 +72,13 @@ export async function requireAuth(ctx: CommandContext<undefined>): Promise<AuthD
 	// Import and run login flow
 	const { loginCommand } = await import('./cmd/auth/login');
 
-	// Ensure apiClient is available for login handler
+	// Ensure apiClient and opts are available for login handler
 	const loginCtx = ctx as unknown as Record<string, unknown>;
 	if (!loginCtx.apiClient) {
 		const apiUrl = getAPIBaseURL(ctx.config ?? null);
 		loginCtx.apiClient = new APIClient(apiUrl, ctx.logger, ctx.config ?? null);
 	}
+	loginCtx.opts ??= {};
 
 	if (loginCommand.handler) {
 		await loginCommand.handler(loginCtx as CommandContext);
@@ -165,12 +166,13 @@ export async function optionalAuth(
 			// Import and run login flow
 			const { loginCommand } = await import('./cmd/auth/login');
 
-			// Ensure apiClient is available for login handler
+			// Ensure apiClient and opts are available for login handler
 			const loginCtx1 = ctx as unknown as Record<string, unknown>;
 			if (!loginCtx1.apiClient) {
 				const apiUrl = getAPIBaseURL(ctx.config ?? null);
 				loginCtx1.apiClient = new APIClient(apiUrl, ctx.logger, ctx.config ?? null);
 			}
+			loginCtx1.opts ??= {};
 
 			if (loginCommand.handler) {
 				await loginCommand.handler(loginCtx1 as CommandContext);
@@ -207,12 +209,13 @@ export async function optionalAuth(
 			// Import and run login flow
 			const { loginCommand } = await import('./cmd/auth/login');
 
-			// Ensure apiClient is available for login handler
+			// Ensure apiClient and opts are available for login handler
 			const loginCtx2 = ctx as unknown as Record<string, unknown>;
 			if (!loginCtx2.apiClient) {
 				const apiUrl = getAPIBaseURL(ctx.config ?? null);
 				loginCtx2.apiClient = new APIClient(apiUrl, ctx.logger, ctx.config ?? null);
 			}
+			loginCtx2.opts ??= {};
 
 			if (loginCommand.handler) {
 				await loginCommand.handler(loginCtx2 as CommandContext);

--- a/packages/cli/src/cmd/auth/login.ts
+++ b/packages/cli/src/cmd/auth/login.ts
@@ -25,7 +25,8 @@ export const loginCommand = createSubcommand({
 		response: z.object({ success: z.boolean() }),
 	},
 	async handler(ctx) {
-		const { logger, config, apiClient, opts, options } = ctx;
+		const { logger, config, apiClient, options } = ctx;
+		const opts = ctx.opts ?? {};
 
 		if (opts.setupToken) {
 			const url = getAPIBaseURL(config);


### PR DESCRIPTION
## Summary

Fixes #716 - CLI error when trying to log in from the `auth` section.

### Problem

When running `agentuity auth whoami` while logged out and choosing "Yes" to login, users got:
```
TypeError: undefined is not an object (evaluating 'K.setupToken')
```

### Root Cause

When `loginCommand.handler` is called directly from `auth.ts` (via `requireAuth` or `optionalAuth`), the context was missing the `opts` property that the command framework normally populates. Accessing `opts.setupToken` threw the error.

### Solution

1. Added `loginCtx.opts ??= {}` at all 3 call sites in `auth.ts`
2. Added defensive `const opts = ctx.opts ?? {}` in `login.ts` handler to prevent future regressions

### Changes

| File | Change |
|------|--------|
| `packages/cli/src/auth.ts` | Added `opts: {}` to context in 3 places |
| `packages/cli/src/cmd/auth/login.ts` | Added defensive fallback for `opts` |

### Testing

- ✅ `bun run typecheck`
- ✅ `bun run lint`
- ✅ `bun run build`
- ✅ `bun run test`

### How to Verify

1. Log out: `agentuity logout`
2. Run: `agentuity auth whoami`
3. Choose "Yes" when prompted to login
4. The browser-based login flow should now work correctly

---
Amp thread: https://ampcode.com/threads/T-019be8f0-c2d4-7029-ae30-235b9907c131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved initialization of login context options to ensure safe handling of configuration properties during authentication flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->