### PR TITLE
fix(cli): add AGENTUITY_BASE_URL to .env when auth is enabled

### DIFF
--- a/packages/cli/src/cmd/project/template-flow.ts
+++ b/packages/cli/src/cmd/project/template-flow.ts
@@ -676,6 +676,11 @@ export async function runCreateFlow(options: CreateFlowOptions): Promise<CreateF
 			resourceEnvVars.AGENTUITY_AUTH_SECRET = devSecret;
 		}
 
+		// Add base URL for local development if auth is enabled
+		if (authEnabled && !resourceEnvVars.AGENTUITY_BASE_URL) {
+			resourceEnvVars.AGENTUITY_BASE_URL = 'http://localhost:3500';
+		}
+
 		// Write resource environment variables to .env
 		if (Object.keys(resourceEnvVars).length > 0) {
 			await addResourceEnvVars(dest, resourceEnvVars);
@@ -690,6 +695,9 @@ export async function runCreateFlow(options: CreateFlowOptions): Promise<CreateF
 					tui.info(
 						`Generate one with: ${tui.muted('npx @better-auth/cli secret')} or ${tui.muted('openssl rand -hex 32')}`
 					);
+				}
+				if (resourceEnvVars.AGENTUITY_BASE_URL) {
+					tui.success('AGENTUITY_BASE_URL added to .env');
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes a bug where new projects created with "Agentuity Auth" fail to run locally due to missing `AGENTUITY_BASE_URL` in the `.env` file.

## Problem

When creating a project with Agentuity Auth enabled, the CLI writes `DATABASE_URL` and `AGENTUITY_AUTH_SECRET` to `.env`, but not `AGENTUITY_BASE_URL`. At runtime, BetterAuth requires a base URL to function. The auth package's `resolveBaseURL()` checks:
1. `AGENTUITY_CLOUD_BASE_URL` (platform-injected, not available locally)
2. `AGENTUITY_BASE_URL` (not in `.env`)
3. `BETTER_AUTH_URL` (not in `.env`)

Since none of these are set locally, auth initialization fails.

## Solution

- Add `AGENTUITY_BASE_URL=http://localhost:3500` to `resourceEnvVars` when auth is enabled during project creation
- Add user feedback message showing the variable was configured
- Uses the standard Agentuity dev server port (3500) as the default

## Changes

- `packages/cli/src/cmd/project/template-flow.ts`: Added conditional block to set `AGENTUITY_BASE_URL` and show success message

## Testing

- ✅ Typecheck passes
- ✅ Follows existing code patterns (same structure as `AGENTUITY_AUTH_SECRET` block)
- ✅ Conditional logic prevents overwriting existing values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic configuration of local development URL when authentication is enabled during project setup. The system now automatically populates the base URL with `http://localhost:3500` and includes it in your `.env` file, with confirmation feedback provided to the user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->