### PR TITLE
fix agent-browser runtime README with correct usage examples

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,7 @@
     },
     "apps/create-agentuity": {
       "name": "create-agentuity",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "bin": {
         "create-agentuity": "./bin.js",
       },
@@ -45,7 +45,7 @@
     },
     "apps/docs": {
       "name": "docs",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "dependencies": {
         "@agentuity/core": "workspace:*",
         "@agentuity/evals": "workspace:*",
@@ -85,7 +85,7 @@
     },
     "apps/testing": {
       "name": "testing",
-      "version": "0.1.26",
+      "version": "0.1.27",
     },
     "apps/testing/auth-package-app": {
       "name": "auth-package-app",
@@ -304,7 +304,7 @@
     },
     "packages/auth": {
       "name": "@agentuity/auth",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "dependencies": {
         "better-auth": "^1.4.9",
         "drizzle-orm": "^0.45.0",
@@ -328,7 +328,7 @@
     },
     "packages/cli": {
       "name": "@agentuity/cli",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "bin": {
         "agentuity": "./bin/cli.ts",
       },
@@ -368,7 +368,7 @@
     },
     "packages/core": {
       "name": "@agentuity/core",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "dependencies": {
         "zod": "^4.3.5",
       },
@@ -382,7 +382,7 @@
     },
     "packages/evals": {
       "name": "@agentuity/evals",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "dependencies": {
         "@agentuity/core": "workspace:*",
         "@agentuity/runtime": "workspace:*",
@@ -399,7 +399,7 @@
     },
     "packages/frontend": {
       "name": "@agentuity/frontend",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "dependencies": {
         "@agentuity/core": "workspace:*",
       },
@@ -412,7 +412,7 @@
     },
     "packages/opencode": {
       "name": "@agentuity/opencode",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "dependencies": {
         "@agentuity/core": "workspace:*",
         "zod": "^4.3.5",
@@ -426,7 +426,7 @@
     },
     "packages/react": {
       "name": "@agentuity/react",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "dependencies": {
         "@agentuity/core": "workspace:*",
         "@agentuity/frontend": "workspace:*",
@@ -445,7 +445,7 @@
     },
     "packages/runtime": {
       "name": "@agentuity/runtime",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "dependencies": {
         "@agentuity/auth": "workspace:*",
         "@agentuity/core": "workspace:*",
@@ -486,7 +486,7 @@
     },
     "packages/schema": {
       "name": "@agentuity/schema",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "dependencies": {
         "@agentuity/core": "workspace:*",
       },
@@ -499,7 +499,7 @@
     },
     "packages/server": {
       "name": "@agentuity/server",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "dependencies": {
         "@agentuity/core": "workspace:*",
         "@agentuity/schema": "workspace:*",
@@ -515,7 +515,7 @@
     },
     "packages/test-utils": {
       "name": "@agentuity/test-utils",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "dependencies": {
         "@agentuity/core": "workspace:*",
       },
@@ -525,7 +525,7 @@
     },
     "packages/vscode": {
       "name": "agentuity-vscode",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "dependencies": {
         "jsonc-parser": "^3.3.1",
         "tar": "^7.4.3",
@@ -539,7 +539,7 @@
     },
     "packages/workbench": {
       "name": "@agentuity/workbench",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "dependencies": {
         "@agentuity/core": "workspace:*",
         "@agentuity/react": "workspace:*",


### PR DESCRIPTION
## Overview

Fixes the agent-browser runtime README in the database with correct CLI usage examples.

## Motivation

The existing README for the agent-browser sandbox runtime had incorrect or incomplete documentation, making it difficult for users to understand how to use the agent-browser CLI effectively.

## Changes

### app
- Added database migration `0162_exotic_machine_man.sql`
- Updates `sandbox_runtime.readme` for all `agent-browser:*` entries
- Provides accurate examples for:
  - `agent-browser navigate` - URL navigation
  - `agent-browser snapshot` - Page snapshots
  - `agent-browser fill` / `click` - Element interaction
  - `agent-browser screenshot` - Full page screenshots
  - `agent-browser close` - Session cleanup

## Testing

1. Run the database migration
2. Query `sandbox_runtime` table for `agent-browser:*` entries
3. Verify README content is updated with correct examples

## Breaking Changes

None - this is a documentation-only update to existing runtime entries.

## Repository-Specific Changes

See main description