### PR TITLE
fix(templates): remove errant backslash in .gitignore env pattern

### DIFF
--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -22,7 +22,7 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]\*.json
 # dotenv environment variable files
 
 .env
-.env.\*
+.env.*
 
 # caches
 

--- a/templates/_base/gitignore
+++ b/templates/_base/gitignore
@@ -22,7 +22,7 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]\*.json
 # dotenv environment variable files
 
 .env
-.env.\*
+.env.*
 
 # caches
 


### PR DESCRIPTION
## Summary

- Fixes the `.env.\*` pattern in `.gitignore` templates — the backslash escaped the asterisk, causing it to match a literal `*` character instead of acting as a wildcard
- This caused `.env.development`, `.env.production`, `.env.local`, and other dotenv variant files to **not** be ignored by git in newly created projects

## Changes

- `templates/_base/gitignore` — `.env.\*` → `.env.*`
- `apps/docs/.gitignore` — `.env.\*` → `.env.*`

Closes #1069

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment file exclusion patterns to properly ignore environment-specific configuration files across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->