### PR TITLE
fix(cli): update devmode to connect to devmode-us.agentuity.com

### DIFF
--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -101,5 +101,5 @@ export function getGravityDevModeURL(region: string, config?: Config | null): st
 	if (config?.name === 'local') {
 		return 'grpc://gravity.agentuity.io:8443';
 	}
-	return `grpc://gravity-${region}.agentuity.cloud`;
+	return 'grpc://devmode-us.agentuity.com';
 }


### PR DESCRIPTION
## Summary
- Update CLI devmode endpoint from `gravity-{region}.agentuity.cloud` to `devmode-us.agentuity.com`
- Simplifies devmode connections by using a single static endpoint instead of region-based routing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Devmode connections now use a fixed US-based endpoint by default, replacing region-based dynamic host selection. Local environment and custom configuration overrides remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->