### PR TITLE
fix(cli): resolve Ctrl+C hang during project import prompts

### DIFF
--- a/packages/cli/src/tui.ts
+++ b/packages/cli/src/tui.ts
@@ -737,7 +737,7 @@ export function banner(title: string, body: string, options?: BannerOptions): vo
 /**
  * Wait for any key press before continuing
  * Displays a prompt message and waits for user input
- * Raises SIGINT if CTRL+C is pressed
+ * Exits the process on CTRL+C
  */
 export async function waitForAnyKey(message = 'Press Enter to continue...'): Promise<void> {
 	process.stdout.write(muted(message));


### PR DESCRIPTION
## Summary

- Fix CLI hanging when pressing Ctrl+C during project import prompts (`tui.confirm()` and `waitForAnyKey()`)
- Replace `process.kill(process.pid, 'SIGINT')` with `process.exit(0)` to ensure clean process termination

## Problem

When a user presses Ctrl+C during the project import prompt (or any prompt using `tui.confirm()`), the CLI hangs indefinitely instead of exiting. 

**Root cause:** Both `confirm()` and `waitForAnyKey()` wrap stdin reading in a Promise. On Ctrl+C, they call `process.kill(process.pid, 'SIGINT')` and `return` from the data callback — but the Promise never resolves or rejects, leaving it permanently pending with no SIGINT handler registered to terminate the process.

## Fix

Replace `process.kill(process.pid, 'SIGINT'); return;` with `process.exit(0)` in both functions. This is consistent with the existing pattern in `PromptFlow.cancel()` (`tui/prompt.ts`). The stdin cleanup (restoring raw mode, pausing stdin) already happens before the Ctrl+C check, so no additional cleanup is needed.

## Changes

- `packages/cli/src/tui.ts`: Fix `waitForAnyKey()` and `confirm()` Ctrl+C handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ctrl+C behavior in the CLI: pressing Ctrl+C now causes a clean process exit with status 0 (including during prompts and wait-for-key flows), preventing an interrupt signal or error and ensuring graceful termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->