### PR TITLE
fix(cli): prevent test script from deleting user's global CLI

### DIFF
--- a/packages/cli/scripts/test-create-flow.ts
+++ b/packages/cli/scripts/test-create-flow.ts
@@ -365,15 +365,21 @@ async function main() {
 	log('╚════════════════════════════════════════════╝', colors.cyan);
 
 	try {
-		// Remove global agentuity to avoid conflicts
+		// Check for global agentuity - only remove in CI to avoid deleting user's CLI
 		const globalAgentuity = Bun.which('agentuity');
 		if (globalAgentuity) {
-			logInfo(`Removing global agentuity at: ${globalAgentuity}`);
-			try {
-				await Bun.$`bun remove -g @agentuity/cli`.nothrow();
-				logSuccess('Removed global agentuity');
-			} catch (_error) {
-				logInfo('Could not remove global agentuity (might not be installed via bun)');
+			const isCI = process.env.CI === 'true' || process.env.CI === '1';
+			if (isCI) {
+				logInfo(`[CI] Removing global agentuity at: ${globalAgentuity}`);
+				try {
+					await Bun.$`bun remove -g @agentuity/cli`.nothrow();
+					logSuccess('Removed global agentuity');
+				} catch (_error) {
+					logInfo('Could not remove global agentuity (might not be installed via bun)');
+				}
+			} else {
+				logInfo(`Found global agentuity at: ${globalAgentuity}`);
+				logInfo('Skipping removal (not in CI) - test uses local CLI directly');
 			}
 		}
 


### PR DESCRIPTION
## Summary

- Fix critical bug where `test-create-flow.ts` was deleting the user's globally installed Agentuity CLI binary
- Restrict global CLI removal to CI environments only (`CI=true` or `CI=1`)

## Problem

The test script at `packages/cli/scripts/test-create-flow.ts` contained code that **unconditionally removed the globally installed CLI** whenever someone ran:
- `bun test` (which includes `test:create`)
- `bun test:create` directly

```typescript
// BEFORE - This deleted the user's CLI!
const globalAgentuity = Bun.which('agentuity');
if (globalAgentuity) {
    await Bun.$`bun remove -g @agentuity/cli`.nothrow();
}
```

This caused developers to unexpectedly lose their CLI installation when running tests locally.

## Solution

The fix now only removes the global CLI in CI environments:

```typescript
// AFTER - Only removes in CI
const isCI = process.env.CI === 'true' || process.env.CI === '1';
if (isCI) {
    await Bun.$`bun remove -g @agentuity/cli`.nothrow();
} else {
    logInfo('Skipping removal (not in CI) - test uses local CLI directly');
}
```

The test already uses the local CLI binary directly (`packages/cli/bin/cli.ts`), so removing the global CLI was never necessary for the test to work correctly.

## Testing

- [x] Typecheck passes
- The change is straightforward and low-risk - it only adds a CI environment check before the removal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test creation flow to better manage global CLI detection across CI and local development environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->