### PR TITLE
feat(cli): trigger Let's Encrypt provisioning during custom DNS validation

### DIFF
--- a/packages/cli/src/domain.ts
+++ b/packages/cli/src/domain.ts
@@ -95,6 +95,30 @@ async function fetchDNSRecord(name: string, type: string): Promise<string | null
 	return records[0] ?? null;
 }
 
+/**
+ * Check if a domain has a valid TLS certificate by making a HEAD request.
+ * This also triggers Let's Encrypt certificate provisioning on first access.
+ * Returns true if the TLS certificate is valid (any HTTP status code received).
+ * Returns false if the certificate is not yet provisioned (timeout or TLS error).
+ */
+async function checkTLSCertificate(domain: string): Promise<boolean> {
+	try {
+		await fetch(`https://${domain}`, {
+			method: 'HEAD',
+			signal: AbortSignal.timeout(timeoutMs),
+			redirect: 'manual',
+			// @ts-expect-error - cache is supported by Bun's fetch at runtime but missing from type definitions
+			cache: 'no-store',
+		});
+		// Any HTTP response means TLS handshake succeeded and certificate is valid
+		return true;
+	} catch {
+		// Timeout, TLS certificate error, connection refused, etc.
+		// All indicate the certificate is not yet provisioned
+		return false;
+	}
+}
+
 const LOCAL_DNS = 'agentuity.io';
 const PRODUCTION_DNS = 'agentuity.run';
 
@@ -171,15 +195,27 @@ export async function checkCustomDomainForDNS(
 					if (timeoutId) clearTimeout(timeoutId);
 				});
 
-				if (result) {
-					if (result === proxy) {
+			if (result) {
+				if (result === proxy) {
+						// DNS is correct — verify TLS certificate (also triggers Let's Encrypt provisioning)
+						const tlsValid = await checkTLSCertificate(domain);
+						if (tlsValid) {
+							return {
+								domain,
+								target: proxy,
+								aRecordTarget,
+								recordType: 'CNAME',
+								success: true,
+							} as DNSSuccess;
+						}
 						return {
 							domain,
 							target: proxy,
 							aRecordTarget,
 							recordType: 'CNAME',
 							success: true,
-						} as DNSSuccess;
+							pending: true,
+						} as DNSPending;
 					}
 					return {
 						domain,
@@ -242,13 +278,25 @@ export async function checkCustomDomainForDNS(
 					if (domainARecords.length > 0) {
 						const matching = domainARecords.some((a) => ionIPs.includes(a));
 						if (matching) {
+							// DNS is correct — verify TLS certificate (also triggers Let's Encrypt provisioning)
+							const tlsValid = await checkTLSCertificate(domain);
+							if (tlsValid) {
+								return {
+									domain,
+									target: proxy,
+									aRecordTarget,
+									recordType: 'A',
+									success: true,
+								} as DNSSuccess;
+							}
 							return {
 								domain,
 								target: proxy,
 								aRecordTarget,
 								recordType: 'A',
 								success: true,
-							} as DNSSuccess;
+								pending: true,
+							} as DNSPending;
 						}
 						return {
 							domain,


### PR DESCRIPTION
## Summary

- During custom DNS polling, makes a HEAD request to `https://{domain}` to trigger Let's Encrypt certificate provisioning in Ion
- Validates TLS certificate is working before marking a domain as fully configured
- If DNS is correct but TLS isn't ready yet (timeout, invalid cert), shows domain as "Pending" and continues polling

## Details

When a user configures a custom domain and the CLI polls to validate DNS, the first HTTPS request to the domain is what triggers Ion to provision a Let's Encrypt certificate. Previously, the CLI only checked DNS records — so even after DNS was correct, the domain wasn't usable until something else triggered the cert.

Now `checkCustomDomainForDNS` adds a TLS verification step after DNS validates:
- `checkTLSCertificate(domain)` — `HEAD https://{domain}` with `AbortSignal.timeout(5s)`, `redirect: 'manual'`, `cache: 'no-store'`
- Any HTTP response (any status code) = TLS valid → `DNSSuccess`
- Any error (timeout, cert error, connection refused) = still provisioning → `DNSPending`

The existing polling loop in `promptForDNS` already handles `DNSPending` with "⌛️ Pending" display and 5s retries, so no UI changes were needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced domain validation to verify TLS certificate readiness alongside DNS configuration checks. The system now provides more granular status reporting, distinguishing between DNS misconfiguration and ongoing TLS provisioning to give users clearer feedback during custom domain setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->