### PR TITLE
fix(cli,runtime): add comprehensive MIME type mappings for static assets

### DIFF
--- a/apps/testing/cloud-deployment/src/generated/app.ts
+++ b/apps/testing/cloud-deployment/src/generated/app.ts
@@ -27,6 +27,7 @@ import {
   bootstrapRuntimeEnv,
   patchBunS3ForStorageDev,
   runShutdown,
+  mimeTypes,
 } from '@agentuity/runtime';
 import type { Context } from 'hono';
 import { websocket, serveStatic } from 'hono/bun';
@@ -429,48 +430,11 @@ if (isDevelopment()) {
 	
 	app.get('/', prodHtmlHandler);
 
-	// Extended MIME types for types Hono may not recognize
-	const customMimes: Record<string, string> = {
-		md: 'text/markdown',
-		markdown: 'text/markdown',
-		txt: 'text/plain',
-		csv: 'text/csv',
-		ics: 'text/calendar',
-		vcf: 'text/vcard',
-		yaml: 'text/yaml',
-		yml: 'text/yaml',
-		avif: 'image/avif',
-		jxl: 'image/jxl',
-		apng: 'image/apng',
-		otf: 'font/otf',
-		aac: 'audio/aac',
-		flac: 'audio/flac',
-		opus: 'audio/opus',
-		m4a: 'audio/mp4',
-		weba: 'audio/webm',
-		mkv: 'video/x-matroska',
-		mov: 'video/quicktime',
-		doc: 'application/msword',
-		docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-		xls: 'application/vnd.ms-excel',
-		xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-		ppt: 'application/vnd.ms-powerpoint',
-		pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-		odt: 'application/vnd.oasis.opendocument.text',
-		ods: 'application/vnd.oasis.opendocument.spreadsheet',
-		odp: 'application/vnd.oasis.opendocument.presentation',
-		rtf: 'application/rtf',
-		webmanifest: 'application/manifest+json',
-		wasm: 'application/wasm',
-		glb: 'model/gltf-binary',
-		gltf: 'model/gltf+json',
-	};
-
 	// Serve static assets from /assets/* (Vite bundled output)
-	app.use('/assets/*', serveStatic({ root: import.meta.dir + '/client', mimes: customMimes }));
+	app.use('/assets/*', serveStatic({ root: import.meta.dir + '/client', mimes: mimeTypes }));
 
 	// Serve static public assets (favicon.ico, robots.txt, etc.)
-	app.use('/*', serveStatic({ root: import.meta.dir + '/client', rewriteRequestPath: (path) => path, mimes: customMimes }));
+	app.use('/*', serveStatic({ root: import.meta.dir + '/client', rewriteRequestPath: (path) => path, mimes: mimeTypes }));
 
 	// 404 for unmatched API/system routes (IMPORTANT: comes before SPA fallback)
 	app.all('/_agentuity/*', (c: Context) => c.notFound());

--- a/apps/testing/e2e-web/src/generated/app.ts
+++ b/apps/testing/e2e-web/src/generated/app.ts
@@ -27,6 +27,7 @@ import {
   bootstrapRuntimeEnv,
   patchBunS3ForStorageDev,
   runShutdown,
+  mimeTypes,
 } from '@agentuity/runtime';
 import type { Context } from 'hono';
 import { websocket, serveStatic } from 'hono/bun';
@@ -437,48 +438,11 @@ if (isDevelopment()) {
 	
 	app.get('/', prodHtmlHandler);
 
-	// Extended MIME types for types Hono may not recognize
-	const customMimes: Record<string, string> = {
-		md: 'text/markdown',
-		markdown: 'text/markdown',
-		txt: 'text/plain',
-		csv: 'text/csv',
-		ics: 'text/calendar',
-		vcf: 'text/vcard',
-		yaml: 'text/yaml',
-		yml: 'text/yaml',
-		avif: 'image/avif',
-		jxl: 'image/jxl',
-		apng: 'image/apng',
-		otf: 'font/otf',
-		aac: 'audio/aac',
-		flac: 'audio/flac',
-		opus: 'audio/opus',
-		m4a: 'audio/mp4',
-		weba: 'audio/webm',
-		mkv: 'video/x-matroska',
-		mov: 'video/quicktime',
-		doc: 'application/msword',
-		docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-		xls: 'application/vnd.ms-excel',
-		xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-		ppt: 'application/vnd.ms-powerpoint',
-		pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-		odt: 'application/vnd.oasis.opendocument.text',
-		ods: 'application/vnd.oasis.opendocument.spreadsheet',
-		odp: 'application/vnd.oasis.opendocument.presentation',
-		rtf: 'application/rtf',
-		webmanifest: 'application/manifest+json',
-		wasm: 'application/wasm',
-		glb: 'model/gltf-binary',
-		gltf: 'model/gltf+json',
-	};
-
 	// Serve static assets from /assets/* (Vite bundled output)
-	app.use('/assets/*', serveStatic({ root: import.meta.dir + '/client', mimes: customMimes }));
+	app.use('/assets/*', serveStatic({ root: import.meta.dir + '/client', mimes: mimeTypes }));
 
 	// Serve static public assets (favicon.ico, robots.txt, etc.)
-	app.use('/*', serveStatic({ root: import.meta.dir + '/client', rewriteRequestPath: (path) => path, mimes: customMimes }));
+	app.use('/*', serveStatic({ root: import.meta.dir + '/client', rewriteRequestPath: (path) => path, mimes: mimeTypes }));
 
 	// 404 for unmatched API/system routes (IMPORTANT: comes before SPA fallback)
 	app.all('/_agentuity/*', (c: Context) => c.notFound());

--- a/apps/testing/integration-suite/src/generated/app.ts
+++ b/apps/testing/integration-suite/src/generated/app.ts
@@ -27,6 +27,7 @@ import {
   bootstrapRuntimeEnv,
   patchBunS3ForStorageDev,
   runShutdown,
+  mimeTypes,
 } from '@agentuity/runtime';
 import type { Context } from 'hono';
 import { websocket, serveStatic } from 'hono/bun';
@@ -445,48 +446,11 @@ if (isDevelopment()) {
 	
 	app.get('/', prodHtmlHandler);
 
-	// Extended MIME types for types Hono may not recognize
-	const customMimes: Record<string, string> = {
-		md: 'text/markdown',
-		markdown: 'text/markdown',
-		txt: 'text/plain',
-		csv: 'text/csv',
-		ics: 'text/calendar',
-		vcf: 'text/vcard',
-		yaml: 'text/yaml',
-		yml: 'text/yaml',
-		avif: 'image/avif',
-		jxl: 'image/jxl',
-		apng: 'image/apng',
-		otf: 'font/otf',
-		aac: 'audio/aac',
-		flac: 'audio/flac',
-		opus: 'audio/opus',
-		m4a: 'audio/mp4',
-		weba: 'audio/webm',
-		mkv: 'video/x-matroska',
-		mov: 'video/quicktime',
-		doc: 'application/msword',
-		docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-		xls: 'application/vnd.ms-excel',
-		xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-		ppt: 'application/vnd.ms-powerpoint',
-		pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-		odt: 'application/vnd.oasis.opendocument.text',
-		ods: 'application/vnd.oasis.opendocument.spreadsheet',
-		odp: 'application/vnd.oasis.opendocument.presentation',
-		rtf: 'application/rtf',
-		webmanifest: 'application/manifest+json',
-		wasm: 'application/wasm',
-		glb: 'model/gltf-binary',
-		gltf: 'model/gltf+json',
-	};
-
 	// Serve static assets from /assets/* (Vite bundled output)
-	app.use('/assets/*', serveStatic({ root: import.meta.dir + '/client', mimes: customMimes }));
+	app.use('/assets/*', serveStatic({ root: import.meta.dir + '/client', mimes: mimeTypes }));
 
 	// Serve static public assets (favicon.ico, robots.txt, etc.)
-	app.use('/*', serveStatic({ root: import.meta.dir + '/client', rewriteRequestPath: (path) => path, mimes: customMimes }));
+	app.use('/*', serveStatic({ root: import.meta.dir + '/client', rewriteRequestPath: (path) => path, mimes: mimeTypes }));
 
 	// 404 for unmatched API/system routes (IMPORTANT: comes before SPA fallback)
 	app.all('/_agentuity/*', (c: Context) => c.notFound());

--- a/apps/testing/svelte-web/src/generated/app.ts
+++ b/apps/testing/svelte-web/src/generated/app.ts
@@ -27,6 +27,7 @@ import {
   bootstrapRuntimeEnv,
   patchBunS3ForStorageDev,
   runShutdown,
+  mimeTypes,
 } from '@agentuity/runtime';
 import type { Context } from 'hono';
 import { websocket, serveStatic } from 'hono/bun';
@@ -433,48 +434,11 @@ if (isDevelopment()) {
 	
 	app.get('/', prodHtmlHandler);
 
-	// Extended MIME types for types Hono may not recognize
-	const customMimes: Record<string, string> = {
-		md: 'text/markdown',
-		markdown: 'text/markdown',
-		txt: 'text/plain',
-		csv: 'text/csv',
-		ics: 'text/calendar',
-		vcf: 'text/vcard',
-		yaml: 'text/yaml',
-		yml: 'text/yaml',
-		avif: 'image/avif',
-		jxl: 'image/jxl',
-		apng: 'image/apng',
-		otf: 'font/otf',
-		aac: 'audio/aac',
-		flac: 'audio/flac',
-		opus: 'audio/opus',
-		m4a: 'audio/mp4',
-		weba: 'audio/webm',
-		mkv: 'video/x-matroska',
-		mov: 'video/quicktime',
-		doc: 'application/msword',
-		docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-		xls: 'application/vnd.ms-excel',
-		xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-		ppt: 'application/vnd.ms-powerpoint',
-		pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-		odt: 'application/vnd.oasis.opendocument.text',
-		ods: 'application/vnd.oasis.opendocument.spreadsheet',
-		odp: 'application/vnd.oasis.opendocument.presentation',
-		rtf: 'application/rtf',
-		webmanifest: 'application/manifest+json',
-		wasm: 'application/wasm',
-		glb: 'model/gltf-binary',
-		gltf: 'model/gltf+json',
-	};
-
 	// Serve static assets from /assets/* (Vite bundled output)
-	app.use('/assets/*', serveStatic({ root: import.meta.dir + '/client', mimes: customMimes }));
+	app.use('/assets/*', serveStatic({ root: import.meta.dir + '/client', mimes: mimeTypes }));
 
 	// Serve static public assets (favicon.ico, robots.txt, etc.)
-	app.use('/*', serveStatic({ root: import.meta.dir + '/client', rewriteRequestPath: (path) => path, mimes: customMimes }));
+	app.use('/*', serveStatic({ root: import.meta.dir + '/client', rewriteRequestPath: (path) => path, mimes: mimeTypes }));
 
 	// 404 for unmatched API/system routes (IMPORTANT: comes before SPA fallback)
 	app.all('/_agentuity/*', (c: Context) => c.notFound());

--- a/packages/cli/src/cmd/build/entry-generator.ts
+++ b/packages/cli/src/cmd/build/entry-generator.ts
@@ -87,6 +87,10 @@ export async function generateEntryFile(options: GenerateEntryOptions): Promise<
 		`  runShutdown,`,
 	];
 
+	if (hasWebFrontend) {
+		runtimeImports.push(`  mimeTypes,`);
+	}
+
 	const imports = [
 		`import { `,
 		...runtimeImports,
@@ -407,48 +411,11 @@ ${
 	
 	app.get('/', prodHtmlHandler);
 
-	// Extended MIME types for types Hono may not recognize
-	const customMimes: Record<string, string> = {
-		md: 'text/markdown',
-		markdown: 'text/markdown',
-		txt: 'text/plain',
-		csv: 'text/csv',
-		ics: 'text/calendar',
-		vcf: 'text/vcard',
-		yaml: 'text/yaml',
-		yml: 'text/yaml',
-		avif: 'image/avif',
-		jxl: 'image/jxl',
-		apng: 'image/apng',
-		otf: 'font/otf',
-		aac: 'audio/aac',
-		flac: 'audio/flac',
-		opus: 'audio/opus',
-		m4a: 'audio/mp4',
-		weba: 'audio/webm',
-		mkv: 'video/x-matroska',
-		mov: 'video/quicktime',
-		doc: 'application/msword',
-		docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-		xls: 'application/vnd.ms-excel',
-		xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-		ppt: 'application/vnd.ms-powerpoint',
-		pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-		odt: 'application/vnd.oasis.opendocument.text',
-		ods: 'application/vnd.oasis.opendocument.spreadsheet',
-		odp: 'application/vnd.oasis.opendocument.presentation',
-		rtf: 'application/rtf',
-		webmanifest: 'application/manifest+json',
-		wasm: 'application/wasm',
-		glb: 'model/gltf-binary',
-		gltf: 'model/gltf+json',
-	};
-
 	// Serve static assets from /assets/* (Vite bundled output)
-	app.use('/assets/*', serveStatic({ root: import.meta.dir + '/client', mimes: customMimes }));
+	app.use('/assets/*', serveStatic({ root: import.meta.dir + '/client', mimes: mimeTypes }));
 
 	// Serve static public assets (favicon.ico, robots.txt, etc.)
-	app.use('/*', serveStatic({ root: import.meta.dir + '/client', rewriteRequestPath: (path) => path, mimes: customMimes }));
+	app.use('/*', serveStatic({ root: import.meta.dir + '/client', rewriteRequestPath: (path) => path, mimes: mimeTypes }));
 
 	// 404 for unmatched API/system routes (IMPORTANT: comes before SPA fallback)
 	app.all('/_agentuity/*', (c: Context) => c.notFound());

--- a/packages/cli/src/cmd/build/vite/metadata-generator.ts
+++ b/packages/cli/src/cmd/build/vite/metadata-generator.ts
@@ -6,7 +6,7 @@
 
 import { join } from 'node:path';
 import { writeFileSync, mkdirSync, existsSync, readFileSync, statSync, readdirSync } from 'node:fs';
-import { type BuildMetadata, DeploymentConfig } from '@agentuity/server';
+import { type BuildMetadata, DeploymentConfig, getContentType } from '@agentuity/server';
 import type { z } from 'zod';
 import type { AgentMetadata } from './agent-discovery';
 import type { RouteMetadata } from './route-discovery';
@@ -29,108 +29,6 @@ interface AssetInfo {
 	contentType: string;
 	size: number;
 	contentEncoding?: string;
-}
-
-const mimeTypes: Record<string, string> = {
-	// Text and code
-	css: 'text/css',
-	csv: 'text/csv',
-	htm: 'text/html',
-	html: 'text/html',
-	ics: 'text/calendar',
-	js: 'application/javascript',
-	mjs: 'application/javascript',
-	cjs: 'application/javascript',
-	json: 'application/json',
-	jsonld: 'application/ld+json',
-	map: 'application/json',
-	md: 'text/markdown',
-	markdown: 'text/markdown',
-	txt: 'text/plain',
-	text: 'text/plain',
-	vcf: 'text/vcard',
-	xml: 'application/xml',
-	yaml: 'text/yaml',
-	yml: 'text/yaml',
-
-	// Images
-	apng: 'image/apng',
-	avif: 'image/avif',
-	bmp: 'image/bmp',
-	gif: 'image/gif',
-	ico: 'image/x-icon',
-	jpeg: 'image/jpeg',
-	jpg: 'image/jpeg',
-	jxl: 'image/jxl',
-	png: 'image/png',
-	svg: 'image/svg+xml',
-	tif: 'image/tiff',
-	tiff: 'image/tiff',
-	webp: 'image/webp',
-
-	// Fonts
-	eot: 'application/vnd.ms-fontobject',
-	otf: 'font/otf',
-	ttf: 'font/ttf',
-	woff: 'font/woff',
-	woff2: 'font/woff2',
-
-	// Audio
-	aac: 'audio/aac',
-	flac: 'audio/flac',
-	m4a: 'audio/mp4',
-	mid: 'audio/midi',
-	midi: 'audio/midi',
-	mp3: 'audio/mpeg',
-	ogg: 'audio/ogg',
-	oga: 'audio/ogg',
-	opus: 'audio/opus',
-	wav: 'audio/wav',
-	weba: 'audio/webm',
-
-	// Video
-	avi: 'video/x-msvideo',
-	m4v: 'video/mp4',
-	mkv: 'video/x-matroska',
-	mov: 'video/quicktime',
-	mp4: 'video/mp4',
-	ogv: 'video/ogg',
-	webm: 'video/webm',
-
-	// Documents and archives
-	doc: 'application/msword',
-	docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-	gz: 'application/gzip',
-	odp: 'application/vnd.oasis.opendocument.presentation',
-	ods: 'application/vnd.oasis.opendocument.spreadsheet',
-	odt: 'application/vnd.oasis.opendocument.text',
-	pdf: 'application/pdf',
-	ppt: 'application/vnd.ms-powerpoint',
-	pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-	rtf: 'application/rtf',
-	tar: 'application/x-tar',
-	xls: 'application/vnd.ms-excel',
-	xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-	zip: 'application/zip',
-	'7z': 'application/x-7z-compressed',
-
-	// Web and application
-	atom: 'application/atom+xml',
-	glb: 'model/gltf-binary',
-	gltf: 'model/gltf+json',
-	rss: 'application/rss+xml',
-	wasm: 'application/wasm',
-	webmanifest: 'application/manifest+json',
-	xsl: 'application/xslt+xml',
-	xslt: 'application/xslt+xml',
-};
-
-function getContentType(filename: string): string {
-	const ext = filename.split('.').pop()?.toLowerCase();
-	if (ext && ext in mimeTypes) {
-		return mimeTypes[ext]!;
-	}
-	return 'application/octet-stream';
 }
 
 /**

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -256,10 +256,10 @@ export type { RouteSchema, GetRouteSchema } from './_validation';
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface AppState {}
 
-// Re-export bootstrapRuntimeEnv from @agentuity/server for convenience
+// Re-export bootstrapRuntimeEnv and mimeTypes from @agentuity/server for convenience
 // This allows generated code to import from @agentuity/runtime instead of having
 // a direct dependency on @agentuity/server
-export { bootstrapRuntimeEnv, type RuntimeBootstrapOptions } from '@agentuity/server';
+export { bootstrapRuntimeEnv, type RuntimeBootstrapOptions, mimeTypes } from '@agentuity/server';
 
 // bun-s3-patch.ts exports
 export { patchBunS3ForStorageDev, isAgentuityStorageEndpoint } from './bun-s3-patch';

--- a/packages/runtime/src/web.ts
+++ b/packages/runtime/src/web.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { serveStatic } from 'hono/bun';
 import { join, relative } from 'node:path';
 import { existsSync } from 'node:fs';
+import { mimeTypes } from '@agentuity/server';
 
 /**
  * Create a router that serves the web application.
@@ -64,48 +65,11 @@ export async function createWebRouter(): Promise<Hono> {
 			relIndexPath = './' + relIndexPath;
 		}
 
-		// Extended MIME types for types Hono may not recognize
-		const customMimes: Record<string, string> = {
-			md: 'text/markdown',
-			markdown: 'text/markdown',
-			txt: 'text/plain',
-			csv: 'text/csv',
-			ics: 'text/calendar',
-			vcf: 'text/vcard',
-			yaml: 'text/yaml',
-			yml: 'text/yaml',
-			avif: 'image/avif',
-			jxl: 'image/jxl',
-			apng: 'image/apng',
-			otf: 'font/otf',
-			aac: 'audio/aac',
-			flac: 'audio/flac',
-			opus: 'audio/opus',
-			m4a: 'audio/mp4',
-			weba: 'audio/webm',
-			mkv: 'video/x-matroska',
-			mov: 'video/quicktime',
-			doc: 'application/msword',
-			docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-			xls: 'application/vnd.ms-excel',
-			xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-			ppt: 'application/vnd.ms-powerpoint',
-			pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-			odt: 'application/vnd.oasis.opendocument.text',
-			ods: 'application/vnd.oasis.opendocument.spreadsheet',
-			odp: 'application/vnd.oasis.opendocument.presentation',
-			rtf: 'application/rtf',
-			webmanifest: 'application/manifest+json',
-			wasm: 'application/wasm',
-			glb: 'model/gltf-binary',
-			gltf: 'model/gltf+json',
-		};
-
 		// Serve static files from .agentuity/client/
-		router.use('/*', serveStatic({ root: relClientDir, mimes: customMimes }));
+		router.use('/*', serveStatic({ root: relClientDir, mimes: mimeTypes }));
 
 		// Fallback to index.html for SPA routing
-		router.get('*', serveStatic({ path: relIndexPath, mimes: customMimes }));
+		router.get('*', serveStatic({ path: relIndexPath, mimes: mimeTypes }));
 	}
 
 	return router;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -13,6 +13,9 @@ export { createServerFetchAdapter } from './server';
 // schema.ts exports
 export { toJSONSchema } from './schema';
 
+// util/mime.ts exports
+export { getContentType, mimeTypes } from './util/mime';
+
 // util/resources.ts exports
 export {
 	validateCPUSpec,

--- a/packages/server/src/util/mime.ts
+++ b/packages/server/src/util/mime.ts
@@ -1,0 +1,109 @@
+/**
+ * Canonical MIME type map and content-type lookup.
+ *
+ * This is the single source of truth for extension → MIME type mappings
+ * used across the CLI (build metadata, generated entry code) and runtime
+ * (serveStatic).
+ */
+
+export const mimeTypes: Record<string, string> = {
+	// Text and code
+	css: 'text/css',
+	csv: 'text/csv',
+	htm: 'text/html',
+	html: 'text/html',
+	ics: 'text/calendar',
+	js: 'application/javascript',
+	mjs: 'application/javascript',
+	cjs: 'application/javascript',
+	json: 'application/json',
+	jsonld: 'application/ld+json',
+	map: 'application/json',
+	md: 'text/markdown',
+	markdown: 'text/markdown',
+	txt: 'text/plain',
+	text: 'text/plain',
+	vcf: 'text/vcard',
+	xml: 'application/xml',
+	yaml: 'text/yaml',
+	yml: 'text/yaml',
+
+	// Images
+	apng: 'image/apng',
+	avif: 'image/avif',
+	bmp: 'image/bmp',
+	gif: 'image/gif',
+	ico: 'image/x-icon',
+	jpeg: 'image/jpeg',
+	jpg: 'image/jpeg',
+	jxl: 'image/jxl',
+	png: 'image/png',
+	svg: 'image/svg+xml',
+	tif: 'image/tiff',
+	tiff: 'image/tiff',
+	webp: 'image/webp',
+
+	// Fonts
+	eot: 'application/vnd.ms-fontobject',
+	otf: 'font/otf',
+	ttf: 'font/ttf',
+	woff: 'font/woff',
+	woff2: 'font/woff2',
+
+	// Audio
+	aac: 'audio/aac',
+	flac: 'audio/flac',
+	m4a: 'audio/mp4',
+	mid: 'audio/midi',
+	midi: 'audio/midi',
+	mp3: 'audio/mpeg',
+	ogg: 'audio/ogg',
+	oga: 'audio/ogg',
+	opus: 'audio/opus',
+	wav: 'audio/wav',
+	weba: 'audio/webm',
+
+	// Video
+	avi: 'video/x-msvideo',
+	m4v: 'video/mp4',
+	mkv: 'video/x-matroska',
+	mov: 'video/quicktime',
+	mp4: 'video/mp4',
+	ogv: 'video/ogg',
+	webm: 'video/webm',
+
+	// Documents and archives
+	doc: 'application/msword',
+	docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+	gz: 'application/gzip',
+	odp: 'application/vnd.oasis.opendocument.presentation',
+	ods: 'application/vnd.oasis.opendocument.spreadsheet',
+	odt: 'application/vnd.oasis.opendocument.text',
+	pdf: 'application/pdf',
+	ppt: 'application/vnd.ms-powerpoint',
+	pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+	rtf: 'application/rtf',
+	tar: 'application/x-tar',
+	xls: 'application/vnd.ms-excel',
+	xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+	zip: 'application/zip',
+	'7z': 'application/x-7z-compressed',
+
+	// Web and application
+	atom: 'application/atom+xml',
+	glb: 'model/gltf-binary',
+	gltf: 'model/gltf+json',
+	rss: 'application/rss+xml',
+	wasm: 'application/wasm',
+	webmanifest: 'application/manifest+json',
+	xsl: 'application/xslt+xml',
+	xslt: 'application/xslt+xml',
+};
+
+export function getContentType(filename: string): string {
+	const ext = filename.split('.').pop()?.toLowerCase();
+	if (ext && ext in mimeTypes) {
+		return mimeTypes[ext]!;
+	}
+	return 'application/octet-stream';
+}


### PR DESCRIPTION
## Summary

Fixes #999 — `.md` files in `public/` download instead of displaying in the browser.

- **Root cause**: The build-time `getContentType()` function in `metadata-generator.ts` had no mapping for `.md` files, defaulting to `application/octet-stream`. This Content-Type was used when uploading assets to CDN during deployment, causing browsers to treat them as binary downloads.
- Replaced the 17-entry switch statement with a comprehensive `Record<string, string>` lookup covering **80+ extensions** across 8 categories (text, images, fonts, audio, video, documents/archives, Microsoft Office, web/application)
- Added matching `customMimes` map to Hono `serveStatic` calls in both the entry generator and web router for consistent runtime fallback behavior

## Files Changed

| File | Change |
|------|--------|
| `packages/cli/src/cmd/build/vite/metadata-generator.ts` | Comprehensive MIME type map (CDN upload path) |
| `packages/cli/src/cmd/build/entry-generator.ts` | `customMimes` for generated `serveStatic` calls |
| `packages/runtime/src/web.ts` | `customMimes` for runtime `serveStatic` calls |
| `apps/testing/*/src/generated/app.ts` | Regenerated from entry-generator |

## Verification

- ✅ `bun run build`
- ✅ `bun run typecheck`
- ✅ `bun run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Static asset serving now respects MIME types for both general assets and SPA fallback paths, improving correct content delivery.
  * Content-type resolution expanded to cover markdown, YAML, CSV, audio, video, images, fonts, Office docs, WASM and other formats across build and runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->