### PR TITLE
feat(cli): add region change detection and confirmation during deploy

### DIFF
--- a/packages/cli/src/cmd/cloud/deploy.ts
+++ b/packages/cli/src/cmd/cloud/deploy.ts
@@ -35,6 +35,8 @@ import {
 	projectDeploymentStatus,
 	projectDeploymentMalwareCheck,
 	validateResources,
+	projectGet,
+	projectUpdateRegion,
 	type Deployment,
 	type BuildMetadata,
 	type DeploymentInstructions,
@@ -118,6 +120,11 @@ export const deploySubcommand = createSubcommand({
 					.optional()
 					.default(false)
 					.describe('Internal: run as forked child process'),
+				confirm: z
+					.boolean()
+					.optional()
+					.default(false)
+					.describe('Confirm region change without prompting (for non-TTY environments)'),
 			})
 		),
 		response: DeployResponseSchema,
@@ -155,6 +162,70 @@ export const deploySubcommand = createSubcommand({
 			// Project was imported - use the new project config
 			project = reconcileResult.project;
 			tui.newline();
+		}
+
+		// Check if local region differs from server region and handle confirmation
+		const hasTTY = process.stdin.isTTY && process.stdout.isTTY;
+		if (project.region) {
+			try {
+				const serverProject = await projectGet(apiClient, { id: project.projectId, keys: false });
+				const serverRegion = serverProject.cloudRegion;
+
+				if (serverRegion && serverRegion !== project.region) {
+					logger.debug(
+						'Region mismatch detected: local=%s, server=%s',
+						project.region,
+						serverRegion
+					);
+
+					if (hasTTY) {
+						// Interactive mode: prompt for confirmation
+						tui.newline();
+						tui.warning(
+							`Region change detected: ${tui.bold(serverRegion)} → ${tui.bold(project.region)}`
+						);
+						const confirmChange = await tui.confirm(
+							'Do you want to update the project region?',
+							false
+						);
+
+						if (!confirmChange) {
+							tui.newline();
+							tui.fatal(
+								'Deployment cancelled. Update the region in agentuity.json or keep the current region.',
+								ErrorCode.CONFIG_INVALID
+							);
+						}
+					} else {
+						// Non-interactive mode: require --confirm flag
+						if (!opts.confirm) {
+							tui.fatal(
+								`Region change detected (${serverRegion} → ${project.region}). Use --confirm flag to proceed with region change in non-interactive mode.`,
+								ErrorCode.CONFIG_INVALID
+							);
+						}
+						logger.debug('Region change confirmed via --confirm flag');
+					}
+
+					// Update the region on the server
+					await tui.spinner({
+						message: 'Updating project region...',
+						type: 'simple',
+						callback: async () => {
+							await projectUpdateRegion(apiClient, project.projectId, project.region);
+						},
+					});
+					tui.success(`Project region updated to ${tui.bold(project.region)}`);
+					tui.newline();
+				}
+			} catch (err) {
+				// If it's a fatal error we threw, re-throw it
+				if (err instanceof Error && err.message.includes('Region change detected')) {
+					throw err;
+				}
+				// Log other errors as non-fatal and continue (e.g., network issues fetching project)
+				logger.trace('Failed to check project region: %s', err);
+			}
 		}
 
 		// Initialize build report collector if reportFile is specified
@@ -366,7 +437,6 @@ export const deploySubcommand = createSubcommand({
 
 			// Check GitHub status and prompt for setup if not linked
 			// Skip in non-TTY environments (CI, automated runs) to prevent hanging
-			const hasTTY = process.stdin.isTTY && process.stdout.isTTY;
 			if (!useExistingDeployment && !project.skipGitSetup && hasTTY) {
 				try {
 					const githubStatus = await getProjectGithubStatus(apiClient, project.projectId);

--- a/packages/server/src/api/project/index.ts
+++ b/packages/server/src/api/project/index.ts
@@ -9,3 +9,4 @@ export * from './exists';
 export * from './get';
 export * from './list';
 export * from './malware';
+export * from './update-region';

--- a/packages/server/src/api/project/update-region.ts
+++ b/packages/server/src/api/project/update-region.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+import { APIClient, APIResponseSchema } from '../api';
+import { ProjectResponseError } from './util';
+
+const UpdateRegionRequestSchema = z.object({
+	cloudRegion: z.string().describe('the cloud region to update the project to'),
+});
+
+const UpdateRegionResponseSchema = APIResponseSchema(
+	z.object({
+		id: z.string().describe('the project id'),
+	})
+);
+
+type UpdateRegionRequest = z.infer<typeof UpdateRegionRequestSchema>;
+type UpdateRegionResponse = z.infer<typeof UpdateRegionResponseSchema>;
+
+/**
+ * Update a project's cloud region
+ *
+ * @param client - The API client
+ * @param projectId - The project id to update
+ * @param region - The new cloud region
+ * @returns The project id on success
+ */
+export async function projectUpdateRegion(
+	client: APIClient,
+	projectId: string,
+	region: string
+): Promise<{ id: string }> {
+	const resp = await client.request<UpdateRegionResponse, UpdateRegionRequest>(
+		'PATCH',
+		`/cli/project/${projectId}`,
+		UpdateRegionResponseSchema,
+		{ cloudRegion: region },
+		UpdateRegionRequestSchema
+	);
+
+	if (resp.success) {
+		return resp.data;
+	}
+
+	throw new ProjectResponseError({ message: resp.message ?? 'failed to update project region' });
+}


### PR DESCRIPTION
## Summary

- Add `projectUpdateRegion` API function to update a project's cloud region
- Detect when local `agentuity.json` region differs from server region during deploy
- Prompt for confirmation in TTY mode before updating region
- Add `--confirm` flag for non-TTY environments (CI/automated deploys)
- Update project region on server when confirmed

## Problem

When users change the `region` value in `agentuity.json`, the deploy command didn't properly handle the region change - it would either use the old project region or fail silently.

## Solution

The deploy command now:
1. Fetches the project from the API to get the current `cloudRegion`
2. Compares with local `project.region` from `agentuity.json`
3. If different:
   - **TTY mode**: Prompts user with confirmation showing old → new region
   - **Non-TTY mode**: Requires `--confirm` flag to proceed
4. If confirmed: Updates the project's region on the server
5. Continues with deployment using the new region

## Usage

**Interactive (TTY):**
```
$ agentuity deploy
⚠ Region change detected: usc → use
Do you want to update the project region? [y/N] y
⠋ Updating project region...
✓ Project region updated to use
```

**Non-interactive (CI):**
```
$ agentuity deploy --confirm
✓ Project region updated to use
```

## Related

Requires https://github.com/agentuity/app/pull/1062 to be merged first (adds `cloudRegion` to project update endpoint).

## Testing

- [x] Typecheck passes
- [x] Lint passes