### PR TITLE
fix(server): retry 502/503 for up to 30s to survive service restarts

### DIFF
--- a/packages/server/src/api/api.ts
+++ b/packages/server/src/api/api.ts
@@ -33,6 +33,12 @@ export interface APIClientConfig {
 	maxRetries?: number;
 	retryDelayMs?: number;
 	headers?: Record<string, string>;
+	/**
+	 * Maximum time in milliseconds to keep retrying 502/503 responses.
+	 * These indicate the service is restarting (hot-swap) and typically
+	 * resolve within seconds. Defaults to 30000 (30 seconds).
+	 */
+	serviceUnavailableTimeoutMs?: number;
 }
 
 export const ZodIssuesSchema = z.array(
@@ -362,6 +368,11 @@ export class APIClient {
 
 		const maxRetries = this.#config?.maxRetries ?? 3;
 		const baseDelayMs = this.#config?.retryDelayMs ?? 100;
+		const serviceUnavailableTimeoutMs =
+			this.#config?.serviceUnavailableTimeoutMs ?? 30_000;
+
+		// Track when we first see a 502/503 so we can retry for up to the timeout
+		let serviceUnavailableStart: number | null = null;
 
 		const url = `${this.#baseUrl}${endpoint}`;
 		const headers: Record<string, string> = {
@@ -404,7 +415,9 @@ export class APIClient {
 
 		const canRetry = !(body instanceof ReadableStream); // we cannot safely retry a ReadableStream as body
 
-		for (let attempt = 0; attempt <= maxRetries; attempt++) {
+		let attempt = 0;
+		// eslint-disable-next-line no-constant-condition
+		while (true) {
 			try {
 				let response: Response;
 
@@ -520,8 +533,34 @@ export class APIClient {
 					}
 				}
 
-				// Check if we should retry on specific status codes (409, 501, 503)
-				const retryableStatuses = [409, 501, 503];
+				// 502/503 indicate the service is restarting (hot-swap) — retry
+				// for up to serviceUnavailableTimeoutMs (default 30s) with a
+				// slower backoff (1s base) so we survive typical restart windows.
+				const isServiceUnavailable =
+					response.status === 502 || response.status === 503;
+
+				if (isServiceUnavailable && canRetry) {
+					if (serviceUnavailableStart === null) {
+						serviceUnavailableStart = Date.now();
+					}
+					const elapsed = Date.now() - serviceUnavailableStart;
+					if (elapsed < serviceUnavailableTimeoutMs) {
+						// Use 1s base delay with exponential backoff, capped at 5s
+						const delayMs = Math.min(
+							this.#getRetryDelay(attempt, 1000),
+							5000
+						);
+						this.#logger.debug(
+							`Got ${response.status} sending to ${url}, service unavailable for ${Math.round(elapsed / 1000)}s, retrying (will delay ${delayMs}ms), sessionId: ${sessionId ?? null}`
+						);
+						await this.#sleep(delayMs);
+						attempt++;
+						continue;
+					}
+				}
+
+				// Check if we should retry on specific status codes (409, 501)
+				const retryableStatuses = [409, 501];
 				if (canRetry && retryableStatuses.includes(response.status) && attempt < maxRetries) {
 					let delayMs = this.#getRetryDelay(attempt, baseDelayMs);
 
@@ -548,6 +587,7 @@ export class APIClient {
 
 					this.#logger.debug(`after sleep for ${url}, sessionId: ${sessionId ?? null}`);
 
+					attempt++;
 					continue;
 				}
 
@@ -693,16 +733,13 @@ export class APIClient {
 						error
 					);
 					await this.#sleep(this.#getRetryDelay(attempt, baseDelayMs));
+					attempt++;
 					continue;
 				}
 
 				throw error;
 			}
 		}
-
-		this.#logger.debug('max retries trying: %s', url);
-
-		throw new MaxRetriesError();
 	}
 
 	#isRetryableError(error: unknown): boolean {


### PR DESCRIPTION
## Summary

- Adds time-based retry for 502/503 responses — retries for up to 30 seconds instead of 3 quick attempts
- New configurable `serviceUnavailableTimeoutMs` option (default: 30000ms)
- Also adds 502 to retryable statuses (was only 503 before)

## Problem

SDK tests hitting `catalyst-usc.agentuity.cloud` during Ion hot-swap/restart were failing with:
```
APIErrorResponse: The API service is currently unavailable (HTTP 503). Please try again later.
```

The SDK did retry 503, but the retry budget was only **3 attempts over ~700ms** — far too short for a service restart that typically takes 5-15 seconds. All retry attempts hit the draining/bootstrapping instance and gave up.

## Fix

502/503 now get a separate **time-based** retry loop instead of the count-based retry used for other errors:

| | Before | After |
|---|---|---|
| **Budget** | 3 retries, ~700ms total | Up to **30 seconds** |
| **Base delay** | 100ms | 1000ms |
| **Backoff** | 100ms → 200ms → 400ms | 1s → 2s → 4s → 5s (cap) |
| **Max per-retry delay** | Unbounded | Capped at 5s |
| **Configurable** | Only via `maxRetries` | `serviceUnavailableTimeoutMs` |

Other retryable statuses (409, 501) keep the original fast retry (3 attempts, 100ms base).

## Changes

| File | Change |
|------|--------|
| `packages/server/src/api/api.ts` | Add `serviceUnavailableTimeoutMs` config, time-based 502/503 retry loop |

## Tests

- ✅ 182/182 tests pass
- ✅ Typecheck clean
- ✅ Build clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New configuration option to control retry timeout for temporary service unavailability

* **Improvements**
  * Enhanced retry logic for temporary service errors with intelligent backoff strategies
  * Improved rate-limit aware retry behavior with header-based delay adjustment
  * Added support for regional request error handling
  * Better error logging with improved diagnostic information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->