### PR TITLE
fix(cli): resolve upgrade command hanging at npm availability check

### DIFF
--- a/packages/cli/bin/cli.ts
+++ b/packages/cli/bin/cli.ts
@@ -299,6 +299,14 @@ await registerCommands(program, commands, ctx as unknown as CommandContext);
 
 try {
 	await program.parseAsync(process.argv);
+	// Ensure clean exit after successful command execution.
+	// In TTY environments, process.stdin may keep the event loop alive
+	// (e.g., after confirm() calls resume()/setRawMode()), and Bun does not
+	// support process.stdin.unref(), so we must explicitly exit.
+	closeDatabase();
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const exit = (globalThis as any).AGENTUITY_PROCESS_EXIT || process.exit;
+	exit(0);
 } catch (error) {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const exit = (globalThis as any).AGENTUITY_PROCESS_EXIT || process.exit;

--- a/packages/cli/src/cmd/upgrade/npm-availability.ts
+++ b/packages/cli/src/cmd/upgrade/npm-availability.ts
@@ -1,14 +1,9 @@
 /**
  * npm registry availability checking utilities.
- * Used to verify a version is available via bun's resolver before attempting upgrade.
+ * Used to verify a version is available on npm before attempting upgrade.
  */
 
-import { tmpdir } from 'node:os';
-
 const PACKAGE_SPEC = '@agentuity/cli';
-
-/** Default timeout for `bun info` subprocess calls (10 seconds) */
-const BUN_INFO_TIMEOUT_MS = 10_000;
 
 /** Default timeout for install (`bun add -g`) subprocess calls (30 seconds) */
 const INSTALL_TIMEOUT_MS = 30_000;
@@ -89,28 +84,24 @@ async function withTimeout<T>(
 }
 
 /**
- * Check if a specific version of @agentuity/cli is resolvable by bun.
- * Uses `bun info` to verify bun's own resolver/CDN can see the version,
- * which avoids the race where npm registry returns 200 but bun's CDN
- * has not yet propagated the version.
+ * Check if a specific version of @agentuity/cli is available on the npm registry.
  *
  * @param version - Version to check (with or without 'v' prefix)
  * @returns true if version is available, false otherwise
  */
-export async function isVersionAvailableOnNpm(version: string): Promise<boolean> {
+export async function isVersionAvailableOnNpm(
+	version: string,
+	options?: { timeoutMs?: number }
+): Promise<boolean> {
 	const normalizedVersion = version.replace(/^v/, '');
+	const timeoutMs = options?.timeoutMs ?? 10_000;
 	try {
-		const result = await spawnWithTimeout(
-			['bun', 'info', `${PACKAGE_SPEC}@${normalizedVersion}`, '--json'],
-			{ cwd: tmpdir(), timeout: BUN_INFO_TIMEOUT_MS }
+		const response = await fetch(
+			`https://registry.npmjs.org/${PACKAGE_SPEC}/${normalizedVersion}`,
+			{ signal: AbortSignal.timeout(timeoutMs) }
 		);
-		if (result.exitCode !== 0) {
-			return false;
-		}
-		const info = JSON.parse(result.stdout.toString());
-		if (info.error) {
-			return false;
-		}
+		if (!response.ok) return false;
+		const info = (await response.json()) as { version?: string };
 		return info.version === normalizedVersion;
 	} catch {
 		return false;
@@ -118,14 +109,14 @@ export async function isVersionAvailableOnNpm(version: string): Promise<boolean>
 }
 
 /**
- * Quick check if a version is available via bun's resolver.
+ * Quick check if a version is available on npm.
  * Used for implicit version checks (auto-upgrade flow).
  *
  * @param version - Version to check (with or without 'v' prefix)
  * @returns true if version is available, false if unavailable or error
  */
 export async function isVersionAvailableOnNpmQuick(version: string): Promise<boolean> {
-	return isVersionAvailableOnNpm(version);
+	return isVersionAvailableOnNpm(version, { timeoutMs: 1_000 });
 }
 
 export interface WaitForNpmOptions {

--- a/packages/cli/test/npm-availability.test.ts
+++ b/packages/cli/test/npm-availability.test.ts
@@ -30,7 +30,9 @@ describe('npm-availability', () => {
 
 	describe('isVersionAvailableOnNpm', () => {
 		test('returns true for existing version (200 response)', async () => {
-			const mockedFetch = mockFetch(async () => new Response(null, { status: 200 }));
+			const mockedFetch = mockFetch(
+				async () => new Response(JSON.stringify({ version: '1.2.3' }), { status: 200 })
+			);
 
 			const result = await isVersionAvailableOnNpm('1.2.3');
 
@@ -39,7 +41,9 @@ describe('npm-availability', () => {
 		});
 
 		test('returns true for version with v prefix', async () => {
-			const mockedFetch = mockFetch(async () => new Response(null, { status: 200 }));
+			const mockedFetch = mockFetch(
+				async () => new Response(JSON.stringify({ version: '1.2.3' }), { status: 200 })
+			);
 
 			const result = await isVersionAvailableOnNpm('v1.2.3');
 
@@ -81,26 +85,21 @@ describe('npm-availability', () => {
 			expect(result).toBe(false);
 		});
 
-		test('uses HEAD method for efficiency', async () => {
-			const mockedFetch = mockFetch(async () => new Response(null, { status: 200 }));
-
-			await isVersionAvailableOnNpm('1.2.3');
-
-			const callArgs = mockedFetch.mock.calls[0] as [string, RequestInit | undefined];
-			expect(callArgs[1]?.method).toBe('HEAD');
-		});
-
 		test('constructs correct npm registry URL', async () => {
-			const mockedFetch = mockFetch(async () => new Response(null, { status: 200 }));
+			const mockedFetch = mockFetch(
+				async () => new Response(JSON.stringify({ version: '1.2.3' }), { status: 200 })
+			);
 
 			await isVersionAvailableOnNpm('1.2.3');
 
 			const callArgs = mockedFetch.mock.calls[0] as [string, RequestInit | undefined];
-			expect(callArgs[0]).toBe('https://registry.npmjs.org/%40agentuity%2Fcli/1.2.3');
+			expect(callArgs[0]).toBe('https://registry.npmjs.org/@agentuity/cli/1.2.3');
 		});
 
 		test('accepts custom timeout option', async () => {
-			const mockedFetch = mockFetch(async () => new Response(null, { status: 200 }));
+			const mockedFetch = mockFetch(
+				async () => new Response(JSON.stringify({ version: '1.2.3' }), { status: 200 })
+			);
 
 			const result = await isVersionAvailableOnNpm('1.2.3', { timeoutMs: 500 });
 
@@ -111,7 +110,7 @@ describe('npm-availability', () => {
 
 	describe('isVersionAvailableOnNpmQuick', () => {
 		test('returns true for existing version', async () => {
-			mockFetch(async () => new Response(null, { status: 200 }));
+			mockFetch(async () => new Response(JSON.stringify({ version: '1.2.3' }), { status: 200 }));
 
 			const result = await isVersionAvailableOnNpmQuick('1.2.3');
 
@@ -153,7 +152,7 @@ describe('npm-availability', () => {
 				// Return a promise that respects the abort signal
 				return new Promise<Response>((resolve, reject) => {
 					const timeoutId = setTimeout(() => {
-						resolve(new Response(null, { status: 200 }));
+						resolve(new Response(JSON.stringify({ version: '1.2.3' }), { status: 200 }));
 					}, TIMING.SLOW_RESPONSE_MS);
 
 					// Listen for abort
@@ -181,7 +180,9 @@ describe('npm-availability', () => {
 
 	describe('waitForNpmAvailability', () => {
 		test('returns true immediately if version is available', async () => {
-			const mockedFetch = mockFetch(async () => new Response(null, { status: 200 }));
+			const mockedFetch = mockFetch(
+				async () => new Response(JSON.stringify({ version: '1.2.3' }), { status: 200 })
+			);
 
 			const result = await waitForNpmAvailability('1.2.3');
 
@@ -197,7 +198,7 @@ describe('npm-availability', () => {
 				if (callCount === 1) {
 					return new Response(null, { status: 404 });
 				}
-				return new Response(null, { status: 200 });
+				return new Response(JSON.stringify({ version: '1.2.3' }), { status: 200 });
 			});
 
 			const result = await waitForNpmAvailability('1.2.3', {
@@ -264,7 +265,7 @@ describe('npm-availability', () => {
 		});
 
 		test('handles version with v prefix', async () => {
-			mockFetch(async () => new Response(null, { status: 200 }));
+			mockFetch(async () => new Response(JSON.stringify({ version: '1.2.3' }), { status: 200 }));
 
 			const result = await waitForNpmAvailability('v1.2.3');
 
@@ -279,7 +280,7 @@ describe('npm-availability', () => {
 				if (callCount < 6) {
 					return new Response(null, { status: 404 });
 				}
-				return new Response(null, { status: 200 });
+				return new Response(JSON.stringify({ version: '1.2.3' }), { status: 200 });
 			});
 
 			// This test would take too long with real delays, so we just verify the function works
@@ -316,7 +317,7 @@ describe('npm-availability', () => {
 				if (attemptCount <= propagationDelay) {
 					return new Response(null, { status: 404 });
 				}
-				return new Response(null, { status: 200 });
+				return new Response(JSON.stringify({ version: '0.1.43' }), { status: 200 });
 			});
 
 			const retryLog: string[] = [];
@@ -385,7 +386,7 @@ describe('npm-availability', () => {
 				// Return a promise that respects the abort signal
 				return new Promise<Response>((resolve, reject) => {
 					const timeoutId = setTimeout(() => {
-						resolve(new Response(null, { status: 200 }));
+						resolve(new Response(JSON.stringify({ version: '0.1.43' }), { status: 200 }));
 					}, TIMING.SLOW_RESPONSE_MS);
 
 					// Listen for abort
@@ -411,7 +412,9 @@ describe('npm-availability', () => {
 
 		test('simulates immediate availability - no delay needed', async () => {
 			// Best case: npm CDN already has the version
-			const mockedFetch = mockFetch(async () => new Response(null, { status: 200 }));
+			const mockedFetch = mockFetch(
+				async () => new Response(JSON.stringify({ version: '0.1.43' }), { status: 200 })
+			);
 
 			const startTime = Date.now();
 			const result = await waitForNpmAvailability('v0.1.43', {
@@ -437,7 +440,7 @@ describe('npm-availability', () => {
 					throw new Error('ECONNREFUSED');
 				}
 				// 3rd attempt: success
-				return new Response(null, { status: 200 });
+				return new Response(JSON.stringify({ version: '0.1.43' }), { status: 200 });
 			});
 
 			const result = await waitForNpmAvailability('v0.1.43', {
@@ -492,7 +495,7 @@ describe('npm-availability', () => {
 				if (attemptCount < 4) {
 					return new Response(null, { status: 404 });
 				}
-				return new Response(null, { status: 200 });
+				return new Response(JSON.stringify({ version: '0.1.43' }), { status: 200 });
 			});
 
 			const result = await waitForNpmAvailability('v0.1.43', {

--- a/packages/cli/test/upgrade.test.ts
+++ b/packages/cli/test/upgrade.test.ts
@@ -85,7 +85,7 @@ describe('upgrade command', () => {
 		});
 
 		test('isVersionAvailableOnNpm is exported and callable', async () => {
-			mockFetch(async () => new Response(null, { status: 200 }));
+			mockFetch(async () => new Response(JSON.stringify({ version: '1.0.0' }), { status: 200 }));
 
 			const result = await isVersionAvailableOnNpm('1.0.0');
 			expect(typeof result).toBe('boolean');
@@ -93,7 +93,7 @@ describe('upgrade command', () => {
 		});
 
 		test('waitForNpmAvailability is exported and callable', async () => {
-			mockFetch(async () => new Response(null, { status: 200 }));
+			mockFetch(async () => new Response(JSON.stringify({ version: '1.0.0' }), { status: 200 }));
 
 			const result = await waitForNpmAvailability('1.0.0', {
 				maxAttempts: 1,
@@ -111,7 +111,7 @@ describe('upgrade command', () => {
 		});
 
 		test('isVersionAvailableOnNpmQuick is exported for implicit version checks', async () => {
-			mockFetch(async () => new Response(null, { status: 200 }));
+			mockFetch(async () => new Response(JSON.stringify({ version: '1.0.0' }), { status: 200 }));
 
 			const result = await isVersionAvailableOnNpmQuick('1.0.0');
 			expect(typeof result).toBe('boolean');


### PR DESCRIPTION
## Summary

- **Fix `agentuity upgrade` hanging** at "Verifying npm availability..." spinner — `isVersionAvailableOnNpm()` always returned `false` because `bun info` was run from `tmpdir()` which has no `package.json`
- **Replace `bun info` subprocess** with direct `fetch` to npm registry — faster, more reliable, no filesystem dependency
- **Add explicit `process.exit(0)`** after successful command execution as safety net for TTY environments where `process.stdin` keeps Bun's event loop alive

## Root Cause

`isVersionAvailableOnNpm()` spawned `bun info @agentuity/cli@<version> --json` with `cwd: tmpdir()`. But `bun info` requires a `package.json` in the working directory, and `tmpdir()` has none — so it **always** exited with code 1:

```
error: Bun could not find a package.json file to install from
```

This caused `waitForNpmAvailability()` to retry 10 times with 5–15 second delays = **~2 minutes of the spinner spinning for nothing**.

## Changes

| File | Change |
|------|--------|
| `packages/cli/src/cmd/upgrade/npm-availability.ts` | Replace `bun info` subprocess with `fetch` to `registry.npmjs.org`; add `timeoutMs` option; give `isVersionAvailableOnNpmQuick` a 1s timeout |
| `packages/cli/bin/cli.ts` | Add `closeDatabase()` + `exit(0)` after successful `parseAsync()` |
| `packages/cli/test/npm-availability.test.ts` | Update mocks to return JSON body with `version` field; remove obsolete HEAD method test |
| `packages/cli/test/upgrade.test.ts` | Update mocks to return JSON body with `version` field |

## Before → After

| Metric | Before | After |
|--------|--------|-------|
| npm availability check result | Always `false` (broken) | ✅ Correct |
| "Verifying npm availability..." duration | **~2 minutes** | **~180ms** |
| Process exit after command in TTY | Could hang | Clean `exit(0)` |

## Testing

- 35 tests pass, 0 failures across `upgrade.test.ts` and `npm-availability.test.ts`
- End-to-end validation: `fetchLatestVersion` → `waitForNpmAvailability` → completes in <500ms total
- `bun run typecheck` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of npm package version availability checks by using direct npm registry queries.
  * Enhanced CLI shutdown process with proper database connection cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->