### PR TITLE
fix(ci): use overrides instead of dependencies in canary PR comment

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -67,14 +67,16 @@ jobs:
 
                  // Build agent prompt
                  const packageList = packagesJson.map(pkg => `- ${pkg.name}`).join('\n');
-                 const agentPrompt = `Add canary overrides to root package.json and run bun install.
-
-version: ${version}
-base url: ${npmBaseUrl}
-tarball pattern: {package-name-without-scope}-${version}.tgz
-
-packages:
-${packageList}`;
+                 const agentPrompt = [
+                   'Add canary overrides to root package.json and run bun install.',
+                   '',
+                   `version: ${version}`,
+                   `base url: ${npmBaseUrl}`,
+                   `tarball pattern: {package-name-without-scope}-${version}.tgz`,
+                   '',
+                   'packages:',
+                   packageList,
+                 ].join('\n');
 
                  const body = `<!-- agentuity-canary-bot -->
                  ## 📦 Canary Packages Published


### PR DESCRIPTION
## Summary
- Changes the canary bot PR comment to show `overrides` instead of `dependencies` so packages replace across the full dependency tree
- Adds a new **Agent Prompt** collapsible section with a ready-to-paste prompt for coding agents to install the canary packages
- Removes the `bun add` direct install option since `bun add` writes to `dependencies`, not `overrides`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Agent Prompt" section to automated PR comments that includes a packages list (name, version, base URL, tarball pattern) to guide explicit name-to-URL mappings.

* **Documentation**
  * Updated installation instructions to instruct adding packages to package.json "overrides" and running the installer.
  * Install details now show an overrides-style payload and reference overrides throughout package guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->