### PR TITLE
docs: deploy lifecycle hooks, build config, and snapshot dir field

### DIFF
--- a/apps/docs/src/web/content/get-started/app-configuration.mdx
+++ b/apps/docs/src/web/content/get-started/app-configuration.mdx
@@ -11,9 +11,9 @@ The project configuration file:
 
 ```json
 {
-  "name": "my-project",
-  "orgId": "org_...",
-  "projectId": "proj_..."
+	"name": "my-project",
+	"orgId": "org_...",
+	"projectId": "proj_..."
 }
 ```
 
@@ -39,16 +39,16 @@ Use `setup` to initialize resources (databases, clients) and `shutdown` to clean
 import { createApp } from '@agentuity/runtime';
 
 const { server, logger } = await createApp({
-  setup: async () => {
-    // Initialize resources, return app state
-    // Available in agents via ctx.app
-    const db = await connectDatabase();
-    return { db };
-  },
-  shutdown: async (state) => {
-    // Clean up resources
-    await state.db.close();
-  },
+	setup: async () => {
+		// Initialize resources, return app state
+		// Available in agents via ctx.app
+		const db = await connectDatabase();
+		return { db };
+	},
+	shutdown: async (state) => {
+		// Clean up resources
+		await state.db.close();
+	},
 });
 
 logger.debug('Running %s', server.url);
@@ -60,32 +60,32 @@ logger.debug('Running %s', server.url);
 import { createApp } from '@agentuity/runtime';
 
 const { server, logger } = await createApp({
-  // CORS configuration
-  cors: {
-    origin: ['https://myapp.com'],
-    credentials: true,
-  },
+	// CORS configuration
+	cors: {
+		origin: ['https://myapp.com'],
+		credentials: true,
+	},
 
-  // Response compression (gzip/deflate)
-  compression: {
-    threshold: 1024, // Compress responses larger than 1KB (default)
-  },
+	// Response compression (gzip/deflate)
+	compression: {
+		threshold: 1024, // Compress responses larger than 1KB (default)
+	},
 
-  // Custom storage implementations (optional)
-  services: {
-    keyvalue: myCustomKV,
-    vector: myCustomVector,
-  },
+	// Custom storage implementations (optional)
+	services: {
+		keyvalue: myCustomKV,
+		vector: myCustomVector,
+	},
 });
 ```
 
 #### Compression Options
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `enabled` | `boolean` | `true` | Enable/disable compression |
-| `threshold` | `number` | `1024` | Minimum response size (bytes) to compress |
-| `filter` | `(c) => boolean` | - | Custom filter function |
+| Option      | Type             | Default | Description                               |
+| ----------- | ---------------- | ------- | ----------------------------------------- |
+| `enabled`   | `boolean`        | `true`  | Enable/disable compression                |
+| `threshold` | `number`         | `1024`  | Minimum response size (bytes) to compress |
+| `filter`    | `(c) => boolean` | -       | Custom filter function                    |
 
 Compression automatically bypasses WebSocket upgrades and requests without `Accept-Encoding` headers.
 
@@ -99,11 +99,11 @@ import { createApp } from '@agentuity/runtime';
 const app = await createApp();
 
 app.addEventListener('agent.started', (event, agent, ctx) => {
-  app.logger.info('Agent started', { name: agent.metadata.name });
+	app.logger.info('Agent started', { name: agent.metadata.name });
 });
 
 app.addEventListener('agent.completed', (event, agent, ctx) => {
-  app.logger.info('Agent completed', { session: ctx.sessionId });
+	app.logger.info('Agent completed', { session: ctx.sessionId });
 });
 ```
 
@@ -115,15 +115,52 @@ For advanced build customization, create an `agentuity.config.ts` file in your p
 import type { AgentuityConfig } from '@agentuity/cli';
 
 export default {
-  // Configuration options here
+	// Configuration options here
 } satisfies AgentuityConfig;
 ```
 
 <Callout type="info" title="When to Use This">
-Use build configuration to add Vite plugins (like Tailwind CSS), exclude packages from server bundling, or define build-time constants.
+	Use build configuration to add Vite plugins (like Tailwind CSS), exclude packages from server
+	bundling, or define build-time constants.
 </Callout>
 
 See the [reference page](/reference/cli/build-configuration) for all options and examples.
+
+## CI/CD Build Settings
+
+When deploying via the [GitHub App](/reference/cli/git-integration), builds run inside a sandbox with default resource limits. For projects with large dependency trees or long build times, configure the sandbox resources in `agentuity.json`:
+
+```json title="agentuity.json"
+{
+	"name": "my-project",
+	"projectId": "proj_...",
+	"orgId": "org_...",
+	"build": {
+		"timeout": "30m",
+		"resources": {
+			"memory": "4Gi",
+			"cpu": "2",
+			"disk": "4Gi"
+		}
+	}
+}
+```
+
+All fields are optional. Defaults: `5m` timeout, `1` CPU, `2Gi` memory, `2Gi` disk.
+
+| Field                    | Default | Description                           |
+| ------------------------ | ------- | ------------------------------------- |
+| `build.timeout`          | `5m`    | Maximum build time (e.g. `5m`, `30m`) |
+| `build.resources.memory` | `2Gi`   | Memory limit (e.g. `512Mi`, `4Gi`)    |
+| `build.resources.cpu`    | `1`     | CPU cores (e.g. `1`, `2`)             |
+| `build.resources.disk`   | `2Gi`   | Disk space (e.g. `2Gi`, `4Gi`)        |
+
+<Callout type="info" title="GitHub Deploys Only">
+	The `build` field configures the sandbox used for GitHub App-triggered deployments. It does not
+	affect local `agentuity deploy` commands, which build on your machine.
+</Callout>
+
+You can also hook into the build pipeline with `predeploy` and `postdeploy` scripts. See [Deploy Lifecycle Scripts](/reference/cli/git-integration#deploy-lifecycle-scripts) for details.
 
 ## Environment Variables
 
@@ -152,11 +189,13 @@ PUBLIC_MY_VAR=...            # - VITE_*
 ```
 
 <Callout type="info" title="AI Gateway">
-If you don't set provider API keys, LLM requests are routed through the Agentuity AI Gateway using your SDK key. This provides unified billing and monitoring.
+	If you don't set provider API keys, LLM requests are routed through the Agentuity AI Gateway
+	using your SDK key. This provides unified billing and monitoring.
 </Callout>
 
 <Callout type="warning" title="Public Environment Variables">
-Environment variables prefixed with `AGENTUITY_PUBLIC_`, `VITE_`, or `PUBLIC_` are exposed to the frontend bundle and visible in the browser. Never put secrets or API keys in these variables.
+	Environment variables prefixed with `AGENTUITY_PUBLIC_`, `VITE_`, or `PUBLIC_` are exposed to the
+	frontend bundle and visible in the browser. Never put secrets or API keys in these variables.
 </Callout>
 
 ## Infrastructure as Code
@@ -172,23 +211,30 @@ import chatHandler from '@agent/chat';
 const router = createRouter();
 
 // Cron job - runs every hour
-router.post('/cleanup', cron('0 * * * *', async (c) => {
-  await scheduler.run({ task: 'cleanup' });
-  return c.text('OK');
-}));
+router.post(
+	'/cleanup',
+	cron('0 * * * *', async (c) => {
+		await scheduler.run({ task: 'cleanup' });
+		return c.text('OK');
+	})
+);
 
 // WebSocket endpoint
-router.get('/chat', websocket((c, ws) => {
-  ws.onMessage(async (event) => {
-    const response = await chatHandler.run({ message: event.data as string });
-    ws.send(response);
-  });
-}));
+router.get(
+	'/chat',
+	websocket((c, ws) => {
+		ws.onMessage(async (event) => {
+			const response = await chatHandler.run({ message: event.data as string });
+			ws.send(response);
+		});
+	})
+);
 
 export default router;
 ```
 
 This approach means:
+
 - **Deployments are self-contained**: rolling back restores exact configuration
 - **Version control**: your infrastructure changes are tracked in Git
 - **No config drift**: what's in code is what runs

--- a/apps/docs/src/web/content/reference/cli/deployment.mdx
+++ b/apps/docs/src/web/content/reference/cli/deployment.mdx
@@ -7,7 +7,7 @@ Deploy your Agentuity project to the cloud with a single command. The platform h
 
 ## Why Deploy to Agentuity?
 
-Deploying agents *should be* as easy as deploying a web app. But agents need long-running processes, persistent storage, sandbox environments, and observability built in. Setting this up yourself means stitching together containers, databases, secret management, and monitoring.
+Deploying agents _should be_ as easy as deploying a web app. But agents need long-running processes, persistent storage, sandbox environments, and observability built in. Setting this up yourself means stitching together containers, databases, secret management, and monitoring.
 
 Agentuity handles all of this automatically. You push code, and the platform provisions everything your agents need: compute, storage, networking, and observability. No infrastructure configuration, no Docker files, no Kubernetes.
 
@@ -27,6 +27,7 @@ bun run deploy
 ```
 
 The deploy command:
+
 1. Syncs environment variables from `.env.production` (or `.env` as fallback)
 2. Builds and packages your project
 3. Encrypts and uploads the deployment bundle securely
@@ -59,11 +60,13 @@ The Dashboard URL links directly to the deployment details in the Agentuity App.
 Each deployment gets two URLs:
 
 **Deployment URL** (`dep_xxx.agentuity.cloud`):
+
 - Unique URL for this specific deployment
 - Persists even after new deployments
 - Use for testing a specific version
 
 **Project URL** (`proj_xxx.agentuity.cloud`):
+
 - Always points to the active deployment
 - Updates automatically when you deploy
 - Use for stable endpoints and webhooks
@@ -95,11 +98,11 @@ agentuity cloud deployment list --project-id=proj_abc123xyz
 
 **Example output:**
 
-| ID | State | Active | Created | Message | Tags |
-|----|-------|--------|---------|---------|------|
-| dep_abc123 | completed | Yes | 12/1/25, 3:45 PM | | staging |
-| dep_def456 | completed | | 12/1/25, 2:30 PM | | v1.2.0 |
-| dep_ghi789 | completed | | 11/30/25, 5:00 PM | | |
+| ID         | State     | Active | Created           | Message | Tags    |
+| ---------- | --------- | ------ | ----------------- | ------- | ------- |
+| dep_abc123 | completed | Yes    | 12/1/25, 3:45 PM  |         | staging |
+| dep_def456 | completed |        | 12/1/25, 2:30 PM  |         | v1.2.0  |
+| dep_ghi789 | completed |        | 11/30/25, 5:00 PM |         |         |
 
 ## Deployment Details
 
@@ -114,6 +117,7 @@ agentuity cloud deployment show dep_abc123xyz --project-id=proj_abc123
 ```
 
 **Output includes:**
+
 - Deployment ID, state, and creation time
 - Active status
 - Tags and custom domains
@@ -146,7 +150,8 @@ Build Information
 ```
 
 <Callout type="tip" title="DNS Records">
-When custom domains are configured, the `show` command displays the required DNS records for each domain. Use this to verify your CNAME configuration.
+	When custom domains are configured, the `show` command displays the required DNS records for each
+	domain. Use this to verify your CNAME configuration.
 </Callout>
 
 ## Viewing Logs
@@ -170,7 +175,7 @@ agentuity cloud deployment logs dep_abc123xyz --project-id=proj_abc123
 Logs show severity (INFO, WARN, ERROR) and message body with color-coded output.
 
 <Callout type="info" title="Real-Time Logs">
-For live streaming logs, use SSH access. See [Debugging](/reference/cli/debugging) for SSH setup.
+	For live streaming logs, use SSH access. See [Debugging](/reference/cli/debugging) for SSH setup.
 </Callout>
 
 ## Rolling Back
@@ -182,6 +187,7 @@ agentuity cloud deployment rollback
 ```
 
 The command:
+
 1. Finds the previous completed deployment
 2. Prompts for confirmation
 3. Activates the previous deployment
@@ -199,7 +205,8 @@ agentuity cloud deployment rollback --project-id=proj_abc123xyz
 ```
 
 <Callout type="warning" title="Rollback Behavior">
-Rollback activates the most recent completed deployment before the current one. The current deployment remains available at its deployment URL but is no longer active.
+	Rollback activates the most recent completed deployment before the current one. The current
+	deployment remains available at its deployment URL but is no longer active.
 </Callout>
 
 ## Undeploying
@@ -218,13 +225,15 @@ agentuity cloud deployment undeploy --project-id=proj_abc123xyz
 ```
 
 After undeploying:
+
 - The project URL becomes unavailable
 - All deployment-specific URLs remain accessible
 - Previous deployments are not deleted
 - You can redeploy or rollback at any time
 
 <Callout type="warning" title="Undeploy Impact">
-Undeploying stops the active deployment immediately. Your project URL will return 404 until you deploy or rollback.
+	Undeploying stops the active deployment immediately. Your project URL will return 404 until you
+	deploy or rollback.
 </Callout>
 
 ## Removing Deployments
@@ -240,7 +249,7 @@ agentuity cloud deployment remove dep_abc123xyz --project-id=proj_abc123xyz
 ```
 
 <Callout type="warning" title="Permanent Deletion">
-Removing a deployment permanently deletes it. You cannot rollback to a removed deployment.
+	Removing a deployment permanently deletes it. You cannot rollback to a removed deployment.
 </Callout>
 
 ## Preview Environments
@@ -252,6 +261,7 @@ Deploy pull requests to isolated preview environments for testing before merging
 3. Enable "Deploy PRs to preview environments for this repository"
 
 Once enabled, every pull request to your connected repository automatically deploys to a unique preview URL. This allows you to:
+
 - Test changes in an isolated environment before merging
 - Share preview links with reviewers
 - Run integration tests against the preview deployment
@@ -259,7 +269,8 @@ Once enabled, every pull request to your connected repository automatically depl
 Preview environments are automatically cleaned up when the pull request is closed or merged.
 
 <Callout type="info" title="GitHub Connection Required">
-Preview environments require a connected GitHub repository. Connect your repo in **Project > Settings > GitHub**.
+	Preview environments require a connected GitHub repository. Connect your repo in **Project >
+	Settings > GitHub**.
 </Callout>
 
 ## Regions
@@ -295,9 +306,9 @@ The region is stored in `agentuity.json` after your first deployment:
 
 ```json
 {
-  "projectId": "proj_abc123xyz",
-  "orgId": "org_def456",
-  "region": "use"
+	"projectId": "proj_abc123xyz",
+	"orgId": "org_def456",
+	"region": "use"
 }
 ```
 
@@ -315,12 +326,12 @@ Configure custom domains in `agentuity.json`:
 
 ```json
 {
-  "projectId": "proj_abc123xyz",
-  "orgId": "org_def456",
-  "region": "use",
-  "deployment": {
-    "domains": ["api.example.com", "app.example.com"]
-  }
+	"projectId": "proj_abc123xyz",
+	"orgId": "org_def456",
+	"region": "use",
+	"deployment": {
+		"domains": ["api.example.com", "app.example.com"]
+	}
 }
 ```
 
@@ -350,11 +361,13 @@ agentuity deploy
 ```
 
 <Callout type="warning" title="DNS Validation">
-Deployment fails if DNS records are missing or incorrect. The CLI shows the required CNAME value in the error message.
+	Deployment fails if DNS records are missing or incorrect. The CLI shows the required CNAME value
+	in the error message.
 </Callout>
 
 <Callout type="info" title="Activate Custom Domains">
-After adding a custom domain to your configuration, you must deploy to activate it. The domain becomes active only after a successful deployment.
+	After adding a custom domain to your configuration, you must deploy to activate it. The domain
+	becomes active only after a successful deployment.
 </Callout>
 
 ### Multiple Domains
@@ -363,9 +376,9 @@ Custom domains replace the default URLs:
 
 ```json
 {
-  "deployment": {
-    "domains": ["api.example.com"]
-  }
+	"deployment": {
+		"domains": ["api.example.com"]
+	}
 }
 ```
 
@@ -384,14 +397,14 @@ Configure CPU, memory, and disk limits in `agentuity.json`:
 
 ```json
 {
-  "deployment": {
-    "resources": {
-      "cpu": "500m",
-      "memory": "512Mi",
-      "disk": "1Gi"
-    },
-    "domains": []
-  }
+	"deployment": {
+		"resources": {
+			"cpu": "500m",
+			"memory": "512Mi",
+			"disk": "1Gi"
+		},
+		"domains": []
+	}
 }
 ```
 
@@ -411,17 +424,22 @@ MY_CUSTOM_API_KEY=xxx
 ```
 
 <Callout type="info" title="AI Provider Keys">
-If you're using the [AI Gateway](/agents/ai-gateway), you don't need to include provider API keys (like `OPENAI_API_KEY`). The gateway handles authentication automatically. Only include provider keys if you're bypassing the gateway.
+	If you're using the [AI Gateway](/agents/ai-gateway), you don't need to include provider API keys
+	(like `OPENAI_API_KEY`). The gateway handles authentication automatically. Only include provider
+	keys if you're bypassing the gateway.
 </Callout>
 
 Variables are automatically:
+
 - Filtered (removes `AGENTUITY_` prefixed keys)
 - Categorized (regular env vs secrets based on naming)
 - Encrypted (secrets only)
 - Synced to cloud before the build step
 
 <Callout type="info" title="Secrets Detection">
-Variables with suffixes like `_SECRET`, `_KEY`, `_TOKEN`, `_PASSWORD`, or `_PRIVATE` are automatically encrypted as secrets. All other variables are stored as regular environment variables.
+	Variables with suffixes like `_SECRET`, `_KEY`, `_TOKEN`, `_PASSWORD`, or `_PRIVATE` are
+	automatically encrypted as secrets. All other variables are stored as regular environment
+	variables.
 </Callout>
 
 ## Machine Management
@@ -445,23 +463,25 @@ agentuity cloud machine deployments mach_abc123xyz
 ```
 
 Machine details include status, region, resource allocation, and uptime. Use machine management to:
+
 - Monitor infrastructure health
 - Debug performance issues
 - Clean up unused machines
 
 <Callout type="warning" title="Deleting Machines">
-Deleting a machine immediately terminates any deployments running on it. Only delete machines that are unused or when intentionally removing capacity.
+	Deleting a machine immediately terminates any deployments running on it. Only delete machines
+	that are unused or when intentionally removing capacity.
 </Callout>
 
 ## Deploy Options
 
-| Option | Description |
-|--------|-------------|
-| `-y, --confirm` | Skip all confirmation prompts (useful for CI/CD) |
-| `--dry-run` | Simulate deployment without executing (place before `deploy`) |
-| `--log-level debug` | Show verbose output |
-| `--project-id <id>` | Deploy specific project |
-| `--message <msg>` | Message to associate with this build |
+| Option              | Description                                                   |
+| ------------------- | ------------------------------------------------------------- |
+| `-y, --confirm`     | Skip all confirmation prompts (useful for CI/CD)              |
+| `--dry-run`         | Simulate deployment without executing (place before `deploy`) |
+| `--log-level debug` | Show verbose output                                           |
+| `--project-id <id>` | Deploy specific project                                       |
+| `--message <msg>`   | Message to associate with this build                          |
 
 ```bash
 # Verbose deployment
@@ -482,6 +502,8 @@ agentuity deploy --confirm
 
 ## CI/CD Pipelines
 
+For GitHub-triggered deployments, you can customize the build with [lifecycle scripts](/reference/cli/git-integration#deploy-lifecycle-scripts) (`predeploy`/`postdeploy` in `package.json`) and [build resource configuration](/get-started/app-configuration#cicd-build-settings) (timeout, memory, CPU, disk in `agentuity.json`).
+
 For automated deployments in CI/CD systems (GitHub Actions, GitLab CI, etc.), you can use a pre-created deployment.
 
 ### Using Pre-Created Deployments
@@ -495,19 +517,21 @@ agentuity deploy
 
 The JSON object requires:
 
-| Field | Description |
-|-------|-------------|
-| `id` | The deployment ID |
-| `orgId` | Your organization ID |
+| Field       | Description                 |
+| ----------- | --------------------------- |
+| `id`        | The deployment ID           |
+| `orgId`     | Your organization ID        |
 | `publicKey` | The deployment's public key |
 
 When this variable is set, the CLI:
+
 - Skips deployment creation and uses the existing deployment
 - Uses plain output mode (no TUI) for cleaner CI logs
 - Validates the JSON schema before proceeding
 
 <Callout type="info" title="Getting Deployment Details">
-Pre-created deployments are typically provisioned by external systems like GitHub Actions workflows or custom CI pipelines that integrate with the Agentuity API.
+	Pre-created deployments are typically provisioned by external systems like GitHub Actions
+	workflows or custom CI pipelines that integrate with the Agentuity API.
 </Callout>
 
 ## Next Steps

--- a/apps/docs/src/web/content/reference/cli/git-integration.mdx
+++ b/apps/docs/src/web/content/reference/cli/git-integration.mdx
@@ -72,7 +72,9 @@ agentuity git account remove --org org_abc123 --account int_xyz --confirm
 ```
 
 <Callout type="info" title="Identity vs Installations">
-Your **identity** is your GitHub user account. **Installations** are per-organization GitHub App installs that grant repository access. You need both: connect your identity first, then add at least one installation.
+	Your **identity** is your GitHub user account. **Installations** are per-organization GitHub App
+	installs that grant repository access. You need both: connect your identity first, then add at
+	least one installation.
 </Callout>
 
 ## Linking a Repository
@@ -109,14 +111,14 @@ agentuity git link --preview true
 
 ### Link Options
 
-| Option | Description |
-|--------|-------------|
-| `--repo <owner/repo>` | Repository full name |
-| `--branch <branch>` | Branch to deploy from (default: repo default branch) |
-| `--root <path>` | Root directory containing `agentuity.json` (default: `.`) |
-| `--deploy <bool>` | Enable auto-deploy on push (default: `true`) |
-| `--preview <bool>` | Enable preview deployments on PRs (default: `true`) |
-| `--confirm` | Skip confirmation prompts |
+| Option                | Description                                               |
+| --------------------- | --------------------------------------------------------- |
+| `--repo <owner/repo>` | Repository full name                                      |
+| `--branch <branch>`   | Branch to deploy from (default: repo default branch)      |
+| `--root <path>`       | Root directory containing `agentuity.json` (default: `.`) |
+| `--deploy <bool>`     | Enable auto-deploy on push (default: `true`)              |
+| `--preview <bool>`    | Enable preview deployments on PRs (default: `true`)       |
+| `--confirm`           | Skip confirmation prompts                                 |
 
 ### Browsing Repositories
 
@@ -158,10 +160,92 @@ agentuity --json git status
 ```
 
 The status output includes:
+
 - Connected GitHub username
 - GitHub App installations (organization or personal)
 - Linked repository, branch, and directory
 - Auto-deploy and preview deployment settings
+
+## Deploy Lifecycle Scripts
+
+When the GitHub App triggers a deployment, you can hook into the build pipeline with `predeploy` and `postdeploy` scripts in your `package.json`.
+
+### predeploy
+
+Runs **before** `agentuity deploy`. If defined, it replaces the default `bun install` step, giving you full control over dependency installation. This is useful for monorepos where you need to install from the repository root instead of the project directory:
+
+```json title="package.json"
+{
+	"scripts": {
+		"predeploy": "cd ../.. && bun install"
+	}
+}
+```
+
+If no `predeploy` script is defined, the default `bun install` runs automatically.
+
+### postdeploy
+
+Runs **after** `agentuity deploy` completes. Use this for notifications, cache warming, or any cleanup:
+
+```json title="package.json"
+{
+	"scripts": {
+		"postdeploy": "curl -X POST https://hooks.slack.com/... -d '{\"text\": \"Deployed!\"}'"
+	}
+}
+```
+
+### Full Example
+
+```json title="package.json"
+{
+	"scripts": {
+		"predeploy": "cd ../.. && bun install",
+		"deploy": "agentuity deploy",
+		"postdeploy": "echo 'Deployment complete'"
+	}
+}
+```
+
+<Callout type="info" title="CLI Deploys Are Unaffected">
+	These scripts only run during GitHub App-triggered deployments (push and PR events). Running
+	`agentuity deploy` locally from the CLI does not execute `predeploy` or `postdeploy`.
+</Callout>
+
+## Build Configuration
+
+Control the sandbox resources allocated for GitHub-triggered builds by adding a `build` field to your `agentuity.json`. This is useful for projects with large dependency trees or long build times:
+
+```json title="agentuity.json"
+{
+	"name": "my-project",
+	"projectId": "proj_...",
+	"orgId": "org_...",
+	"build": {
+		"timeout": "30m",
+		"resources": {
+			"memory": "4Gi",
+			"cpu": "2",
+			"disk": "4Gi"
+		}
+	}
+}
+```
+
+| Field                    | Default | Description                                                     |
+| ------------------------ | ------- | --------------------------------------------------------------- |
+| `build.timeout`          | `5m`    | Maximum execution time for the build sandbox (e.g. `5m`, `30m`) |
+| `build.resources.memory` | `2Gi`   | Memory limit (e.g. `512Mi`, `2Gi`, `4Gi`)                       |
+| `build.resources.cpu`    | `1`     | CPU cores (e.g. `1`, `2`)                                       |
+| `build.resources.disk`   | `2Gi`   | Disk space (e.g. `2Gi`, `4Gi`)                                  |
+
+<Callout type="tip" title="When to Increase Resources">
+	If your GitHub deployments fail with timeout or out-of-memory errors, add the `build` field with
+	higher limits. Most projects work fine with the defaults.
+</Callout>
+
+See [App Configuration](/get-started/app-configuration#cicd-build-settings) for more detail on the `build` field.
 
 ## Next Steps
 

--- a/apps/docs/src/web/content/services/sandbox/snapshots.mdx
+++ b/apps/docs/src/web/content/services/sandbox/snapshots.mdx
@@ -8,7 +8,8 @@ Skip slow dependency installation on every run by saving sandbox filesystem stat
 Manage snapshots via the [Web App](https://app-v1.agentuity.com) under **Services > Sandbox > Snapshots**, the [SDK](/services/sandbox/sdk-usage), or [CLI](/reference/cli/sandbox).
 
 <Callout type="warning" title="Snapshots Are Not Executable">
-A snapshot captures the filesystem state of a sandbox at a point in time. You create new sandboxes *from* snapshots, not run them directly.
+	A snapshot captures the filesystem state of a sandbox at a point in time. You create new
+	sandboxes *from* snapshots, not run them directly.
 </Callout>
 
 ## How Snapshots Work
@@ -52,22 +53,49 @@ agentuity cloud sandbox snapshot build .
 
 ```yaml
 version: 1
-runtime: bun:1  # Base runtime - snapshot layers on top of this
+runtime: bun:1 # Base runtime - snapshot layers on top of this
 description: Node.js environment with common dependencies
 
-dependencies:  # Apt packages to install
-  - curl
-  - jq
+dependencies: # Apt packages to install
+   - curl
+   - jq
 
-files:  # Files to include from your project
-  - src/**
-  - package.json
-  - "!**/*.test.ts"    # Exclude test files
-  - "!node_modules/**" # Exclude node_modules
+files: # Files to include from your project
+   - src/**
+   - package.json
+   - '!**/*.test.ts' # Exclude test files
+   - '!node_modules/**' # Exclude node_modules
 
 env:
-  NODE_ENV: production
+   NODE_ENV: production
 ```
+
+### Monorepo Support with `dir`
+
+For monorepos, use the `dir` field to set the build context to a subdirectory. File patterns are resolved relative to `dir`, and files outside it are excluded:
+
+```yaml
+version: 1
+runtime: bun:1
+description: SDK Explorer app snapshot
+dir: apps/docs # Build context relative to the CLI directory argument
+
+files:
+   - src/**
+   - package.json
+
+env:
+   NODE_ENV: production
+```
+
+When building, pass the repository root as the directory argument. The `dir` field tells the CLI where to find the project files within it:
+
+```bash
+# Build from repo root, snapshot resolves files from apps/docs/
+agentuity cloud sandbox snapshot build .
+```
+
+This replaces the need for nested snapshot directories. All snapshot YAML files can live in a single `snapshots/` folder at the repo root, each with its own `dir` pointing to the right subdirectory.
 
 ### Build Options
 
@@ -84,10 +112,10 @@ agentuity cloud sandbox snapshot build . --force
 
 ### When to Use Declarative vs Manual
 
-| Approach | Best For |
-|----------|----------|
+| Approach        | Best For                                                                        |
+| --------------- | ------------------------------------------------------------------------------- |
 | **Declarative** | CI/CD pipelines, reproducible environments, team collaboration, version control |
-| **Manual** | Quick experimentation, one-off debugging, exploring new configurations |
+| **Manual**      | Quick experimentation, one-off debugging, exploring new configurations          |
 
 ## Creating a Snapshot Manually
 
@@ -117,32 +145,30 @@ Create sandboxes from snapshots using the `snapshot` option:
 import { createAgent } from '@agentuity/runtime';
 
 const agent = createAgent('TypeScriptRunner', {
-  handler: async (ctx, input) => {
-    // Create sandbox from snapshot - dependencies already installed
-    const sandbox = await ctx.sandbox.create({
-      snapshot: 'node-typescript',  // Use tag or snapshot ID
-      resources: { memory: '512Mi' },
-    });
+	handler: async (ctx, input) => {
+		// Create sandbox from snapshot - dependencies already installed
+		const sandbox = await ctx.sandbox.create({
+			snapshot: 'node-typescript', // Use tag or snapshot ID
+			resources: { memory: '512Mi' },
+		});
 
-    try {
-      // Write the user's code
-      await sandbox.writeFiles([
-        { path: 'index.ts', content: Buffer.from(input.code) },
-      ]);
+		try {
+			// Write the user's code
+			await sandbox.writeFiles([{ path: 'index.ts', content: Buffer.from(input.code) }]);
 
-      // Run immediately - no npm install needed
-      const result = await sandbox.execute({
-        command: ['npx', 'tsx', 'index.ts'],
-      });
+			// Run immediately - no npm install needed
+			const result = await sandbox.execute({
+				command: ['npx', 'tsx', 'index.ts'],
+			});
 
-      return { success: true, exitCode: result.exitCode };
-    } catch (error) {
-      ctx.logger.error('Sandbox execution failed', { error });
-      return { success: false, exitCode: -1, error: String(error) };
-    } finally {
-      await sandbox.destroy();
-    }
-  },
+			return { success: true, exitCode: result.exitCode };
+		} catch (error) {
+			ctx.logger.error('Sandbox execution failed', { error });
+			return { success: false, exitCode: -1, error: String(error) };
+		} finally {
+			await sandbox.destroy();
+		}
+	},
 });
 ```
 
@@ -231,13 +257,13 @@ Then use in your agent:
 
 ```typescript
 const languageSnapshots: Record<string, string> = {
-  python: 'python-data',
-  typescript: 'node-typescript',
-  javascript: 'node-typescript',
+	python: 'python-data',
+	typescript: 'node-typescript',
+	javascript: 'node-typescript',
 };
 
 const sandbox = await ctx.sandbox.create({
-  snapshot: languageSnapshots[input.language],
+	snapshot: languageSnapshots[input.language],
 });
 ```
 
@@ -263,7 +289,7 @@ Without snapshots, every sandbox creation requires dependency installation:
 ```typescript
 // Slow: Install dependencies every time
 const sandbox = await ctx.sandbox.create({ network: { enabled: true } });
-await sandbox.execute({ command: ['npm', 'install'] });  // 30+ seconds
+await sandbox.execute({ command: ['npm', 'install'] }); // 30+ seconds
 await sandbox.execute({ command: ['npm', 'run', 'build'] });
 ```
 
@@ -272,7 +298,7 @@ With snapshots:
 ```typescript
 // Fast: Dependencies already installed
 const sandbox = await ctx.sandbox.create({ snapshot: 'project-deps' });
-await sandbox.execute({ command: ['npm', 'run', 'build'] });  // Immediate
+await sandbox.execute({ command: ['npm', 'run', 'build'] }); // Immediate
 ```
 
 ## Snapshot Data


### PR DESCRIPTION
## Summary

- **Deploy Lifecycle Scripts** (`reference/cli/git-integration`): Documents `predeploy` and `postdeploy` package.json scripts for GitHub App deployments. `predeploy` replaces the default `bun install` (useful for monorepos), `postdeploy` runs after deploy completes.
- **Build Configuration** (`get-started/app-configuration` + `reference/cli/git-integration`): Documents the optional `build` field in `agentuity.json` for configuring GitHub deploy sandbox timeout and resources (memory, cpu, disk).
- **Snapshot `dir` Field** (`services/sandbox/snapshots`): Documents the `dir` field in snapshot YAML for monorepo support, allowing build context to resolve from a subdirectory.
- **Cross-links** (`reference/cli/deployment`): Added links from the CI/CD section to the new lifecycle scripts and build config docs.

## Files Changed

| File | Change |
|------|--------|
| `reference/cli/git-integration.mdx` | New "Deploy Lifecycle Scripts" and "Build Configuration" sections |
| `services/sandbox/snapshots.mdx` | New "Monorepo Support with `dir`" subsection |
| `get-started/app-configuration.mdx` | New "CI/CD Build Settings" section |
| `reference/cli/deployment.mdx` | Cross-link paragraph in CI/CD Pipelines section |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CI/CD Build Settings documentation with configuration examples and resource defaults.
  * Added Deploy Lifecycle Scripts documentation for predeploy and postdeploy hooks.
  * Added Build Configuration section in git integration guide.
  * Added Monorepo Support with directory context documentation.
  * Improved documentation formatting and readability across multiple guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->