### PR TITLE
fix(cli): rewrite unquoted CSS url(/public/...) paths in public-asset-path plugin

### DIFF
--- a/packages/cli/src/cmd/build/vite/public-asset-path-plugin.ts
+++ b/packages/cli/src/cmd/build/vite/public-asset-path-plugin.ts
@@ -9,8 +9,10 @@
  * 2. During dev: Warns only about incorrect source paths (src/web/public/)
  *
  * Supported patterns (work in dev, rewritten to CDN in production):
- * - '/public/foo.svg'   → CDN URL (recommended)
- * - './public/foo.svg'  → CDN URL
+ * - '/public/foo.svg'          → CDN URL (recommended)
+ * - './public/foo.svg'         → CDN URL
+ * - 'url(/public/foo.svg)'    → CDN URL (CSS unquoted)
+ * - 'url(./public/foo.svg)'   → CDN URL (CSS unquoted)
  *
  * Incorrect patterns (warned in dev, rewritten in production):
  * - '/src/web/public/foo.svg'  → CDN URL
@@ -65,6 +67,18 @@ function createPublicPatterns(): PathPattern[] {
 			regex: /(['"`])\/public\//g,
 			description: '/public/',
 			replacement: '$1{base}',
+		},
+		// CSS url(/public/...) — unquoted path inside url()
+		{
+			regex: /url\(\/public\//g,
+			description: 'url(/public/)',
+			replacement: 'url({base}',
+		},
+		// CSS url(./public/...) — unquoted relative path inside url()
+		{
+			regex: /url\(\.\/public\//g,
+			description: 'url(./public/)',
+			replacement: 'url({base}',
 		},
 	];
 }
@@ -150,12 +164,12 @@ export function publicAssetPathPlugin(options: PublicAssetPathPluginOptions = {}
 			// Build mode: transform paths to CDN URLs
 			let transformed = code;
 
-			// Determine target URL: CDN base if provided, otherwise root
+			// Determine target URL: CDN base if provided, otherwise /public/
 			const targetBase = cdnBaseUrl
 				? cdnBaseUrl.endsWith('/')
 					? cdnBaseUrl
 					: `${cdnBaseUrl}/`
-				: '/';
+				: '/public/';
 
 			// Transform incorrect source paths (src/web/public/) → CDN
 			if (hasIncorrectSourcePaths) {

--- a/packages/cli/test/cmd/build/vite/public-asset-path-plugin.test.ts
+++ b/packages/cli/test/cmd/build/vite/public-asset-path-plugin.test.ts
@@ -228,6 +228,93 @@ const bg = './public/background.jpg';
 			expect(result).not.toBeNull();
 			expect(result!.code).toBe(`const images = ['/public/a.png', '/public/b.png'];`);
 		});
+
+		test('does not transform unquoted CSS url(/public/...) without CDN', () => {
+			const code = `{ maskImage: "url(/public/logos/typefully.svg)" }`;
+			const id = '/project/src/web/components/Icon.tsx';
+
+			const result = callTransform(code, id);
+
+			// Without CDN, url(/public/...) is already correct — no transformation
+			expect(result).toBeNull();
+		});
+
+		test('transforms unquoted CSS url(./public/...) to url(/public/...)', () => {
+			const code = `{ backgroundImage: "url(./public/images/bg.png)" }`;
+			const id = '/project/src/web/components/Background.tsx';
+
+			const result = callTransform(code, id);
+
+			expect(result).not.toBeNull();
+			expect(result!.code).toBe(`{ backgroundImage: "url(/public/images/bg.png)" }`);
+		});
+
+		test('transforms unquoted CSS url(/public/...) with CDN base URL', () => {
+			plugin = publicAssetPathPlugin({ cdnBaseUrl: 'https://cdn.example.com/deploy/client/' });
+			const configResolved = plugin.configResolved;
+			if (configResolved && typeof configResolved === 'function') {
+				configResolved.call(plugin as never, { command: 'build' } as never);
+			}
+
+			const code = `{ maskImage: "url(/public/logos/icon.svg)" }`;
+			const id = '/project/src/web/components/Icon.tsx';
+
+			const result = callTransform(code, id);
+
+			expect(result).not.toBeNull();
+			expect(result!.code).toBe(
+				`{ maskImage: "url(https://cdn.example.com/deploy/client/logos/icon.svg)" }`
+			);
+		});
+
+		test('transforms unquoted CSS url(./public/...) with CDN base URL', () => {
+			plugin = publicAssetPathPlugin({ cdnBaseUrl: 'https://cdn.example.com/deploy/client/' });
+			const configResolved = plugin.configResolved;
+			if (configResolved && typeof configResolved === 'function') {
+				configResolved.call(plugin as never, { command: 'build' } as never);
+			}
+
+			const code = `{ backgroundImage: "url(./public/images/bg.png)" }`;
+			const id = '/project/src/web/components/Background.tsx';
+
+			const result = callTransform(code, id);
+
+			expect(result).not.toBeNull();
+			expect(result!.code).toBe(
+				`{ backgroundImage: "url(https://cdn.example.com/deploy/client/images/bg.png)" }`
+			);
+		});
+
+		test('transforms multiple url(/public/...) with CDN in same file', () => {
+			plugin = publicAssetPathPlugin({ cdnBaseUrl: 'https://cdn.example.com/deploy/client/' });
+			const configResolved = plugin.configResolved;
+			if (configResolved && typeof configResolved === 'function') {
+				configResolved.call(plugin as never, { command: 'build' } as never);
+			}
+
+			const code = `
+const styles = {
+  maskImage: "url(/public/logos/a.svg)",
+  backgroundImage: "url(/public/images/bg.png)",
+};`;
+			const id = '/project/src/web/components/Styled.tsx';
+
+			const result = callTransform(code, id);
+
+			expect(result).not.toBeNull();
+			expect(result!.code).toContain('url(https://cdn.example.com/deploy/client/logos/a.svg)');
+			expect(result!.code).toContain('url(https://cdn.example.com/deploy/client/images/bg.png)');
+		});
+
+		test('does not transform quoted CSS url("/public/...") without CDN', () => {
+			const code = `{ maskImage: 'url("/public/logos/icon.svg")' }`;
+			const id = '/project/src/web/components/Icon.tsx';
+
+			const result = callTransform(code, id);
+
+			// Without CDN, url("/public/...") is already correct — no transformation
+			expect(result).toBeNull();
+		});
 	});
 
 	describe('dev mode behavior', () => {
@@ -282,7 +369,7 @@ const bg = './public/background.jpg';
 			expect(warnings.length).toBe(1);
 		});
 
-		test('warns for different pattern types in same file', () => {
+		test('warns only about incorrect source paths, not valid ./public/ paths', () => {
 			initDevMode(true);
 
 			const code = `
@@ -294,10 +381,10 @@ const b = './public/b.svg';
 			const warnings: string[] = [];
 			callTransform(code, id, (msg) => warnings.push(msg));
 
-			// Should warn about both patterns
+			// Should only warn about incorrect source paths (src/web/public/)
+			// ./public/ is a valid pattern and should not be warned about
 			expect(warnings.length).toBe(1);
 			expect(warnings[0]).toContain('src/web/public/');
-			expect(warnings[0]).toContain('./public/');
 		});
 	});
 


### PR DESCRIPTION
## Summary

Fixes #1059 — The `agentuity:public-asset-path` Vite plugin now correctly rewrites `/public/` paths inside unquoted CSS `url()` values.

- Add two new regex patterns to `createPublicPatterns()` for `url(/public/...)` and `url(./public/...)` — previously missed because existing regexes required a quote character before `/public/`
- Fix default `targetBase` to `/public/` (was `/`) when no CDN URL is provided, so already-correct paths like `'/public/foo.svg'` are not incorrectly stripped
- Add 7 new test cases covering url() patterns with and without CDN base URLs

### Before

```tsx
// ❌ Broken in production — url(/public/...) left as-is → 404
<span style={{ maskImage: "url(/public/logos/typefully.svg)" }} />
```

### After

```tsx
// ✅ Correctly rewritten to CDN URL in production
<span style={{ maskImage: "url(/public/logos/typefully.svg)" }} />
// → url(https://cdn.example.com/deploy/client/logos/typefully.svg)
```

### Verification

- ✅ 32/32 tests pass
- ✅ Format, lint, typecheck, build all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced CSS URL handling in the build process for improved public asset path transformations.
  * Expanded CDN base URL support for asset path rewriting.

* **Tests**
  * Added comprehensive test coverage for CSS URL transformations with and without CDN configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->