### PR TITLE
fix(runtime): resolve TypeScript errors for verbatimModuleSyntax and Buffer types

### DIFF
--- a/packages/runtime/src/middleware.ts
+++ b/packages/runtime/src/middleware.ts
@@ -22,9 +22,8 @@ import {
 	SpanStatusCode,
 	trace,
 	propagation,
-	Meter,
-	Tracer,
 } from '@opentelemetry/api';
+import type { Meter, Tracer } from '@opentelemetry/api';
 import * as runtimeConfig from './_config';
 import { getSessionEventProvider } from './_services';
 import { internal } from './logger/internal';

--- a/packages/runtime/src/services/local/stream.ts
+++ b/packages/runtime/src/services/local/stream.ts
@@ -329,12 +329,12 @@ class LocalStream extends WritableStream implements Stream {
 
 	async #persist(): Promise<void> {
 		// Read buffered file
-		let data = readFileSync(this.#tempFilePath);
+		let data: Buffer = readFileSync(this.#tempFilePath);
 
 		// Optional: Apply compression if enabled
 		if (this.#compressed) {
 			const { gzipSync } = await import('node:zlib');
-			data = gzipSync(data);
+			data = gzipSync(data) as Buffer;
 		}
 
 		// Update DB with finalized data


### PR DESCRIPTION
## Summary
- Move `Meter` and `Tracer` to type-only imports in `middleware.ts` — they are only used as type annotations, which `verbatimModuleSyntax` requires to be imported with `import type`
- Add explicit `Buffer` type annotation and cast in `stream.ts` to fix `NonSharedBuffer` assignability error from `gzipSync` return type

These errors surface in downstream projects (e.g. `all-in-all`) because the generated `router.ts` imports directly from `@agentuity/runtime/src/index`, causing TypeScript to compile the raw `.ts` source files with the consumer's strict settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized import statements and added explicit type annotations to improve code quality and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->