### PR TITLE
fix: detect bun global bin path instead of assuming default

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,8 +13,9 @@ MIN_BUN_VERSION="1.3.3"
 SETUP_TOKEN="-"
 # BUN_EXEC_DIR: where the bun executable itself lives
 BUN_EXEC_DIR="${BUN_INSTALL:-$HOME/.bun}/bin"
-# BUN_INSTALL_BIN: where globally installed packages go (defaults to same as BUN_EXEC_DIR)
-BUN_INSTALL_BIN="${BUN_INSTALL_BIN:-$BUN_EXEC_DIR}"
+# BUN_INSTALL_BIN: where globally installed packages go
+# Try to detect from bun itself, fall back to BUN_EXEC_DIR
+BUN_INSTALL_BIN="${BUN_INSTALL_BIN:-}"
 
 requested_version=${VERSION:-}
 force_install=false
@@ -101,6 +102,28 @@ print_message() {
   esac
 
   printf "${_pm_color}${_pm_message}${NC}\n"
+}
+
+# Detect where bun installs global packages
+detect_bun_global_bin() {
+  # If already set by user, don't override
+  if [ -n "$BUN_INSTALL_BIN" ]; then
+    return 0
+  fi
+  
+  # Try to get the global bin path from bun itself
+  if command -v bun >/dev/null 2>&1; then
+    detected_bin=$(bun pm bin -g 2>/dev/null || echo "")
+    if [ -n "$detected_bin" ]; then
+      BUN_INSTALL_BIN="$detected_bin"
+      print_message debug "Detected bun global bin: $BUN_INSTALL_BIN"
+      return 0
+    fi
+  fi
+  
+  # Fall back to BUN_EXEC_DIR
+  BUN_INSTALL_BIN="$BUN_EXEC_DIR"
+  print_message debug "Using default bun bin: $BUN_INSTALL_BIN"
 }
 
 # Ensure bun is on PATH
@@ -502,7 +525,18 @@ show_path_reminder() {
 }
 
 run_setup() {
-  agentuity_bin="$BUN_INSTALL_BIN/agentuity"
+  # Ensure the bun bin directory is on PATH for this session
+  case ":$PATH:" in
+  *":$BUN_INSTALL_BIN:"*) ;;
+  *) export PATH="$BUN_INSTALL_BIN:$PATH" ;;
+  esac
+
+  # Try to find the agentuity binary
+  if command -v agentuity >/dev/null 2>&1; then
+    agentuity_bin=$(command -v agentuity)
+  else
+    agentuity_bin="$BUN_INSTALL_BIN/agentuity"
+  fi
 
   if [ -x "$agentuity_bin" ]; then
     if [ "$non_interactive" = true ]; then
@@ -539,6 +573,9 @@ clear_progress() {
 main() {
   # Check prerequisites first (may prompt interactively)
   check_bun
+
+  # Detect where bun installs global packages (after bun is available)
+  detect_bun_global_bin
 
   # Check for legacy installations (may prompt interactively)
   check_brew_install


### PR DESCRIPTION
## Problem

The install script was hardcoding `~/.bun/bin` as the global package location, causing this error when bun is installed to a non-standard path:

```
Could not run setup - agentuity not found at /home/[username]/.bun/bin/agentuity
```

This happens when `BUN_INSTALL` is set to a custom location (e.g., `~/.cache/.bun`).

## Solution

Added `detect_bun_global_bin()` function that uses `bun pm bin -g` to detect the actual global bin directory after bun is available, with fallback to the default path.

## Testing

Tested in Docker containers:
- Clean Debian install (default bun location) ✓
- Custom `BUN_INSTALL=~/.cache/.bun` location ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved installer detection for Bun's global binary installation path with enhanced support for custom configurations.
  * Better PATH handling to ensure the installer properly locates necessary executables during the setup process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->