### PR TITLE
fix(cli): run global install from tmpdir to avoid local node_modules interference

### DIFF
--- a/packages/cli/src/cmd/canary/index.ts
+++ b/packages/cli/src/cmd/canary/index.ts
@@ -1,6 +1,7 @@
 import { createCommand } from '../../types';
 import { z } from 'zod';
 import { $ } from 'bun';
+import { tmpdir } from 'node:os';
 import * as tui from '../../tui';
 
 const CANARY_BASE_URL = 'https://agentuity-sdk-objects.t3.storageapi.dev/npm';
@@ -99,7 +100,8 @@ export const command = createCommand({
 
 		try {
 			// Install the canary version globally using the tarball URL
-			const installResult = await $`bun add -g ${tarballUrl}`.quiet().nothrow();
+			// Run from tmpdir to avoid interference from any local package.json/node_modules
+			const installResult = await $`bun add -g ${tarballUrl}`.cwd(tmpdir()).quiet().nothrow();
 
 			if (installResult.exitCode !== 0) {
 				const stderr = installResult.stderr.toString();

--- a/packages/cli/src/cmd/upgrade/index.ts
+++ b/packages/cli/src/cmd/upgrade/index.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { ErrorCode, createError, exitWithError } from '../../errors';
 import * as tui from '../../tui';
 import { $ } from 'bun';
+import { tmpdir } from 'node:os';
 import { getInstallationType, type InstallationType } from '../../utils/installation-type';
 
 const UpgradeOptionsSchema = z.object({
@@ -77,7 +78,8 @@ async function performBunUpgrade(version: string): Promise<void> {
 	const npmVersion = version.replace(/^v/, '');
 
 	// Use bun to install the specific version globally
-	const result = await $`bun add -g @agentuity/cli@${npmVersion}`.quiet().nothrow();
+	// Run from tmpdir to avoid interference from any local package.json/node_modules
+	const result = await $`bun add -g @agentuity/cli@${npmVersion}`.cwd(tmpdir()).quiet().nothrow();
 
 	if (result.exitCode !== 0) {
 		const stderr = result.stderr.toString();

--- a/packages/cli/src/version-check.ts
+++ b/packages/cli/src/version-check.ts
@@ -5,6 +5,7 @@ import { getVersion, getCompareUrl, getReleaseUrl, toTag } from './version';
 import * as tui from './tui';
 import { saveConfig } from './config';
 import { $ } from 'bun';
+import { tmpdir } from 'node:os';
 import { getExecutingAgent } from './agent-detection';
 
 const ONE_HOUR_MS = 60 * 60 * 1000;
@@ -172,7 +173,8 @@ async function performUpgrade(logger: Logger, targetVersion: string): Promise<vo
 		logger.info('Upgrading to version %s...', npmVersion);
 
 		// Use bun to install the specific version globally
-		await $`bun add -g @agentuity/cli@${npmVersion}`.quiet();
+		// Run from tmpdir to avoid interference from any local package.json/node_modules
+		await $`bun add -g @agentuity/cli@${npmVersion}`.cwd(tmpdir()).quiet();
 
 		// If we got here, the upgrade succeeded
 		// Re-run the original command with the new binary


### PR DESCRIPTION
## Summary

- **Fixes** `agentuity upgrade` failing with `BadPathName: failed opening node_modules/package dir for package` when run from a directory containing a `package.json` or `node_modules` (e.g. the user's home directory)
- Adds `.cwd(tmpdir())` to all `bun add -g` shell commands so global installs execute from a clean temp directory, avoiding interference from local project files
- Applies the fix to all three affected code paths: explicit upgrade, auto-upgrade prompt, and canary install

## Root Cause

Bun's `$` shell template inherits `process.cwd()`. When a user runs `agentuity upgrade` from a directory that happens to have a `package.json` or `node_modules`, `bun add -g` tries to resolve against the local project, causing `BadPathName` errors.

## Changes

| File | Change |
|------|--------|
| `packages/cli/src/cmd/upgrade/index.ts` | `performBunUpgrade()` — added `.cwd(tmpdir())` |
| `packages/cli/src/version-check.ts` | `performUpgrade()` — added `.cwd(tmpdir())` |
| `packages/cli/src/cmd/canary/index.ts` | canary install — added `.cwd(tmpdir())` |

## Verification

- ✅ Build passes
- ✅ Typecheck passes
- ✅ Lint passes

Fixes #922

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified CLI installation operations for canary, upgrade, and version check to execute from isolated temporary directories, ensuring clean execution environments and preventing interference from local project configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->