### PR TITLE
fix(claude-code): fix hooks.json schema for plugin loader

### DIFF
--- a/packages/claude-code/hooks/hooks.json
+++ b/packages/claude-code/hooks/hooks.json
@@ -1,67 +1,69 @@
 {
-	"PreToolUse": [
-		{
-			"matcher": "Bash",
-			"hooks": [
-				{
-					"type": "command",
-					"command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/block-sensitive-commands.sh",
-					"timeout": 5
-				}
-			]
-		}
-	],
-	"PreCompact": [
-		{
-			"matcher": "",
-			"hooks": [
-				{
-					"type": "command",
-					"command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/pre-compact.sh",
-					"timeout": 10
-				}
-			]
-		}
-	],
-	"Stop": [
-		{
-			"matcher": "",
-			"hooks": [
-				{
-					"type": "command",
-					"command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/cadence-stop.sh",
-					"timeout": 15
-				},
-				{
-					"type": "command",
-					"command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/stop-memory-save.sh",
-					"timeout": 10
-				}
-			]
-		}
-	],
-	"SessionStart": [
-		{
-			"matcher": "",
-			"hooks": [
-				{
-					"type": "command",
-					"command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/session-start.sh",
-					"timeout": 15
-				}
-			]
-		}
-	],
-	"SessionEnd": [
-		{
-			"matcher": "",
-			"hooks": [
-				{
-					"type": "command",
-					"command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/session-end.sh",
-					"timeout": 30
-				}
-			]
-		}
-	]
+	"hooks": {
+		"PreToolUse": [
+			{
+				"matcher": "Bash",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/block-sensitive-commands.sh",
+						"timeout": 5
+					}
+				]
+			}
+		],
+		"PreCompact": [
+			{
+				"matcher": "",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/pre-compact.sh",
+						"timeout": 10
+					}
+				]
+			}
+		],
+		"Stop": [
+			{
+				"matcher": "",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/cadence-stop.sh",
+						"timeout": 15
+					},
+					{
+						"type": "command",
+						"command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/stop-memory-save.sh",
+						"timeout": 10
+					}
+				]
+			}
+		],
+		"SessionStart": [
+			{
+				"matcher": "",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/session-start.sh",
+						"timeout": 15
+					}
+				]
+			}
+		],
+		"SessionEnd": [
+			{
+				"matcher": "",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/session-end.sh",
+						"timeout": 30
+					}
+				]
+			}
+		]
+	}
 }


### PR DESCRIPTION
## Summary
- Wraps hook definitions in the required top-level `"hooks"` key in `packages/claude-code/hooks/hooks.json`
- The Claude Code plugin validator expects `{ "hooks": { ... } }` but the file had event types (`PreToolUse`, `PreCompact`, etc.) directly at the root level
- This caused a schema validation error on plugin install: `"expected record, received undefined"` at path `["hooks"]`

## Test plan
- [x] Copied fixed file to local plugin cache and verified the error is gone on restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Hooks configuration structure updated: `PreToolUse`, `PreCompact`, `Stop`, `SessionStart`, and `SessionEnd` are now nested under a top-level `hooks` object rather than at the root level. Existing configurations must be updated to reflect this new structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->