### PR TITLE
feat(cli): add --name flag to auth org current command

### DIFF
--- a/packages/cli/src/cmd/auth/org/index.ts
+++ b/packages/cli/src/cmd/auth/org/index.ts
@@ -75,7 +75,8 @@ const selectCommand = createSubcommand({
 const unselectCommand = createSubcommand({
 	name: 'unselect',
 	description: 'Clear the default organization preference',
-	tags: ['fast'],
+	tags: ['fast', 'requires-auth'],
+	requires: { auth: true, apiClient: true },
 	examples: [
 		{ command: getCommand('auth org unselect'), description: 'Clear default organization' },
 	],
@@ -106,27 +107,54 @@ const unselectCommand = createSubcommand({
 const currentCommand = createSubcommand({
 	name: 'current',
 	description: 'Show the current default organization',
-	tags: ['read-only', 'fast'],
+	tags: ['read-only', 'fast', 'requires-auth'],
 	idempotent: true,
+	requires: { auth: true, apiClient: true },
 	examples: [
-		{ command: getCommand('auth org current'), description: 'Show default organization' },
+		{ command: getCommand('auth org current'), description: 'Show default organization ID' },
+		{ command: getCommand('auth org current --name'), description: 'Show default organization name' },
 		{ command: getCommand('auth org current --json'), description: 'Show output in JSON format' },
 	],
 	schema: {
-		response: z.string().nullable().describe('The current organization ID or null if not set'),
+		options: z.object({
+			name: z.boolean().optional().describe('Show organization name instead of ID'),
+		}),
+		response: z
+			.object({
+				id: z.string().nullable().describe('The current organization ID or null if not set'),
+				name: z.string().nullable().describe('The current organization name or null if not set or not found'),
+			})
+			.describe('The current organization details'),
 	},
 
 	async handler(ctx) {
-		const { options, config } = ctx;
+		const { options, config, apiClient, opts } = ctx;
 		const orgId = config?.preferences?.orgId || null;
 
+		let orgName: string | null = null;
+
+		// Fetch org name if we have an orgId and either --name or --json is requested
+		if (orgId && (opts.name || options.json)) {
+			const orgs = await listOrganizations(apiClient);
+			const org = orgs.find((o) => o.id === orgId);
+			orgName = org?.name ?? null;
+		}
+
 		if (!options.json) {
-			if (orgId) {
-				console.log(orgId);
+			if (opts.name) {
+				// --name flag: print only the org name
+				if (orgName) {
+					console.log(orgName);
+				}
+			} else {
+				// Default behavior: print only the org ID
+				if (orgId) {
+					console.log(orgId);
+				}
 			}
 		}
 
-		return orgId;
+		return { id: orgId, name: orgName };
 	},
 });
 


### PR DESCRIPTION
## Summary

- Add `--name` flag to `agentuity auth org current` command to display the organization name instead of just the ID
- Update `--json` output to include both `id` and `name` fields
- Add `requires: { auth: true, apiClient: true }` to `unselect` and `current` commands for consistency with `select` command

## Usage

| Command | Output |
|---------|--------|
| `agentuity auth org current` | Prints org ID |
| `agentuity auth org current --name` | Prints org name |
| `agentuity auth org current --json` | `{"id": "...", "name": "..."}` |
| `agentuity auth org current --json --name` | `{"id": "...", "name": "..."}` |

## Changes

- `packages/cli/src/cmd/auth/org/index.ts`: Added `--name` flag, updated response schema, and added auth requirements to all org subcommands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added `--name` flag to the org current command to display the organization name
- org current command now returns both the organization id and name
- org current and org unselect commands now require authentication and API client access

## Documentation
- Updated command examples for org current to demonstrate `--name` and `--json` usage patterns

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->