### PR TITLE
feat(publish): attach templates tarball to GitHub releases

### DIFF
--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { readdir, readFile, writeFile, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import { $ } from 'bun';
 import * as readline from 'node:readline';
@@ -511,13 +511,29 @@ async function buildTemplatesTarball(version: string): Promise<string> {
 	const tempDir = join('/tmp', `sdk-v${version}`);
 	const templatesSubdir = join(tempDir, 'templates');
 
+	// Validate templates directory exists
+	try {
+		const stats = await stat(templatesDir);
+		if (!stats.isDirectory()) {
+			throw new Error(`Templates path is not a directory: ${templatesDir}`);
+		}
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+			throw new Error(`Templates directory not found: ${templatesDir}`);
+		}
+		throw err;
+	}
+
 	try {
 		// Clean up any existing temp directory and tarball
 		await $`rm -rf ${tempDir} ${tarballPath}`.quiet().nothrow();
 
-		// Create temp directory with sdk-v{version}/templates structure and copy templates
+		// Create temp directory with sdk-v{version}/templates structure
 		await $`mkdir -p ${templatesSubdir}`;
-		await $`cp -r ${templatesDir}/* ${templatesSubdir}/`;
+
+		// Copy all contents including dotfiles using trailing dot syntax
+		// cp -r source/. dest/ copies all files including hidden ones
+		await $`cp -r ${templatesDir}/. ${templatesSubdir}/`;
 
 		// Create tarball from /tmp with sdk-v{version} as root directory
 		await $`tar -czf ${tarballPath} -C /tmp sdk-v${version}`;


### PR DESCRIPTION
## Summary

- Adds `buildTemplatesTarball` function that creates a `templates-{version}.tar.gz` archive of the templates folder
- The tarball structure uses `templates-{version}/` as the root directory, matching GitHub's tarball format
- Uploads the tarball to GitHub releases alongside the VS Code extension

## Why

This enables `https://agentuity.sh/template/sdk/{branch}/tar.gz` to serve templates directly from release assets instead of cloning the entire repository. This will significantly improve template download performance.

## Testing

- Verified tarball creation produces correct structure with `tar -tzf`
- Typecheck passes
- Lint passes

## Follow-up

Once merged and released, a separate PR will update the template URL endpoint to return the uploaded tarball from the release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Templates are now packaged into a versioned tarball and uploaded as a separate release asset alongside the VS Code extension.
  * The release process now builds the templates tarball and includes it when publishing releases.

* **Documentation**
  * Release help text updated to mention that a templates tarball is built and published as part of the release process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->