### PR TITLE
feat: add signature authentication to cron middleware

### DIFF
--- a/packages/runtime/src/handlers/cron.ts
+++ b/packages/runtime/src/handlers/cron.ts
@@ -51,7 +51,22 @@ async function verifyCronSignature(c: Context, body: string): Promise<boolean> {
 		return false;
 	}
 
-	// Verify the signature
+	// Validate signature format: must be 'v1=' followed by valid hex (64 chars for SHA-256)
+	if (!signature.startsWith('v1=')) {
+		return false;
+	}
+	const hexPayload = signature.slice(3);
+	if (!/^[0-9a-f]{64}$/i.test(hexPayload)) {
+		return false;
+	}
+
+	// Decode hex payload into Uint8Array
+	const incomingSigBytes = new Uint8Array(32);
+	for (let i = 0; i < 32; i++) {
+		incomingSigBytes[i] = parseInt(hexPayload.slice(i * 2, i * 2 + 2), 16);
+	}
+
+	// Verify the signature using constant-time comparison
 	const message = `${timestamp}.${body}`;
 	const encoder = new TextEncoder();
 	const key = await crypto.subtle.importKey(
@@ -59,16 +74,10 @@ async function verifyCronSignature(c: Context, body: string): Promise<boolean> {
 		encoder.encode(sdkKey),
 		{ name: 'HMAC', hash: 'SHA-256' },
 		false,
-		['sign']
+		['verify']
 	);
-	const signatureBytes = await crypto.subtle.sign('HMAC', key, encoder.encode(message));
-	const expectedSignature =
-		'v1=' +
-		Array.from(new Uint8Array(signatureBytes))
-			.map((b) => b.toString(16).padStart(2, '0'))
-			.join('');
 
-	return signature === expectedSignature;
+	return crypto.subtle.verify('HMAC', key, incomingSigBytes, encoder.encode(message));
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add optional `auth` parameter to cron middleware for signature verification
- Verify `X-Agentuity-Cron-Signature` and `X-Agentuity-Cron-Timestamp` headers
- Signatures use HMAC-SHA256 with SDK key, valid for 5 minutes
- Deprecate old `cron(schedule, handler)` signature in favor of explicit auth option
- Skip auth in local dev mode (no `AGENTUITY_SDK_KEY`)

## Usage

```typescript
// New recommended way - must specify auth explicitly
router.post('/daily-cleanup', cron('0 0 * * *', { auth: true }, (c) => { ... }));

// Without auth (not recommended for production)
router.post('/health-check', cron('0 * * * *', { auth: false }, (c) => { ... }));

// Deprecated - defaults to auth: false for backwards compatibility
router.post('/old-cron', cron('0 0 * * *', (c) => { ... }));
```

## Related

Requires catalyst PR for signing: agentuity/catalyst#XXX (cron-job-fix branch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cron endpoints can now require optional signature-based authentication (HMAC with a 5-minute validity window); unauthenticated or invalid requests return 401.
  * Cron handlers enforce POST-only invocation and preserve request body for downstream handling when verifying signatures.

* **Deprecations**
  * The older cron invocation style is deprecated — migrate to the new options-based signature to enable authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->