### PR TITLE
feat(cli): add debugger support to dev command

### DIFF
--- a/packages/cli/src/cmd/build/vite/bun-dev-server.ts
+++ b/packages/cli/src/cmd/build/vite/bun-dev-server.ts
@@ -15,6 +15,9 @@ export interface BunDevServerOptions {
 	deploymentId?: string;
 	logger: Logger;
 	vitePort: number; // Port of already-running Vite asset server
+	inspect?: boolean; // Enable bun debugger
+	inspectWait?: boolean; // Enable bun debugger and wait for connection
+	inspectBrk?: boolean; // Enable bun debugger with breakpoint at first line
 }
 
 export interface BunDevServerResult {
@@ -30,17 +33,15 @@ export interface BunDevServerResult {
  *
  * The bundle is loaded here to ensure AI Gateway routing patches are active.
  * Vite port is read from process.env.VITE_PORT at runtime.
+ *
+ * When debugger flags (inspect, inspectWait, inspectBrk) are passed, bun is spawned
+ * as a subprocess to enable passing the debugger CLI flags.
  */
 export async function startBunDevServer(options: BunDevServerOptions): Promise<BunDevServerResult> {
-	const { rootDir, port = 3500, logger, vitePort } = options;
+	const { rootDir, port = 3500, logger, vitePort, inspect, inspectWait, inspectBrk } = options;
 
 	logger.debug('Starting Bun dev server (Vite already running on port %d)...', vitePort);
 
-	// Load the bundled app - this will start Bun.serve() internally
-	// IMPORTANT: We must import the bundled .agentuity/app.js (NOT src/generated/app.ts)
-	// because the bundled version has LLM provider patches applied that enable AI Gateway routing.
-	// Importing the source file directly would bypass these patches.
-	logger.debug('📦 Loading bundled app (Bun server will start)...');
 	const appPath = `${rootDir}/.agentuity/app.js`;
 
 	// Verify bundle exists before attempting to load
@@ -54,29 +55,45 @@ export async function startBunDevServer(options: BunDevServerOptions): Promise<B
 	// Set PORT env var so the generated app uses the correct port
 	process.env.PORT = String(port);
 
-	// Import the generated app with cache-busting query parameter.
-	// Bun's module cache is keyed by the full specifier including query string,
-	// so adding a unique timestamp forces a fresh import on each reload.
-	const cacheBuster = `?t=${Date.now()}`;
-	try {
-		await import(appPath + cacheBuster);
-	} catch (err) {
-		const errorMessage = err instanceof Error ? err.message : String(err);
-		logger.error('Failed to import generated app from %s: %s', appPath, errorMessage);
-		throw new Error(`Failed to load generated app: ${errorMessage}`);
-	}
+	// Check if any debugger flag is enabled
+	const useDebugger = inspect || inspectWait || inspectBrk;
 
-	// Wait for server to actually start listening
-	// The generated app sets (globalThis as any).__AGENTUITY_SERVER__ when server starts
-	const maxRetries = 50; // Increased retries for slower systems
-	const retryDelay = 100; // ms
-	let serverReady = false;
+	if (useDebugger) {
+		// Spawn bun as subprocess with debugger flag
+		logger.debug('📦 Spawning bun with debugger enabled...');
 
-	for (let i = 0; i < maxRetries; i++) {
-		// Check if global server object exists
+		// Determine which debugger flag to use (priority: inspectBrk > inspectWait > inspect)
+		let debugFlag: string;
+		if (inspectBrk) {
+			debugFlag = '--inspect-brk';
+		} else if (inspectWait) {
+			debugFlag = '--inspect-wait';
+		} else {
+			debugFlag = '--inspect';
+		}
+
+		logger.debug('Using debugger flag: %s', debugFlag);
+
+		const bunProcess = Bun.spawn(['bun', debugFlag, 'run', appPath], {
+			cwd: rootDir,
+			stdout: 'inherit',
+			stderr: 'inherit',
+			env: {
+				...process.env,
+				PORT: String(port),
+			},
+		});
+
+		// Store the process globally so it can be killed on shutdown
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		if ((globalThis as any).__AGENTUITY_SERVER__) {
-			// Server object exists, now verify it's actually listening by making a request
+		(globalThis as any).__AGENTUITY_BUN_SUBPROCESS__ = bunProcess;
+
+		// Wait for server to actually start listening
+		const maxRetries = 50;
+		const retryDelay = 100;
+		let serverReady = false;
+
+		for (let i = 0; i < maxRetries; i++) {
 			try {
 				await fetch(`http://127.0.0.1:${port}/`, {
 					method: 'HEAD',
@@ -88,19 +105,79 @@ export async function startBunDevServer(options: BunDevServerOptions): Promise<B
 			} catch {
 				// Connection refused or timeout - server not ready yet
 			}
+			// Wait before next check
+			await new Promise((resolve) => setTimeout(resolve, retryDelay));
 		}
-		// Wait before next check
-		await new Promise((resolve) => setTimeout(resolve, retryDelay));
-	}
 
-	if (!serverReady) {
-		throw new Error(
-			`Bun server failed to start on port ${port} after ${maxRetries * retryDelay}ms`
-		);
-	}
+		if (!serverReady) {
+			// Kill the subprocess if server didn't start
+			try {
+				bunProcess.kill();
+			} catch (err) {
+				logger.debug('Error killing subprocess during startup failure: %s', err);
+			}
+			throw new Error(
+				`Bun server failed to start on port ${port} after ${maxRetries * retryDelay}ms`
+			);
+		}
 
-	logger.debug(`Bun dev server started on http://127.0.0.1:${port}`);
-	logger.debug(`Asset requests (/@vite/*, /src/web/*, etc.) proxied to Vite:${vitePort}`);
+		logger.debug(`Bun dev server started on http://127.0.0.1:${port} with debugger enabled`);
+		logger.debug(`Asset requests (/@vite/*, /src/web/*, etc.) proxied to Vite:${vitePort}`);
+	} else {
+		// Load the bundled app - this will start Bun.serve() internally
+		// IMPORTANT: We must import the bundled .agentuity/app.js (NOT src/generated/app.ts)
+		// because the bundled version has LLM provider patches applied that enable AI Gateway routing.
+		// Importing the source file directly would bypass these patches.
+		logger.debug('📦 Loading bundled app (Bun server will start)...');
+
+		// Import the generated app with cache-busting query parameter.
+		// Bun's module cache is keyed by the full specifier including query string,
+		// so adding a unique timestamp forces a fresh import on each reload.
+		const cacheBuster = `?t=${Date.now()}`;
+		try {
+			await import(appPath + cacheBuster);
+		} catch (err) {
+			const errorMessage = err instanceof Error ? err.message : String(err);
+			logger.error('Failed to import generated app from %s: %s', appPath, errorMessage);
+			throw new Error(`Failed to load generated app: ${errorMessage}`);
+		}
+
+		// Wait for server to actually start listening
+		// The generated app sets (globalThis as any).__AGENTUITY_SERVER__ when server starts
+		const maxRetries = 50; // Increased retries for slower systems
+		const retryDelay = 100; // ms
+		let serverReady = false;
+
+		for (let i = 0; i < maxRetries; i++) {
+			// Check if global server object exists
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			if ((globalThis as any).__AGENTUITY_SERVER__) {
+				// Server object exists, now verify it's actually listening by making a request
+				try {
+					await fetch(`http://127.0.0.1:${port}/`, {
+						method: 'HEAD',
+						signal: AbortSignal.timeout(1000),
+					});
+					// Any response (even 404) means server is listening
+					serverReady = true;
+					break;
+				} catch {
+					// Connection refused or timeout - server not ready yet
+				}
+			}
+			// Wait before next check
+			await new Promise((resolve) => setTimeout(resolve, retryDelay));
+		}
+
+		if (!serverReady) {
+			throw new Error(
+				`Bun server failed to start on port ${port} after ${maxRetries * retryDelay}ms`
+			);
+		}
+
+		logger.debug(`Bun dev server started on http://127.0.0.1:${port}`);
+		logger.debug(`Asset requests (/@vite/*, /src/web/*, etc.) proxied to Vite:${vitePort}`);
+	}
 
 	return {
 		bunServerPort: port,

--- a/packages/cli/src/cmd/dev/index.ts
+++ b/packages/cli/src/cmd/dev/index.ts
@@ -81,6 +81,7 @@ async function killLingeringGravityProcesses(logger: {
 /**
  * Stop the existing Bun server if one is running.
  * Waits for the port to become available before returning (with timeout).
+ * Handles both in-process server and subprocess (when debugger is enabled).
  */
 async function stopBunServer(
 	port: number,
@@ -88,6 +89,48 @@ async function stopBunServer(
 ): Promise<void> {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const globalAny = globalThis as any;
+
+	// Check for subprocess first (used when debugger flags are enabled)
+	const bunSubprocess = globalAny.__AGENTUITY_BUN_SUBPROCESS__ as ProcessLike | undefined;
+	if (bunSubprocess) {
+		logger.debug('Stopping Bun subprocess...');
+		try {
+			bunSubprocess.kill('SIGTERM');
+			// After SIGTERM, wait and check multiple times before giving up
+			let attempts = 0;
+			while (bunSubprocess.exitCode === null && attempts < 3) {
+				await new Promise((resolve) => setTimeout(resolve, 100));
+				attempts++;
+			}
+			if (bunSubprocess.exitCode === null) {
+				bunSubprocess.kill('SIGKILL');
+			}
+			logger.debug('Bun subprocess killed');
+		} catch (err) {
+			logger.debug('Error killing Bun subprocess: %s', err);
+		}
+		globalAny.__AGENTUITY_BUN_SUBPROCESS__ = undefined;
+
+		// Wait for port to become available
+		const MAX_WAIT_ITERATIONS = 10;
+		for (let i = 0; i < MAX_WAIT_ITERATIONS; i++) {
+			try {
+				await fetch(`http://127.0.0.1:${port}/`, {
+					method: 'HEAD',
+					signal: AbortSignal.timeout(150),
+				});
+				// Still responding, wait a bit more
+				await new Promise((r) => setTimeout(r, 50));
+			} catch {
+				// Connection refused or timeout => server is down
+				logger.debug('Bun subprocess stopped');
+				break;
+			}
+		}
+		return;
+	}
+
+	// Handle in-process server
 	const server = globalAny.__AGENTUITY_SERVER__ as BunServer | undefined;
 	if (!server) {
 		logger.debug('No Bun server to stop');
@@ -171,6 +214,15 @@ export const command = createCommand({
 				.max(MAX_PORT)
 				.default(getDefaultPort())
 				.describe('The TCP port to start the dev server (also reads from PORT env)'),
+			inspect: z.boolean().optional().describe('Enable bun debugger on available port'),
+			inspectWait: z
+				.boolean()
+				.optional()
+				.describe('Enable bun debugger and wait for connection before executing'),
+			inspectBrk: z
+				.boolean()
+				.optional()
+				.describe('Enable bun debugger with breakpoint at first line'),
 		}),
 	},
 	optional: { project: true },
@@ -1026,16 +1078,19 @@ export const command = createCommand({
 
 					logger.debug('Set VITE_PORT=%s for asset proxying', process.env.VITE_PORT);
 
-					// Start Bun dev server (Vite already running, just start backend)
-					await startBunDevServer({
-						rootDir,
-						port: opts.port,
-						projectId: project?.projectId,
-						orgId: project?.orgId,
-						deploymentId,
-						logger,
-						vitePort, // Pass port of already-running Vite server
-					});
+				// Start Bun dev server (Vite already running, just start backend)
+				await startBunDevServer({
+					rootDir,
+					port: opts.port,
+					projectId: project?.projectId,
+					orgId: project?.orgId,
+					deploymentId,
+					logger,
+					vitePort, // Pass port of already-running Vite server
+					inspect: opts.inspect,
+					inspectWait: opts.inspectWait,
+					inspectBrk: opts.inspectBrk,
+				});
 
 					// Wait for app.ts to finish loading (Vite is ready but app may still be initializing)
 					// Give it 2 seconds to ensure app initialization completes


### PR DESCRIPTION
## Summary

Add `--inspect`, `--inspect-wait`, and `--inspect-brk` flags to the `dev` command that pass through to bun when starting the dev server, enabling interactive debugging with VS Code, Chrome DevTools, or the web-based debugger at debug.bun.sh.

## Changes

- Added three new CLI options to the dev command schema
- Modified `startBunDevServer` to spawn bun as a subprocess when debugger flags are used
- Updated `stopBunServer` to handle subprocess cleanup with graceful SIGTERM/SIGKILL

## New CLI Options

```bash
# Enable bun debugger on available port
agentuity dev --inspect

# Enable bun debugger and wait for connection before executing
agentuity dev --inspect-wait

# Enable bun debugger with breakpoint at first line
agentuity dev --inspect-brk
```

## How It Works

When any debugger flag is passed, bun is spawned as a subprocess with the appropriate flag instead of using dynamic import. This allows the debugger CLI flags to be passed through to bun.

Flag priority when multiple are specified: `--inspect-brk` > `--inspect-wait` > `--inspect`

## Testing

- `bun run typecheck` passes
- Manual testing with `--inspect` flag shows debugger output and connection URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three debugging flags to the dev command: --inspect, --inspect-wait, and --inspect-brk.

* **Improvements**
  * Dev server startup now supports debugger-enabled launches via a subprocess, with readiness polling and proxy/logging of debugger details.
  * Shutdown now cleanly terminates debugger subprocesses and waits for ports to free before returning.
  * Previous in-process startup remains unchanged when debugger flags are not used.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->