### PR TITLE
fix(auth): exclude user image from JWT payload to reduce token size

### DIFF
--- a/packages/auth/src/agentuity/config.ts
+++ b/packages/auth/src/agentuity/config.ts
@@ -321,7 +321,28 @@ export interface AuthOptions extends Omit<BetterAuthOptions, 'trustedOrigins'> {
  */
 export function getDefaultPlugins(apiKeyOptions?: ApiKeyPluginOptions | false) {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const plugins: any[] = [organization(), jwt(), bearer()];
+	const plugins: any[] = [
+		organization(),
+		jwt({
+			jwt: {
+				definePayload: ({ user, session }) => ({
+					sub: user.id,
+					email: user.email,
+					name: user.name,
+					emailVerified: user.emailVerified,
+					createdAt: user.createdAt,
+					updatedAt: user.updatedAt,
+					sessionId: session.id,
+					activeOrganizationId: (session as Record<string, unknown>).activeOrganizationId,
+					// Deliberately exclude user.image to keep JWT tokens small.
+					// Profile images (especially base64-encoded data URIs from OAuth)
+					// can significantly bloat the token. Consumers should fetch the
+					// image separately via the user API if needed.
+				}),
+			},
+		}),
+		bearer(),
+	];
 
 	// Add API key plugin unless explicitly disabled
 	if (apiKeyOptions !== false) {


### PR DESCRIPTION
## Summary

- Adds `definePayload` to the JWT plugin in `getDefaultPlugins()` to explicitly control which user/session fields are included in the JWT token
- Excludes `user.image` from the payload — Google OAuth profile images are often large base64 data URIs that significantly bloat JWT tokens
- Preserves all essential fields: `sub`, `email`, `name`, `emailVerified`, `createdAt`, `updatedAt`, `sessionId`, `activeOrganizationId`

## Why

When users sign in via Google OAuth, Better Auth stores the profile image as a base64-encoded data URI. The default JWT plugin includes the full `user` object, which means every JWT token carries this large image string. This causes oversized `Authorization` headers on every API request, wasting bandwidth and potentially hitting header size limits.

## Testing

- `bun run typecheck` ✅
- `bun run build` ✅
- Consumers that need the profile image should fetch it via the user API endpoint instead of extracting it from the JWT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized JWT token configuration to streamline authentication payload structure and improve token efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->