### PR TITLE
fix(cli): guard session.json reading in support report

### DIFF
--- a/packages/cli/src/cmd/support/report.ts
+++ b/packages/cli/src/cmd/support/report.ts
@@ -235,11 +235,20 @@ export default createSubcommand({
 
 		// Use the first (most recent) session for metadata
 		const primarySessionDir = sessionDirs[0]!;
-
-		// Read session data from the primary session to get CLI version
 		const sessionFile = join(primarySessionDir, 'session.json');
-		const sessionData = JSON.parse(readFileSync(sessionFile, 'utf-8'));
-		const cliVersion = sessionData.cli?.version || 'unknown';
+
+		// Safely read session data with fallback for corrupt/missing session.json
+		let sessionData: SessionData = {};
+		let cliVersion = 'unknown';
+		try {
+			if (await Bun.file(sessionFile).exists()) {
+				sessionData = JSON.parse(readFileSync(sessionFile, 'utf-8'));
+				cliVersion = sessionData.cli?.version || 'unknown';
+			}
+		} catch {
+			// Fall back to defaults if session.json is corrupt or unreadable
+			logger.trace('Failed to read session.json, using defaults');
+		}
 
 		// Log how many sessions we're including
 		if (!isJsonMode && sessionDirs.length > 1) {


### PR DESCRIPTION
## Summary

Adds defensive error handling when reading session.json in the support report command to prevent crashes from corrupt or missing files.

## Changes

- Check if session.json exists before reading using `Bun.file().exists()`
- Wrap JSON.parse in try/catch to handle corrupt files gracefully
- Fall back to default values (`sessionData = {}`, `cliVersion = 'unknown'`) on error
- Log trace message when fallback is used for debugging

## Why

The previous code would throw an unhandled exception if:
- The session.json file was missing
- The session.json file was corrupt/invalid JSON
- The file was being written to by another concurrent process

This could cause `agentuity support report` to fail when it should gracefully degrade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced robustness of the support report command to gracefully handle missing or corrupted session files, preventing crashes and providing safe fallback values when session data is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->