### PR TITLE
fix(cli): serve src/web/public/ files at root paths in dev mode

### DIFF
--- a/apps/testing/cloud-deployment/src/generated/app.ts
+++ b/apps/testing/cloud-deployment/src/generated/app.ts
@@ -400,10 +400,20 @@ if (isDevelopment()) {
 	}
 	
 	// SPA fallback - serve index.html for client-side routing
-	app.get('*', (c: Context) => {
+	app.get('*', async (c: Context) => {
 		const path = c.req.path;
-		// If path has a file extension, return 404 (prevents serving HTML for missing assets)
+		// If path has a file extension, try proxying to Vite first (serves public files like robots.txt, llms.txt)
+		// Fall back to 404 if Vite also returns 404
 		if (/\.[a-zA-Z0-9]+$/.test(path)) {
+			try {
+				const viteUrl = `http://127.0.0.1:${VITE_ASSET_PORT}${path}`;
+				const res = await fetch(viteUrl, { signal: AbortSignal.timeout(10000) });
+				if (res.status !== 404) {
+					return new Response(res.body, { status: res.status, headers: res.headers });
+				}
+			} catch {
+				// Vite unavailable, fall through to 404
+			}
 			return c.notFound();
 		}
 		return devHtmlHandler(c);

--- a/apps/testing/e2e-web/src/generated/app.ts
+++ b/apps/testing/e2e-web/src/generated/app.ts
@@ -408,10 +408,20 @@ if (isDevelopment()) {
 	}
 	
 	// SPA fallback - serve index.html for client-side routing
-	app.get('*', (c: Context) => {
+	app.get('*', async (c: Context) => {
 		const path = c.req.path;
-		// If path has a file extension, return 404 (prevents serving HTML for missing assets)
+		// If path has a file extension, try proxying to Vite first (serves public files like robots.txt, llms.txt)
+		// Fall back to 404 if Vite also returns 404
 		if (/\.[a-zA-Z0-9]+$/.test(path)) {
+			try {
+				const viteUrl = `http://127.0.0.1:${VITE_ASSET_PORT}${path}`;
+				const res = await fetch(viteUrl, { signal: AbortSignal.timeout(10000) });
+				if (res.status !== 404) {
+					return new Response(res.body, { status: res.status, headers: res.headers });
+				}
+			} catch {
+				// Vite unavailable, fall through to 404
+			}
 			return c.notFound();
 		}
 		return devHtmlHandler(c);

--- a/apps/testing/integration-suite/src/generated/app.ts
+++ b/apps/testing/integration-suite/src/generated/app.ts
@@ -416,10 +416,20 @@ if (isDevelopment()) {
 	}
 	
 	// SPA fallback - serve index.html for client-side routing
-	app.get('*', (c: Context) => {
+	app.get('*', async (c: Context) => {
 		const path = c.req.path;
-		// If path has a file extension, return 404 (prevents serving HTML for missing assets)
+		// If path has a file extension, try proxying to Vite first (serves public files like robots.txt, llms.txt)
+		// Fall back to 404 if Vite also returns 404
 		if (/\.[a-zA-Z0-9]+$/.test(path)) {
+			try {
+				const viteUrl = `http://127.0.0.1:${VITE_ASSET_PORT}${path}`;
+				const res = await fetch(viteUrl, { signal: AbortSignal.timeout(10000) });
+				if (res.status !== 404) {
+					return new Response(res.body, { status: res.status, headers: res.headers });
+				}
+			} catch {
+				// Vite unavailable, fall through to 404
+			}
 			return c.notFound();
 		}
 		return devHtmlHandler(c);

--- a/apps/testing/svelte-web/src/generated/app.ts
+++ b/apps/testing/svelte-web/src/generated/app.ts
@@ -404,10 +404,20 @@ if (isDevelopment()) {
 	}
 	
 	// SPA fallback - serve index.html for client-side routing
-	app.get('*', (c: Context) => {
+	app.get('*', async (c: Context) => {
 		const path = c.req.path;
-		// If path has a file extension, return 404 (prevents serving HTML for missing assets)
+		// If path has a file extension, try proxying to Vite first (serves public files like robots.txt, llms.txt)
+		// Fall back to 404 if Vite also returns 404
 		if (/\.[a-zA-Z0-9]+$/.test(path)) {
+			try {
+				const viteUrl = `http://127.0.0.1:${VITE_ASSET_PORT}${path}`;
+				const res = await fetch(viteUrl, { signal: AbortSignal.timeout(10000) });
+				if (res.status !== 404) {
+					return new Response(res.body, { status: res.status, headers: res.headers });
+				}
+			} catch {
+				// Vite unavailable, fall through to 404
+			}
 			return c.notFound();
 		}
 		return devHtmlHandler(c);

--- a/packages/cli/src/cmd/build/entry-generator.ts
+++ b/packages/cli/src/cmd/build/entry-generator.ts
@@ -377,10 +377,20 @@ ${
 	}
 	
 	// SPA fallback - serve index.html for client-side routing
-	app.get('*', (c: Context) => {
+	app.get('*', async (c: Context) => {
 		const path = c.req.path;
-		// If path has a file extension, return 404 (prevents serving HTML for missing assets)
+		// If path has a file extension, try proxying to Vite first (serves public files like robots.txt, llms.txt)
+		// Fall back to 404 if Vite also returns 404
 		if (/\\.[a-zA-Z0-9]+$/.test(path)) {
+			try {
+				const viteUrl = \`http://127.0.0.1:\${VITE_ASSET_PORT}\${path}\`;
+				const res = await fetch(viteUrl, { signal: AbortSignal.timeout(10000) });
+				if (res.status !== 404) {
+					return new Response(res.body, { status: res.status, headers: res.headers });
+				}
+			} catch {
+				// Vite unavailable, fall through to 404
+			}
 			return c.notFound();
 		}
 		return devHtmlHandler(c);


### PR DESCRIPTION
## Summary

- Fixes the SPA fallback in the generated dev entry to proxy file-extension requests (e.g. `/robots.txt`, `/llms.txt`, `/favicon.ico`) to Vite instead of immediately returning 404
- Vite already has `src/web/public/` configured as its `publicDir` and can serve these files — they just weren't reaching it because the catch-all route intercepted them first
- Falls back to `c.notFound()` if Vite also returns 404, preserving current behavior for genuinely missing assets

## What changed

In `packages/cli/src/cmd/build/entry-generator.ts`, the SPA fallback wildcard route handler:

**Before:**
```typescript
app.get('*', (c: Context) => {
    const path = c.req.path;
    if (/\.[a-zA-Z0-9]+$/.test(path)) {
        return c.notFound(); // blocks .md, .txt, .xml, .ico, etc.
    }
    return devHtmlHandler(c);
});
```

**After:**
```typescript
app.get('*', async (c: Context) => {
    const path = c.req.path;
    if (/\.[a-zA-Z0-9]+$/.test(path)) {
        try {
            const viteUrl = `http://127.0.0.1:${VITE_ASSET_PORT}${path}`;
            const res = await fetch(viteUrl, { signal: AbortSignal.timeout(10000) });
            if (res.status !== 404) {
                return new Response(res.body, { status: res.status, headers: res.headers });
            }
        } catch {
            // Vite unavailable, fall through to 404
        }
        return c.notFound();
    }
    return devHtmlHandler(c);
});
```

Closes #1012

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asset request handling during development. The development server now better manages requests with file extensions, with enhanced fallback behavior when asset serving is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->