### PR TITLE
fix(opencode): prevent ghost BACKGROUND TASK ERROR re-notifications

### DIFF
--- a/packages/opencode/src/agents/lead.ts
+++ b/packages/opencode/src/agents/lead.ts
@@ -506,9 +506,9 @@ Use \`agentuity_session_dashboard\` when orchestrating Lead-of-Leads to get a fu
 **Example - Parallel Security Review:**
 When asked to review multiple packages for security:
 1. Launch \`agentuity_background_task\` for each package with Scout
-2. Track all task IDs
-3. Periodically check \`agentuity_background_output\` for completed tasks
-4. Synthesize results when all complete
+2. Report the task IDs and descriptions to the user, then STOP
+3. Wait for \`[BACKGROUND TASK COMPLETED]\` notifications (event-driven, no polling)
+4. Synthesize results after all notifications arrive
 
 ## Orchestration Patterns
 

--- a/packages/opencode/src/background/manager.ts
+++ b/packages/opencode/src/background/manager.ts
@@ -734,7 +734,10 @@ Do not poll more than once every 30 seconds. Be patient — Scout tasks reading 
 				agent: monitorAgent.displayName,
 				status: 'pending',
 				queuedAt: new Date(),
-				concurrencyGroup: this.getConcurrencyGroup(monitorAgent.displayName),
+				// Monitor uses a dedicated concurrency lane so it can never be blocked
+				// by the tasks it's watching. If Monitor queued behind regular tasks it
+				// would never start, and Lead would receive no consolidated report.
+				concurrencyGroup: 'monitor',
 				notifiedStatuses: new Set(),
 				isMonitor: true,
 			};
@@ -754,7 +757,10 @@ Do not poll more than once every 30 seconds. Be patient — Scout tasks reading 
 	private async startTask(task: BackgroundTask): Promise<void> {
 		if (this.shuttingDown) return;
 
-		const concurrencyKey = this.getConcurrencyKey(task.agent);
+		// Use task.concurrencyGroup if explicitly set (e.g. 'monitor' for the auto-launched
+		// Monitor agent), otherwise derive from the agent name. This lets Monitor run in its
+		// own concurrency lane so it can never be blocked by the tasks it's watching.
+		const concurrencyKey = task.concurrencyGroup ?? this.getConcurrencyKey(task.agent);
 		task.concurrencyKey = concurrencyKey;
 
 		try {
@@ -967,8 +973,7 @@ Do not poll more than once every 30 seconds. Be patient — Scout tasks reading 
 		// must remain unmarked so future retry attempts (via refreshStatuses
 		// or Monitor) are not blocked. Mark only on confirmed delivery below.
 
-		const statusLine = statusAtCallTime === 'completed' ? 'completed' : statusAtCallTime;
-		const message = `[BACKGROUND TASK ${statusLine.toUpperCase()}]
+		const message = `[BACKGROUND TASK ${statusAtCallTime.toUpperCase()}]
 
 Task: ${task.description}
 Agent: ${task.agent}

--- a/packages/opencode/src/plugin/hooks/completion.ts
+++ b/packages/opencode/src/plugin/hooks/completion.ts
@@ -17,16 +17,36 @@ export function createCompletionHooks(ctx: PluginInput, _config: CoderConfig): C
 
 	return {
 		onParams(input: unknown): void {
+			// OpenCode passes agent and model as structured objects (not plain strings)
+			// in the chat.params hook. Normalize to string here so template literals
+			// don't produce '[object Object]' in the completion log.
 			const inp = input as {
 				sessionID?: string;
-				agent?: string;
-				model?: string;
+				agent?: unknown;
+				model?: unknown;
 			};
 			if (!inp.sessionID) return;
+
+			const agentStr =
+				typeof inp.agent === 'string'
+					? inp.agent
+					: ((inp.agent as { id?: string; name?: string; displayName?: string } | null)
+							?.displayName ??
+						(inp.agent as { id?: string; name?: string } | null)?.name ??
+						(inp.agent as { id?: string } | null)?.id ??
+						String(inp.agent ?? 'unknown'));
+
+			const modelStr =
+				typeof inp.model === 'string'
+					? inp.model
+					: ((inp.model as { id?: string; name?: string } | null)?.id ??
+						(inp.model as { name?: string } | null)?.name ??
+						String(inp.model ?? 'unknown'));
+
 			startTimes.set(inp.sessionID, {
 				startedAt: Date.now(),
-				agent: inp.agent,
-				model: inp.model,
+				agent: agentStr,
+				model: modelStr,
 			});
 		},
 
@@ -40,7 +60,7 @@ export function createCompletionHooks(ctx: PluginInput, _config: CoderConfig): C
 			const durationMs = Date.now() - start.startedAt;
 			const durationSec = (durationMs / 1000).toFixed(1);
 
-			const logLine = `Completion: agent=${start.agent ?? 'unknown'} model=${start.model ?? 'unknown'} duration=${durationSec}s`;
+			const logLine = `Completion: agent=${start.agent} model=${start.model} duration=${durationSec}s`;
 
 			// Verbose local logging for immediate visibility
 			console.debug(`[agentuity-coder] ${logLine}`);


### PR DESCRIPTION
## Problems

This PR fixes five separate bugs in the background task system.

---

### Bug 1 (Primary): Ghost `[BACKGROUND TASK ERROR]` — `refreshStatuses()` downgrades terminal tasks

`refreshStatuses()` runs every 30s. Its inner loop processed **all** tracked tasks including ones already in `error`/`completed`/`cancelled` state. When the API returns `undefined` or unknown status for a cleaned-up session, `mapSessionStatusToTaskStatus()` defaults to `'pending'` — the naked `task.status = newStatus` in the `else` branch illegally downgraded `error → pending` or `completed → pending`, resurrecting dead tasks.

Once resurrected to `pending`, `expireStaleTasks()` (called on every event) would see the task as stale and call `failTask()` again — sending another ghost notification every ~30s.

### Bug 2 (Secondary): Ghost notifications — `notifyParent()` race condition

`notifyParent()` is `async` and called fire-and-forget. It read `task.status` before `await session.prompt()`, yielded the event loop, then read `task.status` again when recording as notified. If Bug 1 fired during the `await` and changed `task.status` from `'error'` to `'pending'`, the method recorded `'pending'` as notified instead of `'error'` — leaving `'error'` permanently unguarded so every future `failTask()` sent another notification.

**Combined cycle (fired every ~30s):**
```
session.error → failTask() → status='error' → notifyParent() begins await
  → refreshStatuses() downgrades error→pending
  → notifyParent() resumes, records 'pending' (not 'error') as notified
  → expireStaleTasks() sees 'pending' + stale → failTask() → ghost notification
  → repeat every 30s
```

### Bug 3: Lead polls background tasks instead of waiting for Monitor

The Lead system prompt contradicted itself. Line 651 said "You do NOT need to poll." But the "Example - Parallel Security Review" block at line 510 said "Periodically check `agentuity_background_output` for completed tasks." LLMs follow examples over prose rules — Lead was polling every few tool calls, burning context and deciding tasks were stuck when they were still running normally.

### Bug 4: Monitor blocked by the tasks it's supposed to watch

Monitor was launched into the same `'default'` concurrency pool (limit 5) as all other agents. With 4+ tasks launching simultaneously, Monitor could queue in `concurrency.acquire()` behind the tasks it's supposed to watch — never starting, never sending Lead the consolidated `[ALL BACKGROUND TASKS COMPLETE]` report. With no signal, Lead sat waiting, then started polling (reinforcing Bug 3).

Additionally, `startTask()` always derived the concurrency key from the agent name, ignoring `task.concurrencyGroup` — so even setting a group on Monitor's task object had no effect.

### Bug 5: `[object Object]` in completion log

`completion.ts` logged `agent` and `model` via template literal interpolation. OpenCode passes these as structured objects (not strings) in the `chat.params` hook input, producing `[agentuity-coder] Completion: agent=[object Object] model=[object Object] duration=50.1s`.

---

## Fixes

**Fix 1** — Skip terminal tasks in `refreshStatuses()` before status mapping (`manager.ts`):
```ts
if (task.status === 'completed' || task.status === 'error' || task.status === 'cancelled') {
    continue;
}
```

**Fix 2** — Snapshot `task.status` at call-time in `notifyParent()`, use snapshot throughout (`manager.ts`):
```ts
const statusAtCallTime = task.status;
// all reads and writes use statusAtCallTime — immune to concurrent mutation
```

**Fix 3** — Add `'compacting'` case to `mapSessionStatusToTaskStatus()` (`manager.ts`), matching the DB reader so compacting sessions aren't mapped to `'pending'`.

**Fix 4** — Remove the contradictory polling example from the Lead system prompt (`lead.ts`). Replace "Periodically check `agentuity_background_output`" with "Wait for `[BACKGROUND TASK COMPLETED]` notifications (event-driven, no polling)".

**Fix 5** — Give Monitor a dedicated `'monitor'` concurrency lane (`manager.ts`). Monitor tasks are created with `concurrencyGroup: 'monitor'`, and `startTask()` now respects `task.concurrencyGroup` when set instead of always deriving the key from the agent name. Monitor can now never be blocked by the tasks it's watching.

**Fix 6** — Normalize `agent` and `model` to strings at capture time in `completion.ts`, extracting `.displayName`, `.name`, or `.id` from the object if it's not already a string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Switched multi-task flow to event-driven background task reporting and synthesis after completion.
  * Normalized agent/model identifiers in completion logs for clearer telemetry.

* **Bug Fixes**
  * Prevented overwriting of terminal task states and guarded terminal statuses during refresh.
  * Used snapshot-based status handling to avoid race conditions in notifications, improve rate limiting, and ensure reliable retry cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->