### PR TITLE
fix(cli): quote dotted path segments in generated RPCRouteRegistry type

### DIFF
--- a/packages/cli/src/cmd/build/vite/registry-generator.ts
+++ b/packages/cli/src/cmd/build/vite/registry-generator.ts
@@ -71,6 +71,21 @@ function sanitizePathSegment(segment: string): string {
 }
 
 /**
+ * Valid unquoted TypeScript/JavaScript property name pattern.
+ * A property name can be unquoted if it starts with a letter, underscore, or dollar sign,
+ * and contains only letters, digits, underscores, or dollar signs.
+ */
+const VALID_UNQUOTED_PROPERTY = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
+
+/**
+ * Quote a property name for TypeScript object type definitions if it contains
+ * characters that require quoting (e.g., dots, hyphens, spaces).
+ */
+function quotePropertyName(name: string): string {
+	return VALID_UNQUOTED_PROPERTY.test(name) ? name : JSON.stringify(name);
+}
+
+/**
  * Generate TypeScript type for path parameters.
  * Returns 'never' if no path params, or '{ param1: string; param2: string }' format.
  */
@@ -479,11 +494,11 @@ function generateRPCRegistryType(
 				const pathParamsType = generatePathParamsType(routeInfo.pathParams);
 				const pathParamsTupleType = generatePathParamsTupleType(routeInfo.pathParams);
 				lines.push(
-					`${indent}${key}: { input: ${value.input}; output: ${value.output}; type: ${value.type}; params: ${pathParamsType}; paramsTuple: ${pathParamsTupleType} };`
+					`${indent}${quotePropertyName(key)}: { input: ${value.input}; output: ${value.output}; type: ${value.type}; params: ${pathParamsType}; paramsTuple: ${pathParamsTupleType} };`
 				);
 			} else {
 				// Nested node
-				lines.push(`${indent}${key}: {`);
+				lines.push(`${indent}${quotePropertyName(key)}: {`);
 				lines.push(treeToTypeString(value as NestedNode, indent + '\t'));
 				lines.push(`${indent}};`);
 			}

--- a/packages/cli/test/cmd/build/vite/registry-generator.test.ts
+++ b/packages/cli/test/cmd/build/vite/registry-generator.test.ts
@@ -207,6 +207,99 @@ describe('registry-generator', () => {
 			expect(routesContent).toContain('get: { input:');
 		});
 
+		test('should quote dotted path segments in RPCRouteRegistry', async () => {
+			const routes: RouteInfo[] = [
+				{
+					method: 'GET',
+					path: '/api/docs/foo.md',
+					filename: './api/docs/foo.md/route.ts',
+					hasValidator: false,
+					routeType: 'api',
+				},
+			];
+
+			await generateRouteRegistry(srcDir, routes);
+
+			const routesPath = join(generatedDir, 'routes.ts');
+			const routesContent = await Bun.file(routesPath).text();
+
+			// Nested RPCRouteRegistry: dotted key must be quoted
+			expect(routesContent).toContain('export interface RPCRouteRegistry');
+			expect(routesContent).toContain('"foo.md": {');
+			// Normal key (docs) should remain unquoted
+			expect(routesContent).toContain('docs: {');
+			expect(routesContent).toContain('get: { input:');
+
+			// Flat RouteRegistry: full route key is always single-quoted, dots are safe
+			expect(routesContent).toContain("'GET /api/docs/foo.md'");
+		});
+
+		test('should escape single quotes in path segments', async () => {
+			const routes: RouteInfo[] = [
+				{
+					method: 'GET',
+					path: "/api/it's",
+					filename: "./api/it's/route.ts",
+					hasValidator: false,
+					routeType: 'api',
+				},
+			];
+
+			await generateRouteRegistry(srcDir, routes);
+
+			const routesPath = join(generatedDir, 'routes.ts');
+			const routesContent = await Bun.file(routesPath).text();
+
+			expect(routesContent).toContain('export interface RPCRouteRegistry');
+			// After toCamelCase("it's") → "it's" (apostrophe preserved)
+			// JSON.stringify produces properly escaped double-quoted string
+			expect(routesContent).toContain('"it\'s"');
+			expect(routesContent).toContain('get: { input:');
+		});
+
+		test('should quote Unicode path segments', async () => {
+			const routes: RouteInfo[] = [
+				{
+					method: 'GET',
+					path: '/api/café',
+					filename: './api/café/route.ts',
+					hasValidator: false,
+					routeType: 'api',
+				},
+			];
+
+			await generateRouteRegistry(srcDir, routes);
+
+			const routesPath = join(generatedDir, 'routes.ts');
+			const routesContent = await Bun.file(routesPath).text();
+
+			expect(routesContent).toContain('export interface RPCRouteRegistry');
+			// Unicode chars not valid as unquoted identifiers in our regex
+			expect(routesContent).toContain('"café"');
+			expect(routesContent).toContain('get: { input:');
+		});
+
+		test('should quote path segments with consecutive dots', async () => {
+			const routes: RouteInfo[] = [
+				{
+					method: 'GET',
+					path: '/api/foo..bar',
+					filename: './api/foo..bar/route.ts',
+					hasValidator: false,
+					routeType: 'api',
+				},
+			];
+
+			await generateRouteRegistry(srcDir, routes);
+
+			const routesPath = join(generatedDir, 'routes.ts');
+			const routesContent = await Bun.file(routesPath).text();
+
+			expect(routesContent).toContain('export interface RPCRouteRegistry');
+			expect(routesContent).toContain('"foo..bar"');
+			expect(routesContent).toContain('get: { input:');
+		});
+
 		test('should generate route registry with multiple routes', async () => {
 			const routes: RouteInfo[] = [
 				{


### PR DESCRIPTION
## Summary

- Fixes route type generator producing invalid TypeScript when API route paths contain dots (e.g., `/api/foo.md`) — the nested `RPCRouteRegistry` type wrote `foo.md:` (unquoted) instead of `"foo.md":` (quoted), causing `TS1005: ';' expected` build errors
- Adds `quotePropertyName()` helper using `JSON.stringify()` for safe escaping of dots, single quotes, Unicode, and other non-identifier characters in property names
- Adds 4 edge case tests: dotted segments, single quotes in paths, Unicode segments, and consecutive dots

Closes #1001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Registry generation now correctly quotes and escapes path segment keys that contain dots, quotes, consecutive dots, or Unicode characters, ensuring generated types are valid and safe.

* **Tests**
  * Added tests covering edge cases: dotted paths, segments with quotes/special characters, consecutive dots, and Unicode names to validate registry output and quoting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->