### PR TITLE
Add devmode url environment variable

### DIFF
--- a/packages/cli/src/cmd/dev/index.ts
+++ b/packages/cli/src/cmd/dev/index.ts
@@ -1068,6 +1068,12 @@ export const command = createCommand({
 						process.env.AGENTUITY_CLOUD_DEPLOYMENT_ID = deploymentId;
 					}
 
+					if (devmode?.hostname) {
+						process.env.AGENTUITY_DEVMODE_URL = `https://${devmode.hostname}`;
+					} else {
+						process.env.AGENTUITY_DEVMODE_URL = `http://localhost:${opts.port}`;
+					}
+
 					// Set Vite port for asset proxying in bundled app
 					process.env.VITE_PORT = String(vitePort);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development environment setup. The development server now automatically configures the development mode URL environment variable during initialization, dynamically selecting between HTTPS when a custom hostname is provided and HTTP localhost as the default fallback option. This improvement ensures consistent and proper URL configuration for local development workflows without requiring manual environment variable management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->