### PR TITLE
fix(cli): clean up stale routes.ts when all API routes are removed

### DIFF
--- a/packages/cli/src/cmd/build/vite/registry-generator.ts
+++ b/packages/cli/src/cmd/build/vite/registry-generator.ts
@@ -658,6 +658,13 @@ export async function generateRouteRegistry(
 	});
 
 	if (apiRoutes.length === 0 && websocketRoutes.length === 0 && sseRoutes.length === 0) {
+		// Clean up stale routes.ts from previous builds (issue #924)
+		// When all API routes are removed, the old file would reference deleted modules
+		const generatedDir = join(srcDir, 'generated');
+		const registryPath = join(generatedDir, 'routes.ts');
+		if (existsSync(registryPath)) {
+			unlinkSync(registryPath);
+		}
 		return;
 	}
 

--- a/packages/cli/test/cmd/build/vite/registry-generator.test.ts
+++ b/packages/cli/test/cmd/build/vite/registry-generator.test.ts
@@ -879,6 +879,24 @@ describe('registry-generator', () => {
 			expect(existsSync(routesPath)).toBe(false);
 		});
 
+		test('should clean up stale routes.ts from previous build when all routes are removed (issue #924)', async () => {
+			// Simulate a previous build that generated routes.ts
+			mkdirSync(generatedDir, { recursive: true });
+			writeFileSync(
+				join(generatedDir, 'routes.ts'),
+				`// @generated\nimport type { StateSchema } from '../api/index';\n`
+			);
+			expect(existsSync(join(generatedDir, 'routes.ts'))).toBe(true);
+
+			// Now rebuild with no routes (user deleted their API files)
+			const routes: RouteInfo[] = [];
+			await generateRouteRegistry(srcDir, routes);
+
+			// Stale file should be cleaned up
+			const routesPath = join(generatedDir, 'routes.ts');
+			expect(existsSync(routesPath)).toBe(false);
+		});
+
 		test('should handle trailing slashes in routes', async () => {
 			const routes: RouteInfo[] = [
 				{


### PR DESCRIPTION
## Summary

- Fixes #924 — deploying after removing all API route files caused TypeScript errors because the stale `routes.ts` from the previous build persisted with imports to now-deleted modules
- When `generateRouteRegistry()` detects no routes, it now deletes the existing `routes.ts` before returning early
- Added test verifying stale file cleanup

## Root Cause

`generateRouteRegistry()` in `registry-generator.ts` had an early return when no routes were found that skipped writing `routes.ts`, leaving the stale file from a previous build intact with its old imports (e.g., `import type { StateSchema } from '../api/index'`).

## Changes

| File | Change |
|------|--------|
| `packages/cli/src/cmd/build/vite/registry-generator.ts` | Delete stale `routes.ts` on no-routes early return |
| `packages/cli/test/cmd/build/vite/registry-generator.test.ts` | Added regression test for issue #924 |

## Verification

- ✅ Build passes (all packages)
- ✅ Typecheck passes (zero errors)
- ✅ Lint passes (zero violations)
- ✅ All 77 registry-generator tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cleanup of stale generated route files when rebuilding with no routes, preventing leftover artifacts from previous builds.

* **Tests**
  * Added tests to verify stale file cleanup behavior during route regeneration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->