### PR TITLE
fix: download gravity binary via agentuity.sh instead of GitHub API

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -377,7 +377,6 @@
         "@agentuity/frontend": "workspace:*",
         "@agentuity/server": "workspace:*",
         "@datasert/cronjs-parser": "^1.4.0",
-        "@terascope/fetch-github-release": "^2.2.1",
         "@vitejs/plugin-react": "^5.1.2",
         "acorn-loose": "^8.5.2",
         "adm-zip": "^0.5.16",
@@ -2510,7 +2509,7 @@
 
     "is-ssh": ["is-ssh@1.4.1", "", { "dependencies": { "protocols": "^2.0.1" } }, "sha512-JNeu1wQsHjyHgn9NcWTaXq6zWSR6hqE0++zhfZlkFBbScNkyvxCdeV8sRkSBaeLKxmbpR21brail63ACNxJ0Tg=="],
 
-    "is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
+    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
     "is-string": ["is-string@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA=="],
 
@@ -2580,7 +2579,7 @@
 
     "keytar": ["keytar@7.9.0", "", { "dependencies": { "node-addon-api": "^4.3.0", "prebuild-install": "^7.0.1" } }, "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ=="],
 
-    "keyv": ["keyv@5.6.0", "", { "dependencies": { "@keyv/serialize": "^1.1.1" } }, "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw=="],
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
 
@@ -3742,6 +3741,8 @@
 
     "cacheable-request/get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
 
+    "cacheable-request/keyv": ["keyv@5.6.0", "", { "dependencies": { "@keyv/serialize": "^1.1.1" } }, "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw=="],
+
     "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
@@ -3784,15 +3785,13 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
-    "flat-cache/keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
-
-    "gaxios/is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
-
     "gaxios/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
     "glob/minimatch": ["minimatch@10.1.2", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.1" } }, "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw=="],
 
     "globby/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "got/keyv": ["keyv@5.6.0", "", { "dependencies": { "@keyv/serialize": "^1.1.1" } }, "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw=="],
 
     "happy-dom/whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
@@ -3965,6 +3964,8 @@
     "@terascope/fetch-github-release/yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "cacheable-request/get-stream/is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
 
     "cloud-deployment-tests/@vitejs/plugin-react/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,7 +45,6 @@
 		"@agentuity/core": "workspace:*",
 		"@agentuity/server": "workspace:*",
 		"@datasert/cronjs-parser": "^1.4.0",
-		"@terascope/fetch-github-release": "^2.2.1",
 		"@vitejs/plugin-react": "^5.1.2",
 		"acorn-loose": "^8.5.2",
 		"adm-zip": "^0.5.16",

--- a/packages/cli/src/cmd/dev/download.ts
+++ b/packages/cli/src/cmd/dev/download.ts
@@ -1,31 +1,30 @@
 import { randomUUID } from 'node:crypto';
-import { existsSync, createReadStream, mkdirSync, rmSync } from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir, platform } from 'node:os';
 import { join, dirname } from 'node:path';
 import * as tar from 'tar';
-import { downloadRelease } from '@terascope/fetch-github-release';
+import { StructuredError } from '@agentuity/core';
 import { spinner } from '../../tui';
-
-const user = 'agentuity';
-const repo = 'gravity';
-
-function filterRelease(release: { prerelease: boolean }) {
-	// Filter out prereleases.
-	return release.prerelease === false;
-}
-
-function filterAsset(asset: { name: string }): boolean {
-	// Filter out the release matching our os and architecture
-	let arch: string = process.arch;
-	if (arch === 'x64') {
-		arch = 'x86_64';
-	}
-	return asset.name.includes(arch) && asset.name.includes(platform());
-}
 
 interface GravityClient {
 	filename: string;
 	version: string;
+}
+
+const GravityVersionError = StructuredError('GravityVersionError')<{
+	status: number;
+	statusText: string;
+}>();
+const GravityDownloadError = StructuredError('GravityDownloadError')<{
+	status: number;
+	statusText: string;
+}>();
+const GravityExtractionError = StructuredError('GravityExtractionError')<{
+	path: string;
+}>();
+
+function getBaseURL(): string {
+	return process.env.AGENTUITY_SH_URL || 'https://agentuity.sh';
 }
 
 /**
@@ -33,86 +32,85 @@ interface GravityClient {
  * @returns full path to the downloaded file
  */
 export async function download(gravityDir: string): Promise<GravityClient> {
-	const outputdir = join(tmpdir(), randomUUID());
+	const baseURL = getBaseURL();
 
-	const res = (await spinner({
+	// Step 1: Get the latest version from agentuity.sh
+	const tag = (await spinner({
 		message: 'Checking Agentuity Gravity',
 		callback: async () => {
-			return downloadRelease(
-				user,
-				repo,
-				outputdir,
-				filterRelease,
-				filterAsset,
-				false,
-				true,
-				true,
-				''
-			);
+			const resp = await fetch(`${baseURL}/release/gravity/version`, {
+				signal: AbortSignal.timeout(10_000),
+			});
+			if (!resp.ok) {
+				throw new GravityVersionError({
+					status: resp.status,
+					statusText: resp.statusText,
+				});
+			}
+			const text = (await resp.text()).trim();
+			return text.startsWith('v') ? text : `v${text}`;
 		},
 		clearOnSuccess: true,
-	})) as { release: string; assetFileNames: string[] };
+	})) as string;
 
-	const versionTok = res.release.split('@');
-	const version = versionTok[1] ?? 'unknown';
+	const version = tag.startsWith('v') ? tag.slice(1) : tag;
 	const releaseFilename = join(gravityDir, version, 'gravity');
-	const mustDownload = !existsSync(releaseFilename);
 
-	if (!mustDownload) {
+	// Step 2: Check if already downloaded
+	if (await Bun.file(releaseFilename).exists()) {
 		return { filename: releaseFilename, version };
 	}
 
-	const downloadedFile = await spinner({
-		message: `Downloading Gravity ${version}`,
-		callback: async () => {
-			const res = (await downloadRelease(
-				user,
-				repo,
-				outputdir,
-				filterRelease,
-				filterAsset,
-				false,
-				true,
-				false,
-				''
-			)) as string[];
-			const file = res[0];
-			if (!file) {
-				throw new Error('No file downloaded from release');
-			}
-			return file;
-		},
-		clearOnSuccess: true,
-	});
+	// Step 3: Download the binary from agentuity.sh
+	const os = platform();
+	let arch: string = process.arch;
+	if (arch === 'x64') {
+		arch = 'x86_64';
+	}
 
-	if (downloadedFile.endsWith('.tar.gz')) {
+	const tmpFile = join(tmpdir(), `${randomUUID()}.tar.gz`);
+
+	try {
 		await spinner({
-			message: 'Extracting release',
+			message: `Downloading Gravity ${version}`,
 			callback: async () => {
-				return new Promise<void>((resolve, reject) => {
-					const input = createReadStream(downloadedFile);
-					const downloadDir = dirname(releaseFilename);
-					if (!existsSync(downloadDir)) {
-						mkdirSync(downloadDir, { recursive: true });
-					}
-					input.on('finish', resolve);
-					input.on('end', resolve);
-					input.on('error', reject);
-					input.pipe(tar.x({ C: downloadDir, chmod: true }));
+				const resp = await fetch(`${baseURL}/release/gravity/${tag}/${os}/${arch}`, {
+					signal: AbortSignal.timeout(60_000),
 				});
+				if (!resp.ok) {
+					throw new GravityDownloadError({
+						status: resp.status,
+						statusText: resp.statusText,
+					});
+				}
+				const buffer = await resp.arrayBuffer();
+				writeFileSync(tmpFile, Buffer.from(buffer));
 			},
 			clearOnSuccess: true,
 		});
-	} else {
-		// TODO:
+
+		// Step 4: Extract the tarball
+		await spinner({
+			message: 'Extracting release',
+			callback: async () => {
+				const downloadDir = dirname(releaseFilename);
+				if (!(await Bun.file(downloadDir).exists())) {
+					mkdirSync(downloadDir, { recursive: true });
+				}
+				await tar.x({ file: tmpFile, cwd: downloadDir, chmod: true });
+			},
+			clearOnSuccess: true,
+		});
+	} finally {
+		// Clean up temp file regardless of success or failure
+		if (await Bun.file(tmpFile).exists()) {
+			rmSync(tmpFile);
+		}
 	}
 
-	if (existsSync(outputdir)) {
-		rmSync(outputdir, { recursive: true });
-	}
-
-	if (!existsSync(releaseFilename)) {
-		throw new Error(`Failed to extract gravity binary to ${releaseFilename}`);
+	// Step 5: Verify the binary was extracted
+	if (!(await Bun.file(releaseFilename).exists())) {
+		throw new GravityExtractionError({ path: releaseFilename });
 	}
 
 	return { filename: releaseFilename, version };


### PR DESCRIPTION
## Summary

- Replaces direct `api.github.com` calls for gravity binary downloads with `agentuity.sh` proxy (fixes 401 on private repo)
- Removes `@terascope/fetch-github-release` dependency (and its transitive deps: `got`, `yargs`, `extract-zip`, `progress`, etc.)
- Uses native `fetch` with the same `agentuity.sh/release/gravity/version` + `agentuity.sh/release/gravity/{tag}/{os}/{arch}` pattern used by pilot/sdk/gluon

## Depends On

- https://github.com/agentuity/get-agentuity-sh/pull/new/fix/add-gravity-release-routes (backend routes must be deployed first)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Redesigned the Gravity binary download flow to use a stable remote endpoint and temporary archive extraction for more reliable installs
  * Improved OS/architecture detection for broader compatibility
  * Enhanced error reporting and validation for download and extraction failures
* **Chores**
  * Removed an unused dependency for GitHub release fetching
<!-- end of auto-generated comment: release notes by coderabbit.ai -->