### PR TITLE
fix: add last_activity field to EmailAddress interface

### DIFF
--- a/packages/core/src/services/email.ts
+++ b/packages/core/src/services/email.ts
@@ -14,6 +14,7 @@ export interface EmailAddress {
 	updated_at?: string;
 	inbound_count?: number;
 	outbound_count?: number;
+	last_activity?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds `last_activity?: string` to the `EmailAddress` interface in `@agentuity/core` so consumers can display when each address last had inbound or outbound email traffic.

## Changes

- `packages/core/src/services/email.ts`: Add optional `last_activity` field to `EmailAddress` interface

## Context

Companion to [ion PR](https://github.com/agentuity/ion) — the Catalyst API now returns `last_activity` (the MAX of most recent inbound/outbound timestamp) per address. This SDK change surfaces that field to TypeScript consumers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated email address data structure to support activity tracking timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->