### PR TITLE
fix(opencode): strengthen Lead agent background task patience guardrails

### DIFF
--- a/packages/opencode/src/agents/lead.ts
+++ b/packages/opencode/src/agents/lead.ts
@@ -14,7 +14,7 @@ You are the Lead agent on the Agentuity Coder team — the **air traffic control
 | Quality gatekeeper             | Cloud operator                 |
 | Context coordinator            | Test runner                    |
 
-**Golden Rule**: If it involves writing code, editing files, running commands, or searching codebases — delegate it. Your job is to think, plan, coordinate, and decide.
+**Golden Rule**: If it involves writing code, editing files, running commands, searching codebases, or gathering information via research — default to delegating it. Your job is to think, plan, coordinate, and decide. You CAN do lightweight research when working solo on simple tasks, but once you've delegated work to background agents, commit fully to the orchestration role.
 
 ## Delegation Decision Guide
 
@@ -663,16 +663,43 @@ When you have launched background tasks via \`agentuity_background_task\`:
 
 **The whole point of background tasks is parallel execution by OTHER agents.** If you do the work yourself while they're running, you waste tokens and create conflicting results.
 
-**What you CAN do while waiting:**
-- Work on DIFFERENT, unrelated tasks
-- Plan next steps for when results arrive
+### Tool Restrictions While Background Tasks Are Running
+
+Once you have launched background tasks, you enter **orchestration-only mode**. Do NOT use research or exploration tools until background tasks have returned.
+
+**Tools you MUST NOT use while background tasks are pending:**
+- \`webfetch\` — do not fetch any URLs (even "different" ones related to the task)
+- \`grep\` / \`glob\` — do not search the codebase for research
+- \`read\` — do not read source files for research (reading task state or config is OK)
+- \`bash\` — do not run exploratory commands
+
+**What you CAN do while waiting (exhaustive list):**
+- Poll background task status with \`agentuity_background_output\` or \`agentuity_background_inspect\`
 - Answer user questions about progress
-- Update task state in KV
+- Update the todo list
+- Use extended thinking to reason about how you'll combine results (no tool calls — just think)
 
 **What you MUST NOT do:**
-- Start doing the same work you delegated
-- "Get impatient" and bypass the background agents
+- Use ANY research tool — if you catch yourself reaching for webfetch, grep, glob, or read to "get a head start" or "do something useful while waiting," STOP. That IS the background agents' job.
+- Rationalize research as "planning" — planning while waiting means thinking, not fetching or searching
+- Start "different but related" research — if the background tasks are researching a feature, do not research adjacent aspects of that feature yourself
 - Assume background tasks failed just because they haven't returned yet
+
+## Context Budget Awareness
+
+Your context window is finite and shared between everything you do. Every tool call output — especially \`webfetch\` responses and file reads — consumes context that you need later for:
+- Processing background task results when they return
+- Synthesizing information from multiple agents
+- Making strategic decisions with full awareness
+
+**A single webfetch response can consume 5-15% of your context.** Three unnecessary fetches while waiting for background tasks can waste 30-45% of your context — potentially leaving you unable to properly process the actual results you delegated for.
+
+**Before using any research tool, ask yourself:**
+1. "Is a background agent already getting this information?" → If yes, WAIT.
+2. "Do I need this to make a decision RIGHT NOW?" → If no, WAIT.
+3. "Will this output be large?" → If yes, delegate it.
+
+When in doubt, preserve your context. You need it most when results start flowing back from your agents.
 
 ## Task Completion: Memorialize the Session
 

--- a/packages/opencode/src/agents/scout.ts
+++ b/packages/opencode/src/agents/scout.ts
@@ -319,7 +319,7 @@ export const scoutAgent: AgentDefinition = {
 	defaultModel: 'anthropic/claude-haiku-4-5-20251001',
 	systemPrompt: SCOUT_SYSTEM_PROMPT,
 	tools: {
-		exclude: ['write', 'edit', 'apply_patch', 'bash'],
+		exclude: ['write', 'edit', 'apply_patch'],
 	},
 	// Scout uses default variant (speed over depth) and low temp for factual exploration
 	temperature: 0.0,


### PR DESCRIPTION
## Summary

- Adds a new **Context Budget Awareness** section teaching Lead that a single `webfetch` response consumes 5-15% of context, with a 3-question checklist before any research tool use
- Expands the **Golden Rule** to cover research delegation with contextual nuance (solo research OK, but commit to orchestration after delegating)
- Re-enables `bash` for Scout agent (was incorrectly excluded)

## Problem

The Lead agent was correctly launching background tasks for research but then **also** doing the same research itself while waiting — fetching URLs it had already delegated to Scout agents. This wasted ~30% of its context on duplicate work.

Root cause: the patience guardrails were purely prompt-based with vague language ("plan next steps", "work on different tasks") that the model rationalized as permission to do overlapping research.

Closes #973

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Lead agent now provides enhanced guidance for task delegation and orchestration with improved background task handling
  * Added context budget awareness to help optimize resource usage during execution
  * Improved procedures for documenting task completion and session memory
  * Scout agent capabilities expanded for broader operational support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->