### PR TITLE
feat(api): handle 421 Misdirected Request for cross-region resources

### DIFF
--- a/packages/server/src/api/api.ts
+++ b/packages/server/src/api/api.ts
@@ -106,6 +106,15 @@ export const MaxRetriesError = StructuredError(
 	'Max Retries attempted and continued failures exhausted.'
 );
 
+export const MisdirectedRequestError = StructuredError(
+	'MisdirectedRequestError',
+	'The request was sent to the wrong regional server.'
+)<{
+	url: string;
+	region: string;
+	sessionId?: string | null;
+}>();
+
 export class APIClient {
 	#baseUrl: string;
 	#apiKey?: string;
@@ -433,6 +442,67 @@ export class APIClient {
 
 				const sessionId = response.headers.get('x-session-id');
 
+				// Handle 421 Misdirected Request - the resource is in a different region
+				// We need to retry against the correct regional Catalyst
+				// Only handle this for Catalyst URLs (not the main API)
+				if (response.status === 421 && this.#isCatalystUrl()) {
+					const targetRegion = response.headers.get('x-agentuity-region');
+					if (targetRegion && canRetry) {
+						const regionalUrl = this.#buildRegionalUrl(targetRegion, endpoint);
+						this.#logger.debug(
+							`Got 421 Misdirected Request, resource is in region ${targetRegion}, retrying against ${regionalUrl} (sessionId: ${sessionId ?? null})`
+						);
+
+						// Retry the request against the correct regional Catalyst
+						let requestBody:
+							| Uint8Array
+							| ArrayBuffer
+							| ReadableStream<Uint8Array>
+							| string
+							| Blob
+							| undefined;
+						if (body !== undefined) {
+							if (contentType && contentType !== 'application/json') {
+								requestBody = body as
+									| Uint8Array
+									| ArrayBuffer
+									| ReadableStream<Uint8Array>
+									| string
+									| Blob;
+							} else {
+								requestBody = JSON.stringify(body);
+							}
+						}
+
+						const regionalResponse = await fetch(regionalUrl, {
+							method,
+							headers,
+							body: requestBody,
+							signal,
+						});
+
+						// If the regional request also fails with 421, throw MisdirectedRequestError
+						if (regionalResponse.status === 421) {
+							throw new MisdirectedRequestError({
+								url: regionalUrl,
+								region: targetRegion,
+								sessionId: regionalResponse.headers.get('x-session-id'),
+							});
+						}
+
+						// For all other responses (success or error), assign to response
+						// and let the normal flow handle it (error handling, validation, etc.)
+						response = regionalResponse;
+					} else {
+						// No region header or can't retry - throw error
+						throw new MisdirectedRequestError({
+							url,
+							region: targetRegion ?? 'unknown',
+							sessionId,
+						});
+					}
+				}
+
 				// Check if we should retry on specific status codes (409, 501, 503)
 				const retryableStatuses = [409, 501, 503];
 				if (canRetry && retryableStatuses.includes(response.status) && attempt < maxRetries) {
@@ -631,6 +701,38 @@ export class APIClient {
 
 	#sleep(ms: number): Promise<void> {
 		return new Promise((resolve) => setTimeout(resolve, ms));
+	}
+
+	/**
+	 * Check if the base URL is a Catalyst URL.
+	 * We only handle 421 Misdirected Request for Catalyst URLs, not the main API.
+	 */
+	#isCatalystUrl(): boolean {
+		try {
+			const url = new URL(this.#baseUrl);
+			return url.hostname.includes('catalyst');
+		} catch {
+			return false;
+		}
+	}
+
+	/**
+	 * Build a URL for a specific regional Catalyst instance.
+	 * Used when retrying requests that received 421 Misdirected Request.
+	 */
+	#buildRegionalUrl(region: string, endpoint: string): string {
+		// Determine the domain suffix based on region
+		const isLocal = region === 'local' || region === 'l';
+		const domainSuffix = isLocal ? 'agentuity.io' : 'agentuity.cloud';
+
+		// Build the regional Catalyst URL
+		// For local: https://catalyst.agentuity.io
+		// For production: https://catalyst-{region}.agentuity.cloud
+		const baseUrl = isLocal
+			? `https://catalyst.${domainSuffix}`
+			: `https://catalyst-${region}.${domainSuffix}`;
+
+		return `${baseUrl}${endpoint}`;
 	}
 
 	#getRateLimitDelay(response: Response): number | null {


### PR DESCRIPTION
## Summary

Adds automatic handling of 421 Misdirected Request responses for Catalyst API calls. This enables seamless cross-region resource access.

## Problem

When a sandbox (or other regional resource) is created in one region (e.g., `use`) but the SDK is configured for a different region (e.g., `usc`), requests would fail because the resource exists on a different regional Catalyst.

## Solution

The SDK now automatically handles 421 responses from Catalyst:

1. **Detects 421 responses** - Only for Catalyst URLs (checked via `#isCatalystUrl()`)
2. **Reads region header** - Extracts target region from `X-Agentuity-Region` header
3. **Builds regional URL** - Constructs the correct Catalyst URL for the target region
4. **Retries automatically** - Sends the request to the correct regional Catalyst

## Changes

- Added `MisdirectedRequestError` structured error type
- Added `#isCatalystUrl()` helper to check if base URL is a Catalyst endpoint
- Added `#buildRegionalUrl()` helper to construct regional Catalyst URLs
- Added 421 handling logic in `#makeRequest()` that retries against correct region

## Related

- Catalyst PR: https://github.com/agentuity/catalyst/pull/465

## Testing

- [x] `bun run --filter @agentuity/server build` passes
- [x] `bun run --filter @agentuity/server typecheck` passes
- [x] `bun test packages/server/test/api.test.ts` passes
- [ ] End-to-end test with cross-region sandbox (requires Catalyst PR to be deployed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for requests routed to the wrong region with automatic retry to the appropriate regional endpoint.
  * Enhanced error reporting that includes regional context and session details for easier troubleshooting.

* **New Features**
  * Automatic detection and dynamic rerouting to regional servers when misrouting is detected, reducing failed requests and retries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->