### PR TITLE
fix(drizzle): use resilient SQL proxy to survive reconnection

### DIFF
--- a/packages/drizzle/src/postgres.ts
+++ b/packages/drizzle/src/postgres.ts
@@ -1,3 +1,4 @@
+import { SQL as BunSQL } from 'bun';
 import { drizzle } from 'drizzle-orm/bun-sql';
 import { postgres, type CallablePostgresClient, type PostgresConfig } from '@agentuity/postgres';
 import type { PostgresDrizzleConfig, PostgresDrizzle } from './types';
@@ -37,6 +38,57 @@ export function resolvePostgresClientConfig<
 	}
 
 	return clientConfig;
+}
+
+/**
+ * Creates a dynamic SQL proxy that always delegates to the PostgresClient's
+ * current raw connection. This ensures that after automatic reconnection,
+ * Drizzle ORM uses the fresh connection instead of a stale reference.
+ *
+ * The proxy also wraps `unsafe()` calls with the client's retry logic,
+ * providing automatic retry on transient connection errors.
+ *
+ * @internal Exported for testing — not part of the public package API.
+ */
+export function createResilientSQLProxy(
+	client: CallablePostgresClient
+): InstanceType<typeof BunSQL> {
+	return new Proxy({} as InstanceType<typeof BunSQL>, {
+		get(_target, prop, _receiver) {
+			// Always resolve from the CURRENT raw connection (changes after reconnect)
+			const raw = client.raw;
+
+			if (prop === 'unsafe') {
+				// Wrap unsafe() with retry logic for resilient queries.
+				// Returns a thenable that also supports .values() chaining,
+				// matching the SQLQuery interface that Drizzle expects:
+				//   client.unsafe(query, params)           → Promise<rows>
+				//   client.unsafe(query, params).values()   → Promise<rows>
+				return (query: string, params?: unknown[]) => {
+					const makeExecutor = (useValues: boolean) =>
+						client.executeWithRetry(async () => {
+							// Re-resolve raw inside retry to get post-reconnect instance
+							const currentRaw = client.raw;
+							const q = currentRaw.unsafe(query, params);
+							return useValues ? q.values() : q;
+						});
+
+					// Return a thenable with .values() to match Bun's SQLQuery interface
+					const result = makeExecutor(false);
+					return Object.assign(result, {
+						values: () => makeExecutor(true),
+					});
+				};
+			}
+
+			const value = (raw as unknown as Record<string | symbol, unknown>)[prop];
+			if (typeof value === 'function') {
+				// Bind to raw so `this` is correct inside begin(), savepoint(), etc.
+				return (value as (...args: unknown[]) => unknown).bind(raw);
+			}
+			return value;
+		},
+	});
 }
 
 /**
@@ -100,10 +152,15 @@ export function createPostgresDrizzle<
 		});
 	}
 
-	// Create Drizzle instance using the client's raw SQL connection
-	// The bun-sql driver accepts a client that implements the Bun.SQL interface
+	// Create a resilient proxy that always delegates to the current raw SQL
+	// connection. This ensures that after reconnection, Drizzle automatically
+	// uses the new connection instead of the stale one.
+	const resilientSQL = createResilientSQLProxy(client);
+
+	// Create Drizzle instance using the resilient proxy instead of a static
+	// reference to client.raw, which would become stale after reconnection.
 	const db = drizzle({
-		client: client.raw,
+		client: resilientSQL,
 		schema: config?.schema,
 		logger: config?.logger,
 	});

--- a/packages/drizzle/test/proxy.test.ts
+++ b/packages/drizzle/test/proxy.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for createResilientSQLProxy.
+ *
+ * Uses mocks to simulate a CallablePostgresClient without a real database.
+ * Verifies that the proxy:
+ * - Delegates to the current `client.raw` at access time
+ * - Wraps `unsafe()` calls through `client.executeWithRetry`
+ * - Supports `.values()` chaining on `unsafe()` results
+ * - Binds other methods (begin, etc.) to the current raw
+ * - Picks up a new raw instance after reconnection
+ * - Re-resolves raw inside the retry callback
+ */
+import { describe, it, expect, mock } from 'bun:test';
+import { createResilientSQLProxy } from '../src/postgres';
+import type { CallablePostgresClient } from '@agentuity/postgres';
+
+/**
+ * Creates a minimal mock that satisfies the proxy's needs.
+ * The mock exposes a `_setRaw` helper to simulate reconnection
+ * (i.e., swapping the underlying raw SQL instance).
+ */
+function createMockClient() {
+	let currentRaw: Record<string, unknown> = {
+		unsafe: mock((_query: string, _params?: unknown[]) => {
+			const result = Promise.resolve([{ id: 1 }]);
+			return Object.assign(result, {
+				values: () => Promise.resolve([[1]]),
+			});
+		}),
+		begin: mock(() => Promise.resolve()),
+		close: mock(() => Promise.resolve()),
+		options: { parsers: {}, serializers: {} },
+	};
+
+	const client = {
+		get raw() {
+			return currentRaw;
+		},
+		executeWithRetry: mock(async <T>(op: () => T | Promise<T>) => {
+			return op();
+		}),
+		_setRaw(newRaw: Record<string, unknown>) {
+			currentRaw = newRaw;
+		},
+	} as unknown as CallablePostgresClient & { _setRaw: (raw: Record<string, unknown>) => void };
+
+	return { client, getRaw: () => currentRaw };
+}
+
+describe('createResilientSQLProxy', () => {
+	it('delegates unsafe() to the current raw', async () => {
+		const { client, getRaw } = createMockClient();
+		const proxy = createResilientSQLProxy(client);
+
+		await proxy.unsafe('SELECT 1');
+
+		expect(getRaw().unsafe).toHaveBeenCalledWith('SELECT 1', undefined);
+	});
+
+	it('uses executeWithRetry for unsafe calls', async () => {
+		const { client } = createMockClient();
+		const proxy = createResilientSQLProxy(client);
+
+		await proxy.unsafe('SELECT 1');
+
+		expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
+	});
+
+	it('proxy.unsafe().values() works', async () => {
+		const { client } = createMockClient();
+		const proxy = createResilientSQLProxy(client);
+
+		const result = await proxy.unsafe('SELECT 1').values();
+
+		expect(result).toEqual([[1]]);
+		// values() creates a separate makeExecutor(true) call, so executeWithRetry
+		// is called once for the base promise and once for values()
+		expect(client.executeWithRetry).toHaveBeenCalledTimes(2);
+	});
+
+	it('picks up new raw after reconnection', async () => {
+		const { client } = createMockClient();
+		const proxy = createResilientSQLProxy(client);
+
+		// Create a new raw to simulate reconnection
+		const newUnsafe = mock((_query: string, _params?: unknown[]) => {
+			const result = Promise.resolve([{ id: 2 }]);
+			return Object.assign(result, {
+				values: () => Promise.resolve([[2]]),
+			});
+		});
+		const newRaw: Record<string, unknown> = {
+			unsafe: newUnsafe,
+			begin: mock(() => Promise.resolve()),
+			options: { parsers: {}, serializers: {} },
+		};
+
+		// Swap the raw to simulate reconnection
+		client._setRaw(newRaw);
+
+		const result = await proxy.unsafe('SELECT 2');
+
+		expect(result).toEqual([{ id: 2 }]);
+		expect(newUnsafe).toHaveBeenCalledWith('SELECT 2', undefined);
+	});
+
+	it('delegates begin() to the current raw', async () => {
+		const { client, getRaw } = createMockClient();
+		const proxy = createResilientSQLProxy(client);
+
+		await (proxy as unknown as Record<string, (...args: unknown[]) => unknown>).begin('test-arg');
+
+		expect(getRaw().begin).toHaveBeenCalledWith('test-arg');
+	});
+
+	it('delegates property access to the current raw', () => {
+		const { client } = createMockClient();
+		const proxy = createResilientSQLProxy(client);
+
+		// Access a custom property set on the mock raw
+		const options = (proxy as unknown as Record<string, unknown>).options;
+
+		expect(options).toEqual({ parsers: {}, serializers: {} });
+	});
+
+	it('re-resolves raw inside retry callback', async () => {
+		const { client } = createMockClient();
+		const proxy = createResilientSQLProxy(client);
+
+		// Track which raw instances are used during retries
+		// Create a new raw to simulate reconnection
+		const newUnsafe = mock((_query: string, _params?: unknown[]) => {
+			const result = Promise.resolve([{ id: 99 }]);
+			return Object.assign(result, {
+				values: () => Promise.resolve([[99]]),
+			});
+		});
+		const newRaw: Record<string, unknown> = {
+			unsafe: newUnsafe,
+			begin: mock(() => Promise.resolve()),
+			options: { parsers: {}, serializers: {} },
+		};
+
+		// Override executeWithRetry to simulate a retry after reconnection
+		let callCount = 0;
+		client.executeWithRetry = mock(async (op: () => unknown) => {
+			callCount++;
+			if (callCount === 1) {
+				// Simulate reconnection before first execution
+				client._setRaw(newRaw);
+			}
+			// op() re-resolves client.raw internally, so it gets the new raw
+			return op();
+		}) as typeof client.executeWithRetry;
+
+		const result = await proxy.unsafe('SELECT 99');
+
+		// Should have used the new raw (post-reconnection)
+		expect(result).toEqual([{ id: 99 }]);
+		expect(newUnsafe).toHaveBeenCalledWith('SELECT 99', undefined);
+	});
+
+	it('passes params to unsafe()', async () => {
+		const { client, getRaw } = createMockClient();
+		const proxy = createResilientSQLProxy(client);
+
+		await proxy.unsafe('SELECT $1', [42]);
+
+		expect(getRaw().unsafe).toHaveBeenCalledWith('SELECT $1', [42]);
+	});
+
+	it('unsafe() returns a thenable with values()', () => {
+		const { client } = createMockClient();
+		const proxy = createResilientSQLProxy(client);
+
+		const result = proxy.unsafe('SELECT 1');
+
+		// Should be thenable
+		expect(typeof result.then).toBe('function');
+		// Should have values() method
+		expect(typeof result.values).toBe('function');
+	});
+
+	it('binds methods to the current raw (not stale)', async () => {
+		const { client } = createMockClient();
+		const proxy = createResilientSQLProxy(client);
+
+		// Get begin from proxy
+		const _beginFn = proxy.begin;
+
+		// Create a new raw with a different begin mock
+		const newBegin = mock(() => Promise.resolve('new-tx'));
+		const newRaw: Record<string, unknown> = {
+			unsafe: mock(() => {
+				const r = Promise.resolve([]);
+				return Object.assign(r, { values: () => Promise.resolve([]) });
+			}),
+			begin: newBegin,
+			options: {},
+		};
+
+		// Swap to the new raw
+		client._setRaw(newRaw);
+
+		// Call begin - but the proxy re-resolves raw each time .begin is accessed
+		await (proxy as unknown as Record<string, (...args: unknown[]) => unknown>).begin('tx-arg');
+
+		expect(newBegin).toHaveBeenCalledWith('tx-arg');
+	});
+});

--- a/packages/postgres/src/client.ts
+++ b/packages/postgres/src/client.ts
@@ -636,6 +636,21 @@ export class PostgresClient {
 	}
 
 	/**
+	 * Execute an operation with automatic retry on retryable errors.
+	 * If reconnection is in progress, waits for it to complete before executing.
+	 *
+	 * This is the public counterpart of the internal `_executeWithRetry` method,
+	 * exposed for use by integration layers (e.g. the Drizzle resilient proxy).
+	 *
+	 * @param operation - The async operation to execute
+	 * @param maxRetries - Maximum number of retries (default: 3)
+	 * @returns The result of the operation
+	 */
+	async executeWithRetry<T>(operation: () => T | Promise<T>, maxRetries?: number): Promise<T> {
+		return this._executeWithRetry(operation, maxRetries);
+	}
+
+	/**
 	 * Wait for the connection to be established.
 	 * If the connection hasn't been established yet (lazy connection), this will
 	 * warm the connection by executing a test query.
@@ -771,6 +786,7 @@ export function createCallableClient(config?: string | PostgresConfig): Callable
 	callable.shutdown = client.shutdown.bind(client);
 	callable.unsafe = client.unsafe.bind(client);
 	callable.waitForConnection = client.waitForConnection.bind(client);
+	callable.executeWithRetry = client.executeWithRetry.bind(client);
 
 	return callable;
 }

--- a/packages/postgres/test/client.test.ts
+++ b/packages/postgres/test/client.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for PostgresClient.executeWithRetry.
+ *
+ * The client is created with a dummy URL (lazy connection). We need to trick
+ * the internal state so that _executeWithRetry doesn't try to warm the real
+ * connection. We do this by setting _connected = true on the client instance.
+ */
+import { describe, it, expect } from 'bun:test';
+import { PostgresClient } from '../src/client';
+
+/**
+ * Creates a PostgresClient with a dummy URL and forces internal state
+ * so that executeWithRetry skips connection warming.
+ */
+function createTestClient(): PostgresClient {
+	const client = new PostgresClient('postgres://localhost:5432/dummy');
+	// Force the client to believe it's connected so _executeWithRetry
+	// doesn't call _warmConnection() (which would try a real TCP connection).
+	(client as unknown as Record<string, boolean>)._connected = true;
+	return client;
+}
+
+describe('PostgresClient.executeWithRetry', () => {
+	it('executes the operation and returns result', async () => {
+		const client = createTestClient();
+		try {
+			const result = await client.executeWithRetry(async () => {
+				return 42;
+			});
+			expect(result).toBe(42);
+		} finally {
+			await client.close();
+		}
+	});
+
+	it('returns non-promise values', async () => {
+		const client = createTestClient();
+		try {
+			const result = await client.executeWithRetry(() => {
+				return 'hello';
+			});
+			expect(result).toBe('hello');
+		} finally {
+			await client.close();
+		}
+	});
+
+	it('retries on retryable errors', async () => {
+		const client = createTestClient();
+		try {
+			let attempts = 0;
+			const result = await client.executeWithRetry(async () => {
+				attempts++;
+				if (attempts < 3) {
+					const err = new Error('Connection closed');
+					(err as unknown as Record<string, string>).code = 'ERR_POSTGRES_CONNECTION_CLOSED';
+					throw err;
+				}
+				return 'success';
+			});
+			expect(result).toBe('success');
+			expect(attempts).toBe(3);
+		} finally {
+			await client.close();
+		}
+	});
+
+	it('throws non-retryable errors immediately', async () => {
+		const client = createTestClient();
+		try {
+			let attempts = 0;
+			await expect(
+				client.executeWithRetry(async () => {
+					attempts++;
+					throw new Error('syntax error at or near "SELEC"');
+				})
+			).rejects.toThrow('syntax error');
+			expect(attempts).toBe(1);
+		} finally {
+			await client.close();
+		}
+	});
+
+	it('respects custom maxRetries parameter', async () => {
+		const client = createTestClient();
+		try {
+			let attempts = 0;
+			await expect(
+				client.executeWithRetry(async () => {
+					attempts++;
+					const err = new Error('Connection closed');
+					(err as unknown as Record<string, string>).code = 'ECONNRESET';
+					throw err;
+				}, 1)
+			).rejects.toThrow('Connection closed');
+			// maxRetries=1 means: initial attempt + 1 retry = 2 total attempts
+			expect(attempts).toBe(2);
+		} finally {
+			await client.close();
+		}
+	});
+
+	it('retries up to default maxRetries (3) then throws', async () => {
+		const client = createTestClient();
+		try {
+			let attempts = 0;
+			await expect(
+				client.executeWithRetry(async () => {
+					attempts++;
+					const err = new Error('Connection reset');
+					(err as unknown as Record<string, string>).code = 'ECONNRESET';
+					throw err;
+				})
+			).rejects.toThrow('Connection reset');
+			// Default maxRetries=3: initial attempt + 3 retries = 4 total
+			expect(attempts).toBe(4);
+		} finally {
+			await client.close();
+		}
+	});
+
+	it('returns result from successful retry', async () => {
+		const client = createTestClient();
+		try {
+			let attempts = 0;
+			const result = await client.executeWithRetry(async () => {
+				attempts++;
+				if (attempts === 1) {
+					const err = new Error('Connection refused');
+					(err as unknown as Record<string, string>).code = 'ECONNREFUSED';
+					throw err;
+				}
+				return { data: 'recovered' };
+			});
+			expect(result).toEqual({ data: 'recovered' });
+			expect(attempts).toBe(2);
+		} finally {
+			await client.close();
+		}
+	});
+
+	it('throws after close', async () => {
+		const client = createTestClient();
+		await client.close();
+
+		await expect(
+			client.executeWithRetry(async () => {
+				return 'should not reach';
+			})
+		).rejects.toThrow();
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #899 — `ERR_POSTGRES_CONNECTION_CLOSED` still happening even with the custom `@agentuity/drizzle` package.

## Root Cause

`createPostgresDrizzle()` passed `client.raw` (a static reference to the Bun.SQL instance) to Drizzle at creation time:

```typescript
const db = drizzle({ client: client.raw, ... });
```

When the connection dropped and `PostgresClient._reconnectLoop()` succeeded, `_reinitializeSql()` created a **new** `this._sql` Bun.SQL instance — but Drizzle's internal `BunSQLSession` still held the old, dead reference. All subsequent Drizzle queries used the dead connection → `ERR_POSTGRES_CONNECTION_CLOSED`.

## Fix

- **Resilient SQL Proxy** (`packages/drizzle/src/postgres.ts`): Replace the static `client.raw` with a `Proxy` that always resolves `client.raw` at call time. After reconnection, Drizzle automatically uses the new connection.
- **Retry-wrapped `unsafe()`**: The proxy intercepts `unsafe()` calls and routes them through `client.executeWithRetry()`, providing automatic retry with exponential backoff on transient connection errors. Supports `.values()` chaining that Drizzle uses internally.
- **Public `executeWithRetry()`** (`packages/postgres/src/client.ts`): Exposes the existing private retry logic as a public method for use by integration layers like the Drizzle proxy.

## Changes

| File | Change |
|------|--------|
| `packages/drizzle/src/postgres.ts` | Added `createResilientSQLProxy()`, replaced `client.raw` with proxy |
| `packages/postgres/src/client.ts` | Added public `executeWithRetry()` method, bound in `createCallableClient()` |
| `packages/drizzle/test/proxy.test.ts` | 10 new tests — proxy delegation, reconnection resilience, `.values()` chaining |
| `packages/postgres/test/client.test.ts` | 8 new tests — `executeWithRetry` behavior, retry logic, error handling |

## Verification

- ✅ `bun run format` — clean
- ✅ `bun run lint` — 0 errors
- ✅ `bun run typecheck` — 0 errors  
- ✅ `bun run build` — clean
- ✅ `bun run test` — 212 pass, 0 fail (postgres + drizzle packages)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SQL operations now automatically retry on transient failures, improving database reliability during network interruptions.
  * Enhanced connection handling ensures fresh database connections are used after reconnections, preventing stale connection issues.

* **Tests**
  * Added comprehensive test coverage for connection resilience, reconnection handling, and automatic retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->