### PR TITLE
feat: add --name flag to CLI storage create command

### DIFF
--- a/packages/cli/src/cmd/cloud/storage/create.ts
+++ b/packages/cli/src/cmd/cloud/storage/create.ts
@@ -116,6 +116,9 @@ export const createSubcommand = defineSubcommand({
 						ErrorCode.INVALID_ARGUMENT
 					);
 				}
+				if (ex.status === 400) {
+					tui.fatal(ex.message || 'invalid bucket name', ErrorCode.INVALID_ARGUMENT);
+				}
 			}
 			throw ex;
 		}

--- a/packages/server/src/api/region/create.ts
+++ b/packages/server/src/api/region/create.ts
@@ -103,6 +103,13 @@ export function validateBucketName(name: string): { valid: boolean; error?: stri
 	if (isIPv4Address(name)) {
 		return { valid: false, error: 'bucket name cannot be an IP address' };
 	}
+	// Reserved prefixes (system-generated names)
+	if (name.startsWith('ag-') || name.startsWith('ago-')) {
+		return {
+			valid: false,
+			error: 'bucket names starting with "ag-" or "ago-" are reserved for system use',
+		};
+	}
 	return { valid: true };
 }
 


### PR DESCRIPTION
## Summary
- Add optional `--name` flag to `agentuity cloud storage create` for custom bucket names
- Validates names using `validateBucketName()`, handles 409 conflicts with user-friendly messages
- Follows the existing pattern from the `cloud db create` command

## Changes
- **CLI** (`storage/create.ts`): Added `--name` flag with validation, 409 error handling, and dry-run support

## Related PRs
- Ion: agentuity/ion (backend API + migration + deploy workflow)
- App: agentuity/app (UI dialog changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional --name flag to specify a custom bucket name when creating cloud storage; example usage updated.

* **Improvements**
  * Stronger bucket-name validation (now disallows reserved prefixes) with clear INVALID_ARGUMENT feedback.
  * Better handling and user guidance for duplicate names.
  * Creation and dry-run messages now show the chosen bucket name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->