### PR TITLE
feat(core): add expiresAt to StreamInfo interface

### DIFF
--- a/packages/core/src/services/stream.ts
+++ b/packages/core/src/services/stream.ts
@@ -100,6 +100,11 @@ export interface StreamInfo {
 	 * the size of the stream in bytes
 	 */
 	sizeBytes: number;
+
+	/**
+	 * ISO 8601 timestamp when stream expires, or undefined if stream never expires
+	 */
+	expiresAt?: string;
 }
 
 /**
@@ -731,6 +736,7 @@ export class StreamStorageService implements StreamStorage {
 				metadata: Record<string, string>;
 				url: string;
 				size_bytes: number;
+				expires_at?: string;
 			}>;
 			total: number;
 		}>(url, {
@@ -744,7 +750,7 @@ export class StreamStorageService implements StreamStorage {
 			},
 		});
 		if (res.ok) {
-			// Transform snake_case to camelCase for sizeBytes
+			// Transform snake_case to camelCase for sizeBytes and expiresAt
 			return {
 				success: res.data.success,
 				message: res.data.message,
@@ -754,6 +760,7 @@ export class StreamStorageService implements StreamStorage {
 					metadata: s.metadata,
 					url: s.url,
 					sizeBytes: s.size_bytes,
+					...(s.expires_at && { expiresAt: s.expires_at }),
 				})),
 				total: res.data.total,
 			};
@@ -773,6 +780,7 @@ export class StreamStorageService implements StreamStorage {
 			metadata: Record<string, string>;
 			url: string;
 			size_bytes: number;
+			expires_at?: string;
 		}>(url, {
 			method: 'POST',
 			signal,
@@ -792,6 +800,7 @@ export class StreamStorageService implements StreamStorage {
 				metadata: res.data.metadata,
 				url: res.data.url,
 				sizeBytes: res.data.size_bytes,
+				...(res.data.expires_at && { expiresAt: res.data.expires_at }),
 			};
 		}
 		throw await toServiceException('POST', url, res.response);


### PR DESCRIPTION
## Summary

- Add `expiresAt` field to `StreamInfo` interface for stream TTL display
- Map `expires_at` from Pulse API responses in both `get()` and `list()` methods

## Changes

- **packages/core/src/services/stream.ts**:
  - Add `expiresAt?: string` to `StreamInfo` interface with JSDoc documentation
  - Add `expires_at` to API response types for list and get
  - Map `expires_at` to `expiresAt` using optional spread in both methods

## TTL Semantics

- `expiresAt: undefined` → Stream never expires (TTL = 0 or null at creation)
- `expiresAt: string` → ISO 8601 timestamp when stream expires

## Testing

- TypeScript compiles without errors
- Lint passes

## Related PRs

- Pulse: Adds `expires_at` to stream API responses
- App: Displays expiration time in stream detail page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streams now surface optional expiration date information. Both list and individual stream operations include expiration metadata when provided by the server.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->