### PR TITLE
fix(cli): support .route() sub-router mounts in route discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,13 +20,7 @@
 			"homepage": "https://agentuity.dev",
 			"repository": "https://github.com/agentuity/sdk",
 			"license": "Apache-2.0",
-			"keywords": [
-				"coding",
-				"agents",
-				"memory",
-				"cloud",
-				"agentuity"
-			],
+			"keywords": ["coding", "agents", "memory", "cloud", "agentuity"],
 			"category": "development"
 		}
 	]

--- a/apps/testing/svelte-web/src/generated/README.md
+++ b/apps/testing/svelte-web/src/generated/README.md
@@ -23,12 +23,14 @@ The `env.d.ts` file provides TypeScript intellisense for your environment variab
 - **ImportMetaEnv**: Only `VITE_*`, `AGENTUITY_PUBLIC_*`, and `PUBLIC_*` prefixed variables (for client-side use)
 
 Files are merged based on build mode:
+
 - **Development**: `.env.{profile}` → `.env.development` → `.env` (later files override)
 - **Production**: `.env.{profile}` → `.env` → `.env.production` (later files override)
 
 ## For Developers
 
 Do not modify these files. Instead:
+
 - Add/modify agents in `src/agent/`
 - Add/modify routes in `src/api/`
 - Configure app in `app.ts`

--- a/packages/claude-code/.claude-plugin/plugin.json
+++ b/packages/claude-code/.claude-plugin/plugin.json
@@ -9,11 +9,5 @@
 	"homepage": "https://agentuity.dev",
 	"repository": "https://github.com/agentuity/sdk",
 	"license": "Apache-2.0",
-	"keywords": [
-		"coding",
-		"agents",
-		"memory",
-		"cloud",
-		"agentuity"
-	]
+	"keywords": ["coding", "agents", "memory", "cloud", "agentuity"]
 }

--- a/packages/cli/src/cmd/build/ast.ts
+++ b/packages/cli/src/cmd/build/ast.ts
@@ -1,5 +1,5 @@
 import * as acornLoose from 'acorn-loose';
-import { dirname, relative, join, basename } from 'node:path';
+import { dirname, relative, join, basename, resolve } from 'node:path';
 import { parse as parseCronExpression } from '@datasert/cronjs-parser';
 import { generate } from 'astring';
 import type { BuildMetadata } from '../../types';
@@ -8,7 +8,7 @@ import * as ts from 'typescript';
 import { StructuredError, type WorkbenchConfig } from '@agentuity/core';
 import type { LogLevel } from '../../types';
 
-import { existsSync, mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync, statSync } from 'node:fs';
 import JSON5 from 'json5';
 import { formatSchemaCode } from './format-schema';
 import {
@@ -1408,12 +1408,56 @@ function findSchemaValidateCall(node: ASTNode): string | undefined {
 	return undefined;
 }
 
+/**
+ * Resolve an import path to an actual file on disk.
+ * Tries the path as-is, then with common extensions.
+ * Returns null for non-relative (package) imports or if no file is found.
+ */
+function resolveImportPath(fromDir: string, importPath: string): string | null {
+	// If it's a package import (not relative), skip
+	if (!importPath.startsWith('.') && !importPath.startsWith('/')) {
+		return null;
+	}
+
+	const basePath = resolve(fromDir, importPath);
+	const extensions = ['.ts', '.tsx', '/index.ts', '/index.tsx'];
+
+	// Try exact path first (might already have extension)
+	if (existsSync(basePath)) {
+		try {
+			const stat = statSync(basePath);
+			if (stat.isFile()) return basePath;
+		} catch {
+			// ignore stat errors
+		}
+	}
+
+	// Try with extensions
+	for (const ext of extensions) {
+		const candidate = basePath + ext;
+		if (existsSync(candidate)) {
+			return candidate;
+		}
+	}
+
+	return null;
+}
+
 export async function parseRoute(
 	rootDir: string,
 	filename: string,
 	projectId: string,
-	deploymentId: string
+	deploymentId: string,
+	visitedFiles?: Set<string>,
+	mountedSubrouters?: Set<string>
 ): Promise<BuildMetadata['routes']> {
+	// Track visited files to prevent infinite recursion
+	const visited = visitedFiles ?? new Set<string>();
+	const resolvedFilename = resolve(filename);
+	if (visited.has(resolvedFilename)) {
+		return []; // Already parsed this file, avoid infinite loop
+	}
+	visited.add(resolvedFilename);
 	const rawContents = await Bun.file(filename).text();
 	const version = hash(rawContents);
 	// Transpile TypeScript to JavaScript so acorn-loose can parse it properly
@@ -1607,9 +1651,101 @@ export async function parseRoute(
 							SUPPORTED_HTTP_METHODS.includes(m.toLowerCase() as SupportedHttpMethod);
 
 						switch (method) {
-							case 'use':
+							case 'use': {
+								// Skip Hono middleware - they don't represent API routes
+								continue;
+							}
 							case 'route': {
-								// Skip Hono middleware and sub-router mounting - they don't represent API routes
+								// router.route(mountPath, subRouterVariable)
+								// Follow the import to discover sub-router routes
+								const mountPathArg = statement.expression.arguments[0];
+								const subRouterArg = statement.expression.arguments[1];
+
+								// First arg must be a string literal (the mount path)
+								if (!mountPathArg || (mountPathArg as ASTLiteral).type !== 'Literal') {
+									continue;
+								}
+								// Second arg must be an identifier (the sub-router variable)
+								if (
+									!subRouterArg ||
+									(subRouterArg as ASTNodeIdentifier).type !== 'Identifier'
+								) {
+									continue;
+								}
+
+								const mountPath = String((mountPathArg as ASTLiteral).value);
+								const subRouterName = (subRouterArg as ASTNodeIdentifier).name;
+
+								// Look up import path
+								const subRouterImportPath = importMap.get(subRouterName);
+								if (!subRouterImportPath) {
+									continue; // Can't resolve, skip
+								}
+
+								// Resolve to actual file path
+								const resolvedFile = resolveImportPath(
+									dirname(filename),
+									subRouterImportPath
+								);
+								if (!resolvedFile || visited.has(resolve(resolvedFile))) {
+									continue;
+								}
+
+								try {
+									// Parse sub-router's routes
+									const subRoutes = await parseRoute(
+										rootDir,
+										resolvedFile,
+										projectId,
+										deploymentId,
+										visited,
+										mountedSubrouters
+									);
+
+									// Track this file as a mounted sub-router
+									if (mountedSubrouters) {
+										mountedSubrouters.add(resolve(resolvedFile));
+									}
+
+									// Compute the sub-router's own basePath so we can strip it
+									const subSrcDir = join(rootDir, 'src');
+									const subRelativeApiPath = extractRelativeApiPath(
+										resolvedFile,
+										subSrcDir
+									);
+									const subBasePath = computeApiMountPath(subRelativeApiPath);
+
+									// The combined mount point for sub-routes
+									const combinedBase = joinMountAndRoute(basePath, mountPath);
+
+									for (const subRoute of subRoutes) {
+										// Strip the sub-router's own basePath from the route path
+										let routeSuffix = subRoute.path;
+										if (routeSuffix.startsWith(subBasePath)) {
+											routeSuffix = routeSuffix.slice(subBasePath.length) || '/';
+										}
+
+										const fullPath = joinMountAndRoute(combinedBase, routeSuffix);
+										const id = generateRouteId(
+											projectId,
+											deploymentId,
+											subRoute.type,
+											subRoute.method,
+											rel,
+											fullPath,
+											version
+										);
+
+										routes.push({
+											...subRoute,
+											id,
+											path: fullPath,
+											filename: rel, // Keep parent file as the filename since routes are mounted here
+										});
+									}
+								} catch {
+									// Sub-router parse failure - skip silently (could be a non-route file)
+								}
 								continue;
 							}
 							case 'on': {

--- a/packages/cli/src/cmd/build/vite/config-loader.ts
+++ b/packages/cli/src/cmd/build/vite/config-loader.ts
@@ -103,8 +103,6 @@ export function hasFrameworkPlugin(userPlugins: import('vite').PluginOption[]): 
 			typeof p === 'object' &&
 			'name' in p &&
 			typeof (p as { name: unknown }).name === 'string' &&
-			FRAMEWORK_PLUGIN_PREFIXES.some((prefix) =>
-				((p as { name: string }).name).startsWith(prefix)
-			)
+			FRAMEWORK_PLUGIN_PREFIXES.some((prefix) => (p as { name: string }).name.startsWith(prefix))
 	);
 }

--- a/packages/cli/src/cmd/build/vite/route-discovery.ts
+++ b/packages/cli/src/cmd/build/vite/route-discovery.ts
@@ -85,6 +85,10 @@ export async function discoverRoutes(
 
 	const transpiler = new Bun.Transpiler({ loader: 'ts', target: 'bun' });
 
+	// Track files that are mounted as sub-routers via .route()
+	// These files will be parsed standalone AND via .route() — we need to deduplicate
+	const mountedSubrouters = new Set<string>();
+
 	// Scan all .ts files in api directory
 	const glob = new Bun.Glob('**/*.ts');
 	for await (const file of glob.scan(apiDir)) {
@@ -104,7 +108,14 @@ export async function discoverRoutes(
 			const relativeFilename = './' + relative(srcDir, filePath);
 
 			try {
-				const parsedRoutes = await parseRoute(rootDir, filePath, projectId, deploymentId);
+				const parsedRoutes = await parseRoute(
+					rootDir,
+					filePath,
+					projectId,
+					deploymentId,
+					undefined,
+					mountedSubrouters
+				);
 
 				if (parsedRoutes.length > 0) {
 					logger.trace('Discovered %d route(s) in %s', parsedRoutes.length, relativeFilename);
@@ -163,6 +174,28 @@ export async function discoverRoutes(
 		} catch (error) {
 			logger.warn(`Failed to parse route file ${filePath}: ${error}`);
 		}
+	}
+
+	// Filter out routes from standalone-parsed sub-router files
+	// When a file is mounted via .route(), its standalone routes have wrong prefixes
+	// Only the .route()-prefixed routes (attached to the parent file) are correct
+	if (mountedSubrouters.size > 0) {
+		const rootDir = join(srcDir, '..');
+		const subrouterRelPaths = new Set<string>();
+		for (const absPath of mountedSubrouters) {
+			subrouterRelPaths.add(relative(rootDir, absPath));
+		}
+
+		// Remove routes whose filename matches a sub-router file
+		// (these are the incorrectly-prefixed standalone routes)
+		const filteredRoutes = routes.filter((r) => !subrouterRelPaths.has(r.filename));
+		const filteredRouteInfoList = routeInfoList.filter((r) => !subrouterRelPaths.has(r.filename));
+
+		// Replace arrays in-place
+		routes.length = 0;
+		routes.push(...filteredRoutes);
+		routeInfoList.length = 0;
+		routeInfoList.push(...filteredRouteInfoList);
 	}
 
 	logger.debug('Discovered %d route(s)', routes.length);

--- a/packages/cli/test/cmd/build/vite/route-discovery.test.ts
+++ b/packages/cli/test/cmd/build/vite/route-discovery.test.ts
@@ -497,4 +497,151 @@ export { adminRouter };
 			expect(extractPathParams('/api/*')).toEqual([]);
 		});
 	});
+
+	describe('.route() sub-router mounting', () => {
+		test('should discover routes from .route() sub-router mounts', async () => {
+			// Create sub-router file
+			const sharedCode = `
+import { createRouter } from '@agentuity/runtime';
+
+const router = createRouter();
+
+router.get('/items', async (c) => c.json({ items: [] }));
+router.post('/items', async (c) => c.json({ created: true }));
+
+export default router;
+`;
+			writeFileSync(join(apiDir, 'shared.ts'), sharedCode);
+
+			// Create main router that mounts the sub-router
+			const mainCode = `
+import { createRouter } from '@agentuity/runtime';
+import sharedRoutes from './shared';
+
+const router = createRouter();
+
+router.get('/health', async (c) => c.json({ ok: true }));
+router.route('/shared', sharedRoutes);
+
+export default router;
+`;
+			writeFileSync(join(apiDir, 'index.ts'), mainCode);
+
+			const { routes } = await discoverRoutes(srcDir, 'test-project', 'test-deployment', logger);
+
+			// Should find /api/health from direct route
+			const healthRoute = routes.find((r) => r.path === '/api/health');
+			expect(healthRoute).toBeDefined();
+
+			// Should find /api/shared/items from sub-router mount
+			const getItems = routes.find((r) => r.path === '/api/shared/items' && r.method === 'get');
+			expect(getItems).toBeDefined();
+
+			const postItems = routes.find(
+				(r) => r.path === '/api/shared/items' && r.method === 'post'
+			);
+			expect(postItems).toBeDefined();
+		});
+
+		test('should discover routes from .route() with path parameters', async () => {
+			// Create sub-router
+			const sessionCode = `
+import { createRouter } from '@agentuity/runtime';
+
+const router = createRouter();
+
+router.get('/', async (c) => c.json({ sessions: [] }));
+router.get('/:id', async (c) => c.json({ session: {} }));
+
+export default router;
+`;
+			writeFileSync(join(apiDir, 'sessions.ts'), sessionCode);
+
+			// Main router mounts with path parameter prefix
+			const mainCode = `
+import { createRouter } from '@agentuity/runtime';
+import sessionRoutes from './sessions';
+
+const router = createRouter();
+
+router.route('/workspaces/:wid/sessions', sessionRoutes);
+
+export default router;
+`;
+			writeFileSync(join(apiDir, 'index.ts'), mainCode);
+
+			const { routes } = await discoverRoutes(srcDir, 'test-project', 'test-deployment', logger);
+
+			// Should find routes with combined path parameters
+			const listSessions = routes.find((r) => r.path === '/api/workspaces/:wid/sessions');
+			expect(listSessions).toBeDefined();
+
+			const getSession = routes.find((r) => r.path === '/api/workspaces/:wid/sessions/:id');
+			expect(getSession).toBeDefined();
+		});
+
+		test('should gracefully skip .route() with unresolvable sub-router', async () => {
+			const mainCode = `
+import { createRouter } from '@agentuity/runtime';
+import unknownRoutes from './nonexistent';
+
+const router = createRouter();
+
+router.get('/health', async (c) => c.json({ ok: true }));
+router.route('/unknown', unknownRoutes);
+
+export default router;
+`;
+			writeFileSync(join(apiDir, 'index.ts'), mainCode);
+
+			const { routes } = await discoverRoutes(srcDir, 'test-project', 'test-deployment', logger);
+
+			// Should still find the health route even though sub-router resolution failed
+			const healthRoute = routes.find((r) => r.path === '/api/health');
+			expect(healthRoute).toBeDefined();
+		});
+
+		test('should discover routes from multiple .route() mounts', async () => {
+			// Create sub-router files
+			const usersCode = `
+import { createRouter } from '@agentuity/runtime';
+const router = createRouter();
+router.get('/', async (c) => c.json({ users: [] }));
+router.post('/', async (c) => c.json({ created: true }));
+export default router;
+`;
+			writeFileSync(join(apiDir, 'users-routes.ts'), usersCode);
+
+			const postsCode = `
+import { createRouter } from '@agentuity/runtime';
+const router = createRouter();
+router.get('/', async (c) => c.json({ posts: [] }));
+export default router;
+`;
+			writeFileSync(join(apiDir, 'posts-routes.ts'), postsCode);
+
+			const mainCode = `
+import { createRouter } from '@agentuity/runtime';
+import userRoutes from './users-routes';
+import postRoutes from './posts-routes';
+
+const router = createRouter();
+router.route('/users', userRoutes);
+router.route('/posts', postRoutes);
+export default router;
+`;
+			writeFileSync(join(apiDir, 'index.ts'), mainCode);
+
+			const { routes } = await discoverRoutes(srcDir, 'test-project', 'test-deployment', logger);
+
+			const getUsers = routes.find((r) => r.path === '/api/users' && r.method === 'get');
+			expect(getUsers).toBeDefined();
+
+			const postUsers = routes.find((r) => r.path === '/api/users' && r.method === 'post');
+			expect(postUsers).toBeDefined();
+
+			const getPosts = routes.find((r) => r.path === '/api/posts' && r.method === 'get');
+			expect(getPosts).toBeDefined();
+		});
+	});
 });

--- a/packages/drizzle/src/index.ts
+++ b/packages/drizzle/src/index.ts
@@ -75,7 +75,12 @@ export {
 } from 'drizzle-orm';
 
 // Re-export Bun SQL driver types for compatibility (type-only to avoid circular dependency)
-export type { BunSQLDatabase, BunSQLPreparedQuery, BunSQLSession, BunSQLTransaction } from 'drizzle-orm/bun-sql';
+export type {
+	BunSQLDatabase,
+	BunSQLPreparedQuery,
+	BunSQLSession,
+	BunSQLTransaction,
+} from 'drizzle-orm/bun-sql';
 
 // Re-export pg-core table and column definitions
 export {

--- a/packages/runtime/src/middleware.ts
+++ b/packages/runtime/src/middleware.ts
@@ -16,13 +16,7 @@ import { runInHTTPContext } from './_context';
 import { DURATION_HEADER, TOKENS_HEADER } from './_tokens';
 import { extractTraceContextFromRequest } from './otel/http';
 import { enrichContextWithTraceState } from './otel/tracestate';
-import {
-	context,
-	SpanKind,
-	SpanStatusCode,
-	trace,
-	propagation,
-} from '@opentelemetry/api';
+import { context, SpanKind, SpanStatusCode, trace, propagation } from '@opentelemetry/api';
 import type { Meter, Tracer } from '@opentelemetry/api';
 import * as runtimeConfig from './_config';
 import { getSessionEventProvider } from './_services';


### PR DESCRIPTION
## Summary

Closes #950

- Route discovery AST parser now follows `.route(path, subRouter)` calls by resolving the imported sub-router module, recursively parsing its routes, and prefixing them with the mount path
- Adds `resolveImportPath()` helper to resolve relative imports to files on disk (tries `.ts`, `.tsx`, `/index.ts`, `/index.tsx` extensions)
- Prevents infinite recursion via a `visitedFiles` set and deduplicates standalone-parsed sub-router routes in `discoverRoutes()`
- Includes 4 new tests: basic `.route()` mounting, path parameters, unresolvable imports, and multiple mounts (27/27 tests pass)

## How it works

When the parser encounters `router.route("/shared", sharedRoutes)`:
1. Extracts the mount path (`/shared`) and sub-router variable (`sharedRoutes`)
2. Looks up the variable in the import map to find its source file
3. Resolves the import to an actual `.ts` file on disk
4. Recursively calls `parseRoute()` on the sub-router file
5. Strips the sub-router's own basePath and prefixes each route with the parent's basePath + mount path
6. `discoverRoutes()` filters out incorrectly-prefixed standalone routes from sub-router files

## Verification

- ✅ 27 tests pass (23 existing + 4 new)
- ✅ Lint clean
- ✅ Typecheck clean (all packages)
- ✅ Build clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for mounting sub-routers recursively with automatic route discovery and path parameter combination.

* **Tests**
  * New test coverage for sub-router mounting scenarios, including path parameter inheritance and error handling.

* **Style**
  * Reformatted JSON arrays and imports across configuration and type definition files for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->