### PR TITLE
fix: prevent internal logger race condition in forked processes

### DIFF
--- a/packages/cli/bin/cli.ts
+++ b/packages/cli/bin/cli.ts
@@ -214,6 +214,9 @@ if (shouldSkipInternalLogging) {
 		}
 	}
 	internalLogger.init(command, filteredArgs, undefined, projectDirArg);
+
+	// Set session ID in environment so forked child processes can share the same log file
+	process.env.AGENTUITY_INTERNAL_SESSION_ID = internalLogger.getSessionId();
 }
 
 // Create composite logger that writes to both console and internal log

--- a/packages/cli/src/internal-logger.ts
+++ b/packages/cli/src/internal-logger.ts
@@ -110,6 +110,14 @@ function getLogsDir(): string {
  * Clean up old log directories, keeping only the most recent one
  */
 function cleanupOldLogs(currentSessionId: string): void {
+	// Skip cleanup when inheriting a parent's session ID to avoid
+	// deleting the parent's session directory (race condition).
+	// This applies to forked deploy processes and any subprocess
+	// that inherits AGENTUITY_INTERNAL_SESSION_ID.
+	if (process.env.AGENTUITY_INTERNAL_SESSION_ID) {
+		return;
+	}
+
 	const logsDir = getLogsDir();
 	if (!existsSync(logsDir)) {
 		return;
@@ -153,7 +161,15 @@ export class InternalLogger implements Logger {
 		private cliVersion: string,
 		private cliName: string
 	) {
-		this.sessionId = randomUUID();
+		// When a parent session ID is set in the environment, use it to ensure
+		// all CLI invocations (parent and any subprocesses) write to the same log file.
+		// This prevents race conditions where child processes delete parent's logs.
+		const parentSessionId = process.env.AGENTUITY_INTERNAL_SESSION_ID;
+		if (parentSessionId) {
+			this.sessionId = parentSessionId;
+		} else {
+			this.sessionId = randomUUID();
+		}
 		this.sessionDir = join(getLogsDir(), this.sessionId);
 		this.sessionFile = join(this.sessionDir, 'session.json');
 		this.logsFile = join(this.sessionDir, 'logs.jsonl');
@@ -170,11 +186,19 @@ export class InternalLogger implements Logger {
 		if (this.disabled) return;
 
 		try {
-			// Create logs directory
+			// Create logs directory (may already exist if we're a child process)
 			mkdirSync(this.sessionDir, { recursive: true, mode: 0o700 });
 
 			// Clean up old logs (keep only this session)
+			// This is skipped for child processes to avoid deleting parent's session
 			cleanupOldLogs(this.sessionId);
+
+			// When inheriting a parent's session ID, skip session.json creation
+			// (parent already created it) but enable logging
+			if (process.env.AGENTUITY_INTERNAL_SESSION_ID) {
+				this.initialized = true;
+				return;
+			}
 
 			// Determine project directory: use provided projectDir, or fall back to cwd
 			let workingDir = projectDir || process.cwd();


### PR DESCRIPTION
## Summary

Fixes ENOENT errors during `agentuity deploy` caused by a race condition between parent and child process internal loggers.

## Problem

During deploy, the CLI forks a child process. Both parent and child were creating separate internal loggers with different session IDs. The child's `cleanupOldLogs()` function would delete the parent's session directory while the parent was still writing to it, causing:

```
Failed to write log entry: Error: ENOENT: no such file or directory, open '/Users/.../.config/agentuity/logs/.../logs.jsonl'
```

## Solution

- Share the session ID between parent and child processes via `AGENTUITY_INTERNAL_SESSION_ID` environment variable
- When a child process inherits a session ID, it reuses the same log directory and skips `cleanupOldLogs()`
- The parent process sets the env var after initializing its logger, so forked children automatically inherit it

## Changes

- **internal-logger.ts**: Check for inherited session ID, skip cleanup when inheriting
- **cli.ts**: Set `AGENTUITY_INTERNAL_SESSION_ID` env var after logger initialization

## Testing

Verified with actual deploy - no more ENOENT errors, single session directory used by both processes.

## Related

- Fixes https://github.com/agentuity/sdk/issues/775
- Related PRs in `go-common` and `gravity` repos fix the gravity client shutdown errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed logging issues in multi-process scenarios by enabling child processes to share the parent's session log file instead of creating separate logs.
  * Eliminated race conditions caused by simultaneous log directory cleanup operations when multiple processes run concurrently.
  * Child processes now properly inherit parent session context, avoiding log data conflicts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->