### PR TITLE
fix(integration-suite): use static bucket name and TTL for stream tests

### DIFF
--- a/apps/testing/integration-suite/src/agent/storage/binary/upload-download.ts
+++ b/apps/testing/integration-suite/src/agent/storage/binary/upload-download.ts
@@ -54,6 +54,7 @@ const binaryStorageAgent = createAgent('storage-binary-upload-download', {
 						size: binaryData.length.toString(),
 						uploadedAt: new Date().toISOString(),
 					},
+					ttl: 1800,
 				});
 
 				// Write data

--- a/apps/testing/integration-suite/src/agent/storage/stream/crud.ts
+++ b/apps/testing/integration-suite/src/agent/storage/stream/crud.ts
@@ -27,7 +27,7 @@ const streamCrudAgent = createAgent('storage-stream-crud', {
 				if (!name) throw new Error('Name required for create operation');
 				if (!data) throw new Error('Data required for write operation');
 
-				const stream = await ctx.stream.create(name);
+				const stream = await ctx.stream.create(name, { ttl: 1800 });
 				await stream.write(data);
 				await stream.close();
 
@@ -43,7 +43,7 @@ const streamCrudAgent = createAgent('storage-stream-crud', {
 				if (!name) throw new Error('Name required for create operation');
 				if (!data) throw new Error('Data required for write operation');
 
-				const stream = await ctx.stream.create(name);
+				const stream = await ctx.stream.create(name, { ttl: 1800 });
 				await stream.write(data);
 				await stream.close();
 

--- a/apps/testing/integration-suite/src/agent/storage/stream/metadata.ts
+++ b/apps/testing/integration-suite/src/agent/storage/stream/metadata.ts
@@ -45,6 +45,7 @@ const streamMetadataAgent = createAgent('storage-stream-metadata', {
 				const stream = await ctx.stream.create(name, {
 					metadata,
 					contentType,
+					ttl: 1800,
 				});
 
 				await stream.write('test data with metadata');

--- a/apps/testing/integration-suite/src/agent/storage/stream/types.ts
+++ b/apps/testing/integration-suite/src/agent/storage/stream/types.ts
@@ -27,6 +27,7 @@ const streamTypesAgent = createAgent('storage-stream-types', {
 
 				const stream = await ctx.stream.create(name, {
 					contentType: 'text/plain',
+					ttl: 1800,
 				});
 
 				await stream.write(data);
@@ -64,6 +65,7 @@ const streamTypesAgent = createAgent('storage-stream-types', {
 
 				const stream = await ctx.stream.create(name, {
 					contentType: 'application/octet-stream',
+					ttl: 1800,
 				});
 
 				const encoder = new TextEncoder();
@@ -103,6 +105,7 @@ const streamTypesAgent = createAgent('storage-stream-types', {
 
 				const stream = await ctx.stream.create(name, {
 					contentType: 'application/json',
+					ttl: 1800,
 				});
 
 				await stream.write(data);

--- a/apps/testing/integration-suite/src/test/storage-stream.ts
+++ b/apps/testing/integration-suite/src/test/storage-stream.ts
@@ -5,7 +5,7 @@
  */
 
 import { test } from './suite';
-import { assert, assertEqual, assertDefined, uniqueId } from './helpers';
+import { assert, assertEqual, assertDefined } from './helpers';
 
 import streamCrudAgent from '@agents/storage/stream/crud';
 import streamMetadataAgent from '@agents/storage/stream/metadata';
@@ -13,7 +13,7 @@ import streamTypesAgent from '@agents/storage/stream/types';
 
 // Test: Create stream, write, and close
 test('storage-stream', 'create-write-close', async () => {
-	const name = uniqueId('stream-basic');
+	const name = 'testing';
 
 	const result = await streamCrudAgent.run({
 		operation: 'create-write-close',
@@ -30,7 +30,7 @@ test('storage-stream', 'create-write-close', async () => {
 
 // Test: Create, write, and read back data
 test('storage-stream', 'create-write-read', async () => {
-	const name = uniqueId('stream-read');
+	const name = 'testing';
 	const testData = 'Test data for reading';
 
 	const result = await streamCrudAgent.run({
@@ -47,7 +47,7 @@ test('storage-stream', 'create-write-read', async () => {
 
 // Test: Download stream by ID
 test('storage-stream', 'download', async () => {
-	const name = uniqueId('stream-download');
+	const name = 'testing';
 	const testData = 'Data to download';
 
 	const createResult = await streamCrudAgent.run({
@@ -69,7 +69,7 @@ test('storage-stream', 'download', async () => {
 
 // Test: Delete stream
 test('storage-stream', 'delete', async () => {
-	const name = uniqueId('stream-delete');
+	const name = 'testing';
 
 	const createResult = await streamCrudAgent.run({
 		operation: 'create-write-close',
@@ -89,7 +89,7 @@ test('storage-stream', 'delete', async () => {
 
 // Test: Create stream with metadata
 test('storage-stream', 'metadata', async () => {
-	const name = uniqueId('stream-metadata');
+	const name = 'testing';
 	const metadata = {
 		author: 'test-user',
 		version: '1.0',
@@ -114,7 +114,7 @@ test('storage-stream', 'metadata', async () => {
 
 // Test: Get stream info
 test('storage-stream', 'get-info', async () => {
-	const name = uniqueId('stream-info');
+	const name = 'testing';
 
 	const createResult = await streamCrudAgent.run({
 		operation: 'create-write-close',
@@ -139,7 +139,7 @@ test('storage-stream', 'get-info', async () => {
 
 // Test: List streams
 test('storage-stream', 'list', async () => {
-	const baseName = uniqueId('stream-list');
+	const baseName = 'testing';
 
 	await Promise.all([
 		streamCrudAgent.run({
@@ -166,7 +166,7 @@ test('storage-stream', 'list', async () => {
 
 // Test: String type stream
 test('storage-stream', 'type-string', async () => {
-	const name = uniqueId('stream-string');
+	const name = 'testing';
 	const testString = 'Hello, World!';
 
 	const result = await streamTypesAgent.run({
@@ -182,7 +182,7 @@ test('storage-stream', 'type-string', async () => {
 
 // Test: Binary type stream
 test('storage-stream', 'type-binary', async () => {
-	const name = uniqueId('stream-binary');
+	const name = 'testing';
 	const testData = 'Binary data test';
 
 	const result = await streamTypesAgent.run({
@@ -198,7 +198,7 @@ test('storage-stream', 'type-binary', async () => {
 
 // Test: JSON object stream
 test('storage-stream', 'type-json', async () => {
-	const name = uniqueId('stream-json');
+	const name = 'testing';
 	const testObject = {
 		id: 123,
 		name: 'Test Object',
@@ -222,7 +222,7 @@ test('storage-stream', 'type-json', async () => {
 
 // Test: Concurrent stream operations
 test('storage-stream', 'concurrent-operations', async () => {
-	const names = Array.from({ length: 5 }, (_, i) => uniqueId(`stream-concurrent-${i}`));
+	const names = Array.from({ length: 5 }, () => 'testing');
 
 	const results = await Promise.all(
 		names.map((name, i) =>
@@ -242,7 +242,7 @@ test('storage-stream', 'concurrent-operations', async () => {
 
 // Test: Stream size validation
 test('storage-stream', 'size-validation', async () => {
-	const name = uniqueId('stream-size');
+	const name = 'testing';
 	const testData = 'A'.repeat(100);
 
 	const createResult = await streamCrudAgent.run({


### PR DESCRIPTION
## Summary

- Replace all `uniqueId('stream-*')` calls with static `'testing'` bucket name to reduce storage cardinality
- Add `ttl: 1800` (30 minutes) to all `ctx.stream.create()` calls so test data expires quickly

## Problem

Stream tests were generating unique bucket names like `stream-basic_abc123_1234567890_0_xyz789` for each test run, creating high cardinality in the storage system. Since each stream already has a unique ID when created, the bucket name doesn't need to be unique.

## Changes

| File | Change |
|------|--------|
| `storage-stream.ts` | Replaced 12 `uniqueId('stream-*')` calls with `'testing'` |
| `crud.ts` | Added `{ ttl: 1800 }` to 2 stream create calls |
| `metadata.ts` | Added `ttl: 1800` to stream create call |
| `types.ts` | Added `ttl: 1800` to 3 stream create calls |
| `upload-download.ts` | Added `ttl: 1800` to stream create call |

## Testing

- [x] Typecheck passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration tests to use fixed stream identifiers instead of randomly generated names for improved test consistency.
  * Added a 30-minute time-to-live (TTL) setting to stream creation operations across storage testing scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->