### PR TITLE
fix: forward SIGINT/SIGTERM signals to child process during deploy

### DIFF
--- a/packages/cli/src/cmd/cloud/deploy-fork.ts
+++ b/packages/cli/src/cmd/cloud/deploy-fork.ts
@@ -93,29 +93,38 @@ export async function runForkedDeploy(options: ForkDeployOptions): Promise<ForkD
 			}
 		}
 
-		// Report deployment as cancelled
+		// Report deployment as cancelled (with timeout to ensure prompt exit)
 		const cancelMessage = 'Deployment cancelled by user';
-		try {
-			await projectDeploymentFail(apiClient, deploymentId, {
+		const timeoutMs = 3000; // 3 second timeout
+		const timeoutPromise = new Promise<void>((resolve) => {
+			setTimeout(() => {
+				logger.debug('API call to report cancellation timed out after %dms', timeoutMs);
+				resolve();
+			}, timeoutMs);
+		});
+
+		const apiCallPromise = projectDeploymentFail(apiClient, deploymentId, {
+			error: cancelMessage,
+			diagnostics: {
+				success: false,
+				errors: [
+					{
+						type: 'general',
+						scope: 'deploy',
+						message: cancelMessage,
+						code: 'DEPLOY_CANCELLED',
+					},
+				],
+				warnings: [],
+				diagnostics: [],
 				error: cancelMessage,
-				diagnostics: {
-					success: false,
-					errors: [
-						{
-							type: 'general',
-							scope: 'deploy',
-							message: cancelMessage,
-							code: 'DEPLOY_CANCELLED',
-						},
-					],
-					warnings: [],
-					diagnostics: [],
-					error: cancelMessage,
-				},
-			});
-		} catch (err) {
+			},
+		}).catch((err) => {
 			logger.debug('Failed to report cancellation: %s', err);
-		}
+		});
+
+		// Race API call against timeout to ensure prompt exit
+		await Promise.race([apiCallPromise, timeoutPromise]);
 
 		// Exit with signal-specific exit code
 		const signalExitCodes: Record<string, number> = {


### PR DESCRIPTION
## Summary

Fixes #790 - Ctrl+C during deploy now properly stops the deployment process

## Problem

When a user pressed Ctrl+C during `agentuity deploy`, the parent process exited but the child process continued running, completing the deployment but marking it as failed with "EIO: i/o error" messages.

## Root Cause

The deploy command uses a fork-based architecture where the parent spawns a child process via `bunx agentuity deploy --child-mode`. The parent process didn't forward SIGINT/SIGTERM signals to the child, so when the parent exited, the child continued independently.

## Solution

Modified `sdk/packages/cli/src/cmd/cloud/deploy-fork.ts` to:
- Add signal handlers that forward SIGINT/SIGTERM from parent to child process
- Kill the child process when parent receives termination signal
- Report deployment as cancelled via API with error code `DEPLOY_CANCELLED`
- Clean up signal handlers in finally block to prevent memory leaks
- Exit with standard code 130 on SIGINT

## Testing

✅ **Build**: Passed  
✅ **Typecheck**: Passed  
✅ **Lint**: Passed  
✅ **Manual Testing**: Validated with local stack
- Created test project with local profile
- Started deploy and sent SIGINT after 8 seconds during upload phase
- Process exited cleanly with no orphaned processes

## Verification

```bash
# Test command used
cd test-project
timeout --signal=INT 8 agentuity deploy

# Verify no orphans
ps aux | grep -E "[b]unx.*deploy|[a]gentuity.*child-mode"
# Result: No orphaned processes found
```

## Expected Behavior

**Before:**
- Ctrl+C exits parent only
- Child continues running
- Deployment completes but shows as failed
- "EIO: i/o error, read" messages

**After:**
- Ctrl+C immediately kills both parent and child
- Deployment properly cancelled and reported to API
- Clean exit with code 130
- No orphaned processes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI deployments now handle interrupts more reliably: interrupt signals are forwarded to spawned processes, in-progress deployments are cleanly cancelled and the cancellation is reported to the API, and signal handlers are removed after completion to prevent leaks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->