### PR TITLE
Fix file types for execute

### DIFF
--- a/packages/server/src/api/sandbox/execute.ts
+++ b/packages/server/src/api/sandbox/execute.ts
@@ -7,9 +7,14 @@ export const ExecuteRequestSchema = z
 	.object({
 		command: z.array(z.string()).describe('Command and arguments to execute'),
 		files: z
-			.record(z.string(), z.string())
+			.array(
+				z.object({
+					path: z.string().describe('Path to the file relative to the sandbox workspace'),
+					content: z.string().describe('Base64-encoded file content'),
+				})
+			)
 			.optional()
-			.describe('Files to write before execution (path -> base64 content)'),
+			.describe('Files to write before execution'),
 		timeout: z.string().optional().describe('Execution timeout (e.g., "30s", "5m")'),
 		stream: z
 			.object({
@@ -62,9 +67,10 @@ export async function sandboxExecute(
 	};
 
 	if (options.files && options.files.length > 0) {
-		body.files = Object.fromEntries(
-			options.files.map((f) => [f.path, f.content.toString('base64')])
-		);
+		body.files = options.files.map((f) => ({
+			path: f.path,
+			content: f.content.toString('base64'),
+		}));
 	}
 	if (options.timeout) {
 		body.timeout = options.timeout;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * The sandbox execution endpoint's file submission format has been updated from key-value pairs to an array of objects. Each object now requires a path and base64-encoded content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->