### PR TITLE
fix(postgres,drizzle): use pool-safe sql.begin() for transaction wrapping

### DIFF
--- a/packages/drizzle/src/postgres.ts
+++ b/packages/drizzle/src/postgres.ts
@@ -99,45 +99,40 @@ export function createResilientSQLProxy(
 					// double-applied updates, or repeated delete side effects.
 					const isMutation = isMutationStatement(query);
 
-					if (isMutation) {
-						// Mutation statements are wrapped in a transaction and retried
-						// via executeWithRetry. This is safe because PostgreSQL
-						// guarantees that uncommitted transactions are automatically
-						// rolled back when the connection drops. If the connection
-						// fails before COMMIT completes, no changes are applied, and
-						// the retry starts a fresh transaction on the new connection.
-						//
-						// NOTE: If the connection drops after the server processes
-						// COMMIT but before the client receives the response, the
-						// changes ARE committed. A retry would then apply them again.
-						// This window is extremely small (< 1ms typically) and is an
-						// inherent limitation of any retry-based approach without
-						// application-level idempotency (e.g., unique constraints
-						// with ON CONFLICT for INSERTs).
-						// See: https://github.com/agentuity/sdk/issues/911
-						const makeTransactionalExecutor = (useValues: boolean) =>
-							client.executeWithRetry(async () => {
-								// Re-resolve raw inside retry to get post-reconnect instance
-								const currentRaw = client.raw;
-								await currentRaw.unsafe('BEGIN');
-								try {
-									const q = currentRaw.unsafe(query, params);
-									const result = useValues ? await q.values() : await q;
-									await currentRaw.unsafe('COMMIT');
-									return result;
-								} catch (error) {
-									try {
-										await currentRaw.unsafe('ROLLBACK');
-									} catch {
-										// Connection may already be dead; Postgres auto-rolls
-										// back uncommitted transactions on connection close.
-									}
-									throw error;
-								}
+				if (isMutation) {
+					// Mutation statements are wrapped in a transaction and retried
+					// via executeWithRetry. This is safe because PostgreSQL
+					// guarantees that uncommitted transactions are automatically
+					// rolled back when the connection drops. If the connection
+					// fails before COMMIT completes, no changes are applied, and
+					// the retry starts a fresh transaction on the new connection.
+					//
+					// We use sql.begin(callback) instead of manual BEGIN/COMMIT
+					// because Bun's SQL driver requires it for pool-safe
+					// transactions (ERR_POSTGRES_UNSAFE_TRANSACTION when max > 1).
+					// sql.begin() reserves a specific connection, auto-COMMITs on
+					// success, and auto-ROLLBACKs on error.
+					//
+					// NOTE: If the connection drops after the server processes
+					// COMMIT but before the client receives the response, the
+					// changes ARE committed. A retry would then apply them again.
+					// This window is extremely small (< 1ms typically) and is an
+					// inherent limitation of any retry-based approach without
+					// application-level idempotency (e.g., unique constraints
+					// with ON CONFLICT for INSERTs).
+					// See: https://github.com/agentuity/sdk/issues/911
+					const makeTransactionalExecutor = (useValues: boolean) =>
+						client.executeWithRetry(async () => {
+							// Re-resolve raw inside retry to get post-reconnect instance
+							const currentRaw = client.raw;
+							return currentRaw.begin(async (tx) => {
+								const q = tx.unsafe(query, params);
+								return useValues ? await q.values() : await q;
 							});
+						});
 
-						return createThenable(makeTransactionalExecutor);
-					}
+					return createThenable(makeTransactionalExecutor);
+				}
 
 					const makeExecutor = (useValues: boolean) =>
 						client.executeWithRetry(async () => {

--- a/packages/drizzle/test/integration/tx-safety.ts
+++ b/packages/drizzle/test/integration/tx-safety.ts
@@ -1,0 +1,311 @@
+/**
+ * Integration test for Drizzle transaction safety with pooled connections.
+ *
+ * Validates that:
+ * - Standalone mutations (db.insert, db.update, db.delete) work through the
+ *   resilient proxy without ERR_POSTGRES_UNSAFE_TRANSACTION
+ * - db.transaction() works (no double-wrapping)
+ * - Concurrent mutations through Drizzle work correctly
+ *
+ * Run:
+ *   DATABASE_URL=postgres://... bun run packages/drizzle/test/integration/tx-safety.ts
+ *
+ * See: https://github.com/agentuity/sdk/issues/911
+ */
+
+import { SQL } from 'bun';
+import { eq } from 'drizzle-orm';
+import { pgTable, serial, text, timestamp } from 'drizzle-orm/pg-core';
+import { createPostgresDrizzle } from '../../src/postgres';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+
+if (!DATABASE_URL) {
+	console.error('❌ Missing DATABASE_URL env var.');
+	console.error('   Usage: DATABASE_URL=postgres://user:pass@host:5432/db bun run this-file.ts');
+	process.exit(1);
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Schema (matches the test table)
+// ───────────────────────────────────────────────────────────────────────
+
+const TEST_TABLE = 'drizzle_tx_safety_test';
+
+const items = pgTable(TEST_TABLE, {
+	id: serial('id').primaryKey(),
+	name: text('name').notNull(),
+	value: text('value'),
+	createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+});
+
+// Mimics the better-auth verification table from the original error report
+const verification = pgTable('drizzle_tx_verification_test', {
+	id: text('id').primaryKey(),
+	identifier: text('identifier').notNull(),
+	value: text('value').notNull(),
+	expiresAt: timestamp('expiresAt', { withTimezone: true }).notNull(),
+	createdAt: timestamp('createdAt', { withTimezone: true }),
+	updatedAt: timestamp('updatedAt', { withTimezone: true }),
+});
+
+let passed = 0;
+let failed = 0;
+
+async function test(name: string, fn: () => Promise<void>): Promise<void> {
+	try {
+		await fn();
+		passed++;
+		console.log(`  ✅ ${name}`);
+	} catch (error) {
+		failed++;
+		console.error(`  ❌ ${name}`);
+		console.error(`     ${error instanceof Error ? error.message : String(error)}`);
+		if (error instanceof Error && error.cause) {
+			console.error(`     cause: ${(error.cause as Error).message ?? error.cause}`);
+		}
+	}
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Setup / Teardown
+// ───────────────────────────────────────────────────────────────────────
+
+async function setup(rawSql: InstanceType<typeof SQL>) {
+	await rawSql.unsafe(`DROP TABLE IF EXISTS ${TEST_TABLE}`);
+	await rawSql.unsafe(`DROP TABLE IF EXISTS drizzle_tx_verification_test`);
+	await rawSql.unsafe(`
+		CREATE TABLE ${TEST_TABLE} (
+			id SERIAL PRIMARY KEY,
+			name TEXT NOT NULL,
+			value TEXT,
+			created_at TIMESTAMPTZ DEFAULT NOW()
+		)
+	`);
+	await rawSql.unsafe(`
+		CREATE TABLE drizzle_tx_verification_test (
+			id TEXT PRIMARY KEY,
+			identifier TEXT NOT NULL,
+			value TEXT NOT NULL,
+			"expiresAt" TIMESTAMPTZ NOT NULL,
+			"createdAt" TIMESTAMPTZ,
+			"updatedAt" TIMESTAMPTZ
+		)
+	`);
+}
+
+async function teardown(rawSql: InstanceType<typeof SQL>) {
+	await rawSql.unsafe(`DROP TABLE IF EXISTS ${TEST_TABLE}`);
+	await rawSql.unsafe(`DROP TABLE IF EXISTS drizzle_tx_verification_test`);
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Tests
+// ───────────────────────────────────────────────────────────────────────
+
+async function testDrizzle() {
+	console.log('\n📦 Drizzle ORM with resilient proxy');
+
+	const { db, client, close } = createPostgresDrizzle({
+		url: DATABASE_URL,
+		schema: { items, verification },
+	});
+
+	await client.waitForConnection();
+
+	try {
+		await setup(client.raw);
+
+		// ── Standalone mutations (go through proxy's unsafe() handler) ──
+
+		await test('db.insert() — standalone INSERT works', async () => {
+			const result = await db
+				.insert(items)
+				.values({ name: 'drizzle-insert', value: 'hello' })
+				.returning();
+			if (result.length !== 1) throw new Error(`Expected 1 row, got ${result.length}`);
+			if (result[0].name !== 'drizzle-insert') {
+				throw new Error(`Expected 'drizzle-insert', got '${result[0].name}'`);
+			}
+		});
+
+		await test('db.insert() — reproduces the original better-auth verification scenario', async () => {
+			// This is the exact scenario from the bug report
+			const now = new Date();
+			const expires = new Date(Date.now() + 10 * 60 * 1000);
+			const result = await db
+				.insert(verification)
+				.values({
+					id: 'test-verification-id',
+					identifier: 'test-identifier',
+					value: JSON.stringify({
+						callbackURL: '/',
+						codeVerifier: 'test-code-verifier-string',
+						expiresAt: expires.getTime(),
+					}),
+					expiresAt: expires,
+					createdAt: now,
+					updatedAt: now,
+				})
+				.returning();
+			if (result.length !== 1) throw new Error(`Expected 1 row, got ${result.length}`);
+			if (result[0].id !== 'test-verification-id') {
+				throw new Error(`Expected id 'test-verification-id', got '${result[0].id}'`);
+			}
+		});
+
+		await test('db.update() — standalone UPDATE works', async () => {
+			const result = await db
+				.update(items)
+				.set({ value: 'updated' })
+				.where(eq(items.name, 'drizzle-insert'))
+				.returning();
+			if (result.length !== 1) throw new Error(`Expected 1 row, got ${result.length}`);
+			if (result[0].value !== 'updated') {
+				throw new Error(`Expected 'updated', got '${result[0].value}'`);
+			}
+		});
+
+		await test('db.delete() — standalone DELETE works', async () => {
+			// Insert a row to delete
+			await db.insert(items).values({ name: 'to-delete', value: 'x' });
+			const result = await db.delete(items).where(eq(items.name, 'to-delete')).returning();
+			if (result.length !== 1) throw new Error(`Expected 1 deleted row, got ${result.length}`);
+		});
+
+		await test('db.select() — standalone SELECT works', async () => {
+			const result = await db.select().from(items);
+			// Should have at least the drizzle-insert row
+			if (result.length === 0) throw new Error('Expected at least 1 row');
+		});
+
+		// ── Explicit transactions (go through proxy.begin → Bun's sql.begin) ──
+
+		await test('db.transaction() — single INSERT works (no double-wrapping)', async () => {
+			const result = await db.transaction(async (tx) => {
+				return tx
+					.insert(items)
+					.values({ name: 'tx-insert', value: 'in-tx' })
+					.returning();
+			});
+			if (result.length !== 1) throw new Error(`Expected 1 row, got ${result.length}`);
+			if (result[0].name !== 'tx-insert') {
+				throw new Error(`Expected 'tx-insert', got '${result[0].name}'`);
+			}
+		});
+
+		await test('db.transaction() — multiple operations work', async () => {
+			const [inserted, updated] = await db.transaction(async (tx) => {
+				const ins = await tx
+					.insert(items)
+					.values({ name: 'tx-multi', value: 'original' })
+					.returning();
+				const upd = await tx
+					.update(items)
+					.set({ value: 'modified' })
+					.where(eq(items.name, 'tx-multi'))
+					.returning();
+				return [ins, upd];
+			});
+			if (inserted.length !== 1) throw new Error('Expected 1 inserted row');
+			if (updated.length !== 1) throw new Error('Expected 1 updated row');
+			if (updated[0].value !== 'modified') throw new Error('Expected value to be modified');
+		});
+
+		await test('db.transaction() — auto-rollback on error', async () => {
+			const countBefore = await db.select().from(items);
+			try {
+				await db.transaction(async (tx) => {
+					await tx.insert(items).values({ name: 'should-rollback', value: 'x' });
+					throw new Error('intentional error');
+				});
+			} catch {
+				// expected
+			}
+			const countAfter = await db.select().from(items);
+			if (countBefore.length !== countAfter.length) {
+				throw new Error('Row was not rolled back');
+			}
+		});
+
+		await test('db.transaction() — INSERT into verification table (exact bug report scenario)', async () => {
+			const now = new Date();
+			const expires = new Date(Date.now() + 10 * 60 * 1000);
+			const result = await db.transaction(async (tx) => {
+				return tx
+					.insert(verification)
+					.values({
+						id: 'tx-verification-id',
+						identifier: 'tx-identifier',
+						value: JSON.stringify({
+							callbackURL: '/',
+							codeVerifier: 'test-code-verifier',
+							expiresAt: expires.getTime(),
+						}),
+						expiresAt: expires,
+						createdAt: now,
+						updatedAt: now,
+					})
+					.returning();
+			});
+			if (result.length !== 1) throw new Error(`Expected 1 row, got ${result.length}`);
+		});
+
+		// ── Concurrency ──
+
+		await test('concurrent standalone INSERTs work', async () => {
+			const inserts = Array.from({ length: 10 }, (_, i) =>
+				db
+					.insert(items)
+					.values({ name: `concurrent-${i}`, value: `v${i}` })
+					.returning()
+			);
+			const results = await Promise.all(inserts);
+			for (let i = 0; i < results.length; i++) {
+				if (results[i].length !== 1) {
+					throw new Error(`Insert ${i}: expected 1 row, got ${results[i].length}`);
+				}
+			}
+		});
+
+		await test('concurrent transactions work', async () => {
+			const txns = Array.from({ length: 5 }, (_, i) =>
+				db.transaction(async (tx) => {
+					return tx
+						.insert(items)
+						.values({ name: `concurrent-tx-${i}`, value: `tv${i}` })
+						.returning();
+				})
+			);
+			const results = await Promise.all(txns);
+			for (let i = 0; i < results.length; i++) {
+				if (results[i].length !== 1) {
+					throw new Error(`Tx ${i}: expected 1 row, got ${results[i].length}`);
+				}
+			}
+		});
+
+		await teardown(client.raw);
+	} finally {
+		await close();
+	}
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Run
+// ───────────────────────────────────────────────────────────────────────
+
+async function main() {
+	console.log('🔬 Drizzle Transaction Safety Integration Tests');
+	console.log(`   Database: ${DATABASE_URL?.replace(/\/\/.*@/, '//***@')}`);
+
+	await testDrizzle();
+
+	console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed`);
+	process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+	console.error('Fatal error:', err);
+	process.exit(1);
+});

--- a/packages/drizzle/test/proxy.test.ts
+++ b/packages/drizzle/test/proxy.test.ts
@@ -18,6 +18,11 @@ import type { CallablePostgresClient } from '@agentuity/postgres';
  * Creates a minimal mock that satisfies the proxy's needs.
  * The mock exposes a `_setRaw` helper to simulate reconnection
  * (i.e., swapping the underlying raw SQL instance).
+ *
+ * The `begin` mock simulates `sql.begin(callback)` behavior:
+ * it accepts a callback, creates a transaction-scoped mock connection,
+ * and passes it to the callback. This mirrors how the production code
+ * uses `currentRaw.begin(async (tx) => { ... })` for pool-safe transactions.
  */
 function createMockClient() {
 	// Track all unsafe calls for transaction verification
@@ -31,7 +36,22 @@ function createMockClient() {
 				values: () => Promise.resolve([[1]]),
 			});
 		}),
-		begin: mock(() => Promise.resolve()),
+		begin: mock(async (fn: unknown) => {
+			if (typeof fn === 'function') {
+				// Simulate sql.begin(callback) behavior for mutation transactions
+				const txUnsafe = mock((query: string, _params?: unknown[]) => {
+					unsafeCalls.push(query);
+					const result = Promise.resolve([{ id: 1 }]);
+					return Object.assign(result, {
+						values: () => Promise.resolve([[1]]),
+					});
+				});
+				const txMock = { unsafe: txUnsafe };
+				return (fn as (tx: Record<string, unknown>) => Promise<unknown>)(txMock);
+			}
+			// For non-callback calls (delegation tests), just resolve
+			return Promise.resolve();
+		}),
 		close: mock(() => Promise.resolve()),
 		options: { parsers: {}, serializers: {} },
 	};
@@ -94,7 +114,10 @@ describe('createResilientSQLProxy', () => {
 		});
 		const newRaw: Record<string, unknown> = {
 			unsafe: newUnsafe,
-			begin: mock(() => Promise.resolve()),
+			begin: mock(async (fn: (tx: Record<string, unknown>) => Promise<unknown>) => {
+				const txMock = { unsafe: newUnsafe };
+				return fn(txMock);
+			}),
 			options: { parsers: {}, serializers: {} },
 		};
 
@@ -140,7 +163,10 @@ describe('createResilientSQLProxy', () => {
 		});
 		const newRaw: Record<string, unknown> = {
 			unsafe: newUnsafe,
-			begin: mock(() => Promise.resolve()),
+			begin: mock(async (fn: (tx: Record<string, unknown>) => Promise<unknown>) => {
+				const txMock = { unsafe: newUnsafe };
+				return fn(txMock);
+			}),
 			options: { parsers: {}, serializers: {} },
 		};
 
@@ -191,7 +217,7 @@ describe('createResilientSQLProxy', () => {
 		await proxy.unsafe('INSERT INTO items (name) VALUES ($1)', ['test']);
 
 		expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
-		expect(unsafeCalls).toEqual(['BEGIN', 'INSERT INTO items (name) VALUES ($1)', 'COMMIT']);
+		expect(unsafeCalls).toEqual(['INSERT INTO items (name) VALUES ($1)']);
 	});
 
 	it('uses transaction-wrapped retry for INSERT with leading whitespace', async () => {
@@ -201,7 +227,7 @@ describe('createResilientSQLProxy', () => {
 		await proxy.unsafe('  INSERT INTO items (name) VALUES ($1)', ['test']);
 
 		expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
-		expect(unsafeCalls).toEqual(['BEGIN', '  INSERT INTO items (name) VALUES ($1)', 'COMMIT']);
+		expect(unsafeCalls).toEqual(['  INSERT INTO items (name) VALUES ($1)']);
 	});
 
 	it('uses transaction-wrapped retry for case-insensitive INSERT', async () => {
@@ -211,7 +237,7 @@ describe('createResilientSQLProxy', () => {
 		await proxy.unsafe('insert into items (name) VALUES ($1)', ['test']);
 
 		expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
-		expect(unsafeCalls).toEqual(['BEGIN', 'insert into items (name) VALUES ($1)', 'COMMIT']);
+		expect(unsafeCalls).toEqual(['insert into items (name) VALUES ($1)']);
 	});
 
 	it('INSERT queries support .values() chaining', async () => {
@@ -226,11 +252,7 @@ describe('createResilientSQLProxy', () => {
 		// With lazy thenable, .values() is called before .then(), so only
 		// one transaction executes (in values mode)
 		expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
-		expect(unsafeCalls).toEqual([
-			'BEGIN',
-			'INSERT INTO items (name) VALUES ($1) RETURNING *',
-			'COMMIT',
-		]);
+		expect(unsafeCalls).toEqual(['INSERT INTO items (name) VALUES ($1) RETURNING *']);
 	});
 
 	it('INSERT lazy thenable only executes once via .values()', async () => {
@@ -246,7 +268,7 @@ describe('createResilientSQLProxy', () => {
 		expect(valuesResult).toEqual([[1]]);
 		// Only ONE execution should have run
 		expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
-		expect(unsafeCalls).toEqual(['BEGIN', 'INSERT INTO items (name) VALUES ($1)', 'COMMIT']);
+		expect(unsafeCalls).toEqual(['INSERT INTO items (name) VALUES ($1)']);
 	});
 
 	it('INSERT lazy thenable executes on direct await (without .values())', async () => {
@@ -257,7 +279,7 @@ describe('createResilientSQLProxy', () => {
 
 		expect(result).toEqual([{ id: 1 }]);
 		expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
-		expect(unsafeCalls).toEqual(['BEGIN', 'INSERT INTO items (name) VALUES ($1)', 'COMMIT']);
+		expect(unsafeCalls).toEqual(['INSERT INTO items (name) VALUES ($1)']);
 	});
 
 	it('uses transaction-wrapped retry for INSERT with leading block comment', async () => {
@@ -268,9 +290,7 @@ describe('createResilientSQLProxy', () => {
 
 		expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
 		expect(unsafeCalls).toEqual([
-			'BEGIN',
 			'/* audit: user-123 */ INSERT INTO items (name) VALUES ($1)',
-			'COMMIT',
 		]);
 	});
 
@@ -282,9 +302,7 @@ describe('createResilientSQLProxy', () => {
 
 		expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
 		expect(unsafeCalls).toEqual([
-			'BEGIN',
 			'-- create new item\nINSERT INTO items (name) VALUES ($1)',
-			'COMMIT',
 		]);
 	});
 
@@ -295,11 +313,7 @@ describe('createResilientSQLProxy', () => {
 		await proxy.unsafe('\n\n  INSERT INTO items (name) VALUES ($1)', ['test']);
 
 		expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
-		expect(unsafeCalls).toEqual([
-			'BEGIN',
-			'\n\n  INSERT INTO items (name) VALUES ($1)',
-			'COMMIT',
-		]);
+		expect(unsafeCalls).toEqual(['\n\n  INSERT INTO items (name) VALUES ($1)']);
 	});
 
 	it('uses transaction-wrapped retry for CTE INSERT', async () => {
@@ -313,9 +327,7 @@ describe('createResilientSQLProxy', () => {
 
 		expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
 		expect(unsafeCalls).toEqual([
-			'BEGIN',
 			'WITH new_item AS (SELECT $1::text AS name) INSERT INTO items (name) SELECT name FROM new_item RETURNING *',
-			'COMMIT',
 		]);
 	});
 
@@ -330,9 +342,7 @@ describe('createResilientSQLProxy', () => {
 
 		expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
 		expect(unsafeCalls).toEqual([
-			'BEGIN',
 			'WITH a AS (SELECT 1), b AS (SELECT 2) INSERT INTO items (name) VALUES ($1)',
-			'COMMIT',
 		]);
 	});
 
@@ -344,9 +354,7 @@ describe('createResilientSQLProxy', () => {
 
 		expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
 		expect(unsafeCalls).toEqual([
-			'BEGIN',
 			'with cte as (select 1) insert into items (name) values ($1)',
-			'COMMIT',
 		]);
 	});
 
@@ -361,9 +369,7 @@ describe('createResilientSQLProxy', () => {
 
 		expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
 		expect(unsafeCalls).toEqual([
-			'BEGIN',
 			'WITH cte AS (SELECT id FROM (SELECT id FROM items WHERE id IN (1, 2))) INSERT INTO archive (id) SELECT id FROM cte',
-			'COMMIT',
 		]);
 	});
 
@@ -384,9 +390,7 @@ describe('createResilientSQLProxy', () => {
 
 		expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
 		expect(unsafeCalls).toEqual([
-			'BEGIN',
 			'WITH cte AS (SELECT 1) UPDATE items SET name = $1',
-			'COMMIT',
 		]);
 	});
 
@@ -398,9 +402,7 @@ describe('createResilientSQLProxy', () => {
 
 		expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
 		expect(unsafeCalls).toEqual([
-			'BEGIN',
 			'WITH cte AS (SELECT 1) DELETE FROM items WHERE id = $1',
-			'COMMIT',
 		]);
 	});
 
@@ -421,9 +423,7 @@ describe('createResilientSQLProxy', () => {
 			await proxy.unsafe("WITH cte AS (SELECT ')' AS x) INSERT INTO items VALUES ($1)", [1]);
 			expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
 			expect(unsafeCalls).toEqual([
-				'BEGIN',
 				"WITH cte AS (SELECT ')' AS x) INSERT INTO items VALUES ($1)",
-				'COMMIT',
 			]);
 		});
 
@@ -433,9 +433,7 @@ describe('createResilientSQLProxy', () => {
 			await proxy.unsafe("WITH cte AS (SELECT '(' AS x) INSERT INTO items VALUES ($1)", [1]);
 			expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
 			expect(unsafeCalls).toEqual([
-				'BEGIN',
 				"WITH cte AS (SELECT '(' AS x) INSERT INTO items VALUES ($1)",
-				'COMMIT',
 			]);
 		});
 
@@ -447,9 +445,7 @@ describe('createResilientSQLProxy', () => {
 			]);
 			expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
 			expect(unsafeCalls).toEqual([
-				'BEGIN',
 				"WITH cte AS (SELECT 'it''s ()' AS x) INSERT INTO items VALUES ($1)",
-				'COMMIT',
 			]);
 		});
 
@@ -461,9 +457,7 @@ describe('createResilientSQLProxy', () => {
 			]);
 			expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
 			expect(unsafeCalls).toEqual([
-				'BEGIN',
 				'WITH cte AS (SELECT "col(1)" FROM t) INSERT INTO items VALUES ($1)',
-				'COMMIT',
 			]);
 		});
 
@@ -473,9 +467,7 @@ describe('createResilientSQLProxy', () => {
 			await proxy.unsafe('WITH cte AS (SELECT /* ) */ 1) INSERT INTO items VALUES ($1)', [1]);
 			expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
 			expect(unsafeCalls).toEqual([
-				'BEGIN',
 				'WITH cte AS (SELECT /* ) */ 1) INSERT INTO items VALUES ($1)',
-				'COMMIT',
 			]);
 		});
 
@@ -487,9 +479,7 @@ describe('createResilientSQLProxy', () => {
 			]);
 			expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
 			expect(unsafeCalls).toEqual([
-				'BEGIN',
 				'WITH cte AS (SELECT 1 -- )\nFROM t) INSERT INTO items VALUES ($1)',
-				'COMMIT',
 			]);
 		});
 
@@ -499,9 +489,7 @@ describe('createResilientSQLProxy', () => {
 			await proxy.unsafe('WITH cte AS (SELECT $$)$$ AS x) INSERT INTO items VALUES ($1)', [1]);
 			expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
 			expect(unsafeCalls).toEqual([
-				'BEGIN',
 				'WITH cte AS (SELECT $$)$$ AS x) INSERT INTO items VALUES ($1)',
-				'COMMIT',
 			]);
 		});
 
@@ -513,9 +501,7 @@ describe('createResilientSQLProxy', () => {
 			]);
 			expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
 			expect(unsafeCalls).toEqual([
-				'BEGIN',
 				'WITH cte AS (SELECT $fn$)($fn$ AS x) INSERT INTO items VALUES ($1)',
-				'COMMIT',
 			]);
 		});
 
@@ -536,11 +522,7 @@ describe('createResilientSQLProxy', () => {
 		await proxy.unsafe('INSERT/*hint*/INTO items (name) VALUES ($1)', ['test']);
 
 		expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
-		expect(unsafeCalls).toEqual([
-			'BEGIN',
-			'INSERT/*hint*/INTO items (name) VALUES ($1)',
-			'COMMIT',
-		]);
+		expect(unsafeCalls).toEqual(['INSERT/*hint*/INTO items (name) VALUES ($1)']);
 	});
 
 	it('detects CTE mutation with inline comment after DML keyword', async () => {
@@ -551,9 +533,7 @@ describe('createResilientSQLProxy', () => {
 
 		expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
 		expect(unsafeCalls).toEqual([
-			'BEGIN',
 			'WITH cte AS (SELECT 1) DELETE/*where*/FROM items WHERE id = $1',
-			'COMMIT',
 		]);
 	});
 
@@ -573,7 +553,7 @@ describe('createResilientSQLProxy', () => {
 		await proxy.unsafe('UPDATE items SET name = $1', ['new']);
 
 		expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
-		expect(unsafeCalls).toEqual(['BEGIN', 'UPDATE items SET name = $1', 'COMMIT']);
+		expect(unsafeCalls).toEqual(['UPDATE items SET name = $1']);
 	});
 
 	it('uses transaction-wrapped retry for DELETE queries', async () => {
@@ -583,30 +563,34 @@ describe('createResilientSQLProxy', () => {
 		await proxy.unsafe('DELETE FROM items WHERE id = $1', [1]);
 
 		expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
-		expect(unsafeCalls).toEqual(['BEGIN', 'DELETE FROM items WHERE id = $1', 'COMMIT']);
+		expect(unsafeCalls).toEqual(['DELETE FROM items WHERE id = $1']);
 	});
 
 	it('rolls back INSERT transaction on query error', async () => {
 		const unsafeCalls: string[] = [];
-		let callIndex = 0;
-		const mockUnsafe = mock((query: string, _params?: unknown[]) => {
-			unsafeCalls.push(query);
-			callIndex++;
-			// First call: BEGIN succeeds
-			// Second call: INSERT fails
-			// Third call: ROLLBACK succeeds
-			if (callIndex === 2) {
-				return Promise.reject(new Error('query failed'));
+		const mockBegin = mock(
+			async (fn: (tx: Record<string, unknown>) => Promise<unknown>) => {
+				// Create a transaction-scoped mock where unsafe fails
+				const txUnsafe = mock((query: string, _params?: unknown[]) => {
+					unsafeCalls.push(query);
+					return Promise.reject(new Error('query failed'));
+				});
+				const txMock = { unsafe: txUnsafe };
+				// sql.begin() calls the callback; if it throws, the driver
+				// auto-rolls back and propagates the error
+				return fn(txMock);
 			}
-			const result = Promise.resolve([{ id: 1 }]);
-			return Object.assign(result, {
-				values: () => Promise.resolve([[1]]),
-			});
-		});
+		);
 
 		const raw: Record<string, unknown> = {
-			unsafe: mockUnsafe,
-			begin: mock(() => Promise.resolve()),
+			unsafe: mock((query: string, _params?: unknown[]) => {
+				unsafeCalls.push(query);
+				const result = Promise.resolve([{ id: 1 }]);
+				return Object.assign(result, {
+					values: () => Promise.resolve([[1]]),
+				});
+			}),
+			begin: mockBegin,
 			close: mock(() => Promise.resolve()),
 			options: { parsers: {}, serializers: {} },
 		};
@@ -628,7 +612,9 @@ describe('createResilientSQLProxy', () => {
 			Promise.resolve(proxy.unsafe('INSERT INTO items (name) VALUES ($1)', ['test']))
 		).rejects.toThrow('query failed');
 
-		expect(unsafeCalls).toEqual(['BEGIN', 'INSERT INTO items (name) VALUES ($1)', 'ROLLBACK']);
+		// With sql.begin(callback), BEGIN/ROLLBACK are handled internally by the driver.
+		// Only the actual query that was executed inside the callback appears in unsafeCalls.
+		expect(unsafeCalls).toEqual(['INSERT INTO items (name) VALUES ($1)']);
 	});
 
 	it('INSERT transaction re-resolves raw on retry after reconnection', async () => {
@@ -643,7 +629,17 @@ describe('createResilientSQLProxy', () => {
 					values: () => Promise.resolve([[1]]),
 				});
 			}),
-			begin: mock(() => Promise.resolve()),
+			begin: mock(async (fn: (tx: Record<string, unknown>) => Promise<unknown>) => {
+				const txUnsafe = mock((query: string, _params?: unknown[]) => {
+					firstUnsafeCalls.push(query);
+					const result = Promise.resolve([{ id: 1 }]);
+					return Object.assign(result, {
+						values: () => Promise.resolve([[1]]),
+					});
+				});
+				const txMock = { unsafe: txUnsafe };
+				return fn(txMock);
+			}),
 			close: mock(() => Promise.resolve()),
 			options: { parsers: {}, serializers: {} },
 		};
@@ -656,7 +652,17 @@ describe('createResilientSQLProxy', () => {
 					values: () => Promise.resolve([[2]]),
 				});
 			}),
-			begin: mock(() => Promise.resolve()),
+			begin: mock(async (fn: (tx: Record<string, unknown>) => Promise<unknown>) => {
+				const txUnsafe = mock((query: string, _params?: unknown[]) => {
+					secondUnsafeCalls.push(query);
+					const result = Promise.resolve([{ id: 2 }]);
+					return Object.assign(result, {
+						values: () => Promise.resolve([[2]]),
+					});
+				});
+				const txMock = { unsafe: txUnsafe };
+				return fn(txMock);
+			}),
 			close: mock(() => Promise.resolve()),
 			options: { parsers: {}, serializers: {} },
 		};
@@ -684,11 +690,8 @@ describe('createResilientSQLProxy', () => {
 		// raw is re-resolved inside the retry callback
 		expect(result).toEqual([{ id: 2 }]);
 		expect(firstUnsafeCalls).toEqual([]); // First raw was never used
-		expect(secondUnsafeCalls).toEqual([
-			'BEGIN',
-			'INSERT INTO items (name) VALUES ($1)',
-			'COMMIT',
-		]);
+		// With sql.begin(callback), only the actual query appears (no BEGIN/COMMIT)
+		expect(secondUnsafeCalls).toEqual(['INSERT INTO items (name) VALUES ($1)']);
 	});
 
 	describe('data safety: single-execution guarantee', () => {
@@ -738,7 +741,7 @@ describe('createResilientSQLProxy', () => {
 			await thenable;
 			await thenable;
 			expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
-			expect(unsafeCalls).toEqual(['BEGIN', 'UPDATE items SET name = $1', 'COMMIT']);
+			expect(unsafeCalls).toEqual(['UPDATE items SET name = $1']);
 		});
 
 		it('multiple .values() calls run single transaction', async () => {
@@ -754,7 +757,7 @@ describe('createResilientSQLProxy', () => {
 			expect(r2).toEqual([[1]]);
 			expect(r3).toEqual([[1]]);
 			expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
-			expect(unsafeCalls).toEqual(['BEGIN', 'INSERT INTO items (name) VALUES ($1)', 'COMMIT']);
+			expect(unsafeCalls).toEqual(['INSERT INTO items (name) VALUES ($1)']);
 		});
 
 		it('.catch() triggers execution exactly once', async () => {
@@ -765,7 +768,7 @@ describe('createResilientSQLProxy', () => {
 			await thenable.catch(() => {});
 			// Verify single execution
 			expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
-			expect(unsafeCalls).toEqual(['BEGIN', 'INSERT INTO items (name) VALUES ($1)', 'COMMIT']);
+			expect(unsafeCalls).toEqual(['INSERT INTO items (name) VALUES ($1)']);
 		});
 
 		it('.finally() triggers execution exactly once', async () => {
@@ -775,7 +778,7 @@ describe('createResilientSQLProxy', () => {
 			// .finally() should start execution (via startExecution(false))
 			await thenable.finally(() => {});
 			expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
-			expect(unsafeCalls).toEqual(['BEGIN', 'UPDATE items SET active = false', 'COMMIT']);
+			expect(unsafeCalls).toEqual(['UPDATE items SET active = false']);
 		});
 
 		it('UPDATE queries support .values() chaining with single transaction', async () => {
@@ -786,7 +789,7 @@ describe('createResilientSQLProxy', () => {
 				.values();
 			expect(result).toEqual([[1]]);
 			expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
-			expect(unsafeCalls).toEqual(['BEGIN', 'UPDATE items SET name = $1 RETURNING *', 'COMMIT']);
+			expect(unsafeCalls).toEqual(['UPDATE items SET name = $1 RETURNING *']);
 		});
 
 		it('DELETE queries support .values() chaining with single transaction', async () => {
@@ -797,11 +800,7 @@ describe('createResilientSQLProxy', () => {
 				.values();
 			expect(result).toEqual([[1]]);
 			expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
-			expect(unsafeCalls).toEqual([
-				'BEGIN',
-				'DELETE FROM items WHERE id = $1 RETURNING *',
-				'COMMIT',
-			]);
+			expect(unsafeCalls).toEqual(['DELETE FROM items WHERE id = $1 RETURNING *']);
 		});
 	});
 
@@ -861,7 +860,7 @@ describe('createResilientSQLProxy', () => {
 			await thenable;
 			await thenable;
 			expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
-			expect(unsafeCalls).toEqual(['BEGIN', 'INSERT INTO items (name) VALUES ($1)', 'COMMIT']);
+			expect(unsafeCalls).toEqual(['INSERT INTO items (name) VALUES ($1)']);
 		});
 
 		it('allows repeated .values() calls on same mutation', async () => {
@@ -874,7 +873,7 @@ describe('createResilientSQLProxy', () => {
 			expect(r1).toEqual([[1]]);
 			expect(r2).toEqual([[1]]);
 			expect(client.executeWithRetry).toHaveBeenCalledTimes(1);
-			expect(unsafeCalls).toEqual(['BEGIN', 'DELETE FROM items WHERE id = $1', 'COMMIT']);
+			expect(unsafeCalls).toEqual(['DELETE FROM items WHERE id = $1']);
 		});
 
 		it('throws when .values() called after .then() on non-mutation', async () => {

--- a/packages/postgres/src/client.ts
+++ b/packages/postgres/src/client.ts
@@ -230,20 +230,14 @@ export class PostgresClient {
 		return this._executeWithRetry(async () => {
 			const sql = await this._ensureConnectedAsync();
 			if (mutation) {
-				await sql.unsafe('BEGIN');
-				try {
-					const result = await sql(strings, ...values);
-					await sql.unsafe('COMMIT');
-					return result as unknown[];
-				} catch (error) {
-					try {
-						await sql.unsafe('ROLLBACK');
-					} catch {
-						// Connection may already be dead; Postgres auto-rolls
-						// back uncommitted transactions on connection close.
-					}
-					throw error;
-				}
+				// Use sql.begin() callback API for pool-safe transactions.
+				// Bun requires this instead of manual BEGIN/COMMIT when max > 1,
+				// because sql.begin() reserves a specific connection for the
+				// transaction. Manual BEGIN via sql.unsafe('BEGIN') would throw
+				// ERR_POSTGRES_UNSAFE_TRANSACTION on pooled connections.
+				return sql.begin(async (tx) => {
+					return tx(strings, ...values) as unknown as unknown[];
+				});
 			}
 			return sql(strings, ...values);
 		});
@@ -273,6 +267,13 @@ export class PostgresClient {
 		// This ensures _warmConnection() updates connection stats before we proceed
 		const sql = await this._ensureConnectedAsync();
 
+		// Reserve a dedicated connection from the pool. Bun requires either
+		// sql.begin(callback), sql.reserve(), or max:1 for transactions.
+		// Since this API returns a Transaction object for manual commit/rollback,
+		// we need a reserved connection to guarantee all queries hit the same
+		// connection as the BEGIN.
+		const reserved = await sql.reserve();
+
 		// Build BEGIN statement with options
 		let beginStatement = 'BEGIN';
 
@@ -292,10 +293,15 @@ export class PostgresClient {
 			beginStatement += ' NOT DEFERRABLE';
 		}
 
-		// Execute BEGIN
-		const connection = await sql.unsafe(beginStatement);
-
-		return new Transaction(sql, connection);
+		// Execute BEGIN on the reserved connection
+		try {
+			const connection = await reserved.unsafe(beginStatement);
+			return new Transaction(reserved, connection);
+		} catch (error) {
+			// Release the reserved connection if BEGIN fails
+			reserved.release();
+			throw error;
+		}
 	}
 
 	/**
@@ -419,24 +425,16 @@ export class PostgresClient {
 	 */
 	unsafeQuery(query: string, params?: unknown[]): UnsafeQueryResult {
 		if (isMutationStatement(query)) {
+			// Use sql.begin() callback API for pool-safe transactions.
+			// Bun requires this instead of manual BEGIN/COMMIT when max > 1.
+			// sql.begin() auto-COMMITs on success and auto-ROLLBACKs on error.
 			const makeTransactionalExecutor = (useValues: boolean) =>
 				this._executeWithRetry(async () => {
 					const raw = this._ensureConnected();
-					await raw.unsafe('BEGIN');
-					try {
-						const q = params ? raw.unsafe(query, params) : raw.unsafe(query);
-						const result = useValues ? await q.values() : await q;
-						await raw.unsafe('COMMIT');
-						return result;
-					} catch (error) {
-						try {
-							await raw.unsafe('ROLLBACK');
-						} catch {
-							// Connection may already be dead; Postgres auto-rolls
-							// back uncommitted transactions on connection close.
-						}
-						throw error;
-					}
+					return raw.begin(async (tx) => {
+						const q = params ? tx.unsafe(query, params) : tx.unsafe(query);
+						return useValues ? await q.values() : await q;
+					});
 				});
 
 			return createThenable(makeTransactionalExecutor);

--- a/packages/postgres/src/transaction.ts
+++ b/packages/postgres/src/transaction.ts
@@ -122,6 +122,8 @@ export class Transaction {
 				phase: 'commit',
 				cause: error,
 			});
+		} finally {
+			this._releaseConnection();
 		}
 	}
 
@@ -142,6 +144,19 @@ export class Transaction {
 				phase: 'rollback',
 				cause: error,
 			});
+		} finally {
+			this._releaseConnection();
+		}
+	}
+
+	/**
+	 * Releases the underlying reserved connection back to the pool.
+	 * Called automatically on commit or rollback. Safe to call multiple times.
+	 */
+	private _releaseConnection(): void {
+		const sql = this._sql as unknown as { release?: () => void };
+		if (typeof sql.release === 'function') {
+			sql.release();
 		}
 	}
 

--- a/packages/postgres/test/integration/tx-safety.ts
+++ b/packages/postgres/test/integration/tx-safety.ts
@@ -1,0 +1,260 @@
+/**
+ * Integration test for transaction safety with pooled connections.
+ *
+ * Validates that:
+ * - Standalone mutations work (wrapped in sql.begin internally)
+ * - Mutations inside explicit transactions work (no double-wrapping)
+ * - Concurrent standalone mutations don't conflict
+ * - Raw Bun SQL sql.begin() works as baseline
+ *
+ * Run:
+ *   DATABASE_URL=postgres://... bun run packages/postgres/test/integration/tx-safety.ts
+ *
+ * See: https://github.com/agentuity/sdk/issues/911
+ */
+
+import { SQL } from 'bun';
+import { postgres } from '../../src/index';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+
+if (!DATABASE_URL) {
+	console.error('❌ Missing DATABASE_URL env var.');
+	console.error('   Usage: DATABASE_URL=postgres://user:pass@host:5432/db bun run this-file.ts');
+	process.exit(1);
+}
+
+const TEST_TABLE = 'tx_safety_test';
+let passed = 0;
+let failed = 0;
+
+async function test(name: string, fn: () => Promise<void>): Promise<void> {
+	try {
+		await fn();
+		passed++;
+		console.log(`  ✅ ${name}`);
+	} catch (error) {
+		failed++;
+		console.error(`  ❌ ${name}`);
+		console.error(`     ${error instanceof Error ? error.message : String(error)}`);
+		if (error instanceof Error && error.cause) {
+			console.error(`     cause: ${error.cause}`);
+		}
+	}
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Setup / Teardown
+// ───────────────────────────────────────────────────────────────────────
+
+async function setup(sql: InstanceType<typeof SQL>) {
+	await sql.unsafe(`DROP TABLE IF EXISTS ${TEST_TABLE}`);
+	await sql.unsafe(`
+		CREATE TABLE ${TEST_TABLE} (
+			id SERIAL PRIMARY KEY,
+			name TEXT NOT NULL,
+			value TEXT,
+			created_at TIMESTAMPTZ DEFAULT NOW()
+		)
+	`);
+}
+
+async function teardown(sql: InstanceType<typeof SQL>) {
+	await sql.unsafe(`DROP TABLE IF EXISTS ${TEST_TABLE}`);
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Part 1: Raw Bun SQL (baseline — proves sql.begin works)
+// ───────────────────────────────────────────────────────────────────────
+
+async function testBunSql() {
+	console.log('\n📦 Part 1: Raw Bun SQL (baseline)');
+
+	const sql = new SQL({ url: DATABASE_URL, adapter: 'postgres' });
+
+	try {
+		await setup(sql);
+
+		await test('SELECT works', async () => {
+			const rows = await sql.unsafe(`SELECT 1 AS one`);
+			if (rows[0].one !== 1) throw new Error(`Expected 1, got ${rows[0].one}`);
+		});
+
+		await test('sql.begin() — INSERT inside transaction', async () => {
+			const result = await sql.begin(async (tx) => {
+				return tx.unsafe(
+					`INSERT INTO ${TEST_TABLE} (name, value) VALUES ($1, $2) RETURNING *`,
+					['bun-tx', 'hello']
+				);
+			});
+			if (result.length !== 1) throw new Error(`Expected 1 row, got ${result.length}`);
+			if (result[0].name !== 'bun-tx') throw new Error(`Expected 'bun-tx', got '${result[0].name}'`);
+		});
+
+		await test('sql.begin() — multiple operations in one transaction', async () => {
+			const [r1, r2] = await sql.begin(async (tx) => {
+				const insert1 = await tx.unsafe(
+					`INSERT INTO ${TEST_TABLE} (name, value) VALUES ($1, $2) RETURNING *`,
+					['bun-multi-1', 'a']
+				);
+				const insert2 = await tx.unsafe(
+					`INSERT INTO ${TEST_TABLE} (name, value) VALUES ($1, $2) RETURNING *`,
+					['bun-multi-2', 'b']
+				);
+				return [insert1, insert2];
+			});
+			if (r1.length !== 1 || r2.length !== 1) throw new Error('Expected 1 row each');
+		});
+
+		await test('sql.begin() — auto-rollback on error', async () => {
+			const countBefore = await sql.unsafe(`SELECT COUNT(*) AS cnt FROM ${TEST_TABLE}`);
+			try {
+				await sql.begin(async (tx) => {
+					await tx.unsafe(
+						`INSERT INTO ${TEST_TABLE} (name, value) VALUES ($1, $2)`,
+						['should-rollback', 'x']
+					);
+					throw new Error('intentional error');
+				});
+			} catch {
+				// expected
+			}
+			const countAfter = await sql.unsafe(`SELECT COUNT(*) AS cnt FROM ${TEST_TABLE}`);
+			if (Number(countBefore[0].cnt) !== Number(countAfter[0].cnt)) {
+				throw new Error('Row was not rolled back');
+			}
+		});
+
+		await teardown(sql);
+	} finally {
+		await sql.close();
+	}
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Part 2: @agentuity/postgres client
+// ───────────────────────────────────────────────────────────────────────
+
+async function testPostgresClient() {
+	console.log('\n📦 Part 2: @agentuity/postgres client');
+
+	const client = postgres({ url: DATABASE_URL });
+	await client.waitForConnection();
+
+	try {
+		await setup(client.raw);
+
+		await test('tagged template SELECT works', async () => {
+			const rows = await client`SELECT 1 AS one`;
+			if ((rows as { one: number }[])[0].one !== 1) throw new Error('Expected 1');
+		});
+
+		await test('tagged template INSERT works (standalone mutation — uses sql.begin internally)', async () => {
+			const name = 'client-insert';
+			const rows = await client`
+				INSERT INTO ${client.raw.unsafe(TEST_TABLE)} (name, value)
+				VALUES (${name}, ${'test-val'})
+				RETURNING *
+			`;
+			if ((rows as { name: string }[]).length !== 1) throw new Error('Expected 1 row');
+		});
+
+		await test('unsafeQuery INSERT works (standalone mutation)', async () => {
+			const result = await client.unsafeQuery(
+				`INSERT INTO ${TEST_TABLE} (name, value) VALUES ($1, $2) RETURNING *`,
+				['unsafe-insert', 'val']
+			);
+			if ((result as unknown[]).length !== 1) throw new Error('Expected 1 row');
+		});
+
+		await test('unsafeQuery INSERT .values() works', async () => {
+			const result = await client.unsafeQuery(
+				`INSERT INTO ${TEST_TABLE} (name, value) VALUES ($1, $2) RETURNING id, name`,
+				['unsafe-values', 'val']
+			).values();
+			if ((result as unknown[][]).length !== 1) throw new Error('Expected 1 row');
+			if (!Array.isArray((result as unknown[][])[0])) throw new Error('Expected array row format');
+		});
+
+		await test('unsafeQuery UPDATE works', async () => {
+			const result = await client.unsafeQuery(
+				`UPDATE ${TEST_TABLE} SET value = $1 WHERE name = $2 RETURNING *`,
+				['updated', 'unsafe-insert']
+			);
+			if ((result as { value: string }[])[0]?.value !== 'updated') {
+				throw new Error('Expected value to be updated');
+			}
+		});
+
+		await test('unsafeQuery DELETE works', async () => {
+			// Insert then delete
+			await client.unsafeQuery(
+				`INSERT INTO ${TEST_TABLE} (name, value) VALUES ($1, $2)`,
+				['to-delete', 'x']
+			);
+			const result = await client.unsafeQuery(
+				`DELETE FROM ${TEST_TABLE} WHERE name = $1 RETURNING *`,
+				['to-delete']
+			);
+			if ((result as unknown[]).length !== 1) throw new Error('Expected 1 deleted row');
+		});
+
+		await test('explicit begin/commit transaction works', async () => {
+			const tx = await client.begin();
+			try {
+				await tx.query`INSERT INTO ${client.raw.unsafe(TEST_TABLE)} (name, value) VALUES (${'tx-insert'}, ${'tx-val'})`;
+				await tx.commit();
+			} catch (e) {
+				await tx.rollback();
+				throw e;
+			}
+			const rows = await client.unsafeQuery(
+				`SELECT * FROM ${TEST_TABLE} WHERE name = $1`,
+				['tx-insert']
+			);
+			if ((rows as unknown[]).length !== 1) throw new Error('Expected 1 row after commit');
+		});
+
+		await test('concurrent standalone mutations work', async () => {
+			const inserts = Array.from({ length: 5 }, (_, i) =>
+				client.unsafeQuery(
+					`INSERT INTO ${TEST_TABLE} (name, value) VALUES ($1, $2) RETURNING *`,
+					[`concurrent-${i}`, `val-${i}`]
+				)
+			);
+			const results = await Promise.all(inserts);
+			for (const r of results) {
+				if ((r as unknown[]).length !== 1) throw new Error('Expected 1 row per insert');
+			}
+		});
+
+		await test('unsafeQuery SELECT works (no transaction wrapping)', async () => {
+			const result = await client.unsafeQuery(`SELECT * FROM ${TEST_TABLE}`);
+			if ((result as unknown[]).length === 0) throw new Error('Expected rows');
+		});
+
+		await teardown(client.raw);
+	} finally {
+		await client.close();
+	}
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Run
+// ───────────────────────────────────────────────────────────────────────
+
+async function main() {
+	console.log('🔬 Transaction Safety Integration Tests');
+	console.log(`   Database: ${DATABASE_URL?.replace(/\/\/.*@/, '//***@')}`);
+
+	await testBunSql();
+	await testPostgresClient();
+
+	console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed`);
+	process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+	console.error('Fatal error:', err);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

Fixes `ERR_POSTGRES_UNSAFE_TRANSACTION` error introduced in v1.0.16 when performing mutations (INSERT/UPDATE/DELETE) through the Drizzle ORM proxy or PostgresClient on pooled connections.

**Root Cause:** Commit 46d812f6 introduced transaction wrapping for mutations using `sql.unsafe('BEGIN')`/`sql.unsafe('COMMIT')`/`sql.unsafe('ROLLBACK')`. Bun's SQL driver rejects these raw transaction commands on pooled connections (`max > 1`) with `ERR_POSTGRES_UNSAFE_TRANSACTION`, requiring either `sql.begin(callback)`, `sql.reserve()`, or `max: 1` for transaction safety.

**Reported Scenario:** better-auth verification table INSERT failing immediately on any mutation through the Drizzle proxy.

## Changes

### `packages/drizzle/src/postgres.ts`
- `createResilientSQLProxy`: Switched mutation wrapping from manual `BEGIN`/`COMMIT`/`ROLLBACK` to `sql.begin(callback)` — Bun's pool-safe API that automatically reserves a connection, commits on success, and rolls back on error.

### `packages/postgres/src/client.ts`
- `query()`: Same fix — mutations now wrapped in `sql.begin(callback)` instead of raw `sql.unsafe('BEGIN')`
- `unsafeQuery()`: Same fix
- `begin()`: Switched from `sql.unsafe('BEGIN')` to `sql.reserve()` + manual BEGIN on the reserved connection — necessary for the manual commit/rollback Transaction API

### `packages/postgres/src/transaction.ts`
- `commit()` / `rollback()`: Added `_releaseConnection()` to release the reserved connection back to the pool after transaction ends

### Test Updates
- `packages/drizzle/test/proxy.test.ts`: Updated ~30 assertions to match new `begin(callback)` mock pattern
- `packages/postgres/test/integration/tx-safety.ts`: **New** — 13 integration tests covering raw Bun SQL baseline, tagged templates, unsafeQuery, explicit begin/commit, and concurrent mutations
- `packages/drizzle/test/integration/tx-safety.ts`: **New** — 11 integration tests covering standalone insert/update/delete, db.transaction(), better-auth verification scenario, and concurrent operations

## Test Results

| Suite | Tests | Status |
|-------|-------|--------|
| Postgres integration | 13/13 | ✅ Pass |
| Drizzle integration | 11/11 | ✅ Pass |
| Drizzle unit (proxy.test.ts) | 149 | ✅ Pass |
| Postgres unit | 254 | ✅ Pass (1 skip) |
| Typecheck | all packages | ✅ Clean |
| Build | all packages | ✅ Clean |

## Transaction API Strategy

| Use Case | API | Behavior |
|----------|-----|----------|
| Automatic (query/unsafeQuery/drizzle proxy) | `sql.begin(callback)` | Reserves connection, auto-commits on success, auto-rollbacks on error |
| Manual (Transaction class) | `sql.reserve()` | Reserves connection, user controls commit/rollback, connection released after |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction safety for pooled database connections by adopting a callback-based transaction approach, preventing unsafe transaction errors.
  * Enhanced connection release handling to ensure connections are properly returned to the pool even when errors occur.

* **Tests**
  * Added comprehensive integration tests for transaction safety across multiple scenarios, including concurrency, auto-rollback, and isolation verification.
  * Updated existing unit tests to reflect improved transaction handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->