### PR TITLE
fix: reject database names starting with pg_ prefix reserved by PostgreSQL

### DIFF
--- a/packages/server/src/api/region/create.ts
+++ b/packages/server/src/api/region/create.ts
@@ -51,6 +51,12 @@ export function validateDatabaseName(name: string): { valid: boolean; error?: st
 			error: 'database name must start with a letter or underscore and contain only lowercase letters, digits, and underscores',
 		};
 	}
+	if (name.startsWith('pg_')) {
+		return {
+			valid: false,
+			error: "database name cannot start with 'pg_' (reserved by PostgreSQL)",
+		};
+	}
 	return { valid: true };
 }
 

--- a/packages/server/test/validation.test.ts
+++ b/packages/server/test/validation.test.ts
@@ -52,6 +52,22 @@ describe('validateDatabaseName', () => {
 		expect(result.valid).toBe(false);
 		expect(result.error).toContain('too short');
 	});
+
+	test('should reject names starting with pg_', () => {
+		const result = validateDatabaseName('pg_fix_test');
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("'pg_'");
+	});
+
+	test('should reject any pg_ prefixed name', () => {
+		const result = validateDatabaseName('pg_something');
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain('reserved by PostgreSQL');
+	});
+
+	test('should allow names containing pg_ not at start', () => {
+		expect(validateDatabaseName('my_pg_database')).toEqual({ valid: true });
+	});
 });
 
 describe('validateBucketName', () => {


### PR DESCRIPTION
## Summary

- Adds client-side validation to reject database names starting with `pg_` in `validateDatabaseName()`, matching the server-side fix in Ion so users get a fast, clear error before the request is even sent.

## Details

When a user creates a database named `pg_fix_test`, the server generates a role name `pg_fix_test_owner`. Neon rejects this because PostgreSQL reserves the `pg_` prefix for system roles, resulting in a 500 error.

This fix adds the same `pg_` prefix check to the SDK's `validateDatabaseName()` so the CLI/SDK catches the issue immediately with: `database name cannot start with 'pg_' (reserved by PostgreSQL)`.

Companion Ion PR: https://github.com/agentuity/ion/pull/new/task/fix-role-name-error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Database name validation now rejects names starting with "pg_" to prevent conflicts with reserved naming conventions.

* **Tests**
  * Added validation test cases for database name restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->