### PR TITLE
Change default app url

### DIFF
--- a/packages/server/src/api/api.ts
+++ b/packages/server/src/api/api.ts
@@ -826,7 +826,7 @@ export function getAPIBaseURL(region?: string, overrides?: { api_url?: string })
 		return 'https://api.agentuity.io';
 	}
 
-	return 'https://api-v1.agentuity.com';
+	return 'https://api.agentuity.com';
 }
 
 export function getAppBaseURL(region?: string, overrides?: { app_url?: string } | null): string {
@@ -842,7 +842,7 @@ export function getAppBaseURL(region?: string, overrides?: { app_url?: string } 
 		return 'https://app.agentuity.io';
 	}
 
-	return 'https://app-v1.agentuity.com';
+	return 'https://app.agentuity.com';
 }
 
 export const APIResponseSchema = <T extends z.ZodType>(dataSchema: T) =>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API and app endpoint URLs to use non-versioned domains. Non-local regions now route through api.agentuity.com and app.agentuity.com instead of versioned endpoints. Local region behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->