### PR TITLE
feat: add IMAP/POP3 email protocol connection config support

### DIFF
--- a/packages/cli/src/cmd/cloud/email/create.ts
+++ b/packages/cli/src/cmd/cloud/email/create.ts
@@ -60,12 +60,10 @@ export const createSubcommand = createCommand({
 					{
 						ID: address.id,
 						Email: address.email,
-						Project: address.project_id ?? '-',
-						Provider: address.provider ?? '-',
 						Created: new Date(address.created_at).toLocaleString(),
 					},
 				],
-				['ID', 'Email', 'Project', 'Provider', 'Created'],
+				['ID', 'Email', 'Created'],
 				{ layout: 'vertical', padStart: '  ' }
 			);
 		}

--- a/packages/cli/src/cmd/cloud/email/get.ts
+++ b/packages/cli/src/cmd/cloud/email/get.ts
@@ -19,6 +19,7 @@ export const getSubcommand = createCommand({
 		const { args, options } = ctx;
 		const email = await createEmailAdapter(ctx);
 		const address = await email.getAddress(args.id);
+		const connection = await email.getConnectionConfig(args.id);
 
 		if (!address) {
 			tui.fatal(`Email address not found: ${args.id}`);
@@ -26,21 +27,57 @@ export const getSubcommand = createCommand({
 
 		if (!options.json) {
 			tui.success(`Email Address: ${tui.bold(address.email)}`);
+			console.log('');
 			tui.table(
 				[
 					{
 						ID: address.id,
 						Email: address.email,
-						Project: address.project_id ?? '-',
-						Provider: address.provider ?? '-',
-						Config: address.config ? JSON.stringify(address.config) : '-',
 						Created: new Date(address.created_at).toLocaleString(),
-						Updated: address.updated_at ? new Date(address.updated_at).toLocaleString() : '-',
 					},
 				],
-				['ID', 'Email', 'Project', 'Provider', 'Config', 'Created', 'Updated'],
+				['ID', 'Email', 'Created'],
 				{ layout: 'vertical', padStart: '  ' }
 			);
+
+			if (connection) {
+				const formatTLS = (tls: string) =>
+					tls.length > 0 ? `${tls.charAt(0).toUpperCase()}${tls.slice(1)}` : '-';
+
+				console.log('');
+				console.log(`  ${tui.bold('IMAP Connection')}`);
+				console.log(`  ${tui.muted('─────────────────')}`);
+				tui.table(
+					[
+						{
+							Host: connection.imap.host,
+							Port: connection.imap.port,
+							TLS: formatTLS(connection.imap.tls),
+							Username: connection.imap.username,
+							Password: connection.imap.password,
+						},
+					],
+					['Host', 'Port', 'TLS', 'Username', 'Password'],
+					{ layout: 'vertical', padStart: '  ' }
+				);
+
+				console.log('');
+				console.log(`  ${tui.bold('POP3 Connection')}`);
+				console.log(`  ${tui.muted('─────────────────')}`);
+				tui.table(
+					[
+						{
+							Host: connection.pop3.host,
+							Port: connection.pop3.port,
+							TLS: formatTLS(connection.pop3.tls),
+							Username: connection.pop3.username,
+							Password: connection.pop3.password,
+						},
+					],
+					['Host', 'Port', 'TLS', 'Username', 'Password'],
+					{ layout: 'vertical', padStart: '  ' }
+				);
+			}
 		}
 
 		return address;

--- a/packages/cli/src/cmd/cloud/email/list.ts
+++ b/packages/cli/src/cmd/cloud/email/list.ts
@@ -23,15 +23,11 @@ export const listSubcommand = createCommand({
 				addresses.map((item) => ({
 					ID: item.id,
 					Email: item.email,
-					Project: item.project_id ?? '-',
-					Provider: item.provider ?? '-',
 					Created: new Date(item.created_at).toLocaleString(),
 				})),
 				[
 					{ name: 'ID', alignment: 'left' },
 					{ name: 'Email', alignment: 'left' },
-					{ name: 'Project', alignment: 'left' },
-					{ name: 'Provider', alignment: 'left' },
 					{ name: 'Created', alignment: 'left' },
 				]
 			);
@@ -40,8 +36,6 @@ export const listSubcommand = createCommand({
 		return addresses.map((item) => ({
 			id: item.id,
 			email: item.email,
-			project_id: item.project_id,
-			provider: item.provider,
 			created_at: item.created_at,
 			updated_at: item.updated_at,
 		}));

--- a/packages/cli/src/cmd/cloud/email/util.ts
+++ b/packages/cli/src/cmd/cloud/email/util.ts
@@ -36,7 +36,6 @@ export function resolveEmailOrgId(ctx: EmailContext): string {
 export const EmailAddressSchema = z.object({
 	id: z.string(),
 	email: z.string(),
-	project_id: z.string().optional(),
 	provider: z.string().optional(),
 	config: z.record(z.string(), z.unknown()).optional(),
 	created_at: z.string(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -100,6 +100,8 @@ export {
 export {
 	type EmailAddress,
 	type EmailDestination,
+	type EmailProtocolConfig,
+	type EmailConnectionConfig,
 	type EmailInbound,
 	type EmailOutbound,
 	type EmailAttachment,

--- a/packages/core/src/services/email.ts
+++ b/packages/core/src/services/email.ts
@@ -8,8 +8,6 @@ import { safeStringify } from '../json.ts';
 export interface EmailAddress {
 	id: string;
 	email: string;
-	project_id?: string;
-	provider?: string;
 	config?: Record<string, unknown>;
 	created_by?: string;
 	created_at: string;
@@ -25,6 +23,20 @@ export interface EmailDestination {
 	config?: Record<string, unknown>;
 	created_at: string;
 	updated_at?: string;
+}
+
+export interface EmailProtocolConfig {
+	host: string;
+	port: number;
+	tls: string;
+	username: string;
+	password: string;
+}
+
+export interface EmailConnectionConfig {
+	email: string;
+	imap: EmailProtocolConfig;
+	pop3: EmailProtocolConfig;
 }
 
 /**
@@ -186,6 +198,14 @@ export interface EmailService {
 	 * ```
 	 */
 	getAddress(id: string): Promise<EmailAddress | null>;
+
+	/**
+	 * Get email connection settings (IMAP/POP3) for an address
+	 *
+	 * @param id - the email address ID
+	 * @returns the connection configuration or null if not found
+	 */
+	getConnectionConfig(id: string): Promise<EmailConnectionConfig | null>;
 
 	/**
 	 * Delete an email address
@@ -449,6 +469,31 @@ export class EmailStorageService implements EmailService {
 		}
 		if (res.ok) {
 			return unwrap<EmailAddress>(res.data, 'address');
+		}
+		throw await toServiceException('GET', url, res.response);
+	}
+
+	async getConnectionConfig(id: string): Promise<EmailConnectionConfig | null> {
+		const url = buildUrl(
+			this.#baseUrl,
+			`/email/2025-03-17/addresses/${encodeURIComponent(id)}/connection`
+		);
+		const signal = AbortSignal.timeout(30_000);
+		const res = await this.#adapter.invoke<unknown>(url, {
+			method: 'GET',
+			signal,
+			telemetry: {
+				name: 'agentuity.email.getConnectionConfig',
+				attributes: {
+					id,
+				},
+			},
+		});
+		if (res.response.status === 404) {
+			return null;
+		}
+		if (res.ok) {
+			return unwrap<EmailConnectionConfig>(res.data, 'connection');
 		}
 		throw await toServiceException('GET', url, res.response);
 	}

--- a/packages/runtime/src/services/local/email.ts
+++ b/packages/runtime/src/services/local/email.ts
@@ -3,6 +3,7 @@ import {
 	type EmailService,
 	type EmailAddress,
 	type EmailDestination,
+	type EmailConnectionConfig,
 	type EmailInbound,
 	type EmailOutbound,
 	type EmailSendParams,
@@ -27,6 +28,10 @@ export class LocalEmailStorage implements EmailService {
 	}
 
 	async getAddress(_id: string): Promise<EmailAddress | null> {
+		throw new LocalEmailNotAvailableError();
+	}
+
+	async getConnectionConfig(_id: string): Promise<EmailConnectionConfig | null> {
 		throw new LocalEmailNotAvailableError();
 	}
 


### PR DESCRIPTION
## Summary

SDK changes to support native IMAP/POP3 email protocols in Ion. Companion PR to [ion#191](https://github.com/agentuity/ion/pull/191).

### Changes

- **`@agentuity/core`**: Add `EmailProtocolConfig` and `EmailConnectionConfig` types for IMAP (993) and POP3 (995) protocol connection details
- **`@agentuity/core`**: Add `password` field to `EmailAddress` model, remove `project_id` 
- **`@agentuity/cli`**: `agentuity cloud email get` now displays IMAP/POP3 connection details including host, port, username, and password
- **`@agentuity/cli`**: Remove `project_id` from email create/list display
- **`@agentuity/runtime`**: Add `getConnectionConfig` stub for local email service

### Related

- Ion PR: https://github.com/agentuity/ion/pull/191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email address details now display IMAP and POP3 connection configuration including host, port, TLS, and credentials.

* **Improvements**
  * Streamlined email address tables by removing redundant project and provider information.
  * Enhanced formatting with improved spacing between sections in email command outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->