### PR TITLE
fix(cli): preserve leading zeros in project identifier for DNS validation

### DIFF
--- a/packages/cli/src/domain.ts
+++ b/packages/cli/src/domain.ts
@@ -104,7 +104,7 @@ export async function checkCustomDomainForDNS(
 	config?: Config | null
 ): Promise<DNSResult[]> {
 	const suffix = config?.overrides?.api_url?.includes('agentuity.io') ? LOCAL_DNS : PRODUCTION_DNS;
-	const id = Bun.hash.xxHash64(projectId).toString(16);
+	const id = Bun.hash.xxHash64(projectId).toString(16).padStart(16, '0');
 	const proxy = `p${id}.${suffix}`;
 
 	return Promise.all(

--- a/packages/cli/test/domain.test.ts
+++ b/packages/cli/test/domain.test.ts
@@ -1,0 +1,78 @@
+import { describe, test, expect } from 'bun:test';
+
+/**
+ * Generates a project identifier from a project ID using xxHash64.
+ * The identifier is always 16 hex characters (zero-padded).
+ *
+ * This must match the implementation in src/domain.ts
+ */
+function generateProjectIdentifier(projectId: string): string {
+	return Bun.hash.xxHash64(projectId).toString(16).padStart(16, '0');
+}
+
+describe('domain DNS validation', () => {
+	describe('project identifier generation', () => {
+		test('generates 16-character hex identifier', () => {
+			const projectId = 'proj_test123';
+			const identifier = generateProjectIdentifier(projectId);
+
+			expect(identifier).toHaveLength(16);
+			expect(identifier).toMatch(/^[0-9a-f]{16}$/);
+		});
+
+		test('preserves leading zeros in identifier', () => {
+			// This project ID is known to produce a hash with a leading zero
+			const projectId = 'proj_81766c4548fe4766c06b90db086527b4';
+			const identifier = generateProjectIdentifier(projectId);
+
+			expect(identifier).toBe('0a21231341cdb560');
+			expect(identifier).toHaveLength(16);
+			expect(identifier[0]).toBe('0'); // Leading zero must be preserved
+		});
+
+		test('generates consistent identifiers', () => {
+			const projectId = 'proj_abc123';
+			const id1 = generateProjectIdentifier(projectId);
+			const id2 = generateProjectIdentifier(projectId);
+
+			expect(id1).toBe(id2);
+		});
+
+		test('generates different identifiers for different projects', () => {
+			const id1 = generateProjectIdentifier('proj_abc');
+			const id2 = generateProjectIdentifier('proj_xyz');
+
+			expect(id1).not.toBe(id2);
+		});
+
+		test('handles edge case where hash would have multiple leading zeros', () => {
+			// Test that padding works correctly for any number of leading zeros
+			// We simulate this by checking the padStart behavior
+			const shortHex = 'abc'; // 3 chars
+			const padded = shortHex.padStart(16, '0');
+
+			expect(padded).toBe('0000000000000abc');
+			expect(padded).toHaveLength(16);
+		});
+	});
+
+	describe('CNAME target generation', () => {
+		test('generates correct CNAME target for production', () => {
+			const projectId = 'proj_81766c4548fe4766c06b90db086527b4';
+			const identifier = generateProjectIdentifier(projectId);
+			const suffix = 'agentuity.run';
+			const proxy = `p${identifier}.${suffix}`;
+
+			expect(proxy).toBe('p0a21231341cdb560.agentuity.run');
+		});
+
+		test('generates correct CNAME target for local development', () => {
+			const projectId = 'proj_81766c4548fe4766c06b90db086527b4';
+			const identifier = generateProjectIdentifier(projectId);
+			const suffix = 'agentuity.io';
+			const proxy = `p${identifier}.${suffix}`;
+
+			expect(proxy).toBe('p0a21231341cdb560.agentuity.io');
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Fixed bug where custom domain DNS validation failed for projects whose xxHash64 identifier has leading zeros
- Added `.padStart(16, '0')` to ensure project identifiers are always 16 hex characters
- Added unit tests for identifier generation and CNAME target validation

## Problem

When validating custom domain DNS configuration, the CLI generates the expected CNAME target by hashing the project ID:

```typescript
const id = Bun.hash.xxHash64(projectId).toString(16);  // BUG: loses leading zeros
const proxy = `p${id}.agentuity.run`;
```

For project `proj_81766c4548fe4766c06b90db086527b4`, the hash produces `0a21231341cdb560`, but `BigInt.toString(16)` strips the leading zero, resulting in:

- **Expected:** `p0a21231341cdb560.agentuity.run`
- **Actual:** `pa21231341cdb560.agentuity.run`

This caused DNS validation to fail with:
```
Status:  ✗ CNAME record is p0a21231341cdb560.agentuity.run
```

## Solution

Added `.padStart(16, '0')` to ensure the hex string is always 16 characters (correct width for a 64-bit hash):

```typescript
const id = Bun.hash.xxHash64(projectId).toString(16).padStart(16, '0');
```

This matches the behavior of:
- `xxhash-wasm`'s `h64ToString` (used in App) which internally does `.padStart(16, "0")`
- `go-common/string.NewHash` which manually pads to 16 chars

## Testing

- Added `test/domain.test.ts` with 7 tests covering:
  - 16-character hex identifier generation
  - Leading zero preservation (using the known problematic project ID)
  - Consistent identifier generation
  - Correct CNAME target format for production and local environments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed DNS proxy hostname generation to ensure consistent fixed-width formatting.

* **Tests**
  * Added comprehensive test suite for domain DNS validation and CNAME target generation to verify correct hostname construction across production and local development environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->