### PR TITLE
feat: add bucket_type and internal fields to S3 resource schemas

### DIFF
--- a/packages/cli/src/cmd/cloud/storage/create.ts
+++ b/packages/cli/src/cmd/cloud/storage/create.ts
@@ -29,6 +29,9 @@ export const createSubcommand = defineSubcommand({
 		},
 	],
 	schema: {
+		options: z.object({
+			description: z.string().optional().describe('Optional description for the bucket'),
+		}),
 		response: z.object({
 			success: z.boolean().describe('Whether creation succeeded'),
 			name: z.string().describe('Created storage bucket name'),
@@ -36,7 +39,7 @@ export const createSubcommand = defineSubcommand({
 	},
 
 	async handler(ctx) {
-		const { logger, orgId, region, auth, options } = ctx;
+		const { logger, orgId, region, auth, options, opts } = ctx;
 
 		// Handle dry-run mode
 		if (isDryRunMode(options)) {
@@ -58,7 +61,9 @@ export const createSubcommand = defineSubcommand({
 			message: `Creating storage in ${region}`,
 			clearOnSuccess: true,
 			callback: async () => {
-				return createResources(catalystClient, orgId, region!, [{ type: 's3' }]);
+				return createResources(catalystClient, orgId, region!, [
+					{ type: 's3', description: opts.description },
+				]);
 			},
 		});
 

--- a/packages/cli/src/cmd/cloud/storage/get.ts
+++ b/packages/cli/src/cmd/cloud/storage/get.ts
@@ -15,6 +15,9 @@ const StorageGetResponseSchema = z.object({
 	endpoint: z.string().optional().describe('S3 endpoint URL'),
 	org_id: z.string().optional().describe('Organization ID that owns this bucket'),
 	org_name: z.string().optional().describe('Organization name that owns this bucket'),
+	bucket_type: z.string().optional().describe('Bucket type (user or snapshots)'),
+	internal: z.boolean().optional().describe('Whether this is a system-managed bucket'),
+	description: z.string().optional().describe('Optional description of the bucket'),
 });
 
 export const getSubcommand = createSubcommand({
@@ -134,6 +137,9 @@ export const getSubcommand = createSubcommand({
 			endpoint: bucket.endpoint ?? undefined,
 			org_id: bucket.org_id,
 			org_name: bucket.org_name,
+			bucket_type: bucket.bucket_type,
+			internal: bucket.internal,
+			description: bucket.description ?? undefined,
 		};
 	},
 });

--- a/packages/cli/src/cmd/cloud/storage/list.ts
+++ b/packages/cli/src/cmd/cloud/storage/list.ts
@@ -20,6 +20,9 @@ const StorageListResponseSchema = z.object({
 				cloud_region: z.string().optional().describe('Cloud region where bucket is hosted'),
 				org_id: z.string().optional().describe('Organization ID that owns this bucket'),
 				org_name: z.string().optional().describe('Organization name that owns this bucket'),
+				bucket_type: z.string().optional().describe('Bucket type (user or snapshots)'),
+				internal: z.boolean().optional().describe('Whether this is a system-managed bucket'),
+				description: z.string().optional().describe('Optional description of the bucket'),
 			})
 		)
 		.optional()
@@ -241,6 +244,9 @@ export const listSubcommand = createSubcommand({
 				cloud_region: s3.cloud_region,
 				org_id: s3.org_id,
 				org_name: s3.org_name,
+				bucket_type: s3.bucket_type,
+				internal: s3.internal,
+				description: s3.description ?? undefined,
 			})),
 		};
 	},

--- a/packages/server/src/api/org/resources.ts
+++ b/packages/server/src/api/org/resources.ts
@@ -11,6 +11,9 @@ const OrgS3Resource = z.object({
 	cloud_region: z.string().describe('the cloud region where this resource is provisioned'),
 	org_id: z.string().describe('the organization ID that owns this resource'),
 	org_name: z.string().describe('the organization name that owns this resource'),
+	bucket_type: z.string().describe('the bucket type (user or snapshots)'),
+	internal: z.boolean().describe('whether this is a system-managed bucket'),
+	description: z.string().nullable().optional().describe('optional description of the bucket'),
 });
 
 const OrgDBResource = z.object({

--- a/packages/server/src/api/region/resources.ts
+++ b/packages/server/src/api/region/resources.ts
@@ -12,6 +12,9 @@ const ResourceListResponse = z.object({
 			endpoint: z.string().nullable().optional().describe('the S3 endpoint'),
 			cname: z.string().nullable().optional().describe('the S3 CNAME'),
 			env: z.record(z.string(), z.string()).describe('environment variables for the resource'),
+			bucket_type: z.string().describe('the bucket type (user or snapshots)'),
+			internal: z.boolean().describe('whether this is a system-managed bucket'),
+			description: z.string().nullable().optional().describe('optional description of the bucket'),
 		})
 	),
 	db: z.array(


### PR DESCRIPTION
## Summary

Add `bucket_type` and `internal` fields to both `listResources` and `listOrgResources` S3 resource schemas to match Catalyst API responses.

## Changes

- **packages/server/src/api/region/resources.ts**: Added `bucket_type` and `internal` to S3 resource schema
- **packages/server/src/api/org/resources.ts**: Added `bucket_type` and `internal` to `OrgS3Resource` schema

## Context

These fields support the system-managed buckets feature:
- `bucket_type`: `'user'` or `'snapshots'` indicating the bucket purpose
- `internal`: boolean indicating if the bucket is system-managed

The Catalyst API already returns these fields - this change updates the SDK schemas to properly type them for consumers.

## Testing

- SDK builds successfully
- App builds successfully with updated SDK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * S3 resources now expose three metadata fields: bucket type (e.g., user or snapshots), an internal/system-managed flag, and an optional description.
  * These fields appear in API responses and CLI list/get outputs for improved classification and visibility.
  * CLI create command accepts an optional bucket description that is preserved on creation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->