### PR TITLE
fix(auth,cli): resolve CLI upgrade BadPathName error from non-optional peer deps

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -51,6 +51,20 @@
 		"hono": "^4.0.0",
 		"drizzle-orm": ">=0.44.0"
 	},
+	"peerDependenciesMeta": {
+		"@agentuity/react": {
+			"optional": true
+		},
+		"react": {
+			"optional": true
+		},
+		"hono": {
+			"optional": true
+		},
+		"drizzle-orm": {
+			"optional": true
+		}
+	},
 	"devDependencies": {
 		"@agentuity/react": "workspace:*",
 		"@agentuity/test-utils": "workspace:*",

--- a/packages/cli/src/version-check.ts
+++ b/packages/cli/src/version-check.ts
@@ -215,10 +215,29 @@ async function performUpgrade(logger: Logger, targetVersion: string): Promise<vo
 		// Exit with the same exit code as the new process
 		process.exit(proc.exitCode ?? 0);
 	} catch (error) {
-		// Upgrade failed - log and continue with original command
-		logger.error('Upgrade failed: %s', error instanceof Error ? error.message : 'Unknown error');
+		const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+		logger.error('Upgrade failed: %s', errorMessage);
+
+		// Check for known bun package manager bug (oven-sh/bun#18354)
+		if (errorMessage.includes('BadPathName')) {
+			tui.newline();
+			tui.warning(
+				'This appears to be a known bun package manager issue with stale global packages.'
+			);
+			tui.info('To fix this, run one of the following:');
+			tui.newline();
+			tui.info(`  ${tui.bold('Option 1:')} Clear stale packages and reinstall`);
+			tui.info(`  ${tui.muted('$')} rm -rf ~/.bun/install/global`);
+			tui.info(`  ${tui.muted('$')} bun add -g @agentuity/cli@latest`);
+			tui.newline();
+			tui.info(`  ${tui.bold('Option 2:')} Use the install script`);
+			tui.info(`  ${tui.muted('$')} curl -fsSL https://agentuity.sh | sh`);
+			tui.newline();
+		}
+
 		tui.warning('Continuing with current version...');
-		tui.info('');
+		tui.info('You can upgrade later by running: agentuity upgrade');
+		tui.newline();
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #1056 — CLI upgrade fails with `BadPathName` error due to non-optional peer dependencies in `@agentuity/auth`.

- **Mark peer deps as optional in `@agentuity/auth`**: Added `peerDependenciesMeta` to mark `@agentuity/react`, `react`, `hono`, and `drizzle-orm` as optional. This prevents bun from auto-installing ~150 unnecessary packages (React, Babel, esbuild, rollup, etc.) during `bun add -g @agentuity/cli`.
- **Improve upgrade error handling**: Enhanced the `performUpgrade` catch block in `version-check.ts` to detect the known bun `BadPathName` bug ([oven-sh/bun#18354](https://github.com/oven-sh/bun/issues/18354)) and surface actionable workaround instructions to users.

## Changes

| File | Change |
|------|--------|
| `packages/auth/package.json` | Added `peerDependenciesMeta` with 4 optional entries |
| `packages/cli/src/version-check.ts` | Improved error handling with `BadPathName` detection and user-friendly workaround guidance |

## Root Cause

1. `@agentuity/auth` declared `@agentuity/react` as a **non-optional** peer dep → bun auto-installs it (and React, Babel, etc.) globally
2. Stale `@agentuity/react@1.0.0` in `~/.bun/install/global/` conflicts with newer versions during upgrade
3. Bun's scoped package update triggers `BadPathName: failed opening node_modules/package dir for package`

## Verification

- ✅ `bun run build`
- ✅ `bun run typecheck`
- ✅ `bun run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced CLI upgrade error handling with improved messaging, providing clearer guidance when specific issues occur during the upgrade process.

* **Chores**
  * Updated package configuration metadata to properly reflect optional peer dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->