### PR TITLE
fix(opencode): remove console.debug calls that corrupt TUI rendering

### DIFF
--- a/packages/opencode/src/background/manager.ts
+++ b/packages/opencode/src/background/manager.ts
@@ -630,17 +630,6 @@ export class BackgroundManager {
 			const error = extractError(event.properties);
 			const errorMsg = error ?? 'Session error.';
 
-			// Log extra context for timeout errors — the server fires these when
-			// a model generates a long text response without tool activity.
-			if (
-				errorMsg.toLowerCase().includes('timeout') ||
-				errorMsg.toLowerCase().includes('no activity')
-			) {
-				console.debug(
-					`[BackgroundManager] Task ${task.id} timed out - may have been generating long response. Progress: ${JSON.stringify(task.progress)}`
-				);
-			}
-
 			this.failTask(task, errorMsg);
 			return;
 		}

--- a/packages/opencode/src/plugin/hooks/completion.ts
+++ b/packages/opencode/src/plugin/hooks/completion.ts
@@ -62,10 +62,8 @@ export function createCompletionHooks(ctx: PluginInput, _config: CoderConfig): C
 
 			const logLine = `Completion: agent=${start.agent} model=${start.model} duration=${durationSec}s`;
 
-			// Verbose local logging for immediate visibility
-			console.debug(`[agentuity-coder] ${logLine}`);
-
-			// Also send to the OpenCode log service
+			// Send to the OpenCode log service (never use console.* in a TUI context —
+			// raw stdout writes bypass the terminal renderer and corrupt the display)
 			ctx.client.app.log({
 				body: {
 					service: 'agentuity-coder',

--- a/packages/opencode/src/plugin/hooks/params.ts
+++ b/packages/opencode/src/plugin/hooks/params.ts
@@ -258,9 +258,6 @@ export class ModelFallbackTracker {
 			errorCode,
 			fallbackIndex,
 		});
-		console.debug(
-			`[ModelFallback] Recorded error for ${agentName}: model=${model} code=${errorCode} fallbackIndex=${fallbackIndex}`
-		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Remove `console.debug()` calls from the opencode plugin that write directly to stdout, bypassing the TUI terminal renderer and causing completion log lines to bleed into the input area
- Fixes rendering artifact where `[agentuity-coder] Completion: agent=... model=... duration=...` text overflows into the cursor/input region

## Details

In a TUI context (BubbleTea), any `console.*` output goes to raw stdout and corrupts the managed terminal display. Three `console.debug` call sites were removed:

| File | What was removed | Why safe |
|---|---|---|
| `completion.ts` | `console.debug(logLine)` | Already sent via `ctx.client.app.log()` — the proper TUI-safe API |
| `params.ts` | `console.debug(ModelFallback error)` | Internal debug state tracked in `agentErrorState` map |
| `manager.ts` | `console.debug(timeout info)` | Error context captured by `failTask()` which surfaces it properly |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up debug logging across the codebase by removing verbose console output while maintaining logging through existing logging services, improving code maintainability without affecting core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->