### PR TITLE
feat(cli): fast FFI-based agent detection with agent-friendly output

### DIFF
--- a/packages/cli/bin/cli.ts
+++ b/packages/cli/bin/cli.ts
@@ -29,12 +29,7 @@ import { closeDatabase } from '../src/cache';
 import { createInternalLogger } from '../src/internal-logger';
 import { createCompositeLogger } from '../src/composite-logger';
 import { getAuth } from '../src/config';
-import {
-	startAgentDetection,
-	isExecutingFromAgent,
-	onAgentDetected,
-	flushAgentDetection,
-} from '../src/agent-detection';
+import { getExecutingAgent } from '../src/agent-detection';
 
 /**
  * Extract --dir flag from process.argv before command parsing
@@ -95,10 +90,6 @@ process.on('SIGTERM', () => {
 
 validateRuntime();
 await ensureBunOnPath();
-
-// Start agent detection early (non-blocking) so it runs in the background
-// while the rest of CLI initialization happens
-startAgentDetection();
 
 // Preprocess arguments to convert --help=json to --help json
 // Commander.js doesn't support --option=value syntax for optional values
@@ -244,12 +235,11 @@ if (shouldSkipInternalLogging) {
 	// Set session ID in environment so forked child processes can share the same log file
 	process.env.AGENTUITY_INTERNAL_SESSION_ID = internalLogger.getSessionId();
 
-	// Register callback to update session with detected agent (non-blocking)
-	onAgentDetected((agent) => {
-		if (agent) {
-			internalLogger.setDetectedAgent(agent);
-		}
-	});
+	// Set detected agent in session logs
+	const detectedAgent = getExecutingAgent();
+	if (detectedAgent) {
+		internalLogger.setDetectedAgent(detectedAgent);
+	}
 }
 
 // Create composite logger that writes to both console and internal log
@@ -276,7 +266,7 @@ const ctx = {
 	config,
 	logger,
 	options: earlyOpts,
-	isExecutingFromAgent,
+	getExecutingAgent,
 };
 
 // Set global output options for utilities to use
@@ -309,8 +299,6 @@ await registerCommands(program, commands, ctx as unknown as CommandContext);
 
 try {
 	await program.parseAsync(process.argv);
-	// Flush agent detection to ensure it's written to session logs before exit
-	await flushAgentDetection();
 } catch (error) {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const exit = (globalThis as any).AGENTUITY_PROCESS_EXIT || process.exit;

--- a/packages/cli/src/agent-detection.ts
+++ b/packages/cli/src/agent-detection.ts
@@ -1,8 +1,9 @@
-import { spawn } from 'node:child_process';
+import { dlopen, FFIType, ptr } from 'bun:ffi';
+import { readFileSync } from 'node:fs';
 
 /**
  * Map of process names to internal agent short names.
- * The key is the process name (or substring) that appears in the parent process command line.
+ * The key is the process name (or substring) that appears in the parent process path or command line.
  * The value is the internal short name used to identify the agent.
  *
  * Process names verified via `agentuity cloud sandbox run --runtime <agent>:latest`:
@@ -39,79 +40,315 @@ export const KNOWN_AGENTS: [string, string][] = [
 export type KnownAgent = (typeof KNOWN_AGENTS)[number][1];
 
 /**
- * Promise for the detection result (set when detection starts)
+ * Display names for known agents (human-friendly names)
  */
-let detectionPromise: Promise<string | undefined> | null = null;
+export const AGENT_DISPLAY_NAMES: Record<string, string> = {
+	opencode: 'Open Code',
+	codex: 'OpenAI Codex',
+	cursor: 'Cursor',
+	'claude-code': 'Claude Code',
+	copilot: 'GitHub Copilot',
+	gemini: 'Gemini',
+	cline: 'Cline',
+	roo: 'Roo Code',
+	windsurf: 'Windsurf',
+	zed: 'Zed',
+	amp: 'Amp',
+	warp: 'Warp',
+};
 
 /**
- * Cached result after detection completes (null = not yet resolved)
+ * Get the display name for an agent ID
+ */
+export function getAgentDisplayName(agentId: string): string {
+	return AGENT_DISPLAY_NAMES[agentId] || agentId;
+}
+
+// ============================================================================
+// FFI-based Fast Process Path Resolution
+// ============================================================================
+
+const PATH_MAX = 4096; // Linux PATH_MAX, also sufficient for macOS
+const ARG_MAX = 65536; // Maximum command line length
+
+/**
+ * Type for the FFI function that gets a process path
+ */
+type GetProcessPath = (pid: number) => string | null;
+
+/**
+ * Type for the FFI function that gets a parent PID
+ */
+type GetParentPid = (pid: number) => number | null;
+
+/**
+ * Type for the FFI function that gets command line arguments
+ */
+type GetProcessCmdline = (pid: number) => string | null;
+
+interface FFIFunctions {
+	getProcessPath: GetProcessPath;
+	getParentPid: GetParentPid;
+	getProcessCmdline: GetProcessCmdline;
+}
+
+/**
+ * Stub FFI functions for unsupported platforms or when FFI fails to load.
+ */
+const unsupportedFFI: FFIFunctions = {
+	getProcessPath: () => null,
+	getParentPid: () => null,
+	getProcessCmdline: () => null,
+};
+
+/**
+ * Initialize FFI functions for the current platform.
+ * Returns null functions for unsupported platforms or if FFI initialization fails.
+ */
+function initFFI(): FFIFunctions {
+	try {
+		if (process.platform === 'darwin') {
+			return initDarwinFFI();
+		} else if (process.platform === 'linux') {
+			return initLinuxFFI();
+		}
+	} catch (err) {
+		// FFI initialization failed (e.g., missing libc on musl/Alpine, dlopen error)
+		// Fall back to unsupported stub - agent detection will be skipped
+		if (process.env.AGENTUITY_DEBUG_AGENT_DETECTION === '1') {
+			console.error('[agent-detection] FFI initialization failed:', err instanceof Error ? err.message : err);
+		}
+		return unsupportedFFI;
+	}
+	// Unsupported platform (Windows, etc.)
+	return unsupportedFFI;
+}
+
+/**
+ * Initialize macOS FFI functions using libSystem.dylib
+ *
+ * NOTE: Shared mutable buffers (pathBuf, argBuf, kinfoBuffer) are safe only in
+ * single-threaded use. Detection is synchronous and single-threaded, but any
+ * future concurrent usage would corrupt these buffers.
+ */
+function initDarwinFFI(): FFIFunctions {
+	// Shared buffers - reused across calls (single-threaded assumption)
+	const pathBuf = new Uint8Array(PATH_MAX);
+	const argBuf = new Uint8Array(ARG_MAX);
+
+	// Size of kinfo_proc struct on macOS (arm64 and x86_64)
+	const KINFO_PROC_SIZE = 648;
+	const kinfoBuffer = new Uint8Array(KINFO_PROC_SIZE);
+
+	// Load libSystem for proc_pidpath and sysctl
+	const lib = dlopen('libSystem.dylib', {
+		proc_pidpath: {
+			args: [FFIType.i32, FFIType.ptr, FFIType.u32],
+			returns: FFIType.i32,
+		},
+		sysctl: {
+			args: [FFIType.ptr, FFIType.u32, FFIType.ptr, FFIType.ptr, FFIType.ptr, FFIType.u64],
+			returns: FFIType.i32,
+		},
+	});
+
+	const getProcessPath: GetProcessPath = (pid: number) => {
+		if (pid <= 0) return null;
+		try {
+			const len = lib.symbols.proc_pidpath(pid, ptr(pathBuf), PATH_MAX);
+			if (len > 0) {
+				return new TextDecoder().decode(pathBuf.subarray(0, len)).replace(/\0.*/, '');
+			}
+		} catch {
+			// Ignore errors (process may have died, permission denied, etc.)
+		}
+		return null;
+	};
+
+	// Get parent PID using sysctl KERN_PROC_PID
+	// CTL_KERN = 1, KERN_PROC = 14, KERN_PROC_PID = 1
+	const getParentPid: GetParentPid = (pid: number) => {
+		if (pid <= 1) return null;
+		try {
+			const mib = new Int32Array([1, 14, 1, pid]);
+			const sizePtr = new BigUint64Array([BigInt(KINFO_PROC_SIZE)]);
+
+			const result = lib.symbols.sysctl(ptr(mib), 4, ptr(kinfoBuffer), ptr(sizePtr), null, 0);
+			if (result === 0) {
+				// e_ppid offset in kinfo_proc on macOS arm64/x86_64:
+				// kp_eproc starts at 296, e_ppid is at offset 264 within kp_eproc
+				// Total offset: 560
+				const view = new DataView(kinfoBuffer.buffer);
+				const ppid = view.getInt32(560, true); // little-endian
+				return ppid > 1 ? ppid : null;
+			}
+		} catch {
+			// Ignore errors
+		}
+		return null;
+	};
+
+	// Get command line using sysctl KERN_PROCARGS2
+	// CTL_KERN = 1, KERN_PROCARGS2 = 49
+	const getProcessCmdline: GetProcessCmdline = (pid: number) => {
+		if (pid <= 0) return null;
+		try {
+			// MIB for KERN_PROCARGS2: [CTL_KERN, KERN_PROCARGS2, pid]
+			const mib = new Int32Array([1, 49, pid]);
+			const sizePtr = new BigUint64Array([BigInt(ARG_MAX)]);
+
+			const result = lib.symbols.sysctl(
+				ptr(mib),
+				3,
+				ptr(argBuf),
+				ptr(sizePtr),
+				null,
+				0
+			);
+
+			if (result === 0) {
+				const size = Number(sizePtr[0]);
+				if (size > 0) {
+					// KERN_PROCARGS2 format:
+					// - 4 bytes: argc (number of arguments)
+					// - exec_path\0
+					// - padding (zeros until aligned)
+					// - arg0\0arg1\0arg2\0...
+					// We want to extract exactly argc args (not env vars that follow)
+					const data = argBuf.subarray(0, size);
+
+					// Read argc (first 4 bytes, little-endian)
+					const argc = new DataView(data.buffer, data.byteOffset).getInt32(0, true);
+					let offset = 4;
+
+					// Skip exec_path (find first null)
+					while (offset < size && data[offset] !== 0) offset++;
+					offset++; // Skip the null
+
+					// Skip padding (multiple nulls)
+					while (offset < size && data[offset] === 0) offset++;
+
+					// Now we're at the arguments - collect exactly argc args
+					const args: string[] = [];
+					let start = offset;
+					for (let i = offset; i < size; i++) {
+						if (data[i] === 0) {
+							if (i > start) {
+								args.push(new TextDecoder().decode(data.subarray(start, i)));
+							}
+							start = i + 1;
+							// Stop after collecting argc args
+							if (args.length >= argc) break;
+						}
+					}
+
+					return args.join(' ');
+				}
+			}
+		} catch {
+			// Ignore errors
+		}
+		return null;
+	};
+
+	return { getProcessPath, getParentPid, getProcessCmdline };
+}
+
+/**
+ * Initialize Linux FFI functions using libc.so.6
+ */
+function initLinuxFFI(): FFIFunctions {
+	const pathBuf = new Uint8Array(PATH_MAX);
+
+	const lib = dlopen('libc.so.6', {
+		readlink: {
+			args: [FFIType.cstring, FFIType.ptr, FFIType.u64],
+			returns: FFIType.i64,
+		},
+	});
+
+	const getProcessPath: GetProcessPath = (pid: number) => {
+		if (pid <= 0) return null;
+		try {
+			const procPath = Buffer.from(`/proc/${pid}/exe\0`);
+			const len = Number(lib.symbols.readlink(ptr(procPath), ptr(pathBuf), PATH_MAX));
+			if (len > 0) {
+				return new TextDecoder().decode(pathBuf.subarray(0, len));
+			}
+		} catch {
+			// Ignore errors (process may have died, permission denied, etc.)
+		}
+		return null;
+	};
+
+	const getParentPid: GetParentPid = (pid: number) => {
+		if (pid <= 1) return null;
+		try {
+			// Read /proc/{pid}/stat to get parent PID (4th field)
+			const statPath = `/proc/${pid}/stat`;
+			const content = readFileSync(statPath, 'utf-8');
+			// Format: pid (comm) state ppid ...
+			// Need to handle comm with spaces/parens: find last ')' then parse
+			const lastParen = content.lastIndexOf(')');
+			if (lastParen === -1) return null;
+			const rest = content.slice(lastParen + 2); // Skip ') '
+			const fields = rest.split(' ');
+			const ppidField = fields[1]; // ppid is 2nd field after state
+			if (!ppidField) return null;
+			const ppid = parseInt(ppidField, 10);
+			return isNaN(ppid) || ppid <= 1 ? null : ppid;
+		} catch {
+			// Ignore errors
+		}
+		return null;
+	};
+
+	// Read command line from /proc/{pid}/cmdline (null-separated args)
+	const getProcessCmdline: GetProcessCmdline = (pid: number) => {
+		if (pid <= 0) return null;
+		try {
+			const cmdlinePath = `/proc/${pid}/cmdline`;
+			const content = readFileSync(cmdlinePath);
+			if (content.length > 0) {
+				// Replace null bytes with spaces to get full command line
+				return new TextDecoder().decode(content).replace(/\0/g, ' ').trim();
+			}
+		} catch {
+			// Ignore errors
+		}
+		return null;
+	};
+
+	return { getProcessPath, getParentPid, getProcessCmdline };
+}
+
+// Initialize FFI functions lazily
+let ffi: FFIFunctions | null = null;
+
+function getFFI(): FFIFunctions {
+	if (!ffi) {
+		ffi = initFFI();
+	}
+	return ffi;
+}
+
+// ============================================================================
+// Agent Detection Logic
+// ============================================================================
+
+/**
+ * Cached detection result (null = not yet run, undefined = no agent detected)
  */
 let cachedResult: string | undefined | null = null;
 
 /**
- * Callbacks to invoke when agent detection completes
+ * Check if a path's basename matches any known agent
  */
-const detectionCallbacks: Array<(agent: string | undefined) => void> = [];
-
-/**
- * Get the command line and parent PID for a given PID in a single ps call
- */
-function getProcessInfo(pid: number): Promise<{ command: string; ppid: number } | undefined> {
-	return new Promise((resolve) => {
-		const ps = spawn('ps', ['-p', String(pid), '-o', 'ppid=,command='], {
-			stdio: ['ignore', 'pipe', 'ignore'],
-		});
-
-		let output = '';
-
-		ps.stdout.on('data', (data: Buffer) => {
-			output += data.toString();
-		});
-
-		ps.on('close', () => {
-			const trimmed = output.trim();
-			if (!trimmed) {
-				resolve(undefined);
-				return;
-			}
-
-			// Output format: "  PPID COMMAND" (ppid is right-aligned, then space, then command)
-			const match = trimmed.match(/^\s*(\d+)\s+(.+)$/);
-			if (!match) {
-				resolve(undefined);
-				return;
-			}
-
-			const ppidStr = match[1];
-			const commandStr = match[2];
-			if (!ppidStr || !commandStr) {
-				resolve(undefined);
-				return;
-			}
-
-			const ppid = parseInt(ppidStr, 10);
-			const command = commandStr.toLowerCase();
-
-			if (isNaN(ppid) || ppid <= 1 || !command) {
-				resolve(undefined);
-				return;
-			}
-
-			resolve({ command, ppid });
-		});
-
-		ps.on('error', () => {
-			resolve(undefined);
-		});
-	});
-}
-
-/**
- * Check if a command matches any known agent
- */
-function matchAgent(command: string): string | undefined {
+function matchAgentPath(path: string): string | undefined {
+	// Extract basename from path
+	const basename = path.split('/').pop()?.toLowerCase() ?? '';
 	for (const [processName, agentName] of KNOWN_AGENTS) {
-		if (command.includes(processName)) {
+		if (basename.includes(processName)) {
 			return agentName;
 		}
 	}
@@ -119,180 +356,213 @@ function matchAgent(command: string): string | undefined {
 }
 
 /**
- * Detect the parent process command and check if it matches a known agent.
- * Walks up the process tree to find the first matching agent.
+ * Check if a cmdline matches any known agent.
+ * Only checks argv[0] and arguments that look like executable paths,
+ * NOT environment variables or arbitrary path strings.
  */
-function detectParentAgent(): Promise<string | undefined> {
-	return new Promise((resolve) => {
-		// Short-circuit: if AGENTUITY_AGENT_MODE is set, use it directly
-		const agentMode = process.env.AGENTUITY_AGENT_MODE;
-		if (agentMode) {
-			resolve(agentMode);
-			return;
+function matchAgentCmdline(cmdline: string): string | undefined {
+	// Split cmdline into arguments (null-separated on macOS/Linux, but we get space-separated here)
+	// The cmdline format from our FFI is: "cmd arg1 arg2 ENV1=val1 ENV2=val2..."
+	// We only want to check the command and args that look like executables
+	const parts = cmdline.split(/\s+/);
+
+	for (const part of parts) {
+		// Skip environment variables (contain =)
+		if (part.includes('=')) {
+			continue;
 		}
 
-		// TODO: Implement Windows support using wmic or PowerShell
-		if (process.platform === 'win32') {
-			resolve(undefined);
-			return;
-		}
+		// Check if this looks like an executable path or command
+		// - Starts with / (absolute path)
+		// - Is a simple command name (no path separators, no special chars)
+		const isPath = part.startsWith('/');
+		const isSimpleCommand = !part.includes('/') && !part.includes('=') && part.length < 50;
 
-		const maxDepth = 10; // Limit how far up we walk the tree
-
-		async function walkTree(pid: number, depth: number): Promise<string | undefined> {
-			if (depth >= maxDepth || pid <= 1) {
-				return undefined;
+		if (isPath || isSimpleCommand) {
+			const basename = part.split('/').pop()?.toLowerCase() ?? '';
+			for (const [processName, agentName] of KNOWN_AGENTS) {
+				if (basename.includes(processName)) {
+					return agentName;
+				}
 			}
-
-			// Get both command and parent PID in a single ps call
-			const info = await getProcessInfo(pid);
-			if (!info) {
-				return undefined;
-			}
-
-			// Check if this process matches a known agent
-			const agent = matchAgent(info.command);
-			if (agent) {
-				return agent;
-			}
-
-			// Walk up to parent
-			return walkTree(info.ppid, depth + 1);
 		}
-
-		const ppid = process.ppid;
-		if (!ppid) {
-			resolve(undefined);
-			return;
-		}
-
-		walkTree(ppid, 0)
-			.then(resolve)
-			.catch(() => resolve(undefined));
-	});
+	}
+	return undefined;
 }
 
 /**
- * Start agent detection immediately (non-blocking).
- * Call this early in CLI startup to begin detection in the background.
+ * Check if stdin is connected to a TTY (interactive terminal).
+ * When humans type commands, stdin is usually a TTY.
+ * When agents run commands programmatically, stdin is usually piped/closed.
  */
-export function startAgentDetection(): void {
-	if (detectionPromise !== null) {
-		// Already started
-		return;
-	}
+function isInteractiveSession(): boolean {
+	return process.stdin.isTTY === true;
+}
 
-	// Short-circuit: if AGENTUITY_AGENT_MODE is set, skip process tree detection
-	const agentMode = process.env.AGENTUITY_AGENT_MODE;
-	if (agentMode) {
-		cachedResult = agentMode;
-		detectionPromise = Promise.resolve(agentMode);
-		return;
-	}
+// Enable debug output with AGENTUITY_DEBUG_AGENT_DETECTION=1
+const DEBUG = process.env.AGENTUITY_DEBUG_AGENT_DETECTION === '1';
 
-	detectionPromise = detectParentAgent().then((result) => {
-		cachedResult = result;
-		// Invoke all registered callbacks
-		for (const callback of detectionCallbacks) {
-			try {
-				callback(result);
-			} catch {
-				// Ignore callback errors
-			}
-		}
-		return result;
-	});
+function debugLog(...args: unknown[]): void {
+	if (DEBUG) {
+		console.error('[agent-detection]', ...args);
+	}
 }
 
 /**
- * Register a callback to be invoked when agent detection completes.
- * If detection has already completed, the callback is invoked immediately.
- * This is non-blocking and does not return a promise.
+ * Synchronously detect the parent agent by walking up the process tree.
+ * Uses FFI for fast process path and command line resolution.
  *
- * @example
- * ```typescript
- * onAgentDetected((agent) => {
- *   if (agent) {
- *     console.log(`Detected agent: ${agent}`);
- *   }
- * });
- * ```
+ * Detection strategy:
+ * - If stdin is a TTY (interactive session), don't report as agent
+ *   (human is typing commands, even if inside an agent's terminal)
+ * - If stdin is NOT a TTY, check the process tree for known agents
  */
-export function onAgentDetected(callback: (agent: string | undefined) => void): void {
-	// If detection already completed, invoke immediately
-	if (cachedResult !== null) {
-		try {
-			callback(cachedResult);
-		} catch {
-			// Ignore callback errors
-		}
-		return;
+function detectParentAgent(): string | undefined {
+	debugLog('Starting detection, PID:', process.pid, 'PPID:', process.ppid);
+	debugLog('stdin.isTTY:', process.stdin.isTTY);
+
+	// Dump relevant env vars for debugging agent detection
+	if (DEBUG) {
+		const relevantEnvVars = Object.entries(process.env)
+			.filter(([key]) =>
+				key.startsWith('WARP') ||
+				key.startsWith('TERM') ||
+				key.startsWith('AGENTUITY') ||
+				key === 'SHELL' ||
+				key === 'LC_TERMINAL' ||
+				key === 'ITERM_SESSION_ID' ||
+				key === 'VSCODE_INJECTION' ||
+				key === 'CURSOR_TRACE_ID'
+			)
+			.map(([key, value]) => `${key}=${value}`)
+			.join(', ');
+		debugLog('Relevant env vars:', relevantEnvVars || '(none)');
+		debugLog('WARP_AGENT_MODE:', process.env.WARP_AGENT_MODE ?? '(not set)');
 	}
 
-	// Otherwise, register for later invocation
-	detectionCallbacks.push(callback);
-}
-
-/**
- * Get the cached detection result synchronously.
- * Returns undefined if detection hasn't completed yet or no agent was detected.
- * Returns null if detection hasn't started or completed yet.
- *
- * Use this for synchronous access when you don't want to wait for detection.
- */
-export function getDetectedAgent(): string | undefined | null {
 	// Short-circuit: if AGENTUITY_AGENT_MODE is set, use it directly
+	// Use "false", "0", or "none" to explicitly disable detection
 	const agentMode = process.env.AGENTUITY_AGENT_MODE;
 	if (agentMode) {
+		if (agentMode === 'false' || agentMode === '0' || agentMode === 'none') {
+			debugLog('AGENTUITY_AGENT_MODE explicitly disabled:', agentMode);
+			return undefined;
+		}
+		debugLog('Using AGENTUITY_AGENT_MODE:', agentMode);
 		return agentMode;
 	}
-	return cachedResult;
-}
 
-/**
- * Wait for agent detection to complete and ensure all callbacks have been invoked.
- * Call this before CLI exit to ensure the detected agent is written to session logs.
- *
- * This is a no-op if detection hasn't started or has already completed.
- */
-export async function flushAgentDetection(): Promise<void> {
-	if (detectionPromise !== null) {
-		await detectionPromise;
+	// Warp terminal: detect via WARP_AGENT_MODE env var (set by Warp AI)
+	// Note: Warp doesn't currently set this, but will in the future
+	if (process.env.WARP_AGENT_MODE === 'true') {
+		debugLog('Detected Warp AI via WARP_AGENT_MODE=true');
+		return 'warp';
 	}
+
+	// If this is an interactive session (TTY), assume human is running the command
+	// Note: Warp AI also runs with TTY=true, so Warp users should set
+	// AGENTUITY_AGENT_MODE=warp until Warp sets WARP_AGENT_MODE=true
+	if (isInteractiveSession()) {
+		debugLog('Interactive session (TTY), skipping detection');
+		return undefined;
+	}
+
+	// Unsupported on Windows (for now)
+	if (process.platform === 'win32') {
+		debugLog('Windows not supported');
+		return undefined;
+	}
+
+	const { getProcessPath, getParentPid, getProcessCmdline } = getFFI();
+
+	// Guard for no parent process (e.g., PID 1 in containers)
+	const ppid = process.ppid;
+	if (!ppid || ppid <= 1) {
+		debugLog('No parent process (ppid:', ppid, ')');
+		return undefined;
+	}
+
+	// Walk up the process tree looking for known agents
+	const maxDepth = 10;
+	let currentPid = ppid;
+
+	for (let depth = 0; depth < maxDepth && currentPid > 1; depth++) {
+		// Check the executable path for agent match
+		const path = getProcessPath(currentPid);
+		debugLog(`[${depth}] PID ${currentPid} path:`, path);
+
+		if (path) {
+			const agent = matchAgentPath(path);
+			if (agent) {
+				debugLog(`[${depth}] Matched agent from path:`, agent);
+				return agent;
+			}
+		}
+
+		// Check the command line (for agents running as node/bun scripts)
+		const cmdline = getProcessCmdline(currentPid);
+		debugLog(`[${depth}] PID ${currentPid} cmdline:`, cmdline?.substring(0, 200) + (cmdline && cmdline.length > 200 ? '...' : ''));
+
+		if (cmdline) {
+			const agent = matchAgentCmdline(cmdline);
+			if (agent) {
+				debugLog(`[${depth}] Matched agent from cmdline:`, agent);
+				return agent;
+			}
+		}
+
+		// Move up
+		const parentPid = getParentPid(currentPid);
+		debugLog(`[${depth}] Parent of ${currentPid}:`, parentPid);
+		if (!parentPid) break;
+		currentPid = parentPid;
+	}
+
+	debugLog('No agent found');
+	return undefined;
 }
 
 /**
- * Check if the CLI is being executed from a known coding agent.
- * Returns the agent name if detected, undefined otherwise.
+ * Get the executing agent if the CLI is being run from a known coding agent.
+ * Returns the agent ID if detected, undefined otherwise.
  *
- * This function returns immediately if detection has already completed,
- * otherwise it awaits the detection promise started by startAgentDetection().
+ * This function runs synchronously using FFI for fast process path resolution.
+ * Results are cached after the first call.
  *
  * @example
  * ```typescript
- * const agent = await isExecutingFromAgent();
+ * const agent = getExecutingAgent();
  * if (agent) {
  *   logger.debug(`Running from agent: ${agent}`);
  * }
  * ```
  */
-export async function isExecutingFromAgent(): Promise<string | undefined> {
-	// Short-circuit: if AGENTUITY_AGENT_MODE is set, use it directly
-	const agentMode = process.env.AGENTUITY_AGENT_MODE;
-	if (agentMode) {
-		return agentMode;
-	}
-
-	// Return cached result if detection has completed
+export function getExecutingAgent(): string | undefined {
+	// Return cached result if already detected
 	if (cachedResult !== null) {
-		return cachedResult;
+		return cachedResult ?? undefined;
 	}
 
-	// If detection hasn't started yet, start it now
-	if (detectionPromise === null) {
-		startAgentDetection();
-	}
+	// Run detection and cache
+	cachedResult = detectParentAgent();
+	return cachedResult;
+}
 
-	// Wait for detection to complete
-	return detectionPromise!;
+/**
+ * Get environment variables to pass to subprocesses for agent detection.
+ * This allows child processes to skip re-detection by using the cached result.
+ *
+ * @example
+ * ```typescript
+ * const proc = Bun.spawn(['bun', 'run', 'dev'], {
+ *   env: { ...process.env, ...getAgentEnv() },
+ * });
+ * ```
+ */
+export function getAgentEnv(): Record<string, string> {
+	const agent = getExecutingAgent();
+	if (agent) {
+		return { AGENTUITY_AGENT_MODE: agent };
+	}
+	return {};
 }

--- a/packages/cli/src/banner.ts
+++ b/packages/cli/src/banner.ts
@@ -7,6 +7,7 @@ import {
 	getDisplayWidth,
 	stripAnsi,
 } from './tui';
+import { getExecutingAgent } from './agent-detection';
 
 export function generateBanner(version?: string, compact?: true): string {
 	const _version = version ?? getVersion();
@@ -83,5 +84,9 @@ export function generateBanner(version?: string, compact?: true): string {
 }
 
 export function showBanner(version?: string, compact?: true): void {
+	// Skip banner when running from an AI coding agent
+	if (getExecutingAgent()) {
+		return;
+	}
 	console.log(generateBanner(version, compact));
 }

--- a/packages/cli/src/cache/agent-intro.ts
+++ b/packages/cli/src/cache/agent-intro.ts
@@ -1,0 +1,61 @@
+import { Database } from 'bun:sqlite';
+import { join } from 'node:path';
+import { mkdirSync } from 'node:fs';
+import { getDefaultConfigDir } from '../config';
+
+let db: Database | null = null;
+
+/**
+ * Get or create the database connection synchronously.
+ * Reuses the existing resource.db file for consistency.
+ */
+function getDatabase(): Database {
+	if (db) return db;
+
+	const configDir = getDefaultConfigDir();
+	mkdirSync(configDir, { recursive: true });
+
+	db = new Database(join(configDir, 'resource.db'));
+	db.run(`
+		CREATE TABLE IF NOT EXISTS agent_intro_seen (
+			agent_id TEXT PRIMARY KEY,
+			first_seen_at INTEGER NOT NULL
+		)
+	`);
+	return db;
+}
+
+/**
+ * Check if an agent has already seen the intro message.
+ * This is a synchronous operation for use in formatHelp.
+ * Returns true on error to avoid blocking CLI (assumes seen).
+ */
+export function hasAgentSeenIntro(agentId: string): boolean {
+	try {
+		const row = getDatabase()
+			.query<{ agent_id: string }, [string]>(
+				'SELECT agent_id FROM agent_intro_seen WHERE agent_id = ?'
+			)
+			.get(agentId);
+		return row !== null;
+	} catch {
+		// Assume seen on error to avoid blocking CLI
+		return true;
+	}
+}
+
+/**
+ * Mark an agent as having seen the intro message.
+ * This is a synchronous operation for use in formatHelp.
+ * Silently fails on error (non-critical feature).
+ */
+export function markAgentIntroSeen(agentId: string): void {
+	try {
+		getDatabase().run(
+			'INSERT OR IGNORE INTO agent_intro_seen (agent_id, first_seen_at) VALUES (?, ?)',
+			[agentId, Date.now()]
+		);
+	} catch {
+		// Non-critical - intro tracking failure shouldn't block CLI
+	}
+}

--- a/packages/cli/src/cache/index.ts
+++ b/packages/cli/src/cache/index.ts
@@ -11,3 +11,5 @@ export {
 } from './resource-region';
 
 export { getCachedProject, setCachedProject, clearProjectCache } from './project-cache';
+
+export { hasAgentSeenIntro, markAgentIntroSeen } from './agent-intro';

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -14,6 +14,7 @@ import type {
 	GlobalOptions,
 } from './types';
 import { showBanner, generateBanner } from './banner';
+import { getExecutingAgent } from './agent-detection';
 import {
 	requireAuth,
 	optionalAuth,
@@ -34,7 +35,15 @@ import { getCommand } from './command-prefix';
 import { isValidateMode, outputValidation, type ValidationResult } from './output';
 import { StructuredError } from '@agentuity/core';
 import { setProgram } from './program-ref';
-import { getCachedProject, getResourceInfo, setCachedProject, type ResourceType } from './cache';
+import { generateIntroPrompt } from './cmd/ai/intro';
+import {
+	getCachedProject,
+	getResourceInfo,
+	setCachedProject,
+	type ResourceType,
+	hasAgentSeenIntro,
+	markAgentIntroSeen,
+} from './cache';
 
 /**
  * Check if an error is a CLI input validation error (Zod error from schema parsing),
@@ -633,13 +642,34 @@ export async function createCLI(version: string): Promise<Command> {
 			// Format each section (show banner for root command)
 			let output = '';
 
+			// Show intro for first-time agents (before normal help output)
+			// AGENTUITY_SHOW_INTRO=1 forces showing the intro (useful for testing)
+			const agent = getExecutingAgent();
+			const forceShowIntro = process.env.AGENTUITY_SHOW_INTRO === '1';
+			const hasSeenIntro = agent ? hasAgentSeenIntro(agent) : true;
+
+			if (agent && (forceShowIntro || !hasSeenIntro)) {
+				// Only mark as seen if this is their first time (not on forced re-shows)
+				if (!hasSeenIntro) {
+					markAgentIntroSeen(agent);
+				}
+
+				const separator = '='.repeat(79);
+				output += `${separator}\n\n`;
+				output += generateIntroPrompt(agent);
+				output += `\n${separator}\n\n`;
+			}
+
 			// Show banner (full for root, compact for subcommands)
+			// Skip banner when running from an AI coding agent
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			const isRootCommand = !(cmd as any).parent;
-			if (isRootCommand) {
-				output += `${generateBanner(version)}\n\n`;
-			} else {
-				output += `${generateBanner(version, true)}\n`;
+			if (!agent) {
+				if (isRootCommand) {
+					output += `${generateBanner(version)}\n\n`;
+				} else {
+					output += `${generateBanner(version, true)}\n`;
+				}
 			}
 
 			// Description

--- a/packages/cli/src/cmd/ai/detect.ts
+++ b/packages/cli/src/cmd/ai/detect.ts
@@ -1,0 +1,52 @@
+import { createSubcommand } from '../../types';
+import { getExecutingAgent, getAgentDisplayName, KNOWN_AGENTS } from '../../agent-detection';
+import { getCommand } from '../../command-prefix';
+import * as tui from '../../tui';
+
+export const detectSubcommand = createSubcommand({
+	name: 'detect',
+	description: 'Detect if the CLI is being run from a known AI coding agent',
+	tags: ['read-only', 'fast'],
+	idempotent: true,
+	examples: [
+		{ command: getCommand('ai detect'), description: 'Detect the executing agent' },
+		{ command: getCommand('ai detect --json'), description: 'Output detection result as JSON' },
+	],
+	handler(ctx) {
+		const agentId = getExecutingAgent();
+		const agentName = agentId ? getAgentDisplayName(agentId) : null;
+
+		if (ctx.options.json) {
+			tui.json({
+				id: agentId ?? null,
+				name: agentName,
+			});
+			// Exit with code 1 when no agent detected (consistent with non-JSON mode)
+			if (!agentId) {
+				process.exit(1);
+			}
+			return;
+		}
+
+		if (agentId) {
+			tui.success(`Detected agent: ${agentName} (${agentId})`);
+		} else {
+			tui.newline();
+			tui.info('No AI coding agent detected.');
+			tui.newline();
+			console.log(`  This CLI can detect when it's being run by an AI coding agent.`);
+			console.log(`  Currently supported agents:\n`);
+			for (const [, id] of KNOWN_AGENTS) {
+				console.log(`    - ${getAgentDisplayName(id)} (${id})`);
+			}
+			tui.newline();
+			console.log(`  You can also set the ${tui.colorPrimary('AGENTUITY_AGENT_MODE')} environment variable`);
+			console.log(`  to manually specify the agent.\n`);
+
+			// Exit with code 1 when no agent detected (non-JSON mode)
+			process.exit(1);
+		}
+	},
+});
+
+export default detectSubcommand;

--- a/packages/cli/src/cmd/ai/index.ts
+++ b/packages/cli/src/cmd/ai/index.ts
@@ -4,6 +4,7 @@ import promptCommand from './prompt';
 import schemaCommand from './schema';
 import opencodeCommand from './opencode';
 import introSubcommand from './intro';
+import detectSubcommand from './detect';
 import { getCommand } from '../../command-prefix';
 
 export const command = createCommand({
@@ -12,6 +13,10 @@ export const command = createCommand({
 	skipUpgradeCheck: true,
 	tags: ['fast'],
 	examples: [
+		{
+			command: getCommand('ai detect'),
+			description: 'Detect if running from an AI coding agent',
+		},
 		{
 			command: getCommand('ai intro'),
 			description: 'Introduce the Agentuity CLI to your AI agent',
@@ -29,5 +34,5 @@ export const command = createCommand({
 			description: 'Output CLI schema for AI consumption',
 		},
 	],
-	subcommands: [introSubcommand, opencodeCommand, capabilitiesCommand, promptCommand, schemaCommand],
+	subcommands: [detectSubcommand, introSubcommand, opencodeCommand, capabilitiesCommand, promptCommand, schemaCommand],
 });

--- a/packages/cli/src/cmd/ai/intro.ts
+++ b/packages/cli/src/cmd/ai/intro.ts
@@ -1,38 +1,15 @@
 import { createSubcommand } from '../../types';
 import type { CommandContext } from '../../types';
 import { getCommand } from '../../command-prefix';
-import { isExecutingFromAgent, KNOWN_AGENTS } from '../../agent-detection';
+import { getExecutingAgent, getAgentDisplayName, KNOWN_AGENTS } from '../../agent-detection';
 import { getVersion } from '../../version';
 import * as tui from '../../tui';
 
 /**
- * Generate a friendly name for the detected agent
- */
-function getAgentDisplayName(agentId: string): string {
-	const displayNames: Record<string, string> = {
-		opencode: 'Open Code',
-		codex: 'OpenAI Codex',
-		cursor: 'Cursor',
-		'claude-code': 'Claude Code',
-		copilot: 'GitHub Copilot',
-		gemini: 'Gemini',
-		cline: 'Cline',
-		roo: 'Roo Code',
-		windsurf: 'Windsurf',
-		zed: 'Zed',
-		amp: 'Amp',
-		warp: 'Warp',
-	};
-	return displayNames[agentId] || agentId;
-}
-
-/**
  * Generate the introduction prompt for AI agents
  */
-function generateIntroPrompt(agent: string | undefined): string {
-	const agentGreeting = agent
-		? `Hello ${getAgentDisplayName(agent)}! `
-		: 'Hello! ';
+export function generateIntroPrompt(agent: string | undefined): string {
+	const agentGreeting = agent ? `Hello ${getAgentDisplayName(agent)}! ` : 'Hello! ';
 
 	const detectedAgents = KNOWN_AGENTS.map(([, name]) => getAgentDisplayName(name)).join(', ');
 
@@ -144,11 +121,9 @@ export const introSubcommand = createSubcommand({
 	description: 'Introduction to Agentuity CLI for AI coding agents',
 	tags: ['read-only', 'fast'],
 	idempotent: true,
-	examples: [
-		{ command: getCommand('ai intro'), description: 'Show introduction for AI agents' },
-	],
-	async handler(_ctx: CommandContext) {
-		const agent = await isExecutingFromAgent();
+	examples: [{ command: getCommand('ai intro'), description: 'Show introduction for AI agents' }],
+	handler(_ctx: CommandContext) {
+		const agent = getExecutingAgent();
 
 		if (!agent) {
 			// Human is running this command directly
@@ -164,7 +139,9 @@ export const introSubcommand = createSubcommand({
 				`  Ask your AI coding agent to run ${tui.colorPrimary(`"${getCommand('ai intro')}"`)} to introduce\n` +
 					`  itself to the Agentuity platform and learn how to help you build and deploy agents.\n`
 			);
-			console.log(`  ${tui.muted('Supported agents:')} ${KNOWN_AGENTS.map(([, name]) => getAgentDisplayName(name)).join(', ')}\n`);
+			console.log(
+				`  ${tui.muted('Supported agents:')} ${KNOWN_AGENTS.map(([, name]) => getAgentDisplayName(name)).join(', ')}\n`
+			);
 			return;
 		}
 

--- a/packages/cli/src/cmd/build/vite/bun-dev-server.ts
+++ b/packages/cli/src/cmd/build/vite/bun-dev-server.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Logger } from '../../../types';
+import { getAgentEnv } from '../../../agent-detection';
 
 export interface BunDevServerOptions {
 	rootDir: string;
@@ -80,6 +81,7 @@ export async function startBunDevServer(options: BunDevServerOptions): Promise<B
 			stderr: 'inherit',
 			env: {
 				...process.env,
+				...getAgentEnv(),
 				PORT: String(port),
 			},
 		});

--- a/packages/cli/src/cmd/cloud/deploy-fork.ts
+++ b/packages/cli/src/cmd/cloud/deploy-fork.ts
@@ -17,6 +17,7 @@ import { existsSync, readFileSync, unlinkSync } from 'node:fs';
 import type { APIClient } from '../../api';
 import { getUserAgent } from '../../api';
 import { isUnicode } from '../../tui/symbols';
+import { getAgentEnv } from '../../agent-detection';
 import { projectDeploymentFail, type ClientDiagnostics, type Deployment } from '@agentuity/server';
 import type { Logger } from '@agentuity/core';
 
@@ -174,6 +175,7 @@ export async function runForkedDeploy(options: ForkDeployOptions): Promise<ForkD
 			cwd: projectDir,
 			env: {
 				...process.env,
+				...getAgentEnv(),
 				AGENTUITY_FORK_PARENT: '1',
 				AGENTUITY_DEPLOYMENT: deploymentEnvValue,
 				// Force color and unicode output since child stdout/stderr are piped (not TTY)

--- a/packages/cli/src/cmd/support/system.ts
+++ b/packages/cli/src/cmd/support/system.ts
@@ -7,7 +7,7 @@ import { getLatestLogSession } from '../../internal-logger';
 import * as tui from '../../tui';
 import { getVersion, getPackageName } from '../../version';
 import { getAuth } from '../../config';
-import { isExecutingFromAgent } from '../../agent-detection';
+import { getExecutingAgent } from '../../agent-detection';
 
 const argsSchema = z.object({});
 
@@ -77,7 +77,7 @@ export default createSubcommand({
 		}
 
 		// Get detected agent (if any)
-		const detectedAgent = await isExecutingFromAgent();
+		const detectedAgent = getExecutingAgent();
 
 		// Gather system information
 		const systemInfo = {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,13 @@
 export { createCLI, registerCommands } from './cli';
 export { generateAIHelp, type DashdashConfig } from './ai-help';
+export {
+	getExecutingAgent,
+	getAgentEnv,
+	getAgentDisplayName,
+	KNOWN_AGENTS,
+	AGENT_DISPLAY_NAMES,
+	type KnownAgent,
+} from './agent-detection';
 export { validateRuntime, isBun } from './runtime';
 export { ensureBunOnPath } from './bun-path';
 export { isGitAvailable, getDefaultBranch } from './git-helper';

--- a/packages/cli/src/tui.ts
+++ b/packages/cli/src/tui.ts
@@ -15,6 +15,7 @@ import type { Profile } from './types';
 import { type APIClient as APIClientType } from './api';
 import { getExitCode } from './errors';
 import { maskSecret } from './env-util';
+import { getExecutingAgent } from './agent-detection';
 
 // Install global exit handler to always restore terminal cursor
 // This ensures cursor is restored even when process.exit() is called directly
@@ -26,6 +27,10 @@ function ensureCursorRestoration(): void {
 	const restoreCursor = () => {
 		// Skip cursor restoration in CI - terminals don't support these sequences
 		if (process.env.CI) {
+			return;
+		}
+		// Skip cursor restoration when running from an AI coding agent
+		if (getExecutingAgent()) {
 			return;
 		}
 		// Restore cursor visibility
@@ -56,24 +61,61 @@ export type {
 	MultiSelectOptions,
 } from './tui/prompt';
 
-// Icons
-export const ICONS = {
-	success: '✓',
-	error: '✗',
-	warning: '⚠',
-	info: 'ℹ',
-	arrow: '→',
-	bullet: '•',
-} as const;
+// Icons - use plain text alternatives when running from an AI coding agent
+function getIcons() {
+	if (getExecutingAgent()) {
+		return {
+			success: '[OK]',
+			error: '[ERROR]',
+			warning: '[WARN]',
+			info: '[INFO]',
+			arrow: '->',
+			bullet: '-',
+		} as const;
+	}
+	return {
+		success: '✓',
+		error: '✗',
+		warning: '⚠',
+		info: 'ℹ',
+		arrow: '→',
+		bullet: '•',
+	} as const;
+}
+
+// Export ICONS as a getter for backward compatibility
+// Proxy with full traps for enumeration and serialization support
+export const ICONS = new Proxy({} as ReturnType<typeof getIcons>, {
+	get(_target, prop: keyof ReturnType<typeof getIcons>) {
+		return getIcons()[prop];
+	},
+	has(_target, prop) {
+		return prop in getIcons();
+	},
+	ownKeys() {
+		return Object.keys(getIcons());
+	},
+	getOwnPropertyDescriptor(_target, prop) {
+		const icons = getIcons();
+		if (prop in icons) {
+			return { configurable: true, enumerable: true, value: icons[prop as keyof typeof icons] };
+		}
+	},
+});
 
 /**
  * Check if we should treat the terminal as TTY-like for interactive output
  * (real TTY on stdout or stderr, or FORCE_COLOR set by fork wrapper).
  * Returns false in CI environments since CI terminals often don't support
  * cursor control sequences reliably.
+ * Returns false when running from an AI coding agent (no interactive prompts/spinners).
  */
 export function isTTYLike(): boolean {
 	if (process.env.CI) {
+		return false;
+	}
+	// Disable interactive features when running from an AI coding agent
+	if (getExecutingAgent()) {
 		return false;
 	}
 	return !!process.stdout.isTTY || !!process.stderr.isTTY || process.env.FORCE_COLOR === '1';
@@ -99,6 +141,10 @@ export function shouldUseColors(): boolean {
 	// FORCE_COLOR overrides TTY detection (used by fork wrapper)
 	if (process.env.FORCE_COLOR === '1') {
 		return true;
+	}
+	// Disable colors when running from an AI coding agent (cleaner output for parsing)
+	if (getExecutingAgent()) {
+		return false;
 	}
 	return (
 		!process.env.NO_COLOR &&

--- a/packages/cli/src/tui/box.ts
+++ b/packages/cli/src/tui/box.ts
@@ -215,7 +215,7 @@ export function errorBox(title: string, message: string, withGuide = true): void
 	const lines: string[] = [];
 
 	// Top border with title
-	const errorSymbol = colors.error('✗');
+	const errorSymbol = colors.error(symbols.error);
 	const titleText = colors.error(title);
 	const titleTextWidth = 1 + stringWidth(title); // symbol + title
 	const barsNeeded = Math.max(innerWidth - titleTextWidth - 3, 1);

--- a/packages/cli/src/tui/colors.ts
+++ b/packages/cli/src/tui/colors.ts
@@ -1,6 +1,7 @@
 /**
  * Color utilities for TUI components using existing tui.ts color system
  */
+import { getExecutingAgent } from '../agent-detection';
 
 // ANSI escape codes for additional colors not in main tui.ts
 const RESET = '\x1b[0m';
@@ -18,6 +19,36 @@ const BLACK = '\x1b[30m';
 const WHITE = '\x1b[37m';
 
 /**
+ * Check if colors should be used.
+ * Disabled for: AI agents, CI, NO_COLOR, dumb terminals, non-TTY, piped output.
+ * FORCE_COLOR=1 overrides all checks.
+ */
+function shouldUseColors(): boolean {
+	// FORCE_COLOR overrides all checks
+	if (process.env.FORCE_COLOR === '1') {
+		return true;
+	}
+	// Disable for AI coding agents
+	if (getExecutingAgent()) {
+		return false;
+	}
+	// Disable for NO_COLOR, CI, dumb terminals, or non-TTY
+	if (process.env.NO_COLOR) {
+		return false;
+	}
+	if (process.env.CI) {
+		return false;
+	}
+	if (process.env.TERM === 'dumb') {
+		return false;
+	}
+	if (!process.stdout.isTTY) {
+		return false;
+	}
+	return true;
+}
+
+/**
  * Detect if terminal is in dark mode
  */
 function isDarkMode(): boolean {
@@ -27,29 +58,55 @@ function isDarkMode(): boolean {
 	return true;
 }
 
-export const colors = {
-	// State colors - using simple ANSI codes (consistent with tui.ts approach)
-	active: (text: string) => `${CYAN}${text}${RESET}`,
-	completed: (text: string) => `${GRAY}${text}${RESET}`,
-	error: (text: string) => `${RED}${text}${RESET}`,
-	warning: (text: string) => `${YELLOW}${text}${RESET}`,
-	success: (text: string) => `${GREEN}${text}${RESET}`,
-	info: (text: string) => `${BLUE}${text}${RESET}`,
+// No-op color function for when colors are disabled
+const noColor = (text: string) => text;
 
-	// Text formatting
-	muted: (text: string) => `${DIM}${text}${RESET}`,
-	bold: (text: string) => `${BOLD}${text}${RESET}`,
-	underline: (text: string) => `${UNDERLINE}${text}${RESET}`,
-	reset: (text: string) => `${RESET}${text}`,
+function createColors() {
+	if (!shouldUseColors()) {
+		return {
+			active: noColor,
+			completed: noColor,
+			error: noColor,
+			warning: noColor,
+			success: noColor,
+			info: noColor,
+			muted: noColor,
+			bold: noColor,
+			underline: noColor,
+			reset: noColor,
+			primary: noColor,
+			secondary: noColor,
+			link: noColor,
+			inverseCyan: noColor,
+		};
+	}
 
-	// Semantic colors
-	primary: (text: string) => `${CYAN}${text}${RESET}`,
-	secondary: (text: string) => `${GRAY}${text}${RESET}`,
-	link: (text: string) => `${CYAN}${UNDERLINE}${text}${RESET}`,
+	return {
+		// State colors - using simple ANSI codes (consistent with tui.ts approach)
+		active: (text: string) => `${CYAN}${text}${RESET}`,
+		completed: (text: string) => `${GRAY}${text}${RESET}`,
+		error: (text: string) => `${RED}${text}${RESET}`,
+		warning: (text: string) => `${YELLOW}${text}${RESET}`,
+		success: (text: string) => `${GREEN}${text}${RESET}`,
+		info: (text: string) => `${BLUE}${text}${RESET}`,
 
-	// Inversed colors (adapt to light/dark mode)
-	inverseCyan: (text: string) => {
-		const dark = isDarkMode();
-		return dark ? `${BG_CYAN}${BLACK}${text}${RESET}` : `${BG_CYAN}${WHITE}${text}${RESET}`;
-	},
-};
+		// Text formatting
+		muted: (text: string) => `${DIM}${text}${RESET}`,
+		bold: (text: string) => `${BOLD}${text}${RESET}`,
+		underline: (text: string) => `${UNDERLINE}${text}${RESET}`,
+		reset: (text: string) => `${RESET}${text}`,
+
+		// Semantic colors
+		primary: (text: string) => `${CYAN}${text}${RESET}`,
+		secondary: (text: string) => `${GRAY}${text}${RESET}`,
+		link: (text: string) => `${CYAN}${UNDERLINE}${text}${RESET}`,
+
+		// Inversed colors (adapt to light/dark mode)
+		inverseCyan: (text: string) => {
+			const dark = isDarkMode();
+			return dark ? `${BG_CYAN}${BLACK}${text}${RESET}` : `${BG_CYAN}${WHITE}${text}${RESET}`;
+		},
+	};
+}
+
+export const colors = createColors();

--- a/packages/cli/src/tui/symbols.ts
+++ b/packages/cli/src/tui/symbols.ts
@@ -2,12 +2,18 @@
  * Box drawing and UI symbols for TUI components
  * Supports Unicode with ASCII fallbacks for non-unicode terminals
  */
+import { getExecutingAgent } from '../agent-detection';
 
 // Detect unicode support
 const isUnicodeSupported = (): boolean => {
 	// FORCE_UNICODE overrides detection (used by fork wrapper)
 	if (process.env.FORCE_UNICODE === '1') {
 		return true;
+	}
+
+	// Use ASCII for AI coding agents (cleaner output for parsing)
+	if (getExecutingAgent()) {
+		return false;
 	}
 
 	if (process.platform !== 'win32') {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -462,13 +462,13 @@ export type CommandContextFromSpecs<
 	 *
 	 * @example
 	 * ```typescript
-	 * const agent = await ctx.isExecutingFromAgent();
+	 * const agent = ctx.getExecutingAgent();
 	 * if (agent) {
 	 *   logger.debug(`Running from agent: ${agent}`);
 	 * }
 	 * ```
 	 */
-	isExecutingFromAgent: () => Promise<string | undefined>;
+	getExecutingAgent: () => string | undefined;
 } & AddArgs<A> &
 	AddOpts<Op> &
 	AddAuth<AuthMode<R, O>> &

--- a/packages/cli/src/version-check.ts
+++ b/packages/cli/src/version-check.ts
@@ -5,6 +5,7 @@ import { getVersion, getCompareUrl, getReleaseUrl, toTag } from './version';
 import * as tui from './tui';
 import { saveConfig } from './config';
 import { $ } from 'bun';
+import { getExecutingAgent } from './agent-detection';
 
 const ONE_HOUR_MS = 60 * 60 * 1000;
 
@@ -30,6 +31,11 @@ function shouldSkipCheck(
 	// Skip if not a global installation (can't auto-upgrade local/source installs)
 	const installationType = getInstallationType();
 	if (installationType !== 'global') {
+		return true;
+	}
+
+	// Skip if running from an AI coding agent (don't interrupt with upgrade prompts)
+	if (getExecutingAgent()) {
 		return true;
 	}
 


### PR DESCRIPTION
## Summary

- Replace slow async agent detection with fast synchronous FFI-based implementation
- Automatically optimize CLI output when running from an AI coding agent
- Show helpful intro on first `--help` per unique agent

## Agent Detection

Uses Bun FFI for direct syscalls instead of spawning `ps` processes:
- **macOS**: `proc_pidpath()` + `sysctl(KERN_PROCARGS2)` 
- **Linux**: `readlink()` + `/proc/{pid}/cmdline`

Performance: ~20µs per detection (cached after first call)

**Supported agents**: Open Code, OpenAI Codex, Cursor, Claude Code, GitHub Copilot, Gemini, Cline, Roo Code, Windsurf, Zed, Amp, Warp

## Agent-Friendly Output

When an agent is detected, the CLI automatically:

| Feature | Human | Agent |
|---------|-------|-------|
| Colors | ✅ ANSI codes | ❌ Plain text |
| Icons | ✓ ✗ ⚠ ℹ → • | [OK] [ERROR] [WARN] [INFO] -> - |
| Box drawing | │ ─ ╭╮╰╯ | \| - + |
| Spinners | ✅ Animated | ❌ Disabled |
| Interactive prompts | ✅ Enabled | ❌ Disabled |
| Cursor sequences | ✅ Enabled | ❌ Disabled |
| Version nag | ✅ Shows upgrade prompt | ❌ Skipped |
| Banner | ✅ Shows | ❌ Skipped |

## First-Run Welcome

Shows AI intro on first `--help` per unique agent:
- Tracked in SQLite (`~/.config/agentuity/resource.db`)
- `AGENTUITY_SHOW_INTRO=1` to force show (for testing)

## Subprocess Support

New `getAgentEnv()` helper passes detection to child processes via `AGENTUITY_AGENT_MODE` env var, avoiding re-detection overhead.

## New Commands & Exports

**Command**: `agentuity ai detect` - returns detected agent ID/name

**Exports**:
```typescript
import { 
  getExecutingAgent,    // Detect current agent
  getAgentEnv,          // Env vars for subprocesses  
  getAgentDisplayName,  // Human-friendly name
  KNOWN_AGENTS,
  AGENT_DISPLAY_NAMES,
  type KnownAgent,
} from '@agentuity/cli';
```

## Testing

```bash
# Force show intro
AGENTUITY_SHOW_INTRO=1 agentuity --help

# Debug detection
AGENTUITY_DEBUG_AGENT_DETECTION=1 agentuity ai detect

# Disable detection
AGENTUITY_AGENT_MODE=false agentuity --help
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * First-time agent intro shown for detected AI coding agents
  * New "ai detect" command to report the running agent and supported agents

* **Improvements**
  * More reliable, synchronous agent detection on macOS/Linux with human-friendly agent names
  * Agent-aware CLI output: banner suppression, ASCII-safe icons, color and TTY behavior
  * Agent identity propagated to subprocesses and persisted intro state

* **Public API**
  * CLI context exposes a synchronous agent getter and new agent-related helpers (display name and env)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->