### PR TITLE
fix: use Catalyst client for malware check endpoint

### DIFF
--- a/packages/cli/src/cmd/cloud/deploy.ts
+++ b/packages/cli/src/cmd/cloud/deploy.ts
@@ -13,6 +13,7 @@ import {
 	getDefaultConfigDir,
 	loadProjectSDKKey,
 	updateProjectConfig,
+	getGlobalCatalystAPIClient,
 } from '../../config';
 import { getProjectGithubStatus } from '../git/api';
 import { runGitLink } from '../git/link';
@@ -341,8 +342,10 @@ export const deploySubcommand = createSubcommand({
 						return null;
 					}
 					logger.debug('Checking %d packages for malware', packages.length);
+					// Use Catalyst client directly for malware check (security routes are on Catalyst)
+					const catalystClient = await getGlobalCatalystAPIClient(logger, auth, config?.name);
 					const result = await projectDeploymentMalwareCheck(
-						apiClient,
+						catalystClient,
 						deployment!.id,
 						packages
 					);


### PR DESCRIPTION
## Summary

The malware check was returning 404 during deploy because the SDK was calling the `/security/2026-01-22/{deploymentId}/malware-check` endpoint on the app API, but this route only exists in Catalyst.

## Changes

Updated the deploy command to use `getGlobalCatalystAPIClient()` for the malware check instead of the app API client.

## Testing

- Typecheck passes
- Lint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the internal malware check infrastructure to use an optimized API client configuration for deployment security processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->