### PR TITLE
fix(cli): pass config to region resolution for proper SSH/SCP region lookup

### DIFF
--- a/packages/cli/src/cmd/cloud/region-lookup.ts
+++ b/packages/cli/src/cmd/cloud/region-lookup.ts
@@ -2,7 +2,7 @@ import type { Logger } from '@agentuity/core';
 import { projectGet, sandboxGet, deploymentGet, type APIClient } from '@agentuity/server';
 import { getResourceRegion, setResourceRegion } from '../../cache';
 import { getGlobalCatalystAPIClient } from '../../config';
-import type { AuthData } from '../../types';
+import type { AuthData, Config } from '../../types';
 import * as tui from '../../tui';
 import { ErrorCode } from '../../errors';
 
@@ -35,7 +35,8 @@ export async function getIdentifierRegion(
 	apiClient: APIClient,
 	profileName = 'production',
 	identifier: string,
-	orgId?: string
+	orgId?: string,
+	config?: Config | null
 ): Promise<string> {
 	const identifierType = getIdentifierType(identifier);
 
@@ -57,8 +58,14 @@ export async function getIdentifierRegion(
 		const deployment = await deploymentGet(apiClient, identifier);
 		region = deployment.cloudRegion ?? null;
 	} else {
-		// sandbox
-		const globalClient = await getGlobalCatalystAPIClient(logger, auth, profileName);
+		// sandbox - pass config to getGlobalCatalystAPIClient for proper region resolution
+		const globalClient = await getGlobalCatalystAPIClient(
+			logger,
+			auth,
+			profileName,
+			orgId,
+			config
+		);
 		const sandbox = await sandboxGet(globalClient, { sandboxId: identifier, orgId });
 		region = sandbox.region ?? null;
 	}
@@ -66,6 +73,14 @@ export async function getIdentifierRegion(
 	if (!region) {
 		tui.fatal(
 			`Could not determine region for ${identifierType} '${identifier}'. Use --region flag to specify.`,
+			ErrorCode.RESOURCE_NOT_FOUND
+		);
+	}
+
+	// Validate region is a non-empty string
+	if (typeof region !== 'string' || region.trim() === '') {
+		tui.fatal(
+			`Invalid region returned for ${identifierType} '${identifier}': '${region}'. Use --region flag to specify a valid region.`,
 			ErrorCode.RESOURCE_NOT_FOUND
 		);
 	}

--- a/packages/cli/src/cmd/cloud/scp/download.ts
+++ b/packages/cli/src/cmd/cloud/scp/download.ts
@@ -72,7 +72,8 @@ export const downloadCommand = createSubcommand({
 			apiClient,
 			profileName,
 			identifier,
-			orgId
+			orgId,
+			config
 		);
 
 		const hostname = getIONHost(config, region);

--- a/packages/cli/src/cmd/cloud/scp/upload.ts
+++ b/packages/cli/src/cmd/cloud/scp/upload.ts
@@ -75,7 +75,8 @@ export const uploadCommand = createSubcommand({
 			apiClient,
 			profileName,
 			identifier,
-			orgId
+			orgId,
+			config
 		);
 
 		const hostname = getIONHost(config, region);

--- a/packages/cli/src/cmd/cloud/ssh.ts
+++ b/packages/cli/src/cmd/cloud/ssh.ts
@@ -80,7 +80,8 @@ export const sshSubcommand = createSubcommand({
 			apiClient,
 			profileName,
 			targetIdentifier,
-			orgId
+			orgId,
+			config
 		);
 
 		const hostname = getIONHost(config, region);

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -809,14 +809,16 @@ export async function getDefaultRegion(
  * @param auth - Authentication data
  * @param profileName - Profile name (default: 'production')
  * @param orgId - Optional organization ID for CLI key authentication
+ * @param config - Optional config for region preference lookup
  */
 export async function getGlobalCatalystAPIClient(
 	logger: Logger,
 	auth: AuthData,
 	profileName = 'production',
-	orgId?: string
+	orgId?: string,
+	config?: Config | null
 ) {
-	const region = await getDefaultRegion(profileName);
+	const region = await getDefaultRegion(profileName, config);
 	return getCatalystAPIClient(logger, auth, region, orgId);
 }
 
@@ -827,6 +829,12 @@ export function getIONHost(config: Config | null, region: string) {
 	}
 	if (config?.name === 'local' || region === 'local') {
 		return 'ion.agentuity.io';
+	}
+	// Validate region is a non-empty string to prevent malformed hostnames
+	if (!region || typeof region !== 'string' || region.trim() === '') {
+		throw new Error(
+			`Invalid region: '${region}'. Region must be a non-empty string. Use --region flag to specify a valid region.`
+		);
 	}
 	return `ion-${region}.agentuity.cloud`;
 }

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -24,7 +24,10 @@ export const ConfigSchema = zod.object({
 	devmode: zod
 		.object({
 			hostname: zod.string().optional().describe('Development mode hostname'),
-			privateKey: zod.string().optional().describe('Development mode private key (base64-encoded PEM)'),
+			privateKey: zod
+				.string()
+				.optional()
+				.describe('Development mode private key (base64-encoded PEM)'),
 		})
 		.optional()
 		.describe('Development mode configuration'),

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -105,14 +105,14 @@ Lead will:
 
 Start with `/agentuity-cadence`, then use natural language:
 
-| Action | How |
-| ------ | --- |
+| Action | How                                         |
+| ------ | ------------------------------------------- |
 | Start  | `/agentuity-cadence build the auth feature` |
-| Status | "what's the status?" |
-| Pause  | "pause" |
-| Resume | "continue" |
-| Extend | "continue for 50 more iterations" |
-| Stop   | "stop" or Ctrl+C |
+| Status | "what's the status?"                        |
+| Pause  | "pause"                                     |
+| Resume | "continue"                                  |
+| Extend | "continue for 50 more iterations"           |
+| Stop   | "stop" or Ctrl+C                            |
 
 ### CLI Control (Headless)
 

--- a/packages/opencode/docs/cadence.md
+++ b/packages/opencode/docs/cadence.md
@@ -80,14 +80,14 @@ interface CadenceLoop {
 
 Use `/agentuity-cadence` to start a Cadence loop. Control is via natural language:
 
-| Action | How |
-| ------ | --- |
+| Action | How                                                    |
+| ------ | ------------------------------------------------------ |
 | Start  | `/agentuity-cadence build the auth feature with tests` |
-| Status | "what's the status?" or "how's it going?" |
-| Pause  | "pause" or "hold on" |
-| Resume | "continue" or "resume" |
-| Stop   | "stop" or Ctrl+C |
-| Extend | "continue for 50 more iterations" or "go until done" |
+| Status | "what's the status?" or "how's it going?"              |
+| Pause  | "pause" or "hold on"                                   |
+| Resume | "continue" or "resume"                                 |
+| Stop   | "stop" or Ctrl+C                                       |
+| Extend | "continue for 50 more iterations" or "go until done"   |
 
 ## CLI Commands
 

--- a/packages/opencode/src/plugin/plugin.ts
+++ b/packages/opencode/src/plugin/plugin.ts
@@ -301,7 +301,6 @@ $ARGUMENTS
 			agent: 'Agentuity Coder Lead',
 			argumentHint: 'build the new auth feature with tests',
 		},
-
 	};
 }
 

--- a/packages/runtime/src/_waituntil.ts
+++ b/packages/runtime/src/_waituntil.ts
@@ -118,16 +118,22 @@ export default class WaitUntilHandler {
 	 * Unlike waitUntilAll, this doesn't mark the handler as "all called" and
 	 * allows additional waitUntil calls afterward.
 	 */
-	public async waitForPromises(promises: Promise<void>[], logger: Logger, sessionId: string): Promise<void> {
+	public async waitForPromises(
+		promises: Promise<void>[],
+		logger: Logger,
+		sessionId: string
+	): Promise<void> {
 		if (promises.length === 0) {
 			internal.debug('No promises to wait for in snapshot');
 			return;
 		}
 
-		internal.debug(`⏳ Waiting for ${promises.length} snapshot promises to complete (session: ${sessionId})...`);
+		internal.debug(
+			`⏳ Waiting for ${promises.length} snapshot promises to complete (session: ${sessionId})...`
+		);
 		try {
 			const results = await Promise.allSettled(promises);
-			
+
 			// Log any failures
 			const failures = results.filter((r) => r.status === 'rejected');
 			if (failures.length > 0) {

--- a/packages/runtime/src/agent.ts
+++ b/packages/runtime/src/agent.ts
@@ -2441,16 +2441,16 @@ const runWithSpan = async <
 		// context's trace state is automatically restored.
 		const currentSpanContext = span.spanContext();
 		let updatedTraceState = currentSpanContext.traceState ?? new TraceState();
-		
+
 		// Add agent ID
 		updatedTraceState = updatedTraceState.set('aid', agent.metadata.id);
-		
+
 		// Add deployment ID, project ID, org ID, and devmode if available
 		const deploymentId = runtimeConfig.getDeploymentId();
 		const projectId = runtimeConfig.getProjectId();
 		const orgId = runtimeConfig.getOrganizationId();
 		const isDevMode = runtimeConfig.isDevMode();
-		
+
 		if (deploymentId) updatedTraceState = updatedTraceState.set('did', deploymentId);
 		if (projectId) updatedTraceState = updatedTraceState.set('pid', projectId);
 		if (orgId) updatedTraceState = updatedTraceState.set('oid', orgId);

--- a/packages/runtime/src/middleware.ts
+++ b/packages/runtime/src/middleware.ts
@@ -361,14 +361,16 @@ export function createOtelMiddleware() {
 							// We need to do this here because the router wrapper hasn't run yet
 							const metadata = loadBuildMetadata();
 							const methodUpper = c.req.method.toUpperCase();
-							
+
 							// Normalize paths: trim trailing slashes for consistent matching
 							const normalizePath = (p: string) => {
 								const decoded = decodeURIComponent(p);
-								return decoded.endsWith('/') && decoded.length > 1 ? decoded.slice(0, -1) : decoded;
+								return decoded.endsWith('/') && decoded.length > 1
+									? decoded.slice(0, -1)
+									: decoded;
 							};
 							const requestPath = normalizePath(c.req.path);
-							
+
 							// Helper to check if requestPath ends with routePath at a segment boundary
 							// e.g., "/api/translate" matches "/translate" but "/api/translate-v2" does not
 							const matchesAtSegmentBoundary = (reqPath: string, routePath: string) => {
@@ -378,19 +380,23 @@ export function createOtelMiddleware() {
 								const charBeforeMatch = reqPath[reqPath.length - routePath.length - 1];
 								return charBeforeMatch === '/';
 							};
-							
+
 							// Try matching by exact normalized path first
 							let route = metadata?.routes?.find(
-								(r) => r.method.toUpperCase() === methodUpper && normalizePath(r.path) === requestPath
+								(r) =>
+									r.method.toUpperCase() === methodUpper &&
+									normalizePath(r.path) === requestPath
 							);
 							// Fall back to segment-boundary matching (handles /api/translate matching /translate)
 							if (!route) {
 								route = metadata?.routes?.find(
-									(r) => r.method.toUpperCase() === methodUpper && matchesAtSegmentBoundary(requestPath, normalizePath(r.path))
+									(r) =>
+										r.method.toUpperCase() === methodUpper &&
+										matchesAtSegmentBoundary(requestPath, normalizePath(r.path))
 								);
 							}
 							const routeId = route?.id || '';
-							
+
 							await sessionEventProvider.start({
 								id: sessionId,
 								threadId: thread.id,
@@ -462,19 +468,32 @@ export function createOtelMiddleware() {
 					let shouldEndSpanInFinally = true;
 
 					try {
-						internal.info('[request] %s %s - handler starting (session: %s)', method, url.pathname, sessionId);
-						
+						internal.info(
+							'[request] %s %s - handler starting (session: %s)',
+							method,
+							url.pathname,
+							sessionId
+						);
+
 						await next();
 
 						// Capture timing immediately after next() returns - this is when the handler completed
 						// This is the HTTP response time we want to report (excludes waitUntil/finalization)
 						handlerDurationMs = performance.now() - requestStartTime;
-						
-						internal.info('[request] %s %s - handler completed in %sms (session: %s)', method, url.pathname, handlerDurationMs.toFixed(2), sessionId);
+
+						internal.info(
+							'[request] %s %s - handler completed in %sms (session: %s)',
+							method,
+							url.pathname,
+							handlerDurationMs.toFixed(2),
+							sessionId
+						);
 
 						// Check if this is a streaming response that needs deferred finalization
 						// eslint-disable-next-line @typescript-eslint/no-explicit-any
-						const streamDone = (c as any).get(STREAM_DONE_PROMISE_KEY) as Promise<void> | undefined;
+						const streamDone = (c as any).get(STREAM_DONE_PROMISE_KEY) as
+							| Promise<void>
+							| undefined;
 						// eslint-disable-next-line @typescript-eslint/no-explicit-any
 						const isStreaming = Boolean((c as any).get(IS_STREAMING_RESPONSE_KEY));
 
@@ -485,8 +504,15 @@ export function createOtelMiddleware() {
 						responseStatus = c.res?.status ?? 200;
 						const isError = honoError || responseStatus >= 500;
 
-						internal.info('[request] %s %s - status: %d, streaming: %s, error: %s (session: %s)', 
-							method, url.pathname, responseStatus, isStreaming, isError, sessionId);
+						internal.info(
+							'[request] %s %s - status: %d, streaming: %s, error: %s (session: %s)',
+							method,
+							url.pathname,
+							responseStatus,
+							isStreaming,
+							isError,
+							sessionId
+						);
 
 						if (isError) {
 							// Capture error message for finalization
@@ -506,25 +532,34 @@ export function createOtelMiddleware() {
 
 						// For streaming responses, defer everything until stream completes
 						if (isStreaming && streamDone) {
-							internal.info('[request] %s %s - streaming response, deferring finalization (session: %s)', 
-								method, url.pathname, sessionId);
-							
+							internal.info(
+								'[request] %s %s - streaming response, deferring finalization (session: %s)',
+								method,
+								url.pathname,
+								sessionId
+							);
+
 							// For streaming, we end the span inside waitUntil after setting attributes
 							shouldEndSpanInFinally = false;
-							
+
 							// Capture pending promises BEFORE adding finalization waitUntil to avoid deadlock
 							const pendingPromises = handler.getPendingSnapshot();
 							const hasPendingTasks = pendingPromises.length > 0;
-							
+
 							if (hasPendingTasks) {
-								internal.info('[request] %s %s - %d pending waitUntil tasks to wait for after stream (session: %s)', 
-									method, url.pathname, pendingPromises.length, sessionId);
+								internal.info(
+									'[request] %s %s - %d pending waitUntil tasks to wait for after stream (session: %s)',
+									method,
+									url.pathname,
+									pendingPromises.length,
+									sessionId
+								);
 							}
-							
+
 							// Capture values needed for span attributes (responseStatus already captured above)
 							const capturedResponseStatus = responseStatus;
 							const capturedErrorMessage = errorMessage;
-							
+
 							// Use waitUntil to handle stream completion and finalization
 							// This runs AFTER the response is sent to the client
 							// Note: We intentionally do NOT use noSpan here - the waitUntil span helps
@@ -532,46 +567,81 @@ export function createOtelMiddleware() {
 							handler.waitUntil(async () => {
 								// Track if stream ended with error so we can update finalization status
 								let streamError: unknown = undefined;
-								
+
 								try {
 									await streamDone;
-									internal.info('[request] %s %s - stream completed (session: %s)', method, url.pathname, sessionId);
+									internal.info(
+										'[request] %s %s - stream completed (session: %s)',
+										method,
+										url.pathname,
+										sessionId
+									);
 								} catch (ex) {
 									streamError = ex;
-									internal.info('[request] %s %s - stream ended with error: %s (session: %s)', 
-										method, url.pathname, ex, sessionId);
+									internal.info(
+										'[request] %s %s - stream ended with error: %s (session: %s)',
+										method,
+										url.pathname,
+										ex,
+										sessionId
+									);
 								}
-								
+
 								// Record duration now that stream is complete - set attributes BEFORE ending span
 								const streamDurationMs = performance.now() - requestStartTime;
 								const durationNs = Math.round(streamDurationMs * 1_000_000);
-								internal.info('[request] %s %s - recording stream duration: %sms (session: %s)', 
-									method, url.pathname, streamDurationMs.toFixed(2), sessionId);
-								
+								internal.info(
+									'[request] %s %s - recording stream duration: %sms (session: %s)',
+									method,
+									url.pathname,
+									streamDurationMs.toFixed(2),
+									sessionId
+								);
+
 								// Determine final status - use stream error if present
 								const finalStatus = streamError ? 500 : capturedResponseStatus;
-								const finalErrorMessage = streamError 
-									? (streamError instanceof Error ? (streamError.stack ?? streamError.message) : String(streamError))
+								const finalErrorMessage = streamError
+									? streamError instanceof Error
+										? (streamError.stack ?? streamError.message)
+										: String(streamError)
 									: capturedErrorMessage;
-								
+
 								try {
 									// Wait for pending tasks (evals, etc.) captured BEFORE this waitUntil was added
 									if (hasPendingTasks) {
-										internal.info('[request] %s %s - waiting for %d pending waitUntil tasks (session: %s)', 
-											method, url.pathname, pendingPromises.length, sessionId);
+										internal.info(
+											'[request] %s %s - waiting for %d pending waitUntil tasks (session: %s)',
+											method,
+											url.pathname,
+											pendingPromises.length,
+											sessionId
+										);
 										const logger = c.get('logger');
 										await handler.waitForPromises(pendingPromises, logger, sessionId);
-										internal.info('[request] %s %s - all waitUntil tasks complete (session: %s)', method, url.pathname, sessionId);
+										internal.info(
+											'[request] %s %s - all waitUntil tasks complete (session: %s)',
+											method,
+											url.pathname,
+											sessionId
+										);
 									}
-									
+
 									// Finalize session after stream completes and evals finish
-									await finalizeSession(finalStatus >= 500 ? finalStatus : undefined, finalErrorMessage);
-									internal.info('[request] %s %s - stream session finalization complete (session: %s)', method, url.pathname, sessionId);
+									await finalizeSession(
+										finalStatus >= 500 ? finalStatus : undefined,
+										finalErrorMessage
+									);
+									internal.info(
+										'[request] %s %s - stream session finalization complete (session: %s)',
+										method,
+										url.pathname,
+										sessionId
+									);
 								} finally {
 									// Set span attributes and end span AFTER all work is done
 									span.setAttribute('@agentuity/request.duration', durationNs);
 									span.setAttribute('http.status_code', finalStatus);
-									
+
 									// Set span status based on whether there was an error
 									if (streamError) {
 										span.setStatus({
@@ -584,9 +654,14 @@ export function createOtelMiddleware() {
 									} else {
 										span.setStatus({ code: SpanStatusCode.OK });
 									}
-									
+
 									span.end();
-									internal.info('[request] %s %s - stream span ended (session: %s)', method, url.pathname, sessionId);
+									internal.info(
+										'[request] %s %s - stream span ended (session: %s)',
+										method,
+										url.pathname,
+										sessionId
+									);
 									// Note: We don't call waitUntilAll() here because this waitUntil callback
 									// IS the final cleanup task. Calling waitUntilAll() would deadlock since
 									// it would wait for this very promise to complete.
@@ -595,57 +670,104 @@ export function createOtelMiddleware() {
 						} else {
 							// Non-streaming: record duration immediately
 							const durationNs = Math.round(handlerDurationMs * 1_000_000);
-							internal.info('[request] %s %s - recording duration: %sms (%dns) (session: %s)', 
-								method, url.pathname, handlerDurationMs.toFixed(2), durationNs, sessionId);
+							internal.info(
+								'[request] %s %s - recording duration: %sms (%dns) (session: %s)',
+								method,
+								url.pathname,
+								handlerDurationMs.toFixed(2),
+								durationNs,
+								sessionId
+							);
 							span.setAttribute('@agentuity/request.duration', durationNs);
 							span.setAttribute('http.status_code', responseStatus);
-							
+
 							// Capture pending promises BEFORE adding finalization waitUntil to avoid deadlock.
 							// If we called waitUntilAll inside waitUntil, it would wait for itself.
 							const pendingPromises = handler.getPendingSnapshot();
 							const hasPendingTasks = pendingPromises.length > 0;
-							
+
 							if (hasPendingTasks) {
-								internal.info('[request] %s %s - %d pending waitUntil tasks to wait for (session: %s)', 
-									method, url.pathname, pendingPromises.length, sessionId);
+								internal.info(
+									'[request] %s %s - %d pending waitUntil tasks to wait for (session: %s)',
+									method,
+									url.pathname,
+									pendingPromises.length,
+									sessionId
+								);
 							}
-							
+
 							// Capture values for use in waitUntil callback
 							const capturedResponseStatus = responseStatus;
 							const capturedErrorMessage = errorMessage;
-							
+
 							// Defer session finalization to run AFTER response is sent
 							// Use noSpan: true since finalizeSession creates its own Session End span
-							handler.waitUntil(async () => {
-								// Wait for the snapshot of pending tasks (evals, etc.) captured BEFORE this waitUntil was added
-								if (hasPendingTasks) {
-									internal.info('[request] %s %s - waiting for %d pending waitUntil tasks (session: %s)', 
-										method, url.pathname, pendingPromises.length, sessionId);
-									const logger = c.get('logger');
-									await handler.waitForPromises(pendingPromises, logger, sessionId);
-									internal.info('[request] %s %s - all waitUntil tasks complete (session: %s)', method, url.pathname, sessionId);
-								}
-								
-								// Finalize session - this is the actual work
-								internal.info('[request] %s %s - starting session finalization (session: %s)', method, url.pathname, sessionId);
-								try {
-									await finalizeSession(capturedResponseStatus >= 500 ? capturedResponseStatus : undefined, capturedErrorMessage);
-									internal.info('[request] %s %s - session finalization complete (session: %s)', method, url.pathname, sessionId);
-								} catch (ex) {
-									internal.error('[request] %s %s - session finalization failed: %s (session: %s)', 
-										method, url.pathname, ex, sessionId);
-								}
-								// Note: We don't call waitUntilAll() here because this waitUntil callback
-								// IS the final cleanup task. Calling waitUntilAll() would deadlock since
-								// it would wait for this very promise to complete.
-							}, { noSpan: true });
+							handler.waitUntil(
+								async () => {
+									// Wait for the snapshot of pending tasks (evals, etc.) captured BEFORE this waitUntil was added
+									if (hasPendingTasks) {
+										internal.info(
+											'[request] %s %s - waiting for %d pending waitUntil tasks (session: %s)',
+											method,
+											url.pathname,
+											pendingPromises.length,
+											sessionId
+										);
+										const logger = c.get('logger');
+										await handler.waitForPromises(pendingPromises, logger, sessionId);
+										internal.info(
+											'[request] %s %s - all waitUntil tasks complete (session: %s)',
+											method,
+											url.pathname,
+											sessionId
+										);
+									}
+
+									// Finalize session - this is the actual work
+									internal.info(
+										'[request] %s %s - starting session finalization (session: %s)',
+										method,
+										url.pathname,
+										sessionId
+									);
+									try {
+										await finalizeSession(
+											capturedResponseStatus >= 500 ? capturedResponseStatus : undefined,
+											capturedErrorMessage
+										);
+										internal.info(
+											'[request] %s %s - session finalization complete (session: %s)',
+											method,
+											url.pathname,
+											sessionId
+										);
+									} catch (ex) {
+										internal.error(
+											'[request] %s %s - session finalization failed: %s (session: %s)',
+											method,
+											url.pathname,
+											ex,
+											sessionId
+										);
+									}
+									// Note: We don't call waitUntilAll() here because this waitUntil callback
+									// IS the final cleanup task. Calling waitUntilAll() would deadlock since
+									// it would wait for this very promise to complete.
+								},
+								{ noSpan: true }
+							);
 						}
 					} catch (ex) {
 						// Record request metrics even on exceptions (500 status)
 						const exceptionDurationMs = performance.now() - requestStartTime;
 						const durationNs = Math.round(exceptionDurationMs * 1_000_000);
-						internal.info('[request] %s %s - recording exception duration: %sms (session: %s)', 
-							method, url.pathname, exceptionDurationMs.toFixed(2), sessionId);
+						internal.info(
+							'[request] %s %s - recording exception duration: %sms (session: %s)',
+							method,
+							url.pathname,
+							exceptionDurationMs.toFixed(2),
+							sessionId
+						);
 						span.setAttribute('@agentuity/request.duration', durationNs);
 						span.setAttribute('http.status_code', 500);
 
@@ -661,38 +783,61 @@ export function createOtelMiddleware() {
 
 						// Capture error message for use in waitUntil callback
 						const capturedErrorMessage = errorMessage;
-						
+
 						// Capture pending promises BEFORE adding finalization waitUntil to avoid deadlock
 						const pendingPromises = handler.getPendingSnapshot();
 						const hasPendingTasks = pendingPromises.length > 0;
-						
+
 						if (hasPendingTasks) {
-							internal.info('[request] %s %s - %d pending waitUntil tasks to wait for after error (session: %s)', 
-								method, url.pathname, pendingPromises.length, sessionId);
+							internal.info(
+								'[request] %s %s - %d pending waitUntil tasks to wait for after error (session: %s)',
+								method,
+								url.pathname,
+								pendingPromises.length,
+								sessionId
+							);
 						}
-						
+
 						// Still defer finalization even on error
 						// Use noSpan: true since finalizeSession creates its own Session End span
-						handler.waitUntil(async () => {
-							// Wait for pending tasks (evals, etc.) captured BEFORE this waitUntil was added
-							if (hasPendingTasks) {
-								internal.info('[request] %s %s - waiting for %d pending waitUntil tasks (session: %s)', 
-									method, url.pathname, pendingPromises.length, sessionId);
-								const logger = c.get('logger');
-								await handler.waitForPromises(pendingPromises, logger, sessionId);
-								internal.info('[request] %s %s - all waitUntil tasks complete (session: %s)', method, url.pathname, sessionId);
-							}
-							
-							try {
-								await finalizeSession(500, capturedErrorMessage);
-							} catch (finalizeEx) {
-								internal.error('[request] %s %s - error session finalization failed: %s (session: %s)', 
-									method, url.pathname, finalizeEx, sessionId);
-							}
-							// Note: We don't call waitUntilAll() here because this waitUntil callback
-							// IS the final cleanup task. Calling waitUntilAll() would deadlock since
-							// it would wait for this very promise to complete.
-						}, { noSpan: true });
+						handler.waitUntil(
+							async () => {
+								// Wait for pending tasks (evals, etc.) captured BEFORE this waitUntil was added
+								if (hasPendingTasks) {
+									internal.info(
+										'[request] %s %s - waiting for %d pending waitUntil tasks (session: %s)',
+										method,
+										url.pathname,
+										pendingPromises.length,
+										sessionId
+									);
+									const logger = c.get('logger');
+									await handler.waitForPromises(pendingPromises, logger, sessionId);
+									internal.info(
+										'[request] %s %s - all waitUntil tasks complete (session: %s)',
+										method,
+										url.pathname,
+										sessionId
+									);
+								}
+
+								try {
+									await finalizeSession(500, capturedErrorMessage);
+								} catch (finalizeEx) {
+									internal.error(
+										'[request] %s %s - error session finalization failed: %s (session: %s)',
+										method,
+										url.pathname,
+										finalizeEx,
+										sessionId
+									);
+								}
+								// Note: We don't call waitUntilAll() here because this waitUntil callback
+								// IS the final cleanup task. Calling waitUntilAll() would deadlock since
+								// it would wait for this very promise to complete.
+							},
+							{ noSpan: true }
+						);
 
 						throw ex;
 					} finally {
@@ -705,9 +850,14 @@ export function createOtelMiddleware() {
 						const traceId = sctx?.traceId || sessionId.replace(/^sess_/, '');
 						c.header(SESSION_HEADER, `sess_${traceId}`);
 
-						internal.info('[request] %s %s - response ready, duration: %sms (session: %s)', 
-							method, url.pathname, handlerDurationMs.toFixed(2), sessionId);
-						
+						internal.info(
+							'[request] %s %s - response ready, duration: %sms (session: %s)',
+							method,
+							url.pathname,
+							handlerDurationMs.toFixed(2),
+							sessionId
+						);
+
 						// Only end span here for non-streaming responses
 						// For streaming, span is ended in the waitUntil callback after setting duration attributes
 						if (shouldEndSpanInFinally) {


### PR DESCRIPTION
## Summary

- Fix SSH/SCP commands failing with malformed ION hostname (`ion.agentuity.cloud` instead of `ion-{region}.agentuity.cloud`)
- Pass `config` through the region resolution chain so saved region preferences are properly checked
- Add validation to prevent malformed hostnames from empty/invalid regions

## Problem

When SSHing into a sandbox, users were getting:
```
ssh: Could not resolve hostname ion.agentuity.cloud: nodename nor servname provided, or not known
```

The expected hostname should be `ion-{region}.agentuity.cloud` (e.g., `ion-use.agentuity.cloud`).

## Root Cause

The `getGlobalCatalystAPIClient` function called `getDefaultRegion(profileName)` without passing the `config`, so the saved region preference in `config.preferences.region` was never checked. This caused the region resolution to fall through to less reliable fallbacks.

## Changes

| File | Change |
|------|--------|
| `packages/cli/src/config.ts` | Add `config` parameter to `getGlobalCatalystAPIClient`; add validation in `getIONHost` |
| `packages/cli/src/cmd/cloud/region-lookup.ts` | Add `config` parameter to `getIdentifierRegion`; add region validation |
| `packages/cli/src/cmd/cloud/ssh.ts` | Pass `config` to `getIdentifierRegion` |
| `packages/cli/src/cmd/cloud/scp/upload.ts` | Pass `config` to `getIdentifierRegion` |
| `packages/cli/src/cmd/cloud/scp/download.ts` | Pass `config` to `getIdentifierRegion` |

Also includes formatting fixes in `packages/runtime`, `packages/opencode`, and `packages/cli/src/types.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cloud region lookup now considers configuration preferences during region resolution across all operations.
  * Enhanced runtime tracing with improved agent identifier tracking.

* **Bug Fixes**
  * Added validation to ensure region values are properly formatted, preventing configuration errors.

* **Documentation**
  * Updated documentation table formatting for improved readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->