### PR TITLE
test: expand sandbox snapshot testing for python:3.14 and edge cases

### DIFF
--- a/scripts/test-sandbox.sh
+++ b/scripts/test-sandbox.sh
@@ -704,12 +704,39 @@ $CLI cloud sandbox rmdir "$SANDBOX_ID" /home/agentuity/testrmdir >/dev/null 2>&1
 
 # Test: JSON output
 info "Test: sandbox rm --json"
-$CLI cloud sandbox exec "$SANDBOX_ID" -- sh -c 'echo "json test" > /home/agentuity/jsontest.txt' >/dev/null 2>&1 || true
-RM_JSON=$($CLI cloud sandbox rm "$SANDBOX_ID" /home/agentuity/jsontest.txt --json 2>&1) || true
-if echo "$RM_JSON" | grep -q '"success"' && echo "$RM_JSON" | grep -q '"path"'; then
-	pass "sandbox rm --json returns structured data"
+RM_JSON_READY=0
+set +e
+RM_JSON_CREATE=$($CLI cloud sandbox exec "$SANDBOX_ID" -- sh -c 'echo "json test" > /home/agentuity/jsontest.txt' 2>&1)
+RM_JSON_CREATE_EXIT=$?
+set -e
+if [ "$RM_JSON_CREATE_EXIT" -ne 0 ]; then
+	fail "sandbox rm --json setup failed to create file (exit code $RM_JSON_CREATE_EXIT)" "$RM_JSON_CREATE"
 else
-	fail "sandbox rm --json missing expected fields" "$RM_JSON"
+	set +e
+	RM_JSON_EXISTS=$($CLI cloud sandbox exec "$SANDBOX_ID" -- test -f /home/agentuity/jsontest.txt 2>&1)
+	RM_JSON_EXISTS_EXIT=$?
+	set -e
+	if [ "$RM_JSON_EXISTS_EXIT" -ne 0 ]; then
+		fail "sandbox rm --json setup could not verify file exists" "$RM_JSON_EXISTS"
+	else
+		RM_JSON_READY=1
+	fi
+fi
+if [ "$RM_JSON_READY" -eq 1 ]; then
+	set +e
+	RM_JSON=$($CLI cloud sandbox rm "$SANDBOX_ID" /home/agentuity/jsontest.txt --json 2>&1)
+	RM_JSON_EXIT=$?
+	set -e
+	if [ "$RM_JSON_EXIT" -ne 0 ]; then
+		fail "sandbox rm --json failed to remove file (exit code $RM_JSON_EXIT)" "$RM_JSON"
+	else
+		pass "sandbox rm --json exits successfully"
+	fi
+	if echo "$RM_JSON" | grep -q '"success"' && echo "$RM_JSON" | grep -q '"path"'; then
+		pass "sandbox rm --json returns structured data"
+	else
+		fail "sandbox rm --json missing expected fields" "$RM_JSON"
+	fi
 fi
 
 # ============================================


### PR DESCRIPTION
## Summary

- Adds 7 new snapshot test sections (~670 lines) to `scripts/test-sandbox.sh` to investigate customer-reported 500 errors when creating snapshots on python:3.14 runtime sandboxes
- Fixes org mismatch bug in ENV/SECRET interpolation tests where `AGENTUITY_CLOUD_ORG_ID` was not used for org context, causing env vars to be set on a different org than the sandbox
- All 157 tests pass with 0 failures

## New Test Sections

| Section | What it Tests |
|---------|--------------|
| Runtime Validation | Verifies `python:3.14` and `bun` runtimes exist in runtime list |
| Python:3.14 Snapshot Lifecycle | Full create→upload .py→verify listing→execute python→snapshot→restore→verify cycle |
| Subdirectory File Preservation | Nested directory structures preserved through snapshot/restore |
| Empty Sandbox Snapshot | Edge case: snapshot of empty sandbox works correctly |
| Re-snapshot Lifecycle | Incremental snapshots, fileCount growth, restore isolation between snapshots |
| Error Handling | Non-existent/deleted sandbox, bad snapshot names, no spurious 500s |
| Field Validation | All JSON fields in snapshot response present and correctly typed |

## Customer Investigation Results

- **Python:3.14 snapshots work correctly** in our tests — full lifecycle completes without 500 errors
- Customer's reported 500 was likely transient or specific to their setup
- The org mismatch bug (pre-existing) could have caused confusing behavior for customers using `AGENTUITY_CLOUD_ORG_ID`

## Bug Fix Detail

The ENV/SECRET interpolation tests used `agentuity auth org current` to get the org ID for setting env vars, but the `AGENTUITY_CLOUD_ORG_ID` env var overrides which org sandbox commands run under. This caused env vars to be set on org A while sandboxes ran under org B. Fixed by preferring `AGENTUITY_CLOUD_ORG_ID` when set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Greatly expanded coverage for Python sandbox runtimes: runtime discovery (including recently reported runtime), sandbox creation/restore, file upload/execute, nested/empty snapshots, lifecycle/error cases, edge cases (long names, special chars), and end-to-end snapshot/build workflows including malware-detection and dependency/substitution scenarios.

* **Chores**
  * Adjusted organization resolution in non-interactive contexts.
  * Added a public tracking identifier for Python sandboxes to improve test cleanup and tracing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->