### PR TITLE
refactor(drizzle): extract resolvePostgresClientConfig for testable URL priority chain

### DIFF
--- a/packages/drizzle/src/postgres.ts
+++ b/packages/drizzle/src/postgres.ts
@@ -1,6 +1,43 @@
 import { drizzle } from 'drizzle-orm/bun-sql';
-import { postgres, type CallablePostgresClient } from '@agentuity/postgres';
+import { postgres, type CallablePostgresClient, type PostgresConfig } from '@agentuity/postgres';
 import type { PostgresDrizzleConfig, PostgresDrizzle } from './types';
+
+/**
+ * Resolves the PostgreSQL client configuration from Drizzle config options.
+ *
+ * URL priority chain: `connection.url` > `url` > `connectionString` > `process.env.DATABASE_URL`
+ *
+ * @internal Exported for testing — not part of the public package API.
+ */
+export function resolvePostgresClientConfig<
+	TSchema extends Record<string, unknown> = Record<string, never>,
+>(config?: PostgresDrizzleConfig<TSchema>): PostgresConfig {
+	// Clone the connection config to avoid mutating the caller's object
+	const clientConfig: PostgresConfig = config?.connection ? { ...config.connection } : {};
+
+	// Resolve URL using priority chain
+	if (!clientConfig.url) {
+		if (config?.url) {
+			clientConfig.url = config.url;
+		} else if (config?.connectionString) {
+			clientConfig.url = config.connectionString;
+		} else if (process.env.DATABASE_URL) {
+			clientConfig.url = process.env.DATABASE_URL;
+		}
+	}
+
+	// Add reconnection configuration
+	if (config?.reconnect) {
+		clientConfig.reconnect = config.reconnect;
+	}
+
+	// Add callbacks
+	if (config?.onReconnected) {
+		clientConfig.onreconnected = config.onReconnected;
+	}
+
+	return clientConfig;
+}
 
 /**
  * Creates a Drizzle ORM instance with a resilient PostgreSQL connection.
@@ -49,31 +86,8 @@ import type { PostgresDrizzleConfig, PostgresDrizzle } from './types';
 export function createPostgresDrizzle<
 	TSchema extends Record<string, unknown> = Record<string, never>,
 >(config?: PostgresDrizzleConfig<TSchema>): PostgresDrizzle<TSchema> {
-	// Build postgres client configuration by cloning the connection config
-	// to avoid mutating the caller's object
-	const clientConfig = config?.connection ? { ...config.connection } : {};
-
-	// Use connectionString only if no url is already present on the cloned config
-	// This ensures connection (when provided) keeps precedence over connectionString
-	if (!clientConfig.url) {
-		if (config?.url) {
-			clientConfig.url = config.url;
-		} else if (config?.connectionString) {
-			clientConfig.url = config.connectionString;
-		} else if (process.env.DATABASE_URL) {
-			clientConfig.url = process.env.DATABASE_URL;
-		}
-	}
-
-	// Add reconnection configuration
-	if (config?.reconnect) {
-		clientConfig.reconnect = config.reconnect;
-	}
-
-	// Add callbacks
-	if (config?.onReconnected) {
-		clientConfig.onreconnected = config.onReconnected;
-	}
+	// Resolve the postgres client configuration
+	const clientConfig = resolvePostgresClientConfig(config);
 
 	// Create the postgres client
 	const client: CallablePostgresClient = postgres(clientConfig);

--- a/packages/drizzle/test/config.test.ts
+++ b/packages/drizzle/test/config.test.ts
@@ -4,10 +4,10 @@
  * Follows the pattern from packages/postgres/test/kysely.test.ts:
  * - Type compatibility tests (compile = pass)
  * - Direct instance creation with various configs (lazy connection, no real DB needed)
- * - Backward compatibility tests
+ * - URL priority chain tests (via resolvePostgresClientConfig)
  */
 import { describe, it, expect } from 'bun:test';
-import { createPostgresDrizzle } from '../src/postgres';
+import { createPostgresDrizzle, resolvePostgresClientConfig } from '../src/postgres';
 import type { PostgresDrizzleConfig } from '../src/types';
 
 describe('createPostgresDrizzle config', () => {
@@ -109,7 +109,7 @@ describe('createPostgresDrizzle config', () => {
 	});
 
 	describe('direct usage', () => {
-		it('can create instance with url', () => {
+		it('can create instance with url', async () => {
 			const { db, client, close } = createPostgresDrizzle({
 				url: 'postgres://localhost:5432/nonexistent_db',
 			});
@@ -118,11 +118,11 @@ describe('createPostgresDrizzle config', () => {
 				expect(client).toBeDefined();
 				expect(typeof close).toBe('function');
 			} finally {
-				close();
+				await close();
 			}
 		});
 
-		it('can create instance with connectionString', () => {
+		it('can create instance with connectionString', async () => {
 			const { db, client, close } = createPostgresDrizzle({
 				connectionString: 'postgres://localhost:5432/nonexistent_db',
 			});
@@ -131,11 +131,11 @@ describe('createPostgresDrizzle config', () => {
 				expect(client).toBeDefined();
 				expect(typeof close).toBe('function');
 			} finally {
-				close();
+				await close();
 			}
 		});
 
-		it('can create instance with connection.url', () => {
+		it('can create instance with connection.url', async () => {
 			const { db, client, close } = createPostgresDrizzle({
 				connection: {
 					url: 'postgres://localhost:5432/nonexistent_db',
@@ -146,11 +146,11 @@ describe('createPostgresDrizzle config', () => {
 				expect(client).toBeDefined();
 				expect(typeof close).toBe('function');
 			} finally {
-				close();
+				await close();
 			}
 		});
 
-		it('can create instance with connection object fields', () => {
+		it('can create instance with connection object fields', async () => {
 			const { db, client, close } = createPostgresDrizzle({
 				connection: {
 					hostname: 'localhost',
@@ -165,11 +165,11 @@ describe('createPostgresDrizzle config', () => {
 				expect(client).toBeDefined();
 				expect(typeof close).toBe('function');
 			} finally {
-				close();
+				await close();
 			}
 		});
 
-		it('can create instance with url and schema', () => {
+		it('can create instance with url and schema', async () => {
 			const mockSchema = { users: {} };
 			const { db, client, close } = createPostgresDrizzle({
 				url: 'postgres://localhost:5432/nonexistent_db',
@@ -180,11 +180,11 @@ describe('createPostgresDrizzle config', () => {
 				expect(client).toBeDefined();
 				expect(typeof close).toBe('function');
 			} finally {
-				close();
+				await close();
 			}
 		});
 
-		it('can create instance with url and logger', () => {
+		it('can create instance with url and logger', async () => {
 			const { db, client, close } = createPostgresDrizzle({
 				url: 'postgres://localhost:5432/nonexistent_db',
 				logger: true,
@@ -194,11 +194,11 @@ describe('createPostgresDrizzle config', () => {
 				expect(client).toBeDefined();
 				expect(typeof close).toBe('function');
 			} finally {
-				close();
+				await close();
 			}
 		});
 
-		it('can create instance with url and reconnect config', () => {
+		it('can create instance with url and reconnect config', async () => {
 			const { db, client, close } = createPostgresDrizzle({
 				url: 'postgres://localhost:5432/nonexistent_db',
 				reconnect: {
@@ -211,11 +211,11 @@ describe('createPostgresDrizzle config', () => {
 				expect(client).toBeDefined();
 				expect(typeof close).toBe('function');
 			} finally {
-				close();
+				await close();
 			}
 		});
 
-		it('can create instance with url and onReconnected callback', () => {
+		it('can create instance with url and onReconnected callback', async () => {
 			const { db, client, close } = createPostgresDrizzle({
 				url: 'postgres://localhost:5432/nonexistent_db',
 				onReconnected: () => {},
@@ -225,11 +225,11 @@ describe('createPostgresDrizzle config', () => {
 				expect(client).toBeDefined();
 				expect(typeof close).toBe('function');
 			} finally {
-				close();
+				await close();
 			}
 		});
 
-		it('can create instance with no config (defaults to DATABASE_URL)', () => {
+		it('can create instance with no config (defaults to DATABASE_URL)', async () => {
 			const originalDatabaseUrl = process.env.DATABASE_URL;
 			process.env.DATABASE_URL = 'postgres://localhost:5432/dummy_test_db';
 			try {
@@ -239,7 +239,7 @@ describe('createPostgresDrizzle config', () => {
 					expect(client).toBeDefined();
 					expect(typeof close).toBe('function');
 				} finally {
-					close();
+					await close();
 				}
 			} finally {
 				if (originalDatabaseUrl === undefined) {
@@ -252,112 +252,89 @@ describe('createPostgresDrizzle config', () => {
 	});
 
 	describe('URL priority chain', () => {
-		// These are type-level / structural tests verifying the config shape.
-		// The actual priority logic (connection.url > url > connectionString > DATABASE_URL)
-		// is validated by the fact that these configs compile and create valid instances.
-
-		it('connection.url takes highest precedence (type check)', () => {
-			const { db, close } = createPostgresDrizzle({
+		it('connection.url takes highest precedence', () => {
+			const resolved = resolvePostgresClientConfig({
 				connection: { url: 'postgres://connection-url:5432/db' },
 				url: 'postgres://top-level-url:5432/db',
 				connectionString: 'postgres://connection-string:5432/db',
 			});
-			try {
-				expect(db).toBeDefined();
-			} finally {
-				close();
-			}
+			expect(resolved.url).toBe('postgres://connection-url:5432/db');
 		});
 
-		it('url takes precedence over connectionString (type check)', () => {
-			const { db, close } = createPostgresDrizzle({
+		it('url takes precedence over connectionString', () => {
+			const resolved = resolvePostgresClientConfig({
 				url: 'postgres://top-level-url:5432/db',
 				connectionString: 'postgres://connection-string:5432/db',
 			});
-			try {
-				expect(db).toBeDefined();
-			} finally {
-				close();
-			}
+			expect(resolved.url).toBe('postgres://top-level-url:5432/db');
 		});
 
-		it('connectionString is used when no url or connection provided (type check)', () => {
-			const { db, close } = createPostgresDrizzle({
+		it('connectionString is used when no url or connection provided', () => {
+			const resolved = resolvePostgresClientConfig({
 				connectionString: 'postgres://connection-string:5432/db',
 			});
-			try {
-				expect(db).toBeDefined();
-			} finally {
-				close();
-			}
+			expect(resolved.url).toBe('postgres://connection-string:5432/db');
 		});
-	});
 
-	describe('backward compatibility', () => {
-		it('connectionString still works', () => {
-			const { db, client, close } = createPostgresDrizzle({
-				connectionString: 'postgres://localhost:5432/nonexistent_db',
-			});
+		it('falls back to DATABASE_URL when no url options provided', () => {
+			const originalDatabaseUrl = process.env.DATABASE_URL;
+			process.env.DATABASE_URL = 'postgres://env-url:5432/db';
 			try {
-				expect(db).toBeDefined();
-				expect(client).toBeDefined();
-				expect(typeof close).toBe('function');
+				const resolved = resolvePostgresClientConfig({});
+				expect(resolved.url).toBe('postgres://env-url:5432/db');
 			} finally {
-				close();
+				if (originalDatabaseUrl === undefined) {
+					delete process.env.DATABASE_URL;
+				} else {
+					process.env.DATABASE_URL = originalDatabaseUrl;
+				}
 			}
 		});
 
-		it('connection object still works', () => {
-			const { db, client, close } = createPostgresDrizzle({
-				connection: {
-					url: 'postgres://localhost:5432/nonexistent_db',
-				},
-			});
+		it('url takes precedence over DATABASE_URL', () => {
+			const originalDatabaseUrl = process.env.DATABASE_URL;
+			process.env.DATABASE_URL = 'postgres://env-url:5432/db';
 			try {
-				expect(db).toBeDefined();
-				expect(client).toBeDefined();
-				expect(typeof close).toBe('function');
+				const resolved = resolvePostgresClientConfig({
+					url: 'postgres://top-level-url:5432/db',
+				});
+				expect(resolved.url).toBe('postgres://top-level-url:5432/db');
 			} finally {
-				close();
+				if (originalDatabaseUrl === undefined) {
+					delete process.env.DATABASE_URL;
+				} else {
+					process.env.DATABASE_URL = originalDatabaseUrl;
+				}
 			}
 		});
 
-		it('connection with individual fields still works', () => {
-			const { db, client, close } = createPostgresDrizzle({
-				connection: {
-					hostname: 'localhost',
-					port: 5432,
-					database: 'nonexistent_db',
-				},
+		it('forwards reconnect config', () => {
+			const resolved = resolvePostgresClientConfig({
+				url: 'postgres://localhost/db',
+				reconnect: { maxAttempts: 5, initialDelayMs: 100 },
 			});
-			try {
-				expect(db).toBeDefined();
-				expect(client).toBeDefined();
-				expect(typeof close).toBe('function');
-			} finally {
-				close();
-			}
+			expect(resolved.reconnect).toEqual({ maxAttempts: 5, initialDelayMs: 100 });
 		});
 
-		it('full config with connectionString and schema still works', () => {
-			const mockSchema = { users: {} };
-			const { db, client, close } = createPostgresDrizzle({
-				connectionString: 'postgres://localhost:5432/nonexistent_db',
-				schema: mockSchema,
-				logger: true,
-				reconnect: {
-					maxAttempts: 5,
-					initialDelayMs: 100,
-				},
-				onReconnected: () => {},
+		it('forwards onReconnected as onreconnected', () => {
+			const cb = () => {};
+			const resolved = resolvePostgresClientConfig({
+				url: 'postgres://localhost/db',
+				onReconnected: cb,
 			});
-			try {
-				expect(db).toBeDefined();
-				expect(client).toBeDefined();
-				expect(typeof close).toBe('function');
-			} finally {
-				close();
-			}
+			expect(resolved.onreconnected).toBe(cb);
+		});
+
+		it('does not mutate the original connection config', () => {
+			const connection = { url: 'postgres://original:5432/db' };
+			const resolved = resolvePostgresClientConfig({
+				connection,
+				reconnect: { maxAttempts: 3 },
+			});
+			expect(resolved.url).toBe('postgres://original:5432/db');
+			expect(resolved.reconnect).toEqual({ maxAttempts: 3 });
+			// Original object should be unmodified
+			expect(connection).toEqual({ url: 'postgres://original:5432/db' });
 		});
 	});
 });


### PR DESCRIPTION
## Summary
Follow-up to #889 — addresses review feedback on the drizzle config tests.

- Extracts `resolvePostgresClientConfig()` as a pure function so the URL priority chain (`connection.url` > `url` > `connectionString` > `DATABASE_URL`) can be tested directly without mocking the postgres constructor.
- Rewrites URL priority tests to assert the resolved `url` value instead of just checking `db` is defined.
- Adds new tests: `DATABASE_URL` fallback, `url` vs `DATABASE_URL` precedence, config forwarding (`reconnect`, `onReconnected`), and non-mutation of the original connection object.
- Removes duplicate backward-compat tests that were identical to direct usage tests.
- Makes all test callbacks `async` and `await close()` to avoid dropped promises.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed a new PostgreSQL configuration resolver function for explicit connection setup.
  * Established transparent URL priority resolution for database connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->