### PR TITLE
fix: use array format for sandbox execute files schema

### DIFF
--- a/packages/server/src/api/sandbox/execute.ts
+++ b/packages/server/src/api/sandbox/execute.ts
@@ -7,9 +7,14 @@ export const ExecuteRequestSchema = z
 	.object({
 		command: z.array(z.string()).describe('Command and arguments to execute'),
 		files: z
-			.record(z.string(), z.string())
+			.array(
+				z.object({
+					path: z.string().describe('File path relative to workspace'),
+					content: z.string().describe('Base64-encoded file content'),
+				})
+			)
 			.optional()
-			.describe('Files to write before execution (path -> base64 content)'),
+			.describe('Files to write before execution'),
 		timeout: z.string().optional().describe('Execution timeout (e.g., "30s", "5m")'),
 		stream: z
 			.object({
@@ -62,9 +67,10 @@ export async function sandboxExecute(
 	};
 
 	if (options.files && options.files.length > 0) {
-		body.files = Object.fromEntries(
-			options.files.map((f) => [f.path, f.content.toString('base64')])
-		);
+		body.files = options.files.map((f) => ({
+			path: f.path,
+			content: f.content.toString('base64'),
+		}));
 	}
 	if (options.timeout) {
 		body.timeout = options.timeout;

--- a/packages/server/test/sandbox-client.test.ts
+++ b/packages/server/test/sandbox-client.test.ts
@@ -314,10 +314,10 @@ describe('SandboxClient', () => {
 
 			expect(requestBody).not.toBeNull();
 			expect(requestBody!.command).toEqual(['bun', 'run', 'script.ts']);
-			expect(requestBody!.files).toEqual({
-				'script.ts': Buffer.from('console.log("hello")').toString('base64'),
-				'data.json': Buffer.from('{"key": "value"}').toString('base64'),
-			});
+			expect(requestBody!.files).toEqual([
+				{ path: 'script.ts', content: Buffer.from('console.log("hello")').toString('base64') },
+				{ path: 'data.json', content: Buffer.from('{"key": "value"}').toString('base64') },
+			]);
 		});
 
 		test('execute with empty files array should not include files in request', async () => {


### PR DESCRIPTION
## Summary
- Changed `ExecuteRequestSchema` files field from `z.record()` (map) to `z.array()` of `{path, content}` objects to match the API contract
- Updated `sandboxExecute` implementation to send files as an array instead of `Object.fromEntries` map
- Fixed test assertion to expect the array format

Fixes failing CI: https://github.com/agentuity/sdk/actions/runs/21744720908/job/62727678710

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured sandbox execution API's file submission mechanism from dictionary object format (mapping file paths to base64-encoded content) to an array of objects with explicit path and content fields for improved API consistency and clarity
  * Updated all related tests to validate the new array-based file format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->