### PR TITLE
fix: always emit Session End span for telemetry

### DIFF
--- a/packages/runtime/src/services/session/http.ts
+++ b/packages/runtime/src/services/session/http.ts
@@ -125,7 +125,6 @@ export class HTTPSessionEventProvider implements SessionEventProvider {
 				span.setStatus({ code: SpanStatusCode.OK });
 				return;
 			}
-			this.startedSessions.delete(event.id);
 
 			internal.info(
 				'[session-http] sending complete event: %s, userData: %s',
@@ -145,6 +144,7 @@ export class HTTPSessionEventProvider implements SessionEventProvider {
 			);
 
 			if (resp.success) {
+				this.startedSessions.delete(event.id);
 				internal.info('[session-http] complete event sent successfully: %s', event.id);
 				this.logger.debug('Session complete event sent successfully: %s', event.id);
 				span.setStatus({ code: SpanStatusCode.OK });


### PR DESCRIPTION
## Summary

Fixes session recalculation timeouts in Catalyst by ensuring the "Session End" span is always emitted.

## Problem

Catalyst's `RecalculateSessionWithRetry` waits for the "Session End" span to appear in ClickHouse before running session recalculation. Previously, this span was only created when:
1. The session start event was successfully sent to Catalyst
2. The HTTP complete event was being sent

If the start event was skipped (e.g., missing `orgId` or `projectId`), no "Session End" span was created, causing Catalyst to timeout with: `session telemetry data not received within timeout`

## Solution

Always create the "Session End" span for telemetry purposes, regardless of whether the HTTP complete event is sent. This ensures:
- Catalyst can always detect session completion via the span in ClickHouse
- The HTTP event logic remains unchanged (only sent when matching start exists)

## Changes

- `packages/runtime/src/services/session/http.ts`: Move span creation before the early return check, so the span is always emitted even when skipping the HTTP event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session termination telemetry now always records an end event so session lifecycles are fully tracked, even when a matching start record is missing. Logging now clarifies whether an event was emitted locally or sent to the server, improving observability and reliability of session reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->