### PR TITLE
feat(server): add CI debug logging for API errors

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -37,13 +37,18 @@ const sensitiveHeaders = new Set([
  * Returns:
  * - 'console' if CI=1/true or AGENTUITY_API_DEBUG=1/true
  * - file path string if AGENTUITY_API_DEBUG is set to a path
- * - null if debug logging is disabled
+ * - null if debug logging is disabled (including AGENTUITY_API_DEBUG=0/false)
  */
 function getDebugOutput(): 'console' | string | null {
-	const apiDebug = process.env.AGENTUITY_API_DEBUG;
+	const apiDebug = process.env.AGENTUITY_API_DEBUG?.trim();
 	if (apiDebug) {
-		// Check if it's a truthy value (console output) or a file path
-		if (apiDebug === '1' || apiDebug === 'true') {
+		const normalized = apiDebug.toLowerCase();
+		// Check if explicitly disabled
+		if (normalized === '0' || normalized === 'false') {
+			return null;
+		}
+		// Check if it's a truthy value (console output)
+		if (normalized === '1' || normalized === 'true') {
 			return 'console';
 		}
 		// Treat any other non-empty value as a file path


### PR DESCRIPTION
## Summary

- Add detailed debug logging to stderr when API requests fail in CI environments
- Only activates when `CI=1` or `CI=true` environment variable is set
- Logs request URL, method, headers (with sensitive values redacted), and body
- Logs response status, headers, and body for easier debugging

## Motivation

When running in CI, API errors can be difficult to debug because we only see the error message and session ID. This change dumps the full request/response details to stderr, making it much easier to diagnose issues from CI logs.

## Example Output

```
============================================================
CI DEBUG: API Request Failed
============================================================

>>> REQUEST
URL: https://api.example.com/v1/resource
Method: POST
Headers:
  content-type: application/json
  authorization: Bearer sk_t****************cdef
Body:
  {"key": "value"}

<<< RESPONSE
Status: 500 Internal Server Error
Headers:
  content-type: application/json
Body:
  {"error": "Something went wrong"}

============================================================
```

## Key Design Decisions

- **Performance optimized**: Response body is only cloned when CI is enabled - no overhead in production
- **Security**: Sensitive headers (authorization, x-api-key) are properly redacted
- **Only on errors**: Successful responses never produce debug output
- **stderr**: Uses `console.error` so it doesn't interfere with stdout

## Testing

- All 170 server package tests pass
- TypeScript compiles without errors
- ESLint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized and expanded API debug logging to capture detailed request/response data for troubleshooting.
  * Logs can be directed to console or a file with robust error-safe fallback to ensure reliable output.
  * Response bodies and 404 handling optionally include debug information when enabled.
  * Sensitive data (authorization tokens, API keys, cookies) are redacted in logs to enhance security.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->