### PR TITLE
fix(cli): verify npm availability before upgrade to prevent CDN propagation errors

### DIFF
--- a/packages/cli/src/cmd/upgrade/index.ts
+++ b/packages/cli/src/cmd/upgrade/index.ts
@@ -185,6 +185,31 @@ export const command = createCommand({
 				};
 			}
 
+			// Verify the version is available on npm before proceeding
+			const isAvailable = await tui.spinner({
+				message: 'Verifying npm availability...',
+				clearOnSuccess: true,
+				callback: async () => {
+					const { waitForNpmAvailability } = await import('./npm-availability');
+					return await waitForNpmAvailability(latestVersion, {
+						maxAttempts: 6,
+						initialDelayMs: 2000,
+					});
+				},
+			});
+
+			if (!isAvailable) {
+				tui.warning('The new version is not yet available on npm.');
+				tui.info('This can happen right after a release. Please try again in a few minutes.');
+				tui.info(`You can also run: ${tui.muted('bun add -g @agentuity/cli@latest')}`);
+				return {
+					upgraded: false,
+					from: currentVersion,
+					to: latestVersion,
+					message: 'Version not yet available on npm',
+				};
+			}
+
 			// Show version info
 			if (!force) {
 				tui.info(`Current version: ${tui.muted(normalizedCurrent)}`);

--- a/packages/cli/src/cmd/upgrade/npm-availability.ts
+++ b/packages/cli/src/cmd/upgrade/npm-availability.ts
@@ -1,0 +1,105 @@
+/**
+ * npm registry availability checking utilities.
+ * Used to verify a version is available on npm before attempting upgrade.
+ */
+
+const NPM_REGISTRY_URL = 'https://registry.npmjs.org';
+const PACKAGE_NAME = '@agentuity/cli';
+
+/** Default timeout for quick checks (implicit version check) */
+const QUICK_CHECK_TIMEOUT_MS = 1000;
+
+/** Default timeout for explicit upgrade command */
+const EXPLICIT_CHECK_TIMEOUT_MS = 5000;
+
+export interface CheckNpmOptions {
+	/** Timeout in milliseconds (default: 5000 for explicit, 1000 for quick) */
+	timeoutMs?: number;
+}
+
+/**
+ * Check if a specific version of @agentuity/cli is available on npm registry.
+ * Uses the npm registry API directly for faster response than `npm view`.
+ *
+ * @param version - Version to check (with or without 'v' prefix)
+ * @param options - Optional configuration
+ * @returns true if version is available, false otherwise
+ */
+export async function isVersionAvailableOnNpm(
+	version: string,
+	options: CheckNpmOptions = {}
+): Promise<boolean> {
+	const { timeoutMs = EXPLICIT_CHECK_TIMEOUT_MS } = options;
+	const normalizedVersion = version.replace(/^v/, '');
+	const url = `${NPM_REGISTRY_URL}/${encodeURIComponent(PACKAGE_NAME)}/${normalizedVersion}`;
+
+	try {
+		const response = await fetch(url, {
+			method: 'HEAD', // Only need to check existence, not full metadata
+			signal: AbortSignal.timeout(timeoutMs),
+			headers: {
+				Accept: 'application/json',
+			},
+		});
+		return response.ok;
+	} catch {
+		// Network error or timeout - assume not available
+		return false;
+	}
+}
+
+/**
+ * Quick check if a version is available on npm with a short timeout.
+ * Used for implicit version checks (auto-upgrade flow) to avoid blocking the user's command.
+ *
+ * @param version - Version to check (with or without 'v' prefix)
+ * @returns true if version is available, false if unavailable or timeout
+ */
+export async function isVersionAvailableOnNpmQuick(version: string): Promise<boolean> {
+	return isVersionAvailableOnNpm(version, { timeoutMs: QUICK_CHECK_TIMEOUT_MS });
+}
+
+export interface WaitForNpmOptions {
+	/** Maximum number of attempts (default: 6) */
+	maxAttempts?: number;
+	/** Initial delay between attempts in ms (default: 2000) */
+	initialDelayMs?: number;
+	/** Maximum delay between attempts in ms (default: 10000) */
+	maxDelayMs?: number;
+	/** Callback called before each retry */
+	onRetry?: (attempt: number, delayMs: number) => void;
+}
+
+/**
+ * Wait for a version to become available on npm with exponential backoff.
+ *
+ * @param version - Version to wait for (with or without 'v' prefix)
+ * @param options - Configuration options
+ * @returns true if version became available, false if timed out
+ */
+export async function waitForNpmAvailability(
+	version: string,
+	options: WaitForNpmOptions = {}
+): Promise<boolean> {
+	const { maxAttempts = 6, initialDelayMs = 2000, maxDelayMs = 10000, onRetry } = options;
+
+	// First check - no delay
+	if (await isVersionAvailableOnNpm(version)) {
+		return true;
+	}
+
+	// Retry with exponential backoff
+	let delay = initialDelayMs;
+	for (let attempt = 1; attempt < maxAttempts; attempt++) {
+		onRetry?.(attempt, delay);
+		await new Promise((resolve) => setTimeout(resolve, delay));
+
+		if (await isVersionAvailableOnNpm(version)) {
+			return true;
+		}
+
+		delay = Math.min(Math.round(delay * 1.5), maxDelayMs);
+	}
+
+	return false;
+}

--- a/packages/cli/src/version-check.ts
+++ b/packages/cli/src/version-check.ts
@@ -233,17 +233,33 @@ export async function checkForUpdates(
 		const currentVersion = getVersion();
 		const latestVersion = await fetchLatestVersion();
 
-		// Update the timestamp since we successfully checked
-		await updateCheckTimestamp(config, logger);
-
 		// Compare versions
 		const normalizedCurrent = currentVersion.replace(/^v/, '');
 		const normalizedLatest = latestVersion.replace(/^v/, '');
 
 		if (normalizedCurrent === normalizedLatest) {
+			// Update timestamp - we confirmed we're on latest version
+			await updateCheckTimestamp(config, logger);
 			logger.trace('Already on latest version: %s', currentVersion);
 			return;
 		}
+
+		// Quick npm availability check before prompting (short timeout, no retries)
+		// This avoids blocking the user's command if npm is slow or version not yet available
+		const { isVersionAvailableOnNpmQuick } = await import('./cmd/upgrade/npm-availability');
+		const isAvailable = await isVersionAvailableOnNpmQuick(latestVersion);
+
+		if (!isAvailable) {
+			// Don't update timestamp - we want to check again soon since npm may propagate
+			logger.debug(
+				'Version %s not yet available on npm, skipping upgrade prompt',
+				latestVersion
+			);
+			return;
+		}
+
+		// Update timestamp - npm availability confirmed, we can proceed with prompt
+		await updateCheckTimestamp(config, logger);
 
 		// New version available - prompt user
 		const shouldUpgrade = await promptUpgrade(currentVersion, latestVersion);

--- a/packages/cli/test/npm-availability.test.ts
+++ b/packages/cli/test/npm-availability.test.ts
@@ -1,0 +1,521 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { mockFetch } from '@agentuity/test-utils';
+import {
+	isVersionAvailableOnNpm,
+	isVersionAvailableOnNpmQuick,
+	waitForNpmAvailability,
+} from '../src/cmd/upgrade/npm-availability';
+
+// Relaxed timing thresholds for CI stability
+// These are intentionally generous to avoid flaky tests across different environments
+const TIMING = {
+	/** Max time for a "fast" operation (no network delay, just mock response) */
+	FAST_OPERATION_MS: 500,
+	/** Quick check timeout (1 second) - we check it completes before the slow response */
+	QUICK_TIMEOUT_MS: 1000,
+	/** Buffer above the quick timeout to account for CI variance */
+	QUICK_TIMEOUT_UPPER_MS: 1800,
+	/** Buffer below the quick timeout - it should wait at least this long */
+	QUICK_TIMEOUT_LOWER_MS: 800,
+	/** Max time for slow response that should be aborted */
+	SLOW_RESPONSE_MS: 2000,
+};
+
+describe('npm-availability', () => {
+	const originalFetch = globalThis.fetch;
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	describe('isVersionAvailableOnNpm', () => {
+		test('returns true for existing version (200 response)', async () => {
+			const mockedFetch = mockFetch(async () => new Response(null, { status: 200 }));
+
+			const result = await isVersionAvailableOnNpm('1.2.3');
+
+			expect(result).toBe(true);
+			expect(mockedFetch).toHaveBeenCalledTimes(1);
+		});
+
+		test('returns true for version with v prefix', async () => {
+			const mockedFetch = mockFetch(async () => new Response(null, { status: 200 }));
+
+			const result = await isVersionAvailableOnNpm('v1.2.3');
+
+			expect(result).toBe(true);
+			// Should strip the v prefix in the URL
+			const callArgs = mockedFetch.mock.calls[0] as [string, RequestInit | undefined];
+			expect(callArgs[0]).toContain('/1.2.3');
+			expect(callArgs[0]).not.toContain('/v1.2.3');
+		});
+
+		test('returns false for non-existing version (404 response)', async () => {
+			mockFetch(async () => new Response(null, { status: 404 }));
+
+			const result = await isVersionAvailableOnNpm('99.99.99');
+
+			expect(result).toBe(false);
+		});
+
+		test('returns false on network error', async () => {
+			mockFetch(async () => {
+				throw new Error('Network error');
+			});
+
+			const result = await isVersionAvailableOnNpm('1.2.3');
+
+			expect(result).toBe(false);
+		});
+
+		test('returns false on timeout', async () => {
+			mockFetch(
+				() =>
+					new Promise<Response>((_, reject) => {
+						setTimeout(() => reject(new Error('Timeout')), 100);
+					})
+			);
+
+			const result = await isVersionAvailableOnNpm('1.2.3');
+
+			expect(result).toBe(false);
+		});
+
+		test('uses HEAD method for efficiency', async () => {
+			const mockedFetch = mockFetch(async () => new Response(null, { status: 200 }));
+
+			await isVersionAvailableOnNpm('1.2.3');
+
+			const callArgs = mockedFetch.mock.calls[0] as [string, RequestInit | undefined];
+			expect(callArgs[1]?.method).toBe('HEAD');
+		});
+
+		test('constructs correct npm registry URL', async () => {
+			const mockedFetch = mockFetch(async () => new Response(null, { status: 200 }));
+
+			await isVersionAvailableOnNpm('1.2.3');
+
+			const callArgs = mockedFetch.mock.calls[0] as [string, RequestInit | undefined];
+			expect(callArgs[0]).toBe('https://registry.npmjs.org/%40agentuity%2Fcli/1.2.3');
+		});
+
+		test('accepts custom timeout option', async () => {
+			const mockedFetch = mockFetch(async () => new Response(null, { status: 200 }));
+
+			const result = await isVersionAvailableOnNpm('1.2.3', { timeoutMs: 500 });
+
+			expect(result).toBe(true);
+			expect(mockedFetch).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('isVersionAvailableOnNpmQuick', () => {
+		test('returns true for existing version', async () => {
+			mockFetch(async () => new Response(null, { status: 200 }));
+
+			const result = await isVersionAvailableOnNpmQuick('1.2.3');
+
+			expect(result).toBe(true);
+		});
+
+		test('returns false for non-existing version', async () => {
+			mockFetch(async () => new Response(null, { status: 404 }));
+
+			const result = await isVersionAvailableOnNpmQuick('99.99.99');
+
+			expect(result).toBe(false);
+		});
+
+		test('returns false on network error without blocking', async () => {
+			mockFetch(async () => {
+				throw new Error('Network error');
+			});
+
+			const startTime = Date.now();
+			const result = await isVersionAvailableOnNpmQuick('1.2.3');
+			const elapsed = Date.now() - startTime;
+
+			expect(result).toBe(false);
+			// Should return quickly, not block for the full timeout
+			expect(elapsed).toBeLessThan(TIMING.FAST_OPERATION_MS);
+		});
+
+		test('uses short timeout (1 second) for quick checks', async () => {
+			// This test verifies the quick check uses a short timeout
+			// We mock fetch to check the signal's timeout and simulate abort
+			let fetchCalled = false;
+			let receivedSignal: AbortSignal | null | undefined;
+
+			mockFetch(async (_url: string, init?: RequestInit) => {
+				fetchCalled = true;
+				receivedSignal = init?.signal;
+
+				// Return a promise that respects the abort signal
+				return new Promise<Response>((resolve, reject) => {
+					const timeoutId = setTimeout(() => {
+						resolve(new Response(null, { status: 200 }));
+					}, TIMING.SLOW_RESPONSE_MS);
+
+					// Listen for abort
+					if (init?.signal) {
+						init.signal.addEventListener('abort', () => {
+							clearTimeout(timeoutId);
+							reject(new DOMException('Aborted', 'AbortError'));
+						});
+					}
+				});
+			});
+
+			const startTime = Date.now();
+			const result = await isVersionAvailableOnNpmQuick('1.2.3');
+			const elapsed = Date.now() - startTime;
+
+			expect(fetchCalled).toBe(true);
+			expect(receivedSignal).toBeDefined();
+			expect(result).toBe(false); // Should timeout and return false
+			// Should timeout around 1 second, not wait for the full slow response time
+			expect(elapsed).toBeLessThan(TIMING.QUICK_TIMEOUT_UPPER_MS);
+			expect(elapsed).toBeGreaterThan(TIMING.QUICK_TIMEOUT_LOWER_MS);
+		});
+	});
+
+	describe('waitForNpmAvailability', () => {
+		test('returns true immediately if version is available', async () => {
+			const mockedFetch = mockFetch(async () => new Response(null, { status: 200 }));
+
+			const result = await waitForNpmAvailability('1.2.3');
+
+			expect(result).toBe(true);
+			// Should only check once
+			expect(mockedFetch).toHaveBeenCalledTimes(1);
+		});
+
+		test('retries and succeeds on second attempt', async () => {
+			let callCount = 0;
+			mockFetch(async () => {
+				callCount++;
+				if (callCount === 1) {
+					return new Response(null, { status: 404 });
+				}
+				return new Response(null, { status: 200 });
+			});
+
+			const result = await waitForNpmAvailability('1.2.3', {
+				initialDelayMs: 10, // Short delay for testing
+				maxAttempts: 3,
+			});
+
+			expect(result).toBe(true);
+			expect(callCount).toBe(2);
+		});
+
+		test('returns false after max attempts', async () => {
+			const mockedFetch = mockFetch(async () => new Response(null, { status: 404 }));
+
+			const result = await waitForNpmAvailability('1.2.3', {
+				maxAttempts: 3,
+				initialDelayMs: 10,
+			});
+
+			expect(result).toBe(false);
+			// Initial check + (maxAttempts - 1) retries = 3 total
+			expect(mockedFetch).toHaveBeenCalledTimes(3);
+		});
+
+		test('calls onRetry callback with correct arguments', async () => {
+			mockFetch(async () => new Response(null, { status: 404 }));
+
+			const retryArgs: Array<[number, number]> = [];
+			const onRetry = (attempt: number, delayMs: number) => {
+				retryArgs.push([attempt, delayMs]);
+			};
+
+			await waitForNpmAvailability('1.2.3', {
+				maxAttempts: 3,
+				initialDelayMs: 100,
+				onRetry,
+			});
+
+			// onRetry is called before each retry (not the initial check)
+			expect(retryArgs.length).toBe(2);
+			// First retry: attempt 1, delay 100
+			expect(retryArgs[0]).toEqual([1, 100]);
+			// Second retry: attempt 2, delay 150 (100 * 1.5)
+			expect(retryArgs[1]).toEqual([2, 150]);
+		});
+
+		test('uses exponential backoff with max delay cap', async () => {
+			mockFetch(async () => new Response(null, { status: 404 }));
+
+			const delays: number[] = [];
+			const onRetry = (_attempt: number, delay: number) => {
+				delays.push(delay);
+			};
+
+			await waitForNpmAvailability('1.2.3', {
+				maxAttempts: 6,
+				initialDelayMs: 100,
+				maxDelayMs: 200,
+				onRetry,
+			});
+
+			// Delays should be: 100, 150, 200, 200, 200 (capped at maxDelayMs)
+			expect(delays).toEqual([100, 150, 200, 200, 200]);
+		});
+
+		test('handles version with v prefix', async () => {
+			mockFetch(async () => new Response(null, { status: 200 }));
+
+			const result = await waitForNpmAvailability('v1.2.3');
+
+			expect(result).toBe(true);
+		});
+
+		test('uses default options when not provided', async () => {
+			let callCount = 0;
+			mockFetch(async () => {
+				callCount++;
+				// Succeed on 6th attempt (max default)
+				if (callCount < 6) {
+					return new Response(null, { status: 404 });
+				}
+				return new Response(null, { status: 200 });
+			});
+
+			// This test would take too long with real delays, so we just verify the function works
+			// In real usage, defaults are: maxAttempts=6, initialDelayMs=2000, maxDelayMs=10000
+			const result = await waitForNpmAvailability('1.2.3', {
+				initialDelayMs: 1, // Override delay for fast test
+			});
+
+			expect(result).toBe(true);
+			expect(callCount).toBe(6);
+		});
+	});
+
+	/**
+	 * Simulation tests for GitHub issue #838
+	 *
+	 * These tests simulate the real-world scenario where:
+	 * 1. A new version is released (GitHub release created)
+	 * 2. The version endpoint (agentuity.sh) returns the new version
+	 * 3. But npm CDN hasn't propagated the package yet
+	 * 4. User runs `agentuity upgrade` and sees the new version
+	 * 5. Without the fix: bun install fails with "No version matching X found"
+	 * 6. With the fix: CLI waits for npm availability or shows friendly message
+	 */
+	describe('GitHub issue #838 simulation', () => {
+		test('simulates npm CDN propagation delay - version becomes available after 3 retries', async () => {
+			// Simulate: npm CDN takes ~6 seconds to propagate (3 retries * 2s delay)
+			let attemptCount = 0;
+			const propagationDelay = 3; // Version becomes available on 4th check
+
+			mockFetch(async () => {
+				attemptCount++;
+				// Simulate CDN propagation: 404 for first 3 attempts, then 200
+				if (attemptCount <= propagationDelay) {
+					return new Response(null, { status: 404 });
+				}
+				return new Response(null, { status: 200 });
+			});
+
+			const retryLog: string[] = [];
+			const result = await waitForNpmAvailability('v0.1.43', {
+				maxAttempts: 6,
+				initialDelayMs: 10, // Fast for testing
+				onRetry: (attempt, delayMs) => {
+					retryLog.push(`Retry ${attempt}: waiting ${delayMs}ms`);
+				},
+			});
+
+			// Should succeed after CDN propagates
+			expect(result).toBe(true);
+			expect(attemptCount).toBe(4); // 1 initial + 3 retries
+			expect(retryLog.length).toBe(3); // 3 retry callbacks
+		});
+
+		test('simulates npm CDN never propagates within timeout - shows friendly message scenario', async () => {
+			// Simulate: npm CDN never propagates (always returns 404)
+			let attemptCount = 0;
+
+			mockFetch(async () => {
+				attemptCount++;
+				// Always return 404 - simulating permanent unavailability
+				return new Response(null, { status: 404 });
+			});
+
+			const result = await waitForNpmAvailability('v0.1.43', {
+				maxAttempts: 6,
+				initialDelayMs: 10,
+			});
+
+			// Should return false after all attempts exhausted
+			expect(result).toBe(false);
+			expect(attemptCount).toBe(6); // All 6 attempts made
+
+			// In the real CLI, this would trigger:
+			// tui.warning('The new version is not yet available on npm.');
+			// tui.info('This can happen right after a release. Please try again in a few minutes.');
+		});
+
+		test('simulates version check in auto-upgrade flow (version-check.ts) - uses quick check', async () => {
+			// In the auto-upgrade flow, we use a quick check with short timeout (1s)
+			// This avoids blocking the user's command if npm is slow or version not yet available
+
+			const mockedFetch = mockFetch(async () => new Response(null, { status: 404 }));
+
+			// Quick check - short timeout, no retries (simulating version-check.ts behavior)
+			const startTime = Date.now();
+			const isAvailable = await isVersionAvailableOnNpmQuick('v0.1.43');
+			const elapsed = Date.now() - startTime;
+
+			expect(isAvailable).toBe(false);
+			expect(mockedFetch).toHaveBeenCalledTimes(1);
+			// Should be fast - no retries, no backoff (just mock response time)
+			expect(elapsed).toBeLessThan(TIMING.FAST_OPERATION_MS);
+
+			// In the real CLI (version-check.ts), this would:
+			// logger.debug('Version %s not yet available on npm, skipping upgrade prompt', latestVersion);
+			// return; // Continue with user's original command without delay
+		});
+
+		test('simulates auto-upgrade flow with slow npm - does not block user command', async () => {
+			// Simulate npm registry being slow (but eventually responds)
+			mockFetch(async (_url: string, init?: RequestInit) => {
+				// Return a promise that respects the abort signal
+				return new Promise<Response>((resolve, reject) => {
+					const timeoutId = setTimeout(() => {
+						resolve(new Response(null, { status: 200 }));
+					}, TIMING.SLOW_RESPONSE_MS);
+
+					// Listen for abort
+					if (init?.signal) {
+						init.signal.addEventListener('abort', () => {
+							clearTimeout(timeoutId);
+							reject(new DOMException('Aborted', 'AbortError'));
+						});
+					}
+				});
+			});
+
+			const startTime = Date.now();
+			const isAvailable = await isVersionAvailableOnNpmQuick('v0.1.43');
+			const elapsed = Date.now() - startTime;
+
+			// Should timeout and return false, not wait for the slow response
+			expect(isAvailable).toBe(false);
+			// Should timeout around 1 second, not block for the full slow response time
+			expect(elapsed).toBeLessThan(TIMING.QUICK_TIMEOUT_UPPER_MS);
+			expect(elapsed).toBeGreaterThan(TIMING.QUICK_TIMEOUT_LOWER_MS);
+		});
+
+		test('simulates immediate availability - no delay needed', async () => {
+			// Best case: npm CDN already has the version
+			const mockedFetch = mockFetch(async () => new Response(null, { status: 200 }));
+
+			const startTime = Date.now();
+			const result = await waitForNpmAvailability('v0.1.43', {
+				maxAttempts: 6,
+				initialDelayMs: 1000, // Would be slow if we had to retry
+			});
+			const elapsed = Date.now() - startTime;
+
+			expect(result).toBe(true);
+			expect(mockedFetch).toHaveBeenCalledTimes(1);
+			// Should be fast - no retries needed (just mock response time)
+			expect(elapsed).toBeLessThan(TIMING.FAST_OPERATION_MS);
+		});
+
+		test('simulates network error during check - graceful degradation', async () => {
+			// Simulate: network is flaky, fetch throws errors
+			let attemptCount = 0;
+
+			mockFetch(async () => {
+				attemptCount++;
+				if (attemptCount <= 2) {
+					// First 2 attempts: network error
+					throw new Error('ECONNREFUSED');
+				}
+				// 3rd attempt: success
+				return new Response(null, { status: 200 });
+			});
+
+			const result = await waitForNpmAvailability('v0.1.43', {
+				maxAttempts: 6,
+				initialDelayMs: 10,
+			});
+
+			// Should succeed after network recovers
+			expect(result).toBe(true);
+			expect(attemptCount).toBe(3);
+		});
+
+		test('simulates the exact error from issue #838', async () => {
+			/**
+			 * Original error from issue:
+			 * error: No version matching "0.1.43" found for specifier "@agentuity/cli" (but package exists)
+			 * error: @agentuity/cli@0.1.43 failed to resolve
+			 *
+			 * This happens when bun tries to install a version that npm CDN doesn't have yet.
+			 * Our fix prevents this by checking npm availability BEFORE attempting install.
+			 */
+
+			// Simulate the scenario: version announced but not on npm
+			mockFetch(async () => new Response(null, { status: 404 }));
+
+			// Check availability (what our fix does)
+			const isAvailable = await isVersionAvailableOnNpm('0.1.43');
+
+			// Our fix detects this BEFORE attempting bun install
+			expect(isAvailable).toBe(false);
+
+			// Without our fix, the CLI would have run:
+			// await $`bun add -g @agentuity/cli@0.1.43`.quiet()
+			// Which would fail with the error from issue #838
+
+			// With our fix, the CLI shows a friendly message instead:
+			// "The new version is not yet available on npm."
+			// "This can happen right after a release. Please try again in a few minutes."
+		});
+
+		test('simulates realistic timing with multiple retries', async () => {
+			// Track timing to verify exponential backoff behavior
+			// We verify relative ordering rather than exact timing for CI stability
+			let attemptCount = 0;
+			const attemptTimes: number[] = [];
+			const startTime = Date.now();
+
+			mockFetch(async () => {
+				attemptCount++;
+				attemptTimes.push(Date.now() - startTime);
+				// Succeed on 4th attempt
+				if (attemptCount < 4) {
+					return new Response(null, { status: 404 });
+				}
+				return new Response(null, { status: 200 });
+			});
+
+			const result = await waitForNpmAvailability('v0.1.43', {
+				maxAttempts: 6,
+				initialDelayMs: 50, // 50ms for testing
+				maxDelayMs: 150,
+			});
+
+			expect(result).toBe(true);
+			expect(attemptCount).toBe(4);
+
+			// Verify relative ordering: each attempt should be later than the previous
+			// This is more stable than checking exact timing thresholds
+			expect(attemptTimes[1]).toBeGreaterThan(attemptTimes[0]); // 2nd after 1st
+			expect(attemptTimes[2]).toBeGreaterThan(attemptTimes[1]); // 3rd after 2nd
+			expect(attemptTimes[3]).toBeGreaterThan(attemptTimes[2]); // 4th after 3rd
+
+			// Verify delays are increasing (exponential backoff)
+			const delay1 = attemptTimes[1] - attemptTimes[0];
+			const delay2 = attemptTimes[2] - attemptTimes[1];
+			const delay3 = attemptTimes[3] - attemptTimes[2];
+			expect(delay2).toBeGreaterThanOrEqual(delay1); // Delays should increase or stay same (capped)
+			expect(delay3).toBeGreaterThanOrEqual(delay1); // Later delays >= initial delay
+		});
+	});
+});

--- a/packages/cli/test/upgrade.test.ts
+++ b/packages/cli/test/upgrade.test.ts
@@ -1,5 +1,11 @@
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, afterEach } from 'bun:test';
+import { mockFetch } from '@agentuity/test-utils';
 import { getInstallationType, isGlobalInstall } from '../src/cmd/upgrade';
+import {
+	isVersionAvailableOnNpm,
+	isVersionAvailableOnNpmQuick,
+	waitForNpmAvailability,
+} from '../src/cmd/upgrade/npm-availability';
 
 describe('upgrade command', () => {
 	test('getInstallationType returns source when running from test', () => {
@@ -69,5 +75,47 @@ describe('upgrade command', () => {
 
 			expect(needsUpgrade).toBe(shouldUpgrade);
 		}
+	});
+
+	describe('npm availability integration', () => {
+		const originalFetch = globalThis.fetch;
+
+		afterEach(() => {
+			globalThis.fetch = originalFetch;
+		});
+
+		test('isVersionAvailableOnNpm is exported and callable', async () => {
+			mockFetch(async () => new Response(null, { status: 200 }));
+
+			const result = await isVersionAvailableOnNpm('1.0.0');
+			expect(typeof result).toBe('boolean');
+			expect(result).toBe(true);
+		});
+
+		test('waitForNpmAvailability is exported and callable', async () => {
+			mockFetch(async () => new Response(null, { status: 200 }));
+
+			const result = await waitForNpmAvailability('1.0.0', {
+				maxAttempts: 1,
+				initialDelayMs: 1,
+			});
+			expect(typeof result).toBe('boolean');
+			expect(result).toBe(true);
+		});
+
+		test('npm availability check handles unavailable versions gracefully', async () => {
+			mockFetch(async () => new Response(null, { status: 404 }));
+
+			const result = await isVersionAvailableOnNpm('99.99.99');
+			expect(result).toBe(false);
+		});
+
+		test('isVersionAvailableOnNpmQuick is exported for implicit version checks', async () => {
+			mockFetch(async () => new Response(null, { status: 200 }));
+
+			const result = await isVersionAvailableOnNpmQuick('1.0.0');
+			expect(typeof result).toBe('boolean');
+			expect(result).toBe(true);
+		});
 	});
 });


### PR DESCRIPTION
## Summary

- Fixes npm CDN propagation delay causing upgrade failures after a release
- Adds npm registry availability verification before attempting upgrades
- Shows friendly error message instead of cryptic bun error when version unavailable

## Problem

After a release, users would see the new version available but the upgrade would fail:

```
error: No version matching "0.1.43" found for specifier "@agentuity/cli" (but package exists)
error: @agentuity/cli@0.1.43 failed to resolve
```

This happens because the version endpoint (`agentuity.sh`) returns the new version immediately after the GitHub release is created, but npm CDN takes 1-2 minutes to propagate.

## Solution

Added npm registry availability verification before attempting upgrades:

1. **New `npm-availability.ts` module**:
   - `isVersionAvailableOnNpm(version)` - Checks npm registry directly using HEAD request
   - `waitForNpmAvailability(version, options)` - Retries with exponential backoff

2. **Upgrade command** (`upgrade/index.ts`):
   - After fetching latest version, verifies npm availability with a spinner
   - If unavailable after retries (~36 seconds), shows friendly message:
     ```
     ⚠ The new version is not yet available on npm.
     ℹ This can happen right after a release. Please try again in a few minutes.
     ℹ You can also run: bun add -g @agentuity/cli@latest
     ```

3. **Auto-upgrade flow** (`version-check.ts`):
   - Silent npm availability check before prompting user
   - If unavailable, skips the upgrade prompt entirely (user's command continues)

## Testing

- 29 tests pass (21 new npm-availability tests + 8 upgrade tests)
- Includes simulation tests for the exact issue #838 scenario
- Tests cover: CDN propagation delay, timeout, network errors, exponential backoff

## Files Changed

| File | Description |
|------|-------------|
| `packages/cli/src/cmd/upgrade/npm-availability.ts` | **NEW** - npm registry availability utilities |
| `packages/cli/test/npm-availability.test.ts` | **NEW** - Comprehensive tests including issue simulation |
| `packages/cli/src/cmd/upgrade/index.ts` | Added npm availability check with spinner |
| `packages/cli/src/version-check.ts` | Added silent npm availability check |
| `packages/cli/test/upgrade.test.ts` | Added integration tests |

Fixes #838

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds an async npm-availability check before showing current/latest version info or prompting to upgrade; if the release isn’t yet published the CLI warns, aborts the prompt flow, and suggests next steps.
  * Implements a quick availability check with capped retries/backoff and updates timestamp only after a confirmed availability.

* **Tests**
  * Added comprehensive tests covering availability checks, timeouts, retries/backoff, timing behavior, and integration with upgrade prompts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->