### PR TITLE
fix: remove redundant success field from MalwareCheckResult schema

### DIFF
--- a/packages/server/src/api/project/malware.ts
+++ b/packages/server/src/api/project/malware.ts
@@ -27,7 +27,6 @@ const MalwareCheckListMetadata = z.object({
 });
 
 const MalwareCheckResult = z.object({
-	success: z.boolean(),
 	action: z.enum(['allow', 'block']),
 	summary: MalwareCheckSummary,
 	findings: z.array(MalwareFinding),

--- a/packages/server/test/malware.test.ts
+++ b/packages/server/test/malware.test.ts
@@ -12,7 +12,6 @@ describe('malware API', () => {
 						JSON.stringify({
 							success: true,
 							data: {
-								success: true,
 								action: 'allow',
 								summary: {
 									scanned: 150,
@@ -39,7 +38,6 @@ describe('malware API', () => {
 				{ name: 'express', version: '4.18.2' },
 			]);
 
-			expect(result.success).toBe(true);
 			expect(result.action).toBe('allow');
 			expect(result.summary.scanned).toBe(150);
 			expect(result.summary.flagged).toBe(0);
@@ -53,7 +51,6 @@ describe('malware API', () => {
 						JSON.stringify({
 							success: true,
 							data: {
-								success: true,
 								action: 'block',
 								summary: {
 									scanned: 150,
@@ -83,7 +80,6 @@ describe('malware API', () => {
 				{ name: '@bad/pkg', version: '2.0.0' },
 			]);
 
-			expect(result.success).toBe(true);
 			expect(result.action).toBe('block');
 			expect(result.summary.flagged).toBe(2);
 			expect(result.findings).toHaveLength(2);
@@ -100,7 +96,6 @@ describe('malware API', () => {
 						JSON.stringify({
 							success: true,
 							data: {
-								success: true,
 								action: 'allow',
 								summary: {
 									scanned: 0,
@@ -120,7 +115,6 @@ describe('malware API', () => {
 
 			const result = await projectDeploymentMalwareCheck(client, 'deploy-123', []);
 
-			expect(result.success).toBe(true);
 			expect(result.action).toBe('allow');
 			expect(result.summary.scanned).toBe(0);
 		});
@@ -132,7 +126,6 @@ describe('malware API', () => {
 						JSON.stringify({
 							success: true,
 							data: {
-								success: false,
 								action: 'allow',
 								summary: {
 									scanned: 0,
@@ -155,7 +148,6 @@ describe('malware API', () => {
 				{ name: 'lodash', version: '4.17.21' },
 			]);
 
-			expect(result.success).toBe(false);
 			expect(result.action).toBe('allow');
 			expect(result.error).toBe('malware detection service unavailable');
 		});
@@ -192,7 +184,6 @@ describe('malware API', () => {
 					JSON.stringify({
 						success: true,
 						data: {
-							success: true,
 							action: 'allow',
 							summary: { scanned: 1, flagged: 0 },
 							findings: [],
@@ -222,7 +213,6 @@ describe('malware API', () => {
 					JSON.stringify({
 						success: true,
 						data: {
-							success: true,
 							action: 'allow',
 							summary: { scanned: 3, flagged: 0 },
 							findings: [],


### PR DESCRIPTION
## Problem

The CLI's `agentuity deploy` command was failing with:

```
[WARN] Malware check failed: ValidationOutputError: There was an unexpected error validating the API response data.
  issues: [
    {
      code: 'invalid_type',
      input: undefined,
      message: 'Invalid input: expected object, received undefined',
      path: [ 'data' ]
```

## Root Cause

The `MalwareCheckResult` schema had a redundant `success` field:

```typescript
const MalwareCheckResult = z.object({
  success: z.boolean(),  // <-- redundant!
  action: z.enum(['allow', 'block']),
  ...
});

const MalwareCheckResponseSchema = APIResponseSchema(MalwareCheckResult);
```

Since `APIResponseSchema` already wraps the inner schema and adds `success` at the outer level, the SDK expected:

```json
{ "success": true, "data": { "success": true, "action": "allow", ... } }
```

But Catalyst (correctly) returns:

```json
{ "success": true, "data": { "action": "allow", ... } }
```

## Solution

Removed the redundant `success` field from `MalwareCheckResult` so the schema matches Catalyst's response format.

This is a companion fix to agentuity/catalyst#451 which wrapped the response in the standard `data` field.

## Testing

- All malware API tests pass
- Full SDK typecheck and build pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined malware check API response structure by removing a redundant field from the inner result object, while maintaining comprehensive status and error information in the outer response wrapper.

* **Tests**
  * Updated malware check test suite to reflect the revised API schema.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->