### PR TITLE
feat(cli): add agent detection to identify when CLI is run from coding agents

### DIFF
--- a/packages/cli/bin/cli.ts
+++ b/packages/cli/bin/cli.ts
@@ -19,6 +19,12 @@ import { closeDatabase } from '../src/cache';
 import { createInternalLogger } from '../src/internal-logger';
 import { createCompositeLogger } from '../src/composite-logger';
 import { getAuth } from '../src/config';
+import {
+	startAgentDetection,
+	isExecutingFromAgent,
+	onAgentDetected,
+	flushAgentDetection,
+} from '../src/agent-detection';
 
 /**
  * Extract --dir flag from process.argv before command parsing
@@ -79,6 +85,10 @@ process.on('SIGTERM', () => {
 
 validateRuntime();
 await ensureBunOnPath();
+
+// Start agent detection early (non-blocking) so it runs in the background
+// while the rest of CLI initialization happens
+startAgentDetection();
 
 // Preprocess arguments to convert --help=json to --help json
 // Commander.js doesn't support --option=value syntax for optional values
@@ -217,6 +227,13 @@ if (shouldSkipInternalLogging) {
 
 	// Set session ID in environment so forked child processes can share the same log file
 	process.env.AGENTUITY_INTERNAL_SESSION_ID = internalLogger.getSessionId();
+
+	// Register callback to update session with detected agent (non-blocking)
+	onAgentDetected((agent) => {
+		if (agent) {
+			internalLogger.setDetectedAgent(agent);
+		}
+	});
 }
 
 // Create composite logger that writes to both console and internal log
@@ -243,6 +260,7 @@ const ctx = {
 	config,
 	logger,
 	options: earlyOpts,
+	isExecutingFromAgent,
 };
 
 // Set global output options for utilities to use
@@ -275,6 +293,8 @@ await registerCommands(program, commands, ctx as unknown as CommandContext);
 
 try {
 	await program.parseAsync(process.argv);
+	// Flush agent detection to ensure it's written to session logs before exit
+	await flushAgentDetection();
 } catch (error) {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const exit = (globalThis as any).AGENTUITY_PROCESS_EXIT || process.exit;

--- a/packages/cli/src/agent-detection.ts
+++ b/packages/cli/src/agent-detection.ts
@@ -1,0 +1,262 @@
+import { spawn } from 'node:child_process';
+
+/**
+ * Map of process names to internal agent short names.
+ * The key is the process name (or substring) that appears in the parent process command line.
+ * The value is the internal short name used to identify the agent.
+ *
+ * Process names verified via `agentuity cloud sandbox run --runtime <agent>:latest`:
+ * - opencode: binary 'opencode' (from bun install -g opencode-ai)
+ * - codex: binary 'codex' (from npm install -g @openai/codex)
+ * - cursor: binary 'cursor-agent' (from curl installer)
+ * - claude-code: binary 'claude', shows as 'node /usr/local/bin/claude'
+ * - copilot: binary 'copilot', shows as 'node /usr/local/bin/copilot' and spawns native binary
+ * - gemini: binary 'gemini', shows as 'node /usr/local/bin/gemini'
+ * - amp: binary 'amp', shows as 'node --no-warnings /usr/local/bin/amp'
+ *
+ * IMPORTANT: Order matters! More specific patterns should come before less specific ones.
+ * For example, 'opencode' must be checked before 'code' to avoid false matches.
+ */
+export const KNOWN_AGENTS: [string, string][] = [
+	// Verified via cloud sandbox runtime - most specific patterns first
+	['opencode', 'opencode'],
+	['codex', 'codex'],
+	['cursor-agent', 'cursor'],
+	['claude', 'claude-code'],
+	['copilot', 'copilot'],
+	['gemini', 'gemini'],
+	['cline', 'cline'],
+	['roo-code', 'roo'],
+	['windsurf', 'windsurf'],
+	['zed', 'zed'],
+	['amp', 'amp'],
+	// TODO: VSCode Agent Mode detection - need to find a reliable way to detect
+	// when VSCode's built-in agent (Copilot Chat) is running commands vs just
+	// running in VSCode's integrated terminal. May need env var detection.
+];
+
+export type KnownAgent = (typeof KNOWN_AGENTS)[number][1];
+
+/**
+ * Promise for the detection result (set when detection starts)
+ */
+let detectionPromise: Promise<string | undefined> | null = null;
+
+/**
+ * Cached result after detection completes (null = not yet resolved)
+ */
+let cachedResult: string | undefined | null = null;
+
+/**
+ * Callbacks to invoke when agent detection completes
+ */
+const detectionCallbacks: Array<(agent: string | undefined) => void> = [];
+
+/**
+ * Get the command line and parent PID for a given PID in a single ps call
+ */
+function getProcessInfo(pid: number): Promise<{ command: string; ppid: number } | undefined> {
+	return new Promise((resolve) => {
+		const ps = spawn('ps', ['-p', String(pid), '-o', 'ppid=,command='], {
+			stdio: ['ignore', 'pipe', 'ignore'],
+		});
+
+		let output = '';
+
+		ps.stdout.on('data', (data: Buffer) => {
+			output += data.toString();
+		});
+
+		ps.on('close', () => {
+			const trimmed = output.trim();
+			if (!trimmed) {
+				resolve(undefined);
+				return;
+			}
+
+			// Output format: "  PPID COMMAND" (ppid is right-aligned, then space, then command)
+			const match = trimmed.match(/^\s*(\d+)\s+(.+)$/);
+			if (!match) {
+				resolve(undefined);
+				return;
+			}
+
+			const ppid = parseInt(match[1], 10);
+			const command = match[2].toLowerCase();
+
+			if (isNaN(ppid) || ppid <= 1 || !command) {
+				resolve(undefined);
+				return;
+			}
+
+			resolve({ command, ppid });
+		});
+
+		ps.on('error', () => {
+			resolve(undefined);
+		});
+	});
+}
+
+/**
+ * Check if a command matches any known agent
+ */
+function matchAgent(command: string): string | undefined {
+	for (const [processName, agentName] of KNOWN_AGENTS) {
+		if (command.includes(processName)) {
+			return agentName;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Detect the parent process command and check if it matches a known agent.
+ * Walks up the process tree to find the first matching agent.
+ */
+function detectParentAgent(): Promise<string | undefined> {
+	return new Promise((resolve) => {
+		// TODO: Implement Windows support using wmic or PowerShell
+		if (process.platform === 'win32') {
+			resolve(undefined);
+			return;
+		}
+
+		const maxDepth = 10; // Limit how far up we walk the tree
+
+		async function walkTree(pid: number, depth: number): Promise<string | undefined> {
+			if (depth >= maxDepth || pid <= 1) {
+				return undefined;
+			}
+
+			// Get both command and parent PID in a single ps call
+			const info = await getProcessInfo(pid);
+			if (!info) {
+				return undefined;
+			}
+
+			// Check if this process matches a known agent
+			const agent = matchAgent(info.command);
+			if (agent) {
+				return agent;
+			}
+
+			// Walk up to parent
+			return walkTree(info.ppid, depth + 1);
+		}
+
+		const ppid = process.ppid;
+		if (!ppid) {
+			resolve(undefined);
+			return;
+		}
+
+		walkTree(ppid, 0).then(resolve).catch(() => resolve(undefined));
+	});
+}
+
+/**
+ * Start agent detection immediately (non-blocking).
+ * Call this early in CLI startup to begin detection in the background.
+ */
+export function startAgentDetection(): void {
+	if (detectionPromise !== null) {
+		// Already started
+		return;
+	}
+
+	detectionPromise = detectParentAgent().then((result) => {
+		cachedResult = result;
+		// Invoke all registered callbacks
+		for (const callback of detectionCallbacks) {
+			try {
+				callback(result);
+			} catch {
+				// Ignore callback errors
+			}
+		}
+		return result;
+	});
+}
+
+/**
+ * Register a callback to be invoked when agent detection completes.
+ * If detection has already completed, the callback is invoked immediately.
+ * This is non-blocking and does not return a promise.
+ *
+ * @example
+ * ```typescript
+ * onAgentDetected((agent) => {
+ *   if (agent) {
+ *     console.log(`Detected agent: ${agent}`);
+ *   }
+ * });
+ * ```
+ */
+export function onAgentDetected(callback: (agent: string | undefined) => void): void {
+	// If detection already completed, invoke immediately
+	if (cachedResult !== null) {
+		try {
+			callback(cachedResult);
+		} catch {
+			// Ignore callback errors
+		}
+		return;
+	}
+
+	// Otherwise, register for later invocation
+	detectionCallbacks.push(callback);
+}
+
+/**
+ * Get the cached detection result synchronously.
+ * Returns undefined if detection hasn't completed yet or no agent was detected.
+ * Returns null if detection hasn't started or completed yet.
+ *
+ * Use this for synchronous access when you don't want to wait for detection.
+ */
+export function getDetectedAgent(): string | undefined | null {
+	return cachedResult;
+}
+
+/**
+ * Wait for agent detection to complete and ensure all callbacks have been invoked.
+ * Call this before CLI exit to ensure the detected agent is written to session logs.
+ *
+ * This is a no-op if detection hasn't started or has already completed.
+ */
+export async function flushAgentDetection(): Promise<void> {
+	if (detectionPromise !== null) {
+		await detectionPromise;
+	}
+}
+
+/**
+ * Check if the CLI is being executed from a known coding agent.
+ * Returns the agent name if detected, undefined otherwise.
+ *
+ * This function returns immediately if detection has already completed,
+ * otherwise it awaits the detection promise started by startAgentDetection().
+ *
+ * @example
+ * ```typescript
+ * const agent = await isExecutingFromAgent();
+ * if (agent) {
+ *   logger.debug(`Running from agent: ${agent}`);
+ * }
+ * ```
+ */
+export async function isExecutingFromAgent(): Promise<string | undefined> {
+	// Return cached result if detection has completed
+	if (cachedResult !== null) {
+		return cachedResult;
+	}
+
+	// If detection hasn't started yet, start it now
+	if (detectionPromise === null) {
+		startAgentDetection();
+	}
+
+	// Wait for detection to complete
+	return detectionPromise!;
+}

--- a/packages/cli/src/cmd/support/system.ts
+++ b/packages/cli/src/cmd/support/system.ts
@@ -7,6 +7,7 @@ import { getLatestLogSession } from '../../internal-logger';
 import * as tui from '../../tui';
 import { getVersion, getPackageName } from '../../version';
 import { getAuth } from '../../config';
+import { isExecutingFromAgent } from '../../agent-detection';
 
 const argsSchema = z.object({});
 
@@ -75,6 +76,9 @@ export default createSubcommand({
 			}
 		}
 
+		// Get detected agent (if any)
+		const detectedAgent = await isExecutingFromAgent();
+
 		// Gather system information
 		const systemInfo = {
 			cli: {
@@ -100,6 +104,7 @@ export default createSubcommand({
 			user: {
 				userId: userId,
 			},
+			agent: detectedAgent || null,
 		};
 
 		if (isJsonMode) {
@@ -122,6 +127,7 @@ export default createSubcommand({
 				{ Property: 'Home Directory', Value: systemInfo.paths.home },
 				{ Property: 'Config Directory', Value: systemInfo.paths.configDir },
 				{ Property: 'User ID', Value: systemInfo.user.userId },
+				{ Property: 'Detected Agent', Value: systemInfo.agent || 'none' },
 			];
 
 			tui.table(tableData, ['Property', 'Value'], { layout: 'vertical' });

--- a/packages/cli/src/internal-logger.ts
+++ b/packages/cli/src/internal-logger.ts
@@ -389,6 +389,24 @@ export class InternalLogger implements Logger {
 	}
 
 	/**
+	 * Update the session with detected agent name
+	 */
+	setDetectedAgent(agent: string): void {
+		if (!this.initialized || this.disabled) return;
+
+		try {
+			// Read existing session data
+			const existingData = JSON.parse(readFileSync(this.sessionFile, 'utf-8'));
+			existingData.detectedAgent = agent;
+			// Write updated session data
+			writeFileSync(this.sessionFile, JSON.stringify(existingData, null, 2));
+		} catch (err) {
+			// Ignore errors - this is a best-effort update
+			console.debug(`Failed to update detectedAgent in session: ${err}`);
+		}
+	}
+
+	/**
 	 * Disable the internal logger (prevents init and logging)
 	 */
 	disable(): void {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -422,6 +422,19 @@ export type CommandContextFromSpecs<
 	config: Config | null;
 	logger: Logger;
 	options: GlobalOptions;
+	/**
+	 * Check if the CLI is being executed from a known coding agent.
+	 * Returns the agent name if detected, undefined otherwise.
+	 *
+	 * @example
+	 * ```typescript
+	 * const agent = await ctx.isExecutingFromAgent();
+	 * if (agent) {
+	 *   logger.debug(`Running from agent: ${agent}`);
+	 * }
+	 * ```
+	 */
+	isExecutingFromAgent: () => Promise<string | undefined>;
 } & AddArgs<A> &
 	AddOpts<Op> &
 	AddAuth<AuthMode<R, O>> &


### PR DESCRIPTION
## Summary

- Add lightweight agent detection that identifies when the CLI is invoked from known coding agents
- Walk up the process tree to find agent ancestors (handles cases like `opencode → shell → bun → cli`)
- Include detected agent in `support system` output and session logs for bug reports

## Changes

### New File: `packages/cli/src/agent-detection.ts`
- Process tree walking (up to 10 levels) to detect known agents
- Non-blocking detection with callback system
- Supported agents: opencode, codex, cursor, claude-code, copilot, gemini, amp, cline, roo, windsurf, zed

### Modified Files
- **cli.ts**: Start detection early, add `isExecutingFromAgent` to context, flush before exit
- **types.ts**: Add `isExecutingFromAgent()` to `CommandContext`
- **support/system.ts**: Show detected agent in output
- **internal-logger.ts**: Add `setDetectedAgent()` to write to session.json

## API

```typescript
// In command handlers
const agent = await ctx.isExecutingFromAgent();
if (agent) {
  logger.debug(`Running from agent: ${agent}`);
}
```

## Testing

```bash
# From opencode (or any supported agent)
bun cli support system
# Shows: Detected Agent: opencode

bun cli support system --json
# Shows: "agent": "opencode"
```

## TODO
- Windows support (currently returns undefined)
- VSCode Agent Mode detection (need to identify reliable signals)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background agent detection added to identify known coding agents (Cursor, Claude, Copilot, etc.) without impacting CLI performance.
  * Detected agent shown in the system support command output.
  * CLI exposes a query for agent execution state and records detected agent to internal session logs.
  * Detection is flushed before process exit to ensure results are persisted.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->