### PR TITLE
fix(cli): prevent project import and cloud env commands from wiping local .env

### DIFF
--- a/packages/cli/src/cmd/cloud/env/delete.ts
+++ b/packages/cli/src/cmd/cloud/env/delete.ts
@@ -2,12 +2,7 @@ import { z } from 'zod';
 import { createSubcommand } from '../../../types';
 import * as tui from '../../../tui';
 import { projectEnvDelete, projectGet, orgEnvDelete, orgEnvGet } from '@agentuity/server';
-import {
-	findExistingEnvFile,
-	readEnvFile,
-	writeEnvFile,
-	isReservedAgentuityKey,
-} from '../../../env-util';
+import { isReservedAgentuityKey } from '../../../env-util';
 import { getCommand } from '../../../command-prefix';
 import { ErrorCode } from '../../../errors';
 import { resolveOrgId, isOrgScope } from './org-util';
@@ -15,10 +10,6 @@ import { resolveOrgId, isOrgScope } from './org-util';
 const EnvDeleteResponseSchema = z.object({
 	success: z.boolean().describe('Whether the operation succeeded'),
 	keys: z.array(z.string()).describe('Variable keys that were deleted'),
-	path: z
-		.string()
-		.optional()
-		.describe('Local file path where variables were removed (project scope only)'),
 	secrets: z.array(z.string()).describe('Keys that were secrets'),
 	env: z.array(z.string()).describe('Keys that were environment variables'),
 	scope: z.enum(['project', 'org']).describe('The scope from which the variables were deleted'),
@@ -61,7 +52,7 @@ export const deleteSubcommand = createSubcommand({
 	},
 
 	async handler(ctx) {
-		const { args, project, projectDir, apiClient, config, opts } = ctx;
+		const { args, project, apiClient, config, opts } = ctx;
 		const useOrgScope = isOrgScope(opts?.org);
 		const keys = args.key;
 
@@ -174,38 +165,16 @@ export const deleteSubcommand = createSubcommand({
 				});
 			});
 
-			// Update local .env file only if we have a project directory and an existing .env file
-			let envFilePath: string | undefined;
-			if (projectDir) {
-				envFilePath = await findExistingEnvFile(projectDir);
-				if (envFilePath) {
-					const currentEnv = await readEnvFile(envFilePath);
-					const originalKeyCount = Object.keys(currentEnv).length;
-					for (const key of [...secretKeys, ...envKeys]) {
-						delete currentEnv[key];
-					}
-					// Only write if we actually removed keys (avoid creating empty file)
-					const keysRemoved = originalKeyCount > Object.keys(currentEnv).length;
-					if (keysRemoved) {
-						await writeEnvFile(envFilePath, currentEnv, { preserveExisting: false });
-					}
-				}
-			}
-
 			const deletedKeys = [...secretKeys, ...envKeys];
 			if (notFoundKeys.length > 0) {
 				tui.warning(`Variables not found (skipped): ${notFoundKeys.join(', ')}`);
 			}
 
-			const locationMsg = envFilePath ? ` (cloud + ${envFilePath})` : ' (cloud only)';
-			tui.success(
-				`Deleted ${deletedKeys.length} variable(s): ${deletedKeys.join(', ')}${locationMsg}`
-			);
+			tui.success(`Deleted ${deletedKeys.length} variable(s): ${deletedKeys.join(', ')}`);
 
 			return {
 				success: true,
 				keys: deletedKeys,
-				path: envFilePath,
 				secrets: secretKeys,
 				env: envKeys,
 				scope: 'project' as const,

--- a/packages/cli/src/cmd/cloud/env/import.ts
+++ b/packages/cli/src/cmd/cloud/env/import.ts
@@ -3,9 +3,7 @@ import { createSubcommand } from '../../../types';
 import * as tui from '../../../tui';
 import { projectEnvUpdate, orgEnvUpdate } from '@agentuity/server';
 import {
-	findExistingEnvFile,
 	readEnvFile,
-	writeEnvFile,
 	filterAgentuitySdkKeys,
 	splitEnvAndSecrets,
 	validateNoPublicSecrets,
@@ -19,17 +17,13 @@ const EnvImportResponseSchema = z.object({
 	envCount: z.number().describe('Number of env vars imported'),
 	secretCount: z.number().describe('Number of secrets imported'),
 	skipped: z.number().describe('Number of items skipped'),
-	path: z
-		.string()
-		.optional()
-		.describe('Local file path where variables were saved (project scope only)'),
 	file: z.string().describe('Source file path'),
 	scope: z.enum(['project', 'org']).describe('The scope where variables were imported'),
 });
 
 export const importSubcommand = createSubcommand({
 	name: 'import',
-	description: 'Import environment variables and secrets from a file to cloud and local .env',
+	description: 'Import environment variables and secrets from a file to cloud',
 	tags: ['mutating', 'creates-resource', 'slow', 'api-intensive', 'requires-auth'],
 	examples: [
 		{
@@ -62,7 +56,7 @@ export const importSubcommand = createSubcommand({
 	},
 
 	async handler(ctx) {
-		const { args, apiClient, project, projectDir, config, opts } = ctx;
+		const { args, apiClient, project, config, opts } = ctx;
 		const useOrgScope = isOrgScope(opts?.org);
 
 		// Require project context if not using org scope
@@ -161,15 +155,6 @@ export const importSubcommand = createSubcommand({
 				});
 			});
 
-			// Merge with local .env file only if we have a project directory
-			let localEnvPath: string | undefined;
-			if (projectDir) {
-				localEnvPath = await findExistingEnvFile(projectDir);
-				// writeEnvFile preserves existing keys by default, so just write the filtered vars
-				// This will merge with existing .env content, preserving AGENTUITY_SDK_KEY and other keys
-				await writeEnvFile(localEnvPath, filteredVars);
-			}
-
 			tui.success(
 				`Imported ${totalCount} variable${totalCount !== 1 ? 's' : ''} from ${args.file} (${envCount} env, ${secretCount} secret${secretCount !== 1 ? 's' : ''})`
 			);
@@ -180,7 +165,6 @@ export const importSubcommand = createSubcommand({
 				envCount,
 				secretCount,
 				skipped: Object.keys(importedVars).length - totalCount,
-				path: localEnvPath,
 				file: args.file,
 				scope: 'project' as const,
 			};

--- a/packages/cli/src/cmd/cloud/env/set.ts
+++ b/packages/cli/src/cmd/cloud/env/set.ts
@@ -3,8 +3,6 @@ import { createSubcommand } from '../../../types';
 import * as tui from '../../../tui';
 import { projectEnvUpdate, orgEnvUpdate } from '@agentuity/server';
 import {
-	findExistingEnvFile,
-	writeEnvFile,
 	looksLikeSecret,
 	isReservedAgentuityKey,
 	isPublicVarKey,
@@ -75,10 +73,6 @@ function parseEnvArgs(rawArgs: string[]): ParsedEnvPair[] {
 const EnvSetResponseSchema = z.object({
 	success: z.boolean().describe('Whether the operation succeeded'),
 	keys: z.array(z.string()).describe('Environment variable keys that were set'),
-	path: z
-		.string()
-		.optional()
-		.describe('Local file path where env vars were saved (project scope only)'),
 	secretKeys: z.array(z.string()).describe('Keys that were stored as secrets'),
 	envKeys: z.array(z.string()).describe('Keys that were stored as env vars'),
 	scope: z.enum(['project', 'org']).describe('The scope where the variables were set'),
@@ -134,7 +128,7 @@ export const setSubcommand = createSubcommand({
 	},
 
 	async handler(ctx) {
-		const { args: cmdArgs, opts, apiClient, project, projectDir, config } = ctx;
+		const { args: cmdArgs, opts, apiClient, project, config } = ctx;
 		const useOrgScope = isOrgScope(opts?.org);
 		const forceSecret = opts?.secret ?? false;
 
@@ -262,26 +256,13 @@ export const setSubcommand = createSubcommand({
 				}
 			);
 
-			// Update local .env file only if we have a project directory
-			let envFilePath: string | undefined;
-			if (projectDir) {
-				envFilePath = await findExistingEnvFile(projectDir);
-				const allPairsForLocal: Record<string, string> = {
-					...envPairs,
-					...secretPairs,
-				};
-				await writeEnvFile(envFilePath, allPairsForLocal);
-			}
-
-			const locationMsg = envFilePath ? ` (cloud + ${envFilePath})` : ' (cloud only)';
 			tui.success(
-				`Variable${totalCount !== 1 ? 's' : ''} set successfully: ${allKeys.join(', ')}${secretSuffix}${locationMsg}`
+				`Variable${totalCount !== 1 ? 's' : ''} set successfully: ${allKeys.join(', ')}${secretSuffix}`
 			);
 
 			return {
 				success: true,
 				keys: allKeys,
-				path: envFilePath,
 				secretKeys: secretKeysList,
 				envKeys: envKeysList,
 				scope: 'project' as const,

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -19,6 +19,7 @@ import {
 	deleteAuthFromKeychain,
 } from './keychain';
 import { clearProfileCache } from './cache';
+import { readEnvFile, writeEnvFile } from './env-util';
 
 export const defaultProfileName = 'production';
 
@@ -634,12 +635,20 @@ export async function createProjectConfig(dir: string, config: InitialProjectCon
 	};
 	await Bun.write(configPath, JSON.stringify(configData, null, 2) + '\n');
 
-	// generate the .env file with initial secret
+	// generate or update the .env file with SDK key
 	const envPath = join(dir, '.env');
-	const comment =
-		'# AGENTUITY_SDK_KEY is a sensitive value and should not be committed to version control.';
-	const content = `${comment}\nAGENTUITY_SDK_KEY=${sdkKey}\n`;
-	await Bun.write(envPath, content);
+	const envFile = Bun.file(envPath);
+	if (await envFile.exists()) {
+		// Preserve existing .env content, just update SDK key
+		const existing = await readEnvFile(envPath);
+		existing.AGENTUITY_SDK_KEY = sdkKey;
+		await writeEnvFile(envPath, existing, { preserveExisting: false });
+	} else {
+		const comment =
+			'# AGENTUITY_SDK_KEY is a sensitive value and should not be committed to version control.';
+		const content = `${comment}\nAGENTUITY_SDK_KEY=${sdkKey}\n`;
+		await Bun.write(envPath, content);
+	}
 	await chmod(envPath, 0o600);
 
 	// generate the vscode settings (only if they don't already exist)

--- a/packages/cli/test/config/create-project-config.test.ts
+++ b/packages/cli/test/config/create-project-config.test.ts
@@ -1,0 +1,111 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createProjectConfig } from '../../src/config';
+import { readEnvFile } from '../../src/env-util';
+
+let testDir: string;
+
+beforeEach(async () => {
+	testDir = await mkdtemp(join(tmpdir(), 'agentuity-create-project-'));
+});
+
+afterEach(async () => {
+	await rm(testDir, { recursive: true, force: true });
+});
+
+function makeConfig(sdkKey: string) {
+	return {
+		projectId: 'proj_test123',
+		orgId: 'org_test123',
+		sdkKey,
+		region: 'us-east-1',
+	};
+}
+
+describe('createProjectConfig > .env handling', () => {
+	test('creates new .env file when none exists', async () => {
+		await createProjectConfig(testDir, makeConfig('test-sdk-key-new'));
+
+		const envPath = join(testDir, '.env');
+		const env = await readEnvFile(envPath);
+		expect(env.AGENTUITY_SDK_KEY).toBe('test-sdk-key-new');
+
+		// Verify the comment header is present in the raw file
+		const raw = await Bun.file(envPath).text();
+		expect(raw).toContain('# AGENTUITY_SDK_KEY is a sensitive value');
+		expect(raw).toContain('AGENTUITY_SDK_KEY=test-sdk-key-new');
+	});
+
+	test('preserves existing .env content when updating SDK key', async () => {
+		// Set up existing .env with multiple variables
+		const envPath = join(testDir, '.env');
+		await Bun.write(
+			envPath,
+			'BASE_URL=http://127.0.0.1:3500\nNODE_ENV=development\nAGENTUITY_SDK_KEY=old-key\n'
+		);
+
+		await createProjectConfig(testDir, makeConfig('new-sdk-key'));
+
+		const env = await readEnvFile(envPath);
+		expect(env.AGENTUITY_SDK_KEY).toBe('new-sdk-key');
+		expect(env.BASE_URL).toBe('http://127.0.0.1:3500');
+		expect(env.NODE_ENV).toBe('development');
+	});
+
+	test('preserves existing .env when no SDK key existed before', async () => {
+		// Set up existing .env without an SDK key
+		const envPath = join(testDir, '.env');
+		await Bun.write(envPath, 'BASE_URL=http://127.0.0.1:3500\nAPI_SECRET=mysecret\n');
+
+		await createProjectConfig(testDir, makeConfig('brand-new-key'));
+
+		const env = await readEnvFile(envPath);
+		expect(env.AGENTUITY_SDK_KEY).toBe('brand-new-key');
+		expect(env.BASE_URL).toBe('http://127.0.0.1:3500');
+		expect(env.API_SECRET).toBe('mysecret');
+	});
+
+	test('sets .env file permissions to 0600', async () => {
+		await createProjectConfig(testDir, makeConfig('test-key'));
+
+		const envPath = join(testDir, '.env');
+		const stat = await Bun.file(envPath).stat();
+		// Check that only owner has read/write (0o600 = 384 decimal)
+		// Use bitwise AND with 0o777 to get just the permission bits
+		expect(stat.mode & 0o777).toBe(0o600);
+	});
+});
+
+describe('createProjectConfig > agentuity.json', () => {
+	test('creates agentuity.json with correct structure', async () => {
+		await createProjectConfig(testDir, makeConfig('test-sdk-key'));
+
+		const configPath = join(testDir, 'agentuity.json');
+		const raw = await Bun.file(configPath).text();
+		const config = JSON.parse(raw);
+
+		expect(config.$schema).toBe('https://agentuity.dev/schema/cli/v1/agentuity.json');
+		expect(config.projectId).toBe('proj_test123');
+		expect(config.orgId).toBe('org_test123');
+		expect(config.region).toBe('us-east-1');
+		expect(config.deployment).toBeDefined();
+		expect(config.deployment.resources).toBeDefined();
+		expect(config.deployment.resources.memory).toBe('500Mi');
+		expect(config.deployment.resources.cpu).toBe('500m');
+		expect(config.deployment.resources.disk).toBe('500Mi');
+	});
+
+	test('does not include sdkKey in agentuity.json', async () => {
+		await createProjectConfig(testDir, makeConfig('secret-key'));
+
+		const configPath = join(testDir, 'agentuity.json');
+		const raw = await Bun.file(configPath).text();
+		const config = JSON.parse(raw);
+
+		expect(config.sdkKey).toBeUndefined();
+		// Also make sure it doesn't appear in the raw JSON at all
+		expect(raw).not.toContain('secret-key');
+	});
+});


### PR DESCRIPTION
## Summary

- **Fix `createProjectConfig()` overwriting `.env`** — was unconditionally replacing the entire file with only the SDK key during project import, destroying all other environment variables
- **Remove local `.env` side effects from `cloud env set/import/delete`** — these commands now only modify cloud state; users use `cloud env pull` to explicitly sync cloud → local
- **Add tests** for `createProjectConfig()` `.env` preservation behavior

## Root Causes

**Root Cause 1 (project import wipe):** `createProjectConfig()` in `config.ts` used `Bun.write()` to create a new `.env` with *only* `AGENTUITY_SDK_KEY`, called *after* `updateSdkKeyInEnv()` had already correctly preserved the file. The sequence was:
1. `updateSdkKeyInEnv()` ✅ reads `.env`, adds SDK key, preserves everything
2. `createProjectConfig()` ❌ then wipes `.env` to just the SDK key
3. `syncEnvToProject()` reads the now-wiped `.env`, so cloud sync was also wrong

**Root Cause 2 (cloud env set overwrite):** `cloud env set`, `cloud env import`, and `cloud env delete` all wrote to the local `.env` as a side effect. Running `agentuity cloud env set BASE_URL "https://prod.example.com"` would overwrite `BASE_URL=http://localhost:3500` in the local `.env`.

## Changes

| File | Change |
|------|--------|
| `packages/cli/src/config.ts` | `createProjectConfig()` now checks if `.env` exists and preserves content (only adds/updates SDK key) |
| `packages/cli/src/cmd/cloud/env/set.ts` | Removed local `.env` write — cloud only |
| `packages/cli/src/cmd/cloud/env/import.ts` | Removed local `.env` write — cloud only |
| `packages/cli/src/cmd/cloud/env/delete.ts` | Removed local `.env` delete — cloud only |
| `packages/cli/test/config/create-project-config.test.ts` | New: 6 tests for `.env` preservation |

## Behavior After Fix

| Command | Behavior | Modifies local `.env`? |
|---------|----------|----------------------|
| `cloud env set` | Cloud only | ❌ No |
| `cloud env delete` | Cloud only | ❌ No |
| `cloud env import` | File → Cloud only | ❌ No |
| `cloud env push` | Local → Cloud | ❌ No (reads only) |
| `cloud env pull` | Cloud → Local | ✅ Yes (explicit sync) |
| `project import` | Preserves existing `.env`, updates SDK key | ✅ SDK key only |

## Testing

- ✅ Unit tests: 6 new tests for `createProjectConfig()` all pass
- ✅ Existing tests: 999 pass (31 pre-existing failures unrelated to this change)
- ✅ Build passes, typecheck passes
- ✅ **Manual E2E testing** against production (Jeff Test org):
  - `cloud env set` — verified local `.env` checksum unchanged
  - `cloud env set --secret` — verified local `.env` checksum unchanged
  - `cloud env set` multi-var — verified local `.env` checksum unchanged
  - `cloud env push` — verified local vars sent to cloud, `.env` unchanged
  - `cloud env pull` — verified new cloud vars added, local values preserved
  - `cloud env pull --force` — verified cloud values overwrite local (expected)
  - `cloud env delete` single + multi — verified deleted from cloud, local `.env` unchanged
  - `cloud env import` from file — verified imported to cloud, local `.env` unchanged
  - `createProjectConfig()` with existing `.env` — verified all 9 vars preserved
  - `createProjectConfig()` without `.env` — verified new file created correctly

Closes #961

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Environment variable deletion, import, and set commands now operate exclusively on cloud storage and no longer modify local .env files.
  * Project configuration now preserves existing .env file content while updating necessary values, instead of overwriting.

* **New Features**
  * Environment variable deletion now reports keys not found in the requested scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->