### PR TITLE
fix: use sdk-main prefix in templates tarball for CLI compatibility

### DIFF
--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -508,7 +508,9 @@ async function buildTemplatesTarball(version: string): Promise<string> {
 	const templatesDir = join(rootDir, 'templates');
 	const tarballName = `templates-${version}.tar.gz`;
 	const tarballPath = join('/tmp', tarballName);
-	const tempDir = join('/tmp', `sdk-v${version}`);
+	// Use sdk-main as the directory prefix to match what the CLI expects
+	// The CLI constructs the prefix as `sdk-${branch}` where branch defaults to 'main'
+	const tempDir = join('/tmp', 'sdk-main');
 	const templatesSubdir = join(tempDir, 'templates');
 
 	// Validate templates directory exists
@@ -526,26 +528,27 @@ async function buildTemplatesTarball(version: string): Promise<string> {
 
 	try {
 		// Clean up any existing temp directory and tarball
-		await $`rm -rf ${tempDir} ${tarballPath}`.quiet().nothrow();
+		// Use explicit /tmp/sdk-main path to ensure we always clean up the fixed location
+		await $`rm -rf /tmp/sdk-main ${tarballPath}`.quiet().nothrow();
 
-		// Create temp directory with sdk-v{version}/templates structure
+		// Create temp directory with sdk-main/templates structure
 		await $`mkdir -p ${templatesSubdir}`;
 
 		// Copy all contents including dotfiles using trailing dot syntax
 		// cp -r source/. dest/ copies all files including hidden ones
 		await $`cp -r ${templatesDir}/. ${templatesSubdir}/`;
 
-		// Create tarball from /tmp with sdk-v{version} as root directory
-		await $`tar -czf ${tarballPath} -C /tmp sdk-v${version}`;
+		// Create tarball from /tmp with sdk-main as root directory
+		await $`tar -czf ${tarballPath} -C /tmp sdk-main`;
 
 		// Clean up temp directory
-		await $`rm -rf ${tempDir}`;
+		await $`rm -rf /tmp/sdk-main`;
 
 		console.log(`✓ Built templates tarball: ${tarballName}`);
 		return tarballPath;
 	} catch (err) {
 		// Clean up on error
-		await $`rm -rf ${tempDir} ${tarballPath}`.quiet().nothrow();
+		await $`rm -rf /tmp/sdk-main ${tarballPath}`.quiet().nothrow();
 		console.error('✗ Failed to build templates tarball:', err);
 		throw err;
 	}


### PR DESCRIPTION
## Summary

Fixes the incorrect template tar.gz format that prevents the CLI from extracting templates from release assets.

## Problem

The CLI's `download.ts` expects tarball entries with prefix `sdk-main/templates/...` (constructed as `sdk-${branch}` where branch defaults to `main`), but the release tarball was being created with `sdk-v{version}/templates/...` (e.g., `sdk-v0.1.43/templates/...`).

This caused all entries to be ignored during extraction because the prefix didn't match:
```
[DEBUG] [extract] Base prefix: sdk-main/templates/_base/
[DEBUG] [extract] IGNORE: sdk-v0.1.43/templates/_base/app.ts
...
[DEBUG] [extract] Base extracted entries: 0
[DEBUG] [extract] Overlay extracted entries: 0
```

## Solution

- Changed the tarball directory prefix from `sdk-v{version}` to `sdk-main`
- Use explicit `/tmp/sdk-main` path in cleanup commands for safety (since it's now a fixed location)

## Testing

- ✅ TypeScript type checking passes
- ✅ ESLint passes  
- ✅ Local tarball build test confirms correct structure:
  - `sdk-main/templates/_base/` ✓
  - `sdk-main/templates/default/` ✓
  - `sdk-main/templates/templates.json` ✓

## Follow-up

Once this fix is merged and a new SDK release is published, the get-agentuity-sh change (commit `e80aaa28`) can be re-applied to serve templates from release assets instead of codeload.

Fixes #839

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and publishing process infrastructure to improve directory management consistency in template packaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->