### PR TITLE
feat(server): add clientId and lastOffset options to queue WebSocket for session resumption

### DIFF
--- a/packages/server/src/api/queue/websocket.ts
+++ b/packages/server/src/api/queue/websocket.ts
@@ -26,6 +26,22 @@
  * connection.close();
  * ```
  *
+ * @example Resuming from a previous session
+ * ```typescript
+ * import { createQueueWebSocket } from '@agentuity/server';
+ *
+ * // Use a previously obtained clientId and lastOffset to resume
+ * const connection = createQueueWebSocket({
+ *     queueName: 'order-processing',
+ *     baseUrl: 'https://catalyst.agentuity.cloud',
+ *     clientId: previousClientId,
+ *     lastOffset: previousOffset,
+ *     onMessage: (message) => {
+ *         console.log('Received:', message.id, message.payload);
+ *     },
+ * });
+ * ```
+ *
  * @example Async iterator API
  * ```typescript
  * import { subscribeToQueue } from '@agentuity/server';
@@ -82,6 +98,10 @@ export interface QueueWebSocketOptions {
 	reconnectDelayMs?: number;
 	/** Maximum reconnection delay in ms (default: 30000). */
 	maxReconnectDelayMs?: number;
+	/** Optional client ID from a previous session to resume a subscription. */
+	clientId?: string;
+	/** Optional last processed offset from a previous session to resume from. */
+	lastOffset?: number;
 }
 
 /** Return type from {@link createQueueWebSocket}. */
@@ -106,6 +126,10 @@ export interface SubscribeToQueueOptions {
 	baseUrl: string;
 	/** AbortSignal to stop the subscription. */
 	signal?: AbortSignal;
+	/** Optional client ID from a previous session to resume a subscription. */
+	clientId?: string;
+	/** Optional last processed offset from a previous session to resume from. */
+	lastOffset?: number;
 }
 
 // ============================================================================
@@ -192,8 +216,8 @@ export function createQueueWebSocket(options: QueueWebSocketOptions): QueueWebSo
 	let intentionallyClosed = false;
 	let reconnectAttempts = 0;
 	let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-	let clientId: string | undefined;
-	let lastProcessedOffset: number | undefined;
+	let clientId: string | undefined = options.clientId;
+	let lastProcessedOffset: number | undefined = options.lastOffset;
 
 	function connect() {
 		if (intentionallyClosed) return;
@@ -440,6 +464,8 @@ export async function* subscribeToQueue(
 		queueName: options.queueName,
 		apiKey: options.apiKey,
 		baseUrl: options.baseUrl,
+		clientId: options.clientId,
+		lastOffset: options.lastOffset,
 		onMessage: push,
 		onError: (err) => finish(err),
 		onClose: () => {


### PR DESCRIPTION
## Summary

- Adds optional `clientId` and `lastOffset` fields to `QueueWebSocketOptions` and `SubscribeToQueueOptions`, enabling callers to resume a queue subscription from a previous session
- Initializes internal state from these options so `client_id` and `last_offset` are sent in the very first auth handshake (previously only sent on reconnection within the same connection lifecycle)
- Adds a "Resuming from a previous session" doc example to the module JSDoc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resuming queue connections. Sessions can now maintain continuity using client identifiers and message offset tracking across reconnections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->