### PR TITLE
feat(server): add internal property to DB resource schemas

### DIFF
--- a/packages/server/src/api/org/resources.ts
+++ b/packages/server/src/api/org/resources.ts
@@ -25,6 +25,7 @@ const OrgDBResource = z.object({
 	cloud_region: z.string().describe('the cloud region where this resource is provisioned'),
 	org_id: z.string().describe('the organization ID that owns this resource'),
 	org_name: z.string().describe('the organization name that owns this resource'),
+	internal: z.boolean().describe('whether this is a system-managed database (KV/Vector/Queue)'),
 });
 
 const OrgResourceListResponse = z.object({

--- a/packages/server/src/api/region/resources.ts
+++ b/packages/server/src/api/region/resources.ts
@@ -28,6 +28,7 @@ const ResourceListResponse = z.object({
 			password: z.string().nullable().optional().describe('the database password'),
 			url: z.string().nullable().optional().describe('the full database connection URL'),
 			env: z.record(z.string(), z.string()).describe('environment variables for the resource'),
+			internal: z.boolean().describe('whether this is a system-managed database (KV/Vector/Queue)'),
 		})
 	),
 	redis: z


### PR DESCRIPTION
## Summary

- Add `internal: z.boolean()` property to DB resource schema in `region/resources.ts`
- Add `internal: z.boolean()` property to `OrgDBResource` schema in `org/resources.ts`

## Details

This aligns the SDK with the Catalyst API which now returns the `internal` field on DB resources. The field indicates if a database is a system-managed internal resource (KV/Vector/Queue).

## Related

- Catalyst PR: https://github.com/agentuity/catalyst/pull/new/task/add-internal-prop-for-keyqueueetc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database resources now include an indicator to identify system-managed databases, enabling better categorization of KV, Vector, and Queue database types across organization and region endpoints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->