### PR TITLE
fix(react): use useLayoutEffect for synchronous authHeader prop sync

### DIFF
--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import React, { useState, useEffect, useLayoutEffect, useMemo, useCallback } from 'react';
 import { createContext, useContext, type Context } from 'react';
 import { defaultBaseUrl } from '@agentuity/frontend';
 import { setGlobalBaseUrl, setGlobalAuthHeader } from './client';
@@ -48,8 +48,10 @@ export const AgentuityProvider = ({
 		setGlobalAuthHeader(authHeader);
 	}, [authHeader]);
 
-	// Sync authHeader prop changes to state
-	useEffect(() => {
+	// Sync authHeader prop changes to state synchronously
+	// useLayoutEffect ensures the state is updated before child effects run,
+	// preventing race conditions where useAPI makes requests before auth is set (issue #732)
+	useLayoutEffect(() => {
 		if (authHeaderProp !== undefined) {
 			setAuthHeaderState(authHeaderProp);
 		}

--- a/packages/react/test/useAuth.test.tsx
+++ b/packages/react/test/useAuth.test.tsx
@@ -153,4 +153,74 @@ describe('useAuth', () => {
 		expect(screen.getByTestId('has-set-auth-header').textContent).toBe('true');
 		expect(screen.getByTestId('has-set-auth-loading').textContent).toBe('true');
 	});
+
+	test('authHeader prop is available synchronously to child components', async () => {
+		// This test verifies the fix for GitHub issue #732
+		// The bug: useAPI hook receives null authHeader on initial mount
+		// because useEffect runs after the initial render
+		let capturedAuthHeader: string | null | undefined;
+
+		function ChildComponent() {
+			const { authHeader } = useAuth();
+			// Capture the authHeader on first render
+			if (capturedAuthHeader === undefined) {
+				capturedAuthHeader = authHeader;
+			}
+			return <div data-testid="auth-header">{authHeader ?? 'null'}</div>;
+		}
+
+		// Simulate the common pattern: parent has auth token ready
+		render(
+			<AgentuityProvider authHeader="Bearer test-token">
+				<ChildComponent />
+			</AgentuityProvider>
+		);
+
+		// The authHeader should be available on the FIRST render, not after an effect
+		expect(capturedAuthHeader).toBe('Bearer test-token');
+		expect(screen.getByTestId('auth-header').textContent).toBe('Bearer test-token');
+	});
+
+	test('authHeader prop change is available synchronously via useLayoutEffect', async () => {
+		// This test verifies that when authHeader prop changes,
+		// child components see the new value before their effects run
+		const authHeaders: (string | null | undefined)[] = [];
+
+		function ChildComponent() {
+			const { authHeader } = useAuth();
+
+			// Track all authHeader values seen during renders
+			React.useEffect(() => {
+				authHeaders.push(authHeader);
+			}, [authHeader]);
+
+			return <div data-testid="auth-header">{authHeader ?? 'null'}</div>;
+		}
+
+		const { rerender } = render(
+			<AgentuityProvider authHeader={null}>
+				<ChildComponent />
+			</AgentuityProvider>
+		);
+
+		// Initial render with null
+		await waitFor(() => {
+			expect(authHeaders).toContain(null);
+		});
+
+		// Update the authHeader prop
+		rerender(
+			<AgentuityProvider authHeader="Bearer new-token">
+				<ChildComponent />
+			</AgentuityProvider>
+		);
+
+		// The effect should see the new token, not null
+		await waitFor(() => {
+			expect(authHeaders).toContain('Bearer new-token');
+		});
+
+		// Verify the DOM shows the new token
+		expect(screen.getByTestId('auth-header').textContent).toBe('Bearer new-token');
+	});
 });


### PR DESCRIPTION
## Summary

Fixes #732 - useAPI hook receives null authHeader on initial mount despite AgentuityProvider prop being set.

- Changed `useEffect` to `useLayoutEffect` for authHeader prop synchronization in `AgentuityProvider`
- Added 2 regression tests to verify synchronous authHeader availability

## Root Cause

The `AgentuityProvider` was using `useEffect` to sync the `authHeader` prop to internal state. Since `useEffect` runs **after** the initial render, child components using `useAPI` would make their initial requests before the auth header was synchronized, resulting in 401 Unauthorized responses.

## Solution

Changed `useEffect` to `useLayoutEffect` for the `authHeader` prop synchronization. `useLayoutEffect` runs **synchronously before the browser paints**, ensuring child components see the correct auth header value before their effects run.

## Changes

| File | Change |
|------|--------|
| `packages/react/src/context.tsx` | Added `useLayoutEffect` import, changed prop sync from `useEffect` to `useLayoutEffect` |
| `packages/react/test/useAuth.test.tsx` | Added 2 regression tests for synchronous authHeader availability |

## Testing

- [x] All 140 tests pass
- [x] Build passes
- [x] Typecheck passes
- [x] Lint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced authentication reliability during initial page load by ensuring auth headers are properly synchronized before rendering child components, preventing potential race conditions with authentication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->