### PR TITLE
feat(sandbox): add timeout and command fields to SandboxInfo response types

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -356,6 +356,15 @@
         "react": "^18.0.0 || ^19.0.0",
       },
     },
+    "packages/claude-code": {
+      "name": "@agentuity/claude-code",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@types/bun": "latest",
+        "bun-types": "latest",
+        "typescript": "^5.9.0",
+      },
+    },
     "packages/cli": {
       "name": "@agentuity/cli",
       "version": "1.0.4",
@@ -684,6 +693,8 @@
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
     "@agentuity/auth": ["@agentuity/auth@workspace:packages/auth"],
+
+    "@agentuity/claude-code": ["@agentuity/claude-code@workspace:packages/claude-code"],
 
     "@agentuity/cli": ["@agentuity/cli@workspace:packages/cli"],
 
@@ -3491,7 +3502,27 @@
 
     "@agentuity/auth/@types/react": ["@types/react@18.3.28", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.2.2" } }, "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw=="],
 
+    "@agentuity/claude-code/bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "@agentuity/core/bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "@agentuity/drizzle/bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
     "@agentuity/drizzle/drizzle-orm": ["drizzle-orm@0.45.1", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA=="],
+
+    "@agentuity/frontend/bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "@agentuity/postgres/bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "@agentuity/react/bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "@agentuity/runtime/bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "@agentuity/schema/bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "@agentuity/server/bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "@agentuity/test-utils/bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
     "@agentuity/workbench/@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 

--- a/packages/core/src/services/sandbox.ts
+++ b/packages/core/src/services/sandbox.ts
@@ -750,6 +750,26 @@ export interface SandboxInfo {
 	 * Organization associated with the sandbox
 	 */
 	org: SandboxOrgInfo;
+
+	/**
+	 * Timeout configuration for this sandbox
+	 */
+	timeout?: {
+		/** Idle timeout duration (e.g., "10m0s") */
+		idle?: string;
+		/** Execution timeout duration (e.g., "5m0s") */
+		execution?: string;
+	};
+
+	/**
+	 * Startup command configured for this sandbox
+	 */
+	command?: {
+		/** Command and arguments */
+		exec: string[];
+		/** Execution mode */
+		mode?: 'oneshot' | 'interactive';
+	};
 }
 
 /**

--- a/packages/server/src/api/sandbox/get.ts
+++ b/packages/server/src/api/sandbox/get.ts
@@ -141,6 +141,18 @@ export const SandboxInfoDataSchema = z
 		agent: SandboxAgentInfoSchema.optional().describe('Agent associated with the sandbox'),
 		project: SandboxProjectInfoSchema.optional().describe('Project associated with the sandbox'),
 		org: SandboxOrgInfoSchema.describe('Organization associated with the sandbox'),
+		timeout: z
+			.object({
+				idle: z.string().optional(),
+				execution: z.string().optional(),
+			})
+			.optional(),
+		command: z
+			.object({
+				exec: z.array(z.string()),
+				mode: z.enum(['oneshot', 'interactive']).optional(),
+			})
+			.optional(),
 	})
 	.describe('Detailed information about a sandbox');
 
@@ -209,6 +221,8 @@ export async function sandboxGet(
 			agent: resp.data.agent,
 			project: resp.data.project,
 			org: resp.data.org,
+			timeout: resp.data.timeout,
+			command: resp.data.command,
 		};
 	}
 

--- a/packages/server/src/api/sandbox/list.ts
+++ b/packages/server/src/api/sandbox/list.ts
@@ -93,6 +93,18 @@ export const SandboxInfoSchema = z
 			.optional()
 			.describe('Public URL for the sandbox (only set if networkPort is configured)'),
 		org: SandboxOrgInfoSchema.describe('Organization associated with the sandbox'),
+		timeout: z
+			.object({
+				idle: z.string().optional(),
+				execution: z.string().optional(),
+			})
+			.optional(),
+		command: z
+			.object({
+				exec: z.array(z.string()),
+				mode: z.enum(['oneshot', 'interactive']).optional(),
+			})
+			.optional(),
 	})
 	.describe('Summary information about a sandbox');
 

--- a/packages/vscode/src/core/cliClient.ts
+++ b/packages/vscode/src/core/cliClient.ts
@@ -1658,6 +1658,14 @@ export interface SandboxInfo {
 	identifier?: string;
 	networkPort?: number;
 	url?: string;
+	timeout?: {
+		idle?: string;
+		execution?: string;
+	};
+	command?: {
+		exec: string[];
+		mode?: 'oneshot' | 'interactive';
+	};
 }
 
 export interface SandboxCreateOptions {


### PR DESCRIPTION
## Summary

- **Core types**: Added `timeout` and `command` optional fields to `SandboxInfo` interface in `@agentuity/core`
- **Zod schemas**: Added corresponding validation schemas in server `get.ts` and `list.ts` endpoints
- **VSCode extension**: Added fields to `SandboxInfo` interface in CLI client
- **Type safety**: Command `mode` is typed as `'oneshot' | 'interactive'` enum (not free string)

## Related PRs
- agentuity/ion + agentuity/catalyst — backend API changes that return these new fields
- agentuity/graviton + agentuity/hadron — enforce execution timeout in oneshot sandboxes
- agentuity/app — adds startupCommand column to Drizzle schema

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional timeout configuration options for sandbox operations, enabling customizable idle duration and execution time limits to optimize resource allocation and system performance monitoring
  * Added optional command execution configuration options for sandbox operations, with flexible execution mode selection (oneshot or interactive) to support diverse operational requirements and workflow patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->