### PR TITLE
fix(core): normalize null stream metadata to enforce StreamInfo interface contract

### DIFF
--- a/apps/testing/integration-suite/src/agent/storage/stream/metadata.ts
+++ b/apps/testing/integration-suite/src/agent/storage/stream/metadata.ts
@@ -59,7 +59,7 @@ const streamMetadataAgent = createAgent('storage-stream-metadata', {
 					namespace: info.namespace,
 					url: info.url,
 					sizeBytes: info.sizeBytes,
-					metadata: info.metadata,
+					metadata: info.metadata ?? undefined,
 					success: true,
 				};
 			}
@@ -75,7 +75,7 @@ const streamMetadataAgent = createAgent('storage-stream-metadata', {
 					namespace: info.namespace,
 					url: info.url,
 					sizeBytes: info.sizeBytes,
-					metadata: info.metadata,
+					metadata: info.metadata ?? undefined,
 					success: true,
 				};
 			}
@@ -90,7 +90,10 @@ const streamMetadataAgent = createAgent('storage-stream-metadata', {
 
 				return {
 					operation,
-					streams: result.streams,
+					streams: result.streams.map((stream) => ({
+						...stream,
+						metadata: stream.metadata ?? {},
+					})),
 					total: result.total,
 					success: true,
 				};

--- a/packages/core/src/services/stream.ts
+++ b/packages/core/src/services/stream.ts
@@ -795,7 +795,7 @@ export class StreamStorageService implements StreamStorage {
 				streams: res.data.streams.map((s) => ({
 					id: s.id,
 					namespace: s.name,
-					metadata: s.metadata,
+					metadata: s.metadata ?? {},
 					url: s.url,
 					sizeBytes: s.size_bytes,
 					...(s.expires_at && { expiresAt: s.expires_at }),
@@ -836,7 +836,7 @@ export class StreamStorageService implements StreamStorage {
 			return {
 				id: res.data.id,
 				namespace: res.data.name,
-				metadata: res.data.metadata,
+				metadata: res.data.metadata ?? {},
 				url: res.data.url,
 				sizeBytes: res.data.size_bytes,
 				...(res.data.expires_at && { expiresAt: res.data.expires_at }),


### PR DESCRIPTION
## Summary

- Fix intermittent CI failure in `storage-stream:get-info` integration test (275/276 passing, 1 failing with `Output validation failed: Expected record, got null`)
- Normalize `null` metadata to `{}` in `StreamStorageService.get()` and `list()` to enforce the SDK's own `StreamInfo` interface contract
- Add defense-in-depth null coalescing in the integration test metadata agent handler

## Root Cause

The backend (Pulse) can return `metadata: null` for streams created without metadata. The SDK's `StreamStorageService` was passing `null` through directly, violating its own `StreamInfo` interface which declares `metadata: Record<string, string>` (required, not nullable).

The failure chain:
1. Test creates stream **without metadata** via `streamCrudAgent`
2. Test retrieves stream info via `streamMetadataAgent` → calls `ctx.stream.get(streamId)`
3. Backend returns `metadata: null`
4. SDK passes `null` through to agent handler
5. Agent returns `metadata: null` in output
6. Schema validation rejects `null` — `s.record(s.string(), s.string()).optional()` allows `undefined` but not `null`

## Investigation

- Confirmed Ion's Pulse plugin (current repo code) properly normalizes metadata to `{}` — the null likely comes from a deployed version mismatch or the standalone Pulse service
- The SDK fix is the correct layer regardless: the SDK owns the `StreamInfo` interface and should enforce it at the boundary

## Changes

| File | Change |
|------|--------|
| `packages/core/src/services/stream.ts` | `get()`: `metadata: res.data.metadata ?? {}` |
| `packages/core/src/services/stream.ts` | `list()`: `metadata: s.metadata ?? {}` in stream mapping |
| `integration-suite/.../metadata.ts` | `create-with-metadata` + `get`: `metadata ?? undefined` |
| `integration-suite/.../metadata.ts` | `list`: map streams with `metadata ?? {}` |

## Verification

- ✅ Typecheck passes (core + integration-suite)
- ✅ Build passes (core)
- ✅ 423 core package tests pass
- Zero risk: `??` only activates when value is `null`/`undefined`, existing non-null metadata passes through unchanged

Fixes intermittent failure in: https://github.com/agentuity/sdk/actions/runs/22264006404/job/64406660190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata consistency in stream operations to ensure reliable and predictable data structures across API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->