### PR TITLE
fix: add SandboxBusyError for 409 Conflict when sandbox is executing

### DIFF
--- a/packages/server/src/api/sandbox/client.ts
+++ b/packages/server/src/api/sandbox/client.ts
@@ -244,7 +244,9 @@ export class SandboxClient {
 
 		const logger = options.logger ?? new ConsoleLogger('warn');
 
-		this.#client = new APIClient(url, logger, apiKey ?? '', {});
+		// Disable retries for sandbox operations - 409 Conflict means sandbox is busy,
+		// not a retryable rate limit. Retrying would waste ~360s (4 attempts × 90s timeout).
+		this.#client = new APIClient(url, logger, apiKey ?? '', { maxRetries: 0 });
 		this.#orgId = options.orgId;
 		this.#apiKey = apiKey;
 		this.#region = region;

--- a/packages/server/src/api/sandbox/execute.ts
+++ b/packages/server/src/api/sandbox/execute.ts
@@ -1,7 +1,7 @@
 import type { ExecuteOptions, Execution, ExecutionStatus } from '@agentuity/core';
 import { z } from 'zod';
 import { type APIClient, APIResponseSchema } from '../api';
-import { API_VERSION, throwSandboxError } from './util';
+import { API_VERSION, SandboxBusyError, throwSandboxError } from './util';
 
 export const ExecuteRequestSchema = z
 	.object({
@@ -86,13 +86,36 @@ export async function sandboxExecute(
 	const queryString = queryParams.toString();
 	const url = `/sandbox/${API_VERSION}/${sandboxId}/execute${queryString ? `?${queryString}` : ''}`;
 
-	const resp = await client.post<z.infer<typeof ExecuteResponseSchema>>(
-		url,
-		body,
-		ExecuteResponseSchema,
-		ExecuteRequestSchema,
-		signal ?? options.signal
-	);
+	let resp: z.infer<typeof ExecuteResponseSchema>;
+	try {
+		resp = await client.post<z.infer<typeof ExecuteResponseSchema>>(
+			url,
+			body,
+			ExecuteResponseSchema,
+			ExecuteRequestSchema,
+			signal ?? options.signal
+		);
+	} catch (error: unknown) {
+		// Detect 409 Conflict (sandbox busy) and throw a specific error.
+		// The sandbox API client is configured with maxRetries: 0 to fail fast
+		// when sandbox is busy (retrying wouldn't help - sandbox is still busy).
+		// Convert APIErrorResponse with status 409 to SandboxBusyError for clarity.
+		if (
+			error &&
+			typeof error === 'object' &&
+			'_tag' in error &&
+			(error as { _tag: string })._tag === 'APIErrorResponse' &&
+			'status' in error &&
+			(error as { status: number }).status === 409
+		) {
+			throw new SandboxBusyError({
+				message:
+					'Sandbox is currently busy executing another command. Please wait for the current execution to complete before submitting a new one.',
+				sandboxId,
+			});
+		}
+		throw error;
+	}
 
 	if (resp.success) {
 		return {

--- a/packages/server/src/api/sandbox/index.ts
+++ b/packages/server/src/api/sandbox/index.ts
@@ -177,6 +177,7 @@ export {
 	ExecutionCancelledError,
 	ExecutionNotFoundError,
 	ExecutionTimeoutError,
+	SandboxBusyError,
 	SandboxNotFoundError,
 	SandboxResponseError,
 	SandboxTerminatedError,

--- a/packages/server/src/api/sandbox/util.ts
+++ b/packages/server/src/api/sandbox/util.ts
@@ -12,6 +12,7 @@ interface WritableWithDrain extends EventEmitter {
 export type SandboxErrorCode =
 	| 'SANDBOX_NOT_FOUND'
 	| 'SANDBOX_TERMINATED'
+	| 'SANDBOX_BUSY'
 	| 'EXECUTION_NOT_FOUND'
 	| 'EXECUTION_TIMEOUT'
 	| 'EXECUTION_CANCELLED'
@@ -67,6 +68,29 @@ export const SandboxNotFoundError = StructuredError('SandboxNotFoundError')<{
  */
 export const SandboxTerminatedError = StructuredError('SandboxTerminatedError')<{
 	sandboxId: string;
+}>();
+
+/**
+ * Error thrown when a sandbox is currently busy executing another command.
+ *
+ * This typically occurs when a second execute request is sent before the
+ * previous execution has completed. Sandbox executions are serialized -
+ * wait for the current execution to complete before sending a new one.
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await sandbox.execute({ command: ['ls'] });
+ * } catch (error) {
+ *   if (error._tag === 'SandboxBusyError') {
+ *     console.error('Sandbox is busy, waiting for current execution to finish');
+ *     // Wait and retry, or use executionGet with long-polling to wait for completion
+ *   }
+ * }
+ * ```
+ */
+export const SandboxBusyError = StructuredError('SandboxBusyError')<{
+	sandboxId?: string;
 }>();
 
 /**
@@ -164,6 +188,7 @@ export interface SandboxErrorContext {
  * @param context - Context about the operation (sandbox ID, execution ID, etc.)
  * @throws {SandboxNotFoundError} When code is 'SANDBOX_NOT_FOUND'
  * @throws {SandboxTerminatedError} When code is 'SANDBOX_TERMINATED'
+ * @throws {SandboxBusyError} When code is 'SANDBOX_BUSY'
  * @throws {ExecutionNotFoundError} When code is 'EXECUTION_NOT_FOUND'
  * @throws {ExecutionTimeoutError} When code is 'EXECUTION_TIMEOUT'
  * @throws {ExecutionCancelledError} When code is 'EXECUTION_CANCELLED'
@@ -182,6 +207,8 @@ export function throwSandboxError(
 			throw new SandboxNotFoundError({ message: resp.message, sandboxId: sandboxId ?? '' });
 		case 'SANDBOX_TERMINATED':
 			throw new SandboxTerminatedError({ message: resp.message, sandboxId: sandboxId ?? '' });
+		case 'SANDBOX_BUSY':
+			throw new SandboxBusyError({ message: resp.message, sandboxId });
 		case 'EXECUTION_NOT_FOUND':
 			throw new ExecutionNotFoundError({
 				message: resp.message,


### PR DESCRIPTION
## Summary

- Add `SandboxBusyError` structured error type for programmatic detection
- Add `SANDBOX_BUSY` to `SandboxErrorCode` union and `throwSandboxError` switch
- Catch 409 in `sandboxExecute` and throw `SandboxBusyError` with clear message
- Disable auto-retry of 409 for sandbox operations (fast-fail via `maxRetries: 0`)

## Problem

When a user sent a second `execute` call while the first was still running, they received a generic `APIErrorResponse: Internal Server Error`. After the backend fixes (hadron + ion), the server now returns 409 Conflict — but the SDK's API client auto-retries 409 responses (for rate limiting on other endpoints). This meant sandbox users would wait through 3 retry attempts (~270s) before getting a generic error.

## Solution

1. `sandboxExecute()` wraps the API call in a try/catch and intercepts `APIErrorResponse` with status 409, throwing a specific `SandboxBusyError`
2. `SandboxClient` configures `maxRetries: 0` to disable auto-retry for sandbox operations, providing immediate fast-fail behavior
3. Users can now programmatically detect the error: `error._tag === 'SandboxBusyError'`

### Before
```
APIErrorResponse: Internal Server Error
```

### After
```
SandboxBusyError: Sandbox is currently busy executing another command.
Please wait for the current execution to complete before submitting a new one.
```

## Related PRs

This is part of a cross-repo fix:
- **hadron**: Sentinel error + 409 from HTTP handler
- **graviton**: Same changes in monorepo copy
- **ion**: Detect 409 from Hadron, propagate to SDK
- **sdk** (this PR): `SandboxBusyError` type + 409 handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error messaging when sandbox execution encounters a busy sandbox, providing clearer feedback to users.
  * Optimized sandbox operations by disabling automatic retries, reducing wait times when immediate execution is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->