### PR TITLE
fix(cli): skip Hono lifecycle and config methods in route parser

### DIFF
--- a/packages/cli/src/cmd/build/ast.ts
+++ b/packages/cli/src/cmd/build/ast.ts
@@ -1651,8 +1651,12 @@ export async function parseRoute(
 							SUPPORTED_HTTP_METHODS.includes(m.toLowerCase() as SupportedHttpMethod);
 
 						switch (method) {
-							case 'use': {
-								// Skip Hono middleware - they don't represent API routes
+							case 'use':
+							case 'onError':
+							case 'notFound':
+							case 'basePath':
+							case 'mount': {
+								// Skip Hono middleware, lifecycle handlers, and configuration methods - they don't represent API routes
 								continue;
 							}
 							case 'route': {

--- a/packages/cli/test/ast.test.ts
+++ b/packages/cli/test/ast.test.ts
@@ -296,6 +296,109 @@ export default router;
 
 		cleanup();
 	});
+
+	test('should skip Hono lifecycle and config methods (onError, notFound, basePath, mount)', async () => {
+		setup();
+		const routeFile = join(API_DIR, 'route.ts');
+		const code = `
+import { createRouter } from '@agentuity/runtime';
+
+const router = createRouter();
+
+// Hono lifecycle and config methods should be silently skipped
+router.onError((err, c) => c.json({ error: 'Internal error' }, 500));
+router.notFound((c) => c.json({ error: 'Not found' }, 404));
+router.basePath('/v1');
+router.mount('/external', (req) => new Response('external'));
+
+// Regular route should still be parsed
+router.get('/health', (c) => c.json({ status: 'ok' }));
+
+export default router;
+		`;
+		writeFileSync(routeFile, code);
+
+		const routes = await parseRoute(TEST_DIR, routeFile, 'proj_1', 'dep_1');
+		// Only the GET /health route should be parsed, lifecycle/config methods should be skipped
+		expect(routes).toHaveLength(1);
+		expect(routes[0].method).toBe('get');
+		expect(routes[0].path).toBe('/api/health');
+
+		cleanup();
+	});
+
+	test('should skip basePath() when setting router base path', async () => {
+		setup();
+		const routeFile = join(API_DIR, 'route.ts');
+		const code = `
+import { createRouter } from '@agentuity/runtime';
+
+const router = createRouter();
+
+// basePath() is a config method, not a route
+router.basePath('/api/v1');
+
+router.get('/users', (c) => c.json({ users: [] }));
+
+export default router;
+		`;
+		writeFileSync(routeFile, code);
+
+		const routes = await parseRoute(TEST_DIR, routeFile, 'proj_1', 'dep_1');
+		expect(routes).toHaveLength(1);
+		expect(routes[0].path).toBe('/api/users');
+
+		cleanup();
+	});
+
+	test('should skip mount() when mounting external applications', async () => {
+		setup();
+		const routeFile = join(API_DIR, 'route.ts');
+		const code = `
+import { createRouter } from '@agentuity/runtime';
+
+const router = createRouter();
+
+// mount() is for mounting external apps, not defining routes
+router.mount('/external', (req) => new Response('from external app'));
+
+router.post('/internal', (c) => c.json({ source: 'internal' }));
+
+export default router;
+		`;
+		writeFileSync(routeFile, code);
+
+		const routes = await parseRoute(TEST_DIR, routeFile, 'proj_1', 'dep_1');
+		expect(routes).toHaveLength(1);
+		expect(routes[0].method).toBe('post');
+		expect(routes[0].path).toBe('/api/internal');
+
+		cleanup();
+	});
+
+	test('should skip notFound() 404 handler', async () => {
+		setup();
+		const routeFile = join(API_DIR, 'route.ts');
+		const code = `
+import { createRouter } from '@agentuity/runtime';
+
+const router = createRouter();
+
+// notFound() is a lifecycle method for 404 handling
+router.notFound((c) => c.text('Custom 404', 404));
+
+router.get('/exists', (c) => c.text('Found'));
+
+export default router;
+		`;
+		writeFileSync(routeFile, code);
+
+		const routes = await parseRoute(TEST_DIR, routeFile, 'proj_1', 'dep_1');
+		expect(routes).toHaveLength(1);
+		expect(routes[0].path).toBe('/api/exists');
+
+		cleanup();
+	});
 });
 
 describe('analyzeWorkbench - Detection Scenarios', () => {


### PR DESCRIPTION
## Summary

- Skip Hono lifecycle methods (`onError`, `notFound`) and configuration methods (`basePath`, `mount`) in the CLI's AST route parser instead of throwing `InvalidRouterConfigError`
- These are valid Hono API methods that don't represent API routes, so they should be silently ignored during build — same as the existing `use` middleware case

## Problem

Users registering Hono lifecycle handlers like `router.onError(...)` or `router.notFound(...)` in their route files got a build error:

```
[WARN] Failed to parse route file: InvalidRouterConfigError: unsupported router method onError
```

## Changes

**`packages/cli/src/cmd/build/ast.ts`**
- Added `onError`, `notFound`, `basePath`, and `mount` as fall-through cases alongside `use` in the router method switch statement

**`packages/cli/test/ast.test.ts`**
- Added 4 new test cases covering all skipped methods (30 total AST tests, all passing)

## Verification

- ✅ All 30 AST tests pass
- ✅ Typecheck clean
- ✅ Build clean
- ✅ Invalid methods like `router.foo(...)` still correctly throw errors

Closes #978

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed API route parsing to correctly exclude Hono middleware and configuration methods (onError, notFound, basePath, mount) from being identified as routes, improving accuracy in CLI builds.

## Tests
* Added comprehensive tests verifying correct handling of lifecycle and configuration methods during route parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->