### PR TITLE
fix(integration-suite): use static bucket name and TTL for KV tests

### DIFF
--- a/apps/testing/integration-suite/src/agent/storage/kv/crud.ts
+++ b/apps/testing/integration-suite/src/agent/storage/kv/crud.ts
@@ -9,6 +9,7 @@ const kvCrudAgent = createAgent('storage-kv-crud', {
 			key: s.string(),
 			value: s.string().optional(),
 			namespace: s.string().optional(),
+			ttl: s.number().optional(),
 		}),
 		output: s.object({
 			operation: s.string(),
@@ -19,12 +20,12 @@ const kvCrudAgent = createAgent('storage-kv-crud', {
 		}),
 	},
 	handler: async (ctx, input) => {
-		const { operation, key, value, namespace = 'test' } = input;
+		const { operation, key, value, namespace = 'test', ttl } = input;
 
 		switch (operation) {
 			case 'set':
 				if (!value) throw new Error('Value required for set operation');
-				await ctx.kv.set(namespace, key, value);
+				await ctx.kv.set(namespace, key, value, ttl ? { ttl } : undefined);
 				return { operation, key, value, success: true };
 
 			case 'get': {

--- a/apps/testing/integration-suite/src/agent/storage/kv/isolation.ts
+++ b/apps/testing/integration-suite/src/agent/storage/kv/isolation.ts
@@ -8,6 +8,7 @@ const kvIsolationAgent = createAgent('storage-kv-isolation', {
 			key: s.string(),
 			value: s.string(),
 			namespace: s.string().optional(),
+			ttl: s.number().optional(),
 		}),
 		output: s.object({
 			key: s.string(),
@@ -17,10 +18,10 @@ const kvIsolationAgent = createAgent('storage-kv-isolation', {
 		}),
 	},
 	handler: async (ctx, input) => {
-		const { namespace = 'test' } = input;
+		const { namespace = 'test', ttl } = input;
 
 		// Set a value
-		await ctx.kv.set(namespace, input.key, input.value);
+		await ctx.kv.set(namespace, input.key, input.value, ttl ? { ttl } : undefined);
 
 		// Immediately get it back
 		const result = await ctx.kv.get<string>(namespace, input.key);

--- a/apps/testing/integration-suite/src/agent/storage/kv/types.ts
+++ b/apps/testing/integration-suite/src/agent/storage/kv/types.ts
@@ -9,6 +9,7 @@ const kvTypesAgent = createAgent('storage-kv-types', {
 			key: s.string(),
 			value: s.any().optional(),
 			namespace: s.string().optional(),
+			ttl: s.number().optional(),
 		}),
 		output: s.object({
 			operation: s.string(),
@@ -19,24 +20,24 @@ const kvTypesAgent = createAgent('storage-kv-types', {
 		}),
 	},
 	handler: async (ctx, input) => {
-		const { operation, key, value, namespace = 'test' } = input;
+		const { operation, key, value, namespace = 'test', ttl } = input;
 
 		switch (operation) {
 			case 'set-string':
-				await ctx.kv.set(namespace, key, String(value));
+				await ctx.kv.set(namespace, key, String(value), ttl ? { ttl } : undefined);
 				return { operation, key, value, valueType: 'string', success: true };
 
 			case 'set-object':
 				// Store object as JSON
-				await ctx.kv.set(namespace, key, value, { contentType: 'application/json' });
+				await ctx.kv.set(namespace, key, value, { contentType: 'application/json', ...(ttl ? { ttl } : {}) });
 				return { operation, key, value, valueType: 'object', success: true };
 
 			case 'set-number':
-				await ctx.kv.set(namespace, key, Number(value));
+				await ctx.kv.set(namespace, key, Number(value), ttl ? { ttl } : undefined);
 				return { operation, key, value: Number(value), valueType: 'number', success: true };
 
 			case 'set-boolean':
-				await ctx.kv.set(namespace, key, Boolean(value));
+				await ctx.kv.set(namespace, key, Boolean(value), ttl ? { ttl } : undefined);
 				return { operation, key, value: Boolean(value), valueType: 'boolean', success: true };
 
 			case 'get': {

--- a/apps/testing/integration-suite/src/test/storage-kv.ts
+++ b/apps/testing/integration-suite/src/test/storage-kv.ts
@@ -16,12 +16,13 @@ import kvIsolationAgent from '@agents/storage/kv/isolation';
 // Test: KV Set operation
 test('storage-kv', 'set', async () => {
 	const key = uniqueId('kv-set');
-	const namespace = uniqueId('ns-set');
+	const namespace = 'testing';
 	const result = await kvCrudAgent.run({
 		operation: 'set',
 		key,
 		namespace,
 		value: 'test-value',
+		ttl: 1800,
 	});
 
 	assertDefined(result, 'Result should be defined');
@@ -34,7 +35,7 @@ test('storage-kv', 'set', async () => {
 // Test: KV Get operation
 test('storage-kv', 'get', async () => {
 	const key = uniqueId('kv-get');
-	const namespace = uniqueId('ns-get');
+	const namespace = 'testing';
 
 	// Set a value first
 	await kvCrudAgent.run({
@@ -42,6 +43,7 @@ test('storage-kv', 'get', async () => {
 		key,
 		namespace,
 		value: 'retrieved-value',
+		ttl: 1800,
 	});
 
 	// Get it back
@@ -60,7 +62,7 @@ test('storage-kv', 'get', async () => {
 // Test: KV Get non-existent key
 test('storage-kv', 'get-missing', async () => {
 	const key = uniqueId('kv-missing');
-	const namespace = uniqueId('ns-get-missing');
+	const namespace = 'testing';
 
 	const result = await kvCrudAgent.run({
 		operation: 'get',
@@ -77,7 +79,7 @@ test('storage-kv', 'get-missing', async () => {
 // Test: KV Delete operation
 test('storage-kv', 'delete', async () => {
 	const key = uniqueId('kv-delete');
-	const namespace = uniqueId('ns-delete');
+	const namespace = 'testing';
 
 	// Set a value
 	await kvCrudAgent.run({
@@ -85,6 +87,7 @@ test('storage-kv', 'delete', async () => {
 		key,
 		namespace,
 		value: 'to-be-deleted',
+		ttl: 1800,
 	});
 
 	// Delete it
@@ -113,7 +116,7 @@ test('storage-kv', 'delete', async () => {
 // Test: KV Has operation
 test('storage-kv', 'has', async () => {
 	const key = uniqueId('kv-has');
-	const namespace = uniqueId('ns-has');
+	const namespace = 'testing';
 
 	// Check non-existent key
 	const notExistsResult = await kvCrudAgent.run({
@@ -130,6 +133,7 @@ test('storage-kv', 'has', async () => {
 		key,
 		namespace,
 		value: 'exists',
+		ttl: 1800,
 	});
 
 	// Check existing key
@@ -145,13 +149,14 @@ test('storage-kv', 'has', async () => {
 // Test: KV String type
 test('storage-kv', 'type-string', async () => {
 	const key = uniqueId('kv-string');
-	const namespace = uniqueId('ns-type-string');
+	const namespace = 'testing';
 
 	await kvTypesAgent.run({
 		operation: 'set-string',
 		key,
 		namespace,
 		value: 'hello world',
+		ttl: 1800,
 	});
 
 	const result = await kvTypesAgent.run({
@@ -170,13 +175,14 @@ test('storage-kv', 'type-string', async () => {
 // Test: KV Number type
 test('storage-kv', 'type-number', async () => {
 	const key = uniqueId('kv-number');
-	const namespace = uniqueId('ns-type-number');
+	const namespace = 'testing';
 
 	await kvTypesAgent.run({
 		operation: 'set-number',
 		key,
 		namespace,
 		value: 123,
+		ttl: 1800,
 	});
 
 	const result = await kvTypesAgent.run({
@@ -193,13 +199,14 @@ test('storage-kv', 'type-number', async () => {
 // Test: KV Boolean type (true)
 test('storage-kv', 'type-boolean-true', async () => {
 	const key = uniqueId('kv-bool-true');
-	const namespace = uniqueId('ns-type-boolean-true');
+	const namespace = 'testing';
 
 	await kvTypesAgent.run({
 		operation: 'set-boolean',
 		key,
 		namespace,
 		value: true,
+		ttl: 1800,
 	});
 
 	const result = await kvTypesAgent.run({
@@ -216,13 +223,14 @@ test('storage-kv', 'type-boolean-true', async () => {
 // Test: KV Boolean type (false)
 test('storage-kv', 'type-boolean-false', async () => {
 	const key = uniqueId('kv-bool-false');
-	const namespace = uniqueId('ns-type-boolean-false');
+	const namespace = 'testing';
 
 	await kvTypesAgent.run({
 		operation: 'set-boolean',
 		key,
 		namespace,
 		value: false,
+		ttl: 1800,
 	});
 
 	const result = await kvTypesAgent.run({
@@ -239,7 +247,7 @@ test('storage-kv', 'type-boolean-false', async () => {
 // Test: KV Isolation between calls
 test('storage-kv', 'isolation', async () => {
 	const baseKey = uniqueId('kv-isolation');
-	const namespace = uniqueId('ns-isolation');
+	const namespace = 'testing';
 
 	// Make two concurrent calls with different keys
 	const [result1, result2] = await Promise.all([
@@ -247,11 +255,13 @@ test('storage-kv', 'isolation', async () => {
 			key: `${baseKey}-1`,
 			namespace,
 			value: 'value-1',
+			ttl: 1800,
 		}),
 		kvIsolationAgent.run({
 			key: `${baseKey}-2`,
 			namespace,
 			value: 'value-2',
+			ttl: 1800,
 		}),
 	]);
 
@@ -271,7 +281,7 @@ test('storage-kv', 'isolation', async () => {
 // Test: KV Overwrite value
 test('storage-kv', 'overwrite', async () => {
 	const key = uniqueId('kv-overwrite');
-	const namespace = uniqueId('ns-overwrite');
+	const namespace = 'testing';
 
 	// Set initial value
 	await kvCrudAgent.run({
@@ -279,6 +289,7 @@ test('storage-kv', 'overwrite', async () => {
 		key,
 		namespace,
 		value: 'original',
+		ttl: 1800,
 	});
 
 	// Overwrite it
@@ -287,6 +298,7 @@ test('storage-kv', 'overwrite', async () => {
 		key,
 		namespace,
 		value: 'updated',
+		ttl: 1800,
 	});
 
 	// Verify new value
@@ -302,7 +314,7 @@ test('storage-kv', 'overwrite', async () => {
 // Test: KV Concurrent operations
 test('storage-kv', 'concurrent-operations', async () => {
 	const keys = Array.from({ length: 5 }, (_, i) => uniqueId(`kv-concurrent-${i}`));
-	const namespace = uniqueId('ns-concurrent-operations');
+	const namespace = 'testing';
 
 	// Set multiple values concurrently
 	await Promise.all(
@@ -312,6 +324,7 @@ test('storage-kv', 'concurrent-operations', async () => {
 				key,
 				namespace,
 				value: `value-${i}`,
+				ttl: 1800,
 			})
 		)
 	);


### PR DESCRIPTION
## Summary

- Use a consistent `"testing"` bucket name for all KV integration tests instead of generating unique bucket names per test run
- Add 30-minute TTL (1800 seconds) to all KV set operations for automatic data expiration
- Update KV test agents (crud, types, isolation) to accept and forward the TTL parameter

## Problem

The integration tests were creating unique bucket/namespace names using `uniqueId('ns-...')` for each test run, which created high cardinality in the KV storage with many buckets that never expired.

## Solution

1. **Static bucket name**: Changed all namespace variables from `uniqueId('ns-...')` to the literal string `'testing'`
2. **Unique keys for isolation**: Keys remain unique via `uniqueId()` to maintain test isolation within the shared bucket
3. **Auto-expiration**: Added `ttl: 1800` (30 minutes) to all set operations so test data automatically expires
4. **Agent schema updates**: Updated all three KV test agents to accept an optional `ttl` parameter and forward it to `ctx.kv.set()`

## Changes

| File | Changes |
|------|---------|
| `apps/testing/integration-suite/src/test/storage-kv.ts` | Changed 12 namespace vars to `'testing'`, added `ttl: 1800` to 13 set operations |
| `apps/testing/integration-suite/src/agent/storage/kv/crud.ts` | Added `ttl` to input schema and handler |
| `apps/testing/integration-suite/src/agent/storage/kv/types.ts` | Added `ttl` to input schema and all 4 set operations |
| `apps/testing/integration-suite/src/agent/storage/kv/isolation.ts` | Added `ttl` to input schema and handler |

## Testing

- TypeScript compilation passes (`bun run typecheck`)
- Integration tests require deployed agents to run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Key-value storage operations now support optional TTL (time-to-live) parameters, allowing stored values to automatically expire after a configurable duration in seconds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->