### PR TITLE
fix(opencode): use toast instead of session.prompt for Cadence status

### DIFF
--- a/packages/opencode/src/plugin/hooks/cadence.ts
+++ b/packages/opencode/src/plugin/hooks/cadence.ts
@@ -80,7 +80,7 @@ export function createCadenceHooks(ctx: PluginContext, _config: CoderConfig): Ca
 					injectCadenceTag(output);
 				}
 
-				await injectStatusMessage(ctx, sessionId, state);
+				showToast(ctx, `⚡ Cadence started · ${state.iteration}/${state.maxIterations}`);
 				return;
 			}
 
@@ -112,7 +112,8 @@ export function createCadenceHooks(ctx: PluginContext, _config: CoderConfig): Ca
 				state.maxIterations = newMax;
 
 				if (changed) {
-					await injectStatusMessage(ctx, sessionId, state);
+					const loopInfo = state.loopId ? ` · ${state.loopId}` : '';
+					showToast(ctx, `⚡ Cadence · ${state.iteration}/${state.maxIterations}${loopInfo}`);
 				}
 				return;
 			}
@@ -123,7 +124,8 @@ export function createCadenceHooks(ctx: PluginContext, _config: CoderConfig): Ca
 				const newIteration = parseInt(iterMatch[1], 10);
 				if (newIteration !== state.iteration) {
 					state.iteration = newIteration;
-					await injectStatusMessage(ctx, sessionId, state);
+					const loopInfo = state.loopId ? ` · ${state.loopId}` : '';
+					showToast(ctx, `⚡ Cadence · ${state.iteration}/${state.maxIterations}${loopInfo}`);
 				}
 			}
 
@@ -343,41 +345,4 @@ function showToast(ctx: PluginContext, message: string): void {
 	} catch {
 		// Toast may not be available
 	}
-}
-
-async function injectStatusMessage(
-	ctx: PluginContext,
-	sessionId: string,
-	state: CadenceSessionState
-): Promise<void> {
-	try {
-		const elapsed = getElapsedTime(state.startedAt);
-		const loopInfo = state.loopId ? ` · ${state.loopId}` : '';
-		const status = `⚡ **Cadence** · ${state.iteration}/${state.maxIterations}${loopInfo} · ${elapsed}`;
-
-		await ctx.client.session?.prompt?.({
-			path: { id: sessionId },
-			body: {
-				parts: [{ type: 'text', text: status }],
-			},
-			noReply: true,
-		});
-	} catch {
-		// Status injection may not be available
-	}
-}
-
-function getElapsedTime(startedAt: string): string {
-	if (!startedAt) return '-';
-
-	const start = new Date(startedAt).getTime();
-	if (isNaN(start)) return '-';
-
-	const now = Date.now();
-	const seconds = Math.floor((now - start) / 1000);
-
-	if (seconds < 0) return '-';
-	if (seconds < 60) return `${seconds}s`;
-	if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
-	return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`;
 }


### PR DESCRIPTION
## Summary

Replace `injectStatusMessage()` with `showToast()` for Cadence iteration status updates.

## Problem

The previous implementation used `session.prompt()` without specifying an agent, which caused OpenCode to fall back to the default Build agent and break agent context during Cadence loops.

## Solution

- Replace `session.prompt()` calls for status display with `showToast()` (matches oh-my-opencode pattern)
- Remove unused `injectStatusMessage()` and `getElapsedTime()` functions

## What's Preserved

- **`onCompacting` hook** — Still injects Cadence state into compaction summary via `output.context.push()`
- **`session.compacted` handler** — Still uses `session.prompt()` but correctly specifies `agent: 'Agentuity Coder Lead'` to maintain Cadence loop continuity after context compaction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cadence status updates now appear as on-screen toasts during execution, providing real-time feedback with iteration counts and loop information for improved visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->