### PR TITLE
fix(publish): prevent hallucinated GitHub profile URLs in release notes

### DIFF
--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -459,7 +459,7 @@ const CONTRIBUTORS: Record<string, string> = {
 	'Matt Congrove': 'https://github.com/mcongrove',
 	'Robin Diddams': 'https://github.com/robindiddams',
 	'Pedro Enrique': 'https://github.com/pec1985',
-	'Gabriel Rodqigues Campos': 'https://github.com/Huijiro',
+	'Gabriel Rodrigues Campos': 'https://github.com/Huijiro',
 	'Parteek Singh': 'https://github.com/parteeksingh24',
 	'Jason Walkow': 'https://github.com/jsw324',
 	'Nicholas Mirigliani': 'https://github.com/NobbyBop',


### PR DESCRIPTION
## Summary

- Adds a `CONTRIBUTORS` mapping of team member names → verified GitHub profile URLs to `scripts/publish.ts`
- Injects the mapping into the release notes generation prompt so the LLM uses only known URLs
- Explicitly instructs the LLM to use plain names (no URL) for any author not in the mapping, preventing fabricated links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release notes now include verified contributor attribution with official GitHub profile links, ensuring accurate credit and avoiding fabricated URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->