### PR TITLE
fix(cli): normalize Windows backslash paths in generated files and cross-platform utilities

### DIFF
--- a/packages/cli/src/agent-detection.ts
+++ b/packages/cli/src/agent-detection.ts
@@ -342,7 +342,7 @@ let cachedResult: string | undefined | null = null;
  */
 function matchAgentPath(path: string): string | undefined {
 	// Extract basename from path
-	const basename = path.split('/').pop()?.toLowerCase() ?? '';
+	const basename = path.split(/[/\\]/).pop()?.toLowerCase() ?? '';
 	for (const [processName, agentName] of KNOWN_AGENTS) {
 		if (basename.includes(processName)) {
 			return agentName;
@@ -375,7 +375,7 @@ function matchAgentCmdline(cmdline: string): string | undefined {
 		const isSimpleCommand = !part.includes('/') && !part.includes('=') && part.length < 50;
 
 		if (isPath || isSimpleCommand) {
-			const basename = part.split('/').pop()?.toLowerCase() ?? '';
+			const basename = part.split(/[/\\]/).pop()?.toLowerCase() ?? '';
 			for (const [processName, agentName] of KNOWN_AGENTS) {
 				if (basename.includes(processName)) {
 					return agentName;

--- a/packages/cli/src/bun-path.ts
+++ b/packages/cli/src/bun-path.ts
@@ -21,6 +21,7 @@ export async function ensureBunOnPath(): Promise<void> {
 	// Check if bun exists in $HOME/.bun/bin
 	if (await Bun.file(bunPath).exists()) {
 		// Add to PATH for this process
-		process.env.PATH = process.env.PATH ? `${bunBinDir}:${process.env.PATH}` : bunBinDir;
+		const pathSep = process.platform === 'win32' ? ';' : ':';
+		process.env.PATH = process.env.PATH ? `${bunBinDir}${pathSep}${process.env.PATH}` : bunBinDir;
 	}
 }

--- a/packages/cli/src/cmd/build/ast.ts
+++ b/packages/cli/src/cmd/build/ast.ts
@@ -11,6 +11,7 @@ import type { LogLevel } from '../../types';
 import { existsSync, mkdirSync, statSync } from 'node:fs';
 import JSON5 from 'json5';
 import { formatSchemaCode } from './format-schema';
+import { toForwardSlash } from '../../utils/normalize-path';
 import {
 	computeApiMountPath,
 	joinMountAndRoute,
@@ -488,7 +489,7 @@ export async function parseEvalMetadata(
 		ecmaVersion: 'latest',
 		sourceType: 'module',
 	});
-	const rel = relative(rootDir, filename);
+	const rel = toForwardSlash(relative(rootDir, filename));
 	const version = hash(contents);
 	const evals: Array<{
 		filename: string;
@@ -706,7 +707,7 @@ export async function parseAgentMetadata(
 		sourceType: 'module',
 	});
 	let exportName: string | undefined;
-	const rel = relative(rootDir, filename);
+	const rel = toForwardSlash(relative(rootDir, filename));
 	let name: string | undefined; // Will be set from createAgent identifier
 	const version = hash(contents);
 	const id = getAgentId(projectId, deploymentId, rel, version);
@@ -910,7 +911,7 @@ export async function parseAgentMetadata(
 		| 'error';
 	const logger = createLogger(logLevel);
 	const agentDir = dirname(filename);
-	const evalsPath = `${agentDir}/eval.ts`;
+	const evalsPath = join(agentDir, 'eval.ts');
 	logger.trace(`Checking for evals file at ${evalsPath}`);
 	const evalsFile = Bun.file(evalsPath);
 	if (await evalsFile.exists()) {
@@ -1599,7 +1600,7 @@ export async function parseRoute(
 		});
 	}
 
-	const rel = relative(rootDir, filename);
+	const rel = toForwardSlash(relative(rootDir, filename));
 
 	// Compute the API mount path using the shared helper
 	// This ensures consistency between route type generation (here) and runtime mounting (entry-generator.ts)
@@ -2703,7 +2704,7 @@ export async function generateLifecycleTypes(
 	// local dev (symlinked to packages/) and CI (actual node_modules)
 	if (existsSync(runtimePkgPath)) {
 		// Calculate relative path from src/generated/ to node_modules package
-		const relPath = relative(outDir, runtimePkgPath);
+		const relPath = toForwardSlash(relative(outDir, runtimePkgPath));
 		runtimeImportPath = relPath;
 		logger.debug(`Using relative path to runtime package: ${relPath}`);
 	} else {

--- a/packages/cli/src/cmd/build/vite/agent-discovery.ts
+++ b/packages/cli/src/cmd/build/vite/agent-discovery.ts
@@ -11,6 +11,7 @@ import { dirname, join, relative } from 'node:path';
 import { existsSync } from 'node:fs';
 import type { Logger } from '../../../types';
 import { formatSchemaCode } from '../format-schema';
+import { toForwardSlash } from '../../../utils/normalize-path';
 
 interface ASTNode {
 	type: string;
@@ -728,7 +729,7 @@ export async function discoverAgents(
 
 			// Use 'src/' prefix for consistency with bun bundler and registry imports
 			const rootDir = join(srcDir, '..');
-			const relativeFilename = relative(rootDir, filePath);
+			const relativeFilename = toForwardSlash(relative(rootDir, filePath));
 			const agentMetadata = extractAgentMetadata(
 				contents,
 				relativeFilename,
@@ -763,7 +764,7 @@ export async function discoverAgents(
 				// 2. Check for evals in separate eval.ts file in same directory
 				const agentDir = dirname(filePath);
 				const evalsPath = join(agentDir, 'eval.ts');
-				const relativeEvalsPath = relative(rootDir, evalsPath);
+				const relativeEvalsPath = toForwardSlash(relative(rootDir, evalsPath));
 				const evalsInSeparateFile = await extractEvalMetadata(
 					evalsPath,
 					relativeEvalsPath,

--- a/packages/cli/src/cmd/build/vite/metadata-generator.ts
+++ b/packages/cli/src/cmd/build/vite/metadata-generator.ts
@@ -11,6 +11,7 @@ import type { z } from 'zod';
 import type { AgentMetadata } from './agent-discovery';
 import type { RouteMetadata } from './route-discovery';
 import type { Logger, DeployOptions } from '../../../types';
+import { toForwardSlash } from '../../../utils/normalize-path';
 import { getVersion } from '../../../version';
 import { getGitInfo, buildGitTags } from '../../../utils/git';
 
@@ -174,7 +175,7 @@ export interface MetadataGeneratorOptions {
  */
 function normalizeImportKey(path: string): string {
 	// Strip leading './' or 'src/' or '@'
-	let p = path.replace(/^src\//, '');
+	let p = toForwardSlash(path).replace(/^src\//, '');
 	if (p.startsWith('./')) p = p.slice(2);
 	if (p.startsWith('@')) p = p.slice(1);
 

--- a/packages/cli/src/cmd/build/vite/registry-generator.ts
+++ b/packages/cli/src/cmd/build/vite/registry-generator.ts
@@ -9,6 +9,7 @@ import { writeFileSync, mkdirSync, existsSync, unlinkSync, readFileSync } from '
 import { stat } from 'node:fs/promises';
 import { StructuredError } from '@agentuity/core';
 import { toCamelCase, toPascalCase } from '../../../utils/string';
+import { toForwardSlash } from '../../../utils/normalize-path';
 import type { AgentMetadata } from './agent-discovery';
 import type { RouteInfo } from './route-discovery';
 
@@ -27,7 +28,7 @@ function rebaseImportPath(routeFilename: string, schemaImportPath: string, srcDi
 
 	// Normalize route filename to get its directory relative to srcDir
 	let routeDir: string;
-	const cleanFilename = routeFilename.replace(/\\/g, '/');
+	const cleanFilename = toForwardSlash(routeFilename);
 	if (cleanFilename.startsWith('./')) {
 		routeDir = dirname(join(srcDir, cleanFilename.substring(2)));
 	} else if (cleanFilename.startsWith('src/')) {
@@ -41,7 +42,7 @@ function rebaseImportPath(routeFilename: string, schemaImportPath: string, srcDi
 
 	// Calculate the relative path from src/generated/ to the resolved schema path
 	const generatedDir = join(srcDir, 'generated');
-	let rebasedPath = relative(generatedDir, resolvedSchemaPath).replace(/\\/g, '/');
+	let rebasedPath = toForwardSlash(relative(generatedDir, resolvedSchemaPath));
 
 	// Ensure it starts with './' or '../'
 	if (!rebasedPath.startsWith('.') && !rebasedPath.startsWith('/')) {
@@ -136,7 +137,7 @@ export function generateAgentRegistry(srcDir: string, agents: AgentMetadata[]): 
 				if (evalMeta.filename === agent.filename) continue;
 
 				// Build the relative path for the eval file
-				let evalRelativePath = evalMeta.filename;
+				let evalRelativePath = toForwardSlash(evalMeta.filename);
 				if (evalRelativePath.startsWith('./agent/')) {
 					evalRelativePath = evalRelativePath
 						.replace(/^\.\/agent\//, '../agent/')
@@ -165,7 +166,7 @@ export function generateAgentRegistry(srcDir: string, agents: AgentMetadata[]): 
 		.map(({ name, filename }) => {
 			const camelName = toCamelCase(name);
 			// Handle both './agent/...' and 'src/agent/...' formats
-			let relativePath = filename;
+			let relativePath = toForwardSlash(filename);
 			if (relativePath.startsWith('./agent/')) {
 				// ./agent/foo.ts -> ../agent/foo.js (use .js extension for TypeScript)
 				relativePath = relativePath
@@ -716,7 +717,8 @@ export async function generateRouteRegistry(
 				resolvedPath = `../api/${finalPath}`;
 			} else if (resolvedPath.startsWith('./') || resolvedPath.startsWith('../')) {
 				// Resolve relative import from route file's directory
-				const routeDir = route.filename.substring(0, route.filename.lastIndexOf('/'));
+				const normalizedFilename = toForwardSlash(route.filename);
+				const routeDir = normalizedFilename.substring(0, normalizedFilename.lastIndexOf('/'));
 				// Join and normalize the path
 				const joined = `${routeDir}/${resolvedPath}`;
 				// Normalize by resolving .. and . segments
@@ -784,7 +786,7 @@ export async function generateRouteRegistry(
 						: (route.inputSchemaImportedName ?? route.inputSchemaVariable);
 			} else {
 				// Schema is locally defined - import from the route file
-				const filename = route.filename.replace(/\\/g, '/');
+				const filename = toForwardSlash(route.filename);
 				const withoutSrc = filename.startsWith('src/') ? filename.substring(4) : filename;
 				const withoutLeadingDot = withoutSrc.startsWith('./')
 					? withoutSrc.substring(2)
@@ -819,7 +821,7 @@ export async function generateRouteRegistry(
 						: (route.outputSchemaImportedName ?? route.outputSchemaVariable);
 			} else {
 				// Schema is locally defined - import from the route file
-				const filename = route.filename.replace(/\\/g, '/');
+				const filename = toForwardSlash(route.filename);
 				const withoutSrc = filename.startsWith('src/') ? filename.substring(4) : filename;
 				const withoutLeadingDot = withoutSrc.startsWith('./')
 					? withoutSrc.substring(2)

--- a/packages/cli/src/cmd/build/vite/route-discovery.ts
+++ b/packages/cli/src/cmd/build/vite/route-discovery.ts
@@ -9,6 +9,7 @@ import { join, relative } from 'node:path';
 import { existsSync } from 'node:fs';
 import type { Logger } from '../../../types';
 import { parseRoute } from '../ast';
+import { toForwardSlash } from '../../../utils/normalize-path';
 
 export interface RouteMetadata {
 	id: string;
@@ -105,7 +106,7 @@ export async function discoverRoutes(
 			}
 
 			const rootDir = join(srcDir, '..');
-			const relativeFilename = './' + relative(srcDir, filePath);
+			const relativeFilename = './' + toForwardSlash(relative(srcDir, filePath));
 
 			try {
 				const parsedRoutes = await parseRoute(
@@ -183,7 +184,7 @@ export async function discoverRoutes(
 		const rootDir = join(srcDir, '..');
 		const subrouterRelPaths = new Set<string>();
 		for (const absPath of mountedSubrouters) {
-			subrouterRelPaths.add(relative(rootDir, absPath));
+			subrouterRelPaths.add(toForwardSlash(relative(rootDir, absPath)));
 		}
 
 		// Remove routes whose filename matches a sub-router file

--- a/packages/cli/src/cmd/cloud/sandbox/cp.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/cp.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { readFileSync, writeFileSync, mkdirSync, statSync, readdirSync } from 'node:fs';
 import { dirname, resolve, basename, join, relative } from 'node:path';
 import { createCommand } from '../../../types';
+import { toForwardSlash } from '../../../utils/normalize-path';
 import * as tui from '../../../tui';
 import { createSandboxClient } from './util';
 import { getCommand } from '../../../command-prefix';
@@ -265,7 +266,7 @@ async function uploadDirectory(
 		: effectiveRemotePath;
 
 	for (const filePath of allFiles) {
-		const relativePath = relative(localDir, filePath);
+		const relativePath = toForwardSlash(relative(localDir, filePath));
 		const targetPath = `${baseRemotePath}/${relativePath}`;
 		const buffer = readFileSync(filePath);
 		files.push({ path: targetPath, content: buffer });

--- a/packages/cli/src/utils/detectSubagent.ts
+++ b/packages/cli/src/utils/detectSubagent.ts
@@ -1,3 +1,5 @@
+import { toForwardSlash } from './normalize-path';
+
 /**
  * Detects if a file path represents a subagent based on path structure.
  *
@@ -18,6 +20,9 @@ export function detectSubagent(
 	if (srcDir && normalizedPath.startsWith(srcDir)) {
 		normalizedPath = normalizedPath.replace(srcDir, '');
 	}
+
+	// Normalize path separators for cross-platform compatibility
+	normalizedPath = toForwardSlash(normalizedPath);
 
 	// Strip leading './' and split into parts, filtering out empty segments
 	const pathParts = normalizedPath.replace(/^\.\//, '').split('/').filter(Boolean);

--- a/packages/cli/src/utils/normalize-path.ts
+++ b/packages/cli/src/utils/normalize-path.ts
@@ -1,0 +1,12 @@
+/**
+ * Normalize path separators to forward slashes for cross-platform compatibility.
+ *
+ * On Windows, Node.js path functions (relative, resolve, join) return backslashes.
+ * JavaScript import paths, zip entry names, and remote file paths must use forward slashes.
+ *
+ * @param p - The path to normalize
+ * @returns The path with all backslashes replaced by forward slashes
+ */
+export function toForwardSlash(p: string): string {
+	return p.replace(/\\/g, '/');
+}

--- a/packages/cli/src/utils/zip.ts
+++ b/packages/cli/src/utils/zip.ts
@@ -1,6 +1,7 @@
 import { relative } from 'node:path';
 import { Glob } from 'bun';
 import AdmZip from 'adm-zip';
+import { toForwardSlash } from './normalize-path';
 
 interface Options {
 	progress?: (val: number) => void;
@@ -15,7 +16,7 @@ export async function zipDir(dir: string, outdir: string, options?: Options) {
 	const total = files.length;
 	let count = 0;
 	for (const file of files) {
-		const rel = relative(dir, file);
+		const rel = toForwardSlash(relative(dir, file));
 		let skip = false;
 		if (options?.filter) {
 			if (!options.filter(file, rel)) {


### PR DESCRIPTION
## Summary

- Fixes Windows path separator issues that corrupt JavaScript import paths in generated files (`router.ts`, `registry.ts`), causing TypeScript type-checking and Bun bundler resolution to fail on Windows and cloud deployment via GitHub push.
- Introduces a centralized `toForwardSlash()` utility and applies it systematically across the CLI package — at the source (discovery layer), in code-gen consumers, and in cross-platform utilities.

## Changes

### New File
| File | Purpose |
|------|---------|
| `packages/cli/src/utils/normalize-path.ts` | `toForwardSlash()` utility — replaces scattered `.replace(/\\/g, '/')` pattern |

### Modified Files (10)

| File | Fix |
|------|-----|
| `agent-discovery.ts` | Normalize `relativeFilename` and `relativeEvalsPath` at source |
| `route-discovery.ts` | Normalize route filenames and subrouter paths at source |
| `registry-generator.ts` | Fix eval import paths, route directory extraction; refactor 5 inline normalizations |
| `ast.ts` | Normalize `rel` for consistent agent/eval/route IDs; use `join()` for eval path |
| `metadata-generator.ts` | Normalize import key before `.startsWith()` checks |
| `detectSubagent.ts` | Normalize path before `.split('/')` for subagent detection |
| `zip.ts` | Normalize zip entry names (forward slashes required by ZIP spec) |
| `sandbox/cp.ts` | Normalize remote file paths for sandbox uploads |
| `bun-path.ts` | Platform-appropriate PATH separator (`;` on Windows, `:` on Unix) |
| `agent-detection.ts` | Split on both `/` and `\` for process path basename extraction |

## Fix Strategy

**Normalize at the source** — `agent-discovery.ts` and `route-discovery.ts` always produce forward-slash paths, fixing all downstream consumers automatically. Individual fixes for non-discovery issues (zip, sandbox cp, PATH separator, process detection).

## Verification

- ✅ `bun run format`
- ✅ `bun run lint`
- ✅ `bun run typecheck`
- ✅ `bun run build`

Closes #980

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced cross-platform path handling to properly support both Windows and Unix-style file paths throughout the CLI.
  * Standardized internal path representations to use consistent forward-slash format across all platforms.
  * Improved PATH environment variable handling with platform-specific separators for Windows compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->