### PR TITLE
chore: update publish script to bump claude-code plugin versions and add package to docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
 	"name": "agentuity",
 	"owner": {
 		"name": "Agentuity",
-		"email": "support@agentuity.dev"
+		"email": "support@agentuity.com"
 	},
 	"metadata": {
 		"description": "Agentuity plugins for Claude Code",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,23 +14,24 @@
 
 Bun workspaces monorepo with packages in `packages/`:
 
-| Package      | Runtime  | Description                                          |
-| ------------ | -------- | ---------------------------------------------------- |
-| `core`       | Node/Bun | Shared types and utilities (publish first)           |
-| `schema`     | Any      | Schema validation (StandardSchema v1)                |
-| `server`     | Node/Bun | Runtime-agnostic server utilities                    |
-| `runtime`    | Bun      | Hono-based server runtime with WebRTC signaling      |
-| `react`      | Browser  | React hooks for agents and WebRTC                    |
-| `frontend`   | Browser  | Framework-agnostic web utilities with WebRTC manager |
-| `auth`       | Both     | Authentication providers (Clerk, etc.)               |
-| `cli`        | Bun      | CLI framework with commander.js                      |
-| `postgres`   | Node/Bun | Resilient PostgreSQL client with auto-reconnection   |
-| `drizzle`    | Node/Bun | Drizzle ORM integration with resilient connections   |
-| `evals`      | Any      | Reusable evaluation presets                          |
-| `opencode`   | Bun      | Opencoder agent plugins for Agentuity                |
-| `workbench`  | Browser  | Workbench UI component for agent testing             |
-| `vscode`     | Node     | VS Code extension for Agentuity                      |
-| `test-utils` | Test     | Private test helpers (never published)               |
+| Package       | Runtime  | Description                                          |
+| ------------- | -------- | ---------------------------------------------------- |
+| `core`        | Node/Bun | Shared types and utilities (publish first)           |
+| `schema`      | Any      | Schema validation (StandardSchema v1)                |
+| `server`      | Node/Bun | Runtime-agnostic server utilities                    |
+| `runtime`     | Bun      | Hono-based server runtime with WebRTC signaling      |
+| `react`       | Browser  | React hooks for agents and WebRTC                    |
+| `frontend`    | Browser  | Framework-agnostic web utilities with WebRTC manager |
+| `auth`        | Both     | Authentication providers (Clerk, etc.)               |
+| `claude-code` | Bun      | Claude Code plugin with multi-agent coding team      |
+| `cli`         | Bun      | CLI framework with commander.js                      |
+| `postgres`    | Node/Bun | Resilient PostgreSQL client with auto-reconnection   |
+| `drizzle`     | Node/Bun | Drizzle ORM integration with resilient connections   |
+| `evals`       | Any      | Reusable evaluation presets                          |
+| `opencode`    | Bun      | Opencoder agent plugins for Agentuity                |
+| `workbench`   | Browser  | Workbench UI component for agent testing             |
+| `vscode`      | Node     | VS Code extension for Agentuity                      |
+| `test-utils`  | Test     | Private test helpers (never published)               |
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ To chat with other community members you can join the [Agentuity Discord server]
 The structure of this mono repository:
 
 - `packages/auth` - Agentuity unified Authentication package
+- `packages/claude-code` - Claude Code plugin with multi-agent coding team
 - `packages/cli` - the Agentuity command line tool
 - `packages/core` - Shared utilities used by most packages
 - `packages/drizzle` - Drizzle ORM integration with resilient PostgreSQL connections

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -157,6 +157,35 @@ async function updateVersions(version: string) {
 	await writeJSON(rootPkgPath, rootPkg);
 	console.log(`✓ Updated root package.json to ${version}`);
 
+	// Update .claude-plugin/marketplace.json
+	const marketplacePath = join(rootDir, '.claude-plugin', 'marketplace.json');
+	try {
+		const marketplace = await readJSON(marketplacePath);
+		if (marketplace.metadata) {
+			marketplace.metadata.version = version;
+		}
+		if (marketplace.plugins) {
+			for (const plugin of marketplace.plugins) {
+				plugin.version = version;
+			}
+		}
+		await writeJSON(marketplacePath, marketplace);
+		console.log(`✓ Updated .claude-plugin/marketplace.json to ${version}`);
+	} catch {
+		console.log(`⊘ Skipped .claude-plugin/marketplace.json (not found)`);
+	}
+
+	// Update packages/claude-code/.claude-plugin/plugin.json
+	const pluginJsonPath = join(packagesDir, 'claude-code', '.claude-plugin', 'plugin.json');
+	try {
+		const pluginJson = await readJSON(pluginJsonPath);
+		pluginJson.version = version;
+		await writeJSON(pluginJsonPath, pluginJson);
+		console.log(`✓ Updated packages/claude-code/.claude-plugin/plugin.json to ${version}`);
+	} catch {
+		console.log(`⊘ Skipped packages/claude-code/.claude-plugin/plugin.json (not found)`);
+	}
+
 	// Update packages/*
 	const packages = await readdir(packagesDir);
 	for (const pkg of packages) {
@@ -368,7 +397,7 @@ async function getPublishablePackages(): Promise<
 }
 
 async function revertVersionChanges() {
-	await $`git checkout -- package.json packages/*/package.json apps/*/package.json bun.lock`.cwd(
+	await $`git checkout -- package.json packages/*/package.json apps/*/package.json .claude-plugin/marketplace.json packages/claude-code/.claude-plugin/plugin.json bun.lock`.cwd(
 		rootDir
 	);
 }


### PR DESCRIPTION
## Summary

- Update `scripts/publish.ts` to set version in `.claude-plugin/marketplace.json` (`metadata.version` + `plugins[].version`) and `packages/claude-code/.claude-plugin/plugin.json` during publish
- Include both files in `revertVersionChanges()` so they are restored on failure or dry-run
- Add `claude-code` package to the package listings in `README.md` and `AGENTS.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new claude-code package entry to documentation, describing it as a multi-agent coding team plugin.

* **Chores**
  * Updated contact email in marketplace configuration.
  * Enhanced publishing workflow to propagate version updates across plugin and dependency configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->