### PR TITLE
feat: add sync option for queue publish

### DIFF
--- a/packages/cli/src/cmd/cloud/queue/publish.ts
+++ b/packages/cli/src/cmd/cloud/queue/publish.ts
@@ -38,6 +38,7 @@ export const publishSubcommand = createCommand({
 			partitionKey: z.string().optional().describe('Partition key for ordering'),
 			idempotencyKey: z.string().optional().describe('Idempotency key to prevent duplicates'),
 			ttl: z.coerce.number().optional().describe('Message TTL in seconds'),
+			sync: z.boolean().optional().describe('Publish synchronously (wait for persistence)'),
 		}),
 		response: MessageSchema,
 	},
@@ -62,6 +63,11 @@ export const publishSubcommand = createCommand({
 			}
 		}
 
+		const apiOptions = getQueueApiOptions(ctx) ?? {};
+		if (opts.sync) {
+			apiOptions.sync = true;
+		}
+
 		const message = await publishMessage(
 			client,
 			args.queue_name,
@@ -72,7 +78,7 @@ export const publishSubcommand = createCommand({
 				idempotency_key: opts.idempotencyKey,
 				ttl_seconds: opts.ttl,
 			},
-			getQueueApiOptions(ctx)
+			apiOptions
 		);
 
 		if (!options.json) {

--- a/packages/core/src/services/queue.ts
+++ b/packages/core/src/services/queue.ts
@@ -71,6 +71,13 @@ export interface QueuePublishParams {
 	 * If not specified, uses the current agent context.
 	 */
 	agentId?: string;
+
+	/**
+	 * Whether to publish synchronously.
+	 * When true, the API waits for the message to be fully persisted before returning.
+	 * When false (default), the API returns immediately with a pending message.
+	 */
+	sync?: boolean;
 }
 
 /**
@@ -320,9 +327,10 @@ export class QueueStorageService implements QueueService {
 			});
 		}
 
+		const basePath = `/queue/messages/publish/2026-01-15/${encodeURIComponent(queueName)}`;
 		const url = buildUrl(
 			this.#baseUrl,
-			`/queue/messages/publish/2026-01-15/${encodeURIComponent(queueName)}`
+			params?.sync ? `${basePath}?sync=true` : basePath
 		);
 
 		const requestBody: Record<string, unknown> = {

--- a/packages/server/src/api/queue/messages.ts
+++ b/packages/server/src/api/queue/messages.ts
@@ -96,7 +96,9 @@ export async function publishMessage(
 		validateTTL(params.ttl_seconds);
 	}
 
-	const url = queueApiPath('messages/publish', queueName);
+	const url = options?.sync
+		? queueApiPathWithQuery('messages/publish', 'sync=true', queueName)
+		: queueApiPath('messages/publish', queueName);
 	const resp = await client.post(
 		url,
 		params,

--- a/packages/server/src/api/queue/types.ts
+++ b/packages/server/src/api/queue/types.ts
@@ -415,6 +415,13 @@ export interface QueueApiOptions {
 	 * Required when using user authentication (CLI) instead of SDK key.
 	 */
 	orgId?: string;
+
+	/**
+	 * Whether to publish synchronously.
+	 * When true, the API waits for the message to be fully persisted before returning.
+	 * When false (default), the API returns immediately with a pending message.
+	 */
+	sync?: boolean;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Add `sync` option for queue publish operations to support the new async publish feature in Catalyst.

### Changes

- Add `sync?: boolean` to `QueueApiOptions` interface
- Add `sync?: boolean` to `QueuePublishParams` interface  
- Pass `?sync=true` query param when sync mode is requested
- Add `--sync` flag to CLI `cloud queue publish` command

### Behavior

- **Default (async)**: Returns immediately with pending message (ID generated, offset=-1)
- **Sync mode (`--sync`)**: Waits for DB insert, returns actual message with offset

### Usage

```bash
# Async (default) - returns immediately
agentuity cloud queue publish my-queue '{"data": "value"}'

# Sync - waits for DB insert
agentuity cloud queue publish my-queue '{"data": "value"}' --sync
```

### Files Changed

| File | Changes |
|------|---------|
| `packages/server/src/api/queue/types.ts` | Add sync to QueueApiOptions |
| `packages/server/src/api/queue/messages.ts` | Pass sync query param |
| `packages/core/src/services/queue.ts` | Add sync to QueuePublishParams |
| `packages/cli/src/cmd/cloud/queue/publish.ts` | Add --sync flag |

## Related

- Companion to Catalyst PR: https://github.com/agentuity/catalyst/pull/493

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional `sync` flag for queue message publishing. When enabled, publish operations wait for the message to be persisted before completing. When disabled (default), operations return immediately with the message in a pending state, providing you control over publication behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->