### PR TITLE
fix(opencode): fix background task concurrency limit and queued task inspection

### DIFF
--- a/packages/opencode/src/background/manager.ts
+++ b/packages/opencode/src/background/manager.ts
@@ -200,7 +200,21 @@ export class BackgroundManager {
 	 */
 	async inspectTask(taskId: string): Promise<TaskInspection | undefined> {
 		const task = this.tasks.get(taskId);
-		if (!task?.sessionId) return undefined;
+		if (!task) return undefined;
+
+		// Task exists but has not yet acquired a concurrency slot — it is queued
+		// and no session has been created yet. Return a lightweight inspection so
+		// callers can distinguish "queued/pending" from "not found".
+		if (!task.sessionId) {
+			return {
+				taskId: task.id,
+				sessionId: '',
+				status: task.status,
+				session: null,
+				messages: [],
+				lastActivity: task.queuedAt?.toISOString(),
+			};
+		}
 
 		try {
 			if (this.dbReader?.isAvailable()) {

--- a/packages/opencode/src/config/loader.ts
+++ b/packages/opencode/src/config/loader.ts
@@ -146,7 +146,7 @@ const DEFAULT_BLOCKED_COMMANDS = [
 
 const DEFAULT_BACKGROUND_CONFIG: BackgroundTaskConfig = {
 	enabled: true,
-	defaultConcurrency: 1,
+	defaultConcurrency: 5,
 	staleTimeoutMs: 30 * 60 * 1000,
 	providerConcurrency: {},
 	modelConcurrency: {},
@@ -199,7 +199,7 @@ function mergeBackgroundConfig(
 	if (!base && !override) return undefined;
 	return {
 		enabled: override?.enabled ?? base?.enabled ?? true,
-		defaultConcurrency: override?.defaultConcurrency ?? base?.defaultConcurrency ?? 1,
+		defaultConcurrency: override?.defaultConcurrency ?? base?.defaultConcurrency ?? 5,
 		staleTimeoutMs: override?.staleTimeoutMs ?? base?.staleTimeoutMs ?? 30 * 60 * 1000,
 		providerConcurrency: {
 			...(base?.providerConcurrency ?? {}),


### PR DESCRIPTION
## Summary

- **`config/loader.ts`**: Raises `defaultConcurrency` from `1` to `5`, matching the `manager.ts` default. The previous value of `1` meant only one background task could run at a time (all others queued behind a single slot), silently breaking every parallel `agentuity_background_task` call.
- **`manager.ts`**: `inspectTask()` now returns a lightweight inspection result for tasks that are queued but have not yet created a session (no `sessionId`), instead of returning `undefined`. Previously this caused the plugin tool to emit `{ found: false, status: 'unknown' }` — indistinguishable from a task that never existed — prompting Lead to incorrectly conclude the task failed.

## Root Cause

Discovered from the "Personal assistant TUI with server architecture" Cadence session. Lead launched 4 parallel background tasks:

| Task | Agent | Result |
|------|-------|--------|
| `bg_uno1gl` | Scout | ✅ Succeeded — acquired the sole concurrency slot, session created |
| `bg_36s9i6` | Scout | ❌ Queued — no session, `inspect` returned `"not found"` |
| `bg_g6qdfp` | Product | ❌ Queued — no session, `inspect` returned `"not found"` |
| `bg_s5f4d4` | Memory | ❌ Queued — no session, `inspect` returned `"not found"` |

With `defaultConcurrency: 1`, tasks 2–4 were blocked in the `ConcurrencyManager` queue with `task.sessionId === undefined`. When Lead called `agentuity_background_inspect` ~95s later, `inspectTask()` hit the early-return guard `if (!task?.sessionId) return undefined` and the plugin translated that as `{ found: false, error: 'Task not found or session no longer exists.' }`. Lead concluded the tasks had failed and re-launched them synchronously via `task()` instead.

## Changes

```
packages/opencode/src/config/loader.ts   defaultConcurrency: 1 → 5 (both constant and merge fallback)
packages/opencode/src/background/manager.ts  inspectTask(): return lightweight result for queued tasks
```

## Verification

- `bun run typecheck` passes in `packages/opencode`
- `bun run build` passes in `packages/opencode`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Task inspection now correctly identifies and reports pending tasks in the queue rather than returning undefined.

* **Chores**
  * Increased default concurrent background task execution from 1 to 5 for improved throughput.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->