### PR TITLE
feat: expose queue provisioning API via ctx.queue (createQueue / deleteQueue)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -92,6 +92,8 @@ export {
 	type QueueService,
 	type QueuePublishParams,
 	type QueuePublishResult,
+	type QueueCreateParams,
+	type QueueCreateResult,
 	QueueStorageService,
 	QueuePublishError,
 	QueueNotFoundError,

--- a/packages/core/src/services/queue.ts
+++ b/packages/core/src/services/queue.ts
@@ -109,6 +109,59 @@ export interface QueuePublishResult {
 }
 
 /**
+ * Parameters for creating a queue.
+ *
+ * @example
+ * ```typescript
+ * const result = await ctx.queue.createQueue('my-queue', {
+ *   queueType: 'pubsub',
+ *   settings: { defaultTtlSeconds: 86400 },
+ * });
+ * ```
+ */
+export interface QueueCreateParams {
+	/**
+	 * Type of queue to create.
+	 * - `worker`: Messages are consumed by exactly one consumer with acknowledgment.
+	 * - `pubsub`: Messages are broadcast to all subscribers.
+	 * @default 'worker'
+	 */
+	queueType?: 'worker' | 'pubsub';
+
+	/**
+	 * Optional description of the queue's purpose.
+	 */
+	description?: string;
+
+	/**
+	 * Optional settings to customize queue behavior.
+	 * Only provided fields are applied; others use server defaults.
+	 */
+	settings?: {
+		/** Default time-to-live for messages in seconds. Null means no expiration. */
+		defaultTtlSeconds?: number | null;
+		/** Time in seconds a message is invisible after being received. */
+		defaultVisibilityTimeoutSeconds?: number;
+		/** Maximum number of delivery attempts before moving to DLQ. */
+		defaultMaxRetries?: number;
+		/** Maximum number of messages a single client can process concurrently. */
+		maxInFlightPerClient?: number;
+		/** Retention period for acknowledged messages in seconds. */
+		retentionSeconds?: number;
+	};
+}
+
+/**
+ * Result of creating a queue.
+ */
+export interface QueueCreateResult {
+	/** The queue name. */
+	name: string;
+	/** The queue type ('worker' or 'pubsub'). */
+	queueType: string;
+}
+
+/**
  * Queue service interface for publishing messages.
  *
  * This is the interface available to agents via `ctx.queue`. It provides
@@ -167,6 +220,49 @@ export interface QueueService {
 		payload: string | object,
 		params?: QueuePublishParams
 	): Promise<QueuePublishResult>;
+
+	/**
+	 * Create a queue with idempotent semantics.
+	 *
+	 * If the queue already exists, this returns successfully without error.
+	 * Safe to call multiple times — uses an internal cache to avoid redundant API calls.
+	 *
+	 * @param queueName - The name of the queue to create
+	 * @param params - Optional creation parameters (queue type, settings, etc.)
+	 * @returns The create result with queue name and type
+	 * @throws {QueueValidationError} If the queue name is invalid
+	 *
+	 * @example Creating a worker queue
+	 * ```typescript
+	 * const result = await ctx.queue.createQueue('task-queue');
+	 * ```
+	 *
+	 * @example Creating a pubsub queue with settings
+	 * ```typescript
+	 * const result = await ctx.queue.createQueue('events', {
+	 *   queueType: 'pubsub',
+	 *   settings: { defaultTtlSeconds: 86400 },
+	 * });
+	 * ```
+	 */
+	createQueue(queueName: string, params?: QueueCreateParams): Promise<QueueCreateResult>;
+
+	/**
+	 * Delete a queue.
+	 *
+	 * Permanently deletes a queue and all its messages. This action cannot be undone.
+	 * If the queue has already been deleted or does not exist, a {@link QueueNotFoundError} is thrown.
+	 *
+	 * @param queueName - The name of the queue to delete
+	 * @throws {QueueNotFoundError} If the queue does not exist
+	 * @throws {QueueValidationError} If the queue name is invalid
+	 *
+	 * @example Deleting a queue
+	 * ```typescript
+	 * await ctx.queue.deleteQueue('old-queue');
+	 * ```
+	 */
+	deleteQueue(queueName: string): Promise<void>;
 }
 
 // ============================================================================
@@ -277,6 +373,7 @@ function validatePayloadInternal(payload: string): void {
 export class QueueStorageService implements QueueService {
 	#adapter: FetchAdapter;
 	#baseUrl: string;
+	#knownQueues = new Set<string>();
 
 	/**
 	 * Creates a new QueueStorageService.
@@ -387,5 +484,123 @@ export class QueueStorageService implements QueueService {
 		}
 
 		throw await toServiceException('POST', url, res.response);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	async createQueue(queueName: string, params?: QueueCreateParams): Promise<QueueCreateResult> {
+		validateQueueNameInternal(queueName);
+
+		if (this.#knownQueues.has(queueName)) {
+			return {
+				name: queueName,
+				queueType: params?.queueType ?? 'worker',
+			};
+		}
+
+		const url = buildUrl(this.#baseUrl, '/queue/create/2026-01-15');
+
+		const requestBody: Record<string, unknown> = {
+			name: queueName,
+			queue_type: params?.queueType ?? 'worker',
+		};
+
+		if (params?.description !== undefined) {
+			requestBody.description = params.description;
+		}
+
+		if (params?.settings) {
+			const settings: Record<string, unknown> = {};
+			if (params.settings.defaultTtlSeconds !== undefined) {
+				settings.default_ttl_seconds = params.settings.defaultTtlSeconds;
+			}
+			if (params.settings.defaultVisibilityTimeoutSeconds !== undefined) {
+				settings.default_visibility_timeout_seconds =
+					params.settings.defaultVisibilityTimeoutSeconds;
+			}
+			if (params.settings.defaultMaxRetries !== undefined) {
+				settings.default_max_retries = params.settings.defaultMaxRetries;
+			}
+			if (params.settings.maxInFlightPerClient !== undefined) {
+				settings.max_in_flight_per_client = params.settings.maxInFlightPerClient;
+			}
+			if (params.settings.retentionSeconds !== undefined) {
+				settings.retention_seconds = params.settings.retentionSeconds;
+			}
+			if (Object.keys(settings).length > 0) {
+				requestBody.settings = settings;
+			}
+		}
+
+		const signal = AbortSignal.timeout(30_000);
+		const res = await this.#adapter.invoke<QueueCreateResult>(url, {
+			method: 'POST',
+			signal,
+			body: JSON.stringify(requestBody),
+			contentType: 'application/json',
+			telemetry: {
+				name: 'agentuity.queue.create',
+				attributes: {
+					queueName,
+				},
+			},
+		});
+
+		if (res.ok) {
+			const data = res.data as unknown as Record<string, unknown>;
+			this.#knownQueues.add(queueName);
+			return {
+				name: (data.name as string) ?? queueName,
+				queueType: (data.queue_type as string) ?? params?.queueType ?? 'worker',
+			};
+		}
+
+		if (res.response.status === 409) {
+			this.#knownQueues.add(queueName);
+			return {
+				name: queueName,
+				queueType: params?.queueType ?? 'worker',
+			};
+		}
+
+		throw await toServiceException('POST', url, res.response);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	async deleteQueue(queueName: string): Promise<void> {
+		validateQueueNameInternal(queueName);
+
+		const url = buildUrl(
+			this.#baseUrl,
+			`/queue/delete/2026-01-15/${encodeURIComponent(queueName)}`
+		);
+
+		const signal = AbortSignal.timeout(30_000);
+		const res = await this.#adapter.invoke<void>(url, {
+			method: 'DELETE',
+			signal,
+			telemetry: {
+				name: 'agentuity.queue.delete',
+				attributes: {
+					queueName,
+				},
+			},
+		});
+
+		if (res.ok) {
+			this.#knownQueues.delete(queueName);
+			return;
+		}
+
+		if (res.response.status === 404) {
+			throw new QueueNotFoundError({
+				message: `Queue not found: ${queueName}`,
+			});
+		}
+
+		throw await toServiceException('DELETE', url, res.response);
 	}
 }

--- a/packages/core/test/queue.test.ts
+++ b/packages/core/test/queue.test.ts
@@ -469,4 +469,279 @@ describe('QueueStorageService', () => {
 			expect(afterCalls[0].hasError).toBe(true);
 		});
 	});
+
+	describe('createQueue', () => {
+		test('should create queue and return result', async () => {
+			const mockData = { name: 'my_queue', queue_type: 'worker' };
+			const { adapter, calls } = createMockAdapter([{ ok: true, data: mockData }]);
+			const service = new QueueStorageService(baseUrl, adapter);
+			const result = await service.createQueue('my_queue');
+			expect(result.name).toBe('my_queue');
+			expect(result.queueType).toBe('worker');
+			expect(calls).toHaveLength(1);
+			expect(calls[0].url).toContain('/queue/create/2026-01-15');
+			expect(calls[0].options.method).toBe('POST');
+		});
+
+		test('should create pubsub queue when specified', async () => {
+			const mockData = { name: 'events', queue_type: 'pubsub' };
+			const { adapter, calls } = createMockAdapter([{ ok: true, data: mockData }]);
+			const service = new QueueStorageService(baseUrl, adapter);
+			const result = await service.createQueue('events', { queueType: 'pubsub' });
+			expect(result.queueType).toBe('pubsub');
+			const body = JSON.parse(calls[0].options.body as string);
+			expect(body.queue_type).toBe('pubsub');
+		});
+
+		test('should default to worker queue type', async () => {
+			const mockData = { name: 'tasks', queue_type: 'worker' };
+			const { adapter, calls } = createMockAdapter([{ ok: true, data: mockData }]);
+			const service = new QueueStorageService(baseUrl, adapter);
+			await service.createQueue('tasks');
+			const body = JSON.parse(calls[0].options.body as string);
+			expect(body.queue_type).toBe('worker');
+		});
+
+		test('should include description when provided', async () => {
+			const mockData = { name: 'my_queue', queue_type: 'worker' };
+			const { adapter, calls } = createMockAdapter([{ ok: true, data: mockData }]);
+			const service = new QueueStorageService(baseUrl, adapter);
+			await service.createQueue('my_queue', { description: 'Test queue' });
+			const body = JSON.parse(calls[0].options.body as string);
+			expect(body.description).toBe('Test queue');
+		});
+
+		test('should include settings when provided', async () => {
+			const mockData = { name: 'my_queue', queue_type: 'worker' };
+			const { adapter, calls } = createMockAdapter([{ ok: true, data: mockData }]);
+			const service = new QueueStorageService(baseUrl, adapter);
+			await service.createQueue('my_queue', {
+				settings: {
+					defaultTtlSeconds: 3600,
+					defaultMaxRetries: 3,
+					maxInFlightPerClient: 5,
+				},
+			});
+			const body = JSON.parse(calls[0].options.body as string);
+			expect(body.settings.default_ttl_seconds).toBe(3600);
+			expect(body.settings.default_max_retries).toBe(3);
+			expect(body.settings.max_in_flight_per_client).toBe(5);
+		});
+
+		test('should handle null defaultTtlSeconds in settings', async () => {
+			const mockData = { name: 'my_queue', queue_type: 'worker' };
+			const { adapter, calls } = createMockAdapter([{ ok: true, data: mockData }]);
+			const service = new QueueStorageService(baseUrl, adapter);
+			await service.createQueue('my_queue', {
+				settings: { defaultTtlSeconds: null },
+			});
+			const body = JSON.parse(calls[0].options.body as string);
+			expect(body.settings.default_ttl_seconds).toBeNull();
+		});
+
+		test('should treat 409 as success (idempotent)', async () => {
+			const { adapter, calls } = createMockAdapter([{ ok: false, status: 409 }]);
+			const service = new QueueStorageService(baseUrl, adapter);
+			const result = await service.createQueue('existing_queue', { queueType: 'pubsub' });
+			expect(result.name).toBe('existing_queue');
+			expect(result.queueType).toBe('pubsub');
+			expect(calls).toHaveLength(1);
+		});
+
+		test('should cache known queues and skip API call on second create', async () => {
+			const mockData = { name: 'my_queue', queue_type: 'worker' };
+			const { adapter, calls } = createMockAdapter([{ ok: true, data: mockData }]);
+			const service = new QueueStorageService(baseUrl, adapter);
+
+			// First call hits API
+			await service.createQueue('my_queue');
+			expect(calls).toHaveLength(1);
+
+			// Second call should use cache (no additional API call)
+			const result2 = await service.createQueue('my_queue');
+			expect(calls).toHaveLength(1); // Still 1 — cached
+			expect(result2.name).toBe('my_queue');
+			expect(result2.queueType).toBe('worker');
+		});
+
+		test('should cache after 409 response', async () => {
+			const { adapter, calls } = createMockAdapter([{ ok: false, status: 409 }]);
+			const service = new QueueStorageService(baseUrl, adapter);
+
+			// First call gets 409
+			await service.createQueue('existing_queue');
+			expect(calls).toHaveLength(1);
+
+			// Second call should use cache
+			await service.createQueue('existing_queue');
+			expect(calls).toHaveLength(1); // Still 1 — cached
+		});
+
+		test('should throw ServiceException on server error', async () => {
+			const { adapter } = createMockAdapter([
+				{ ok: false, status: 500, body: { error: 'Internal Server Error' } },
+			]);
+			const service = new QueueStorageService(baseUrl, adapter);
+			await expect(service.createQueue('my_queue')).rejects.toThrow(ServiceException);
+		});
+
+		test('should set content type to application/json', async () => {
+			const mockData = { name: 'my_queue', queue_type: 'worker' };
+			const { adapter, calls } = createMockAdapter([{ ok: true, data: mockData }]);
+			const service = new QueueStorageService(baseUrl, adapter);
+			await service.createQueue('my_queue');
+			expect(calls[0].options.contentType).toBe('application/json');
+		});
+
+		test('should set telemetry attributes', async () => {
+			const mockData = { name: 'my_queue', queue_type: 'worker' };
+			const { adapter, calls } = createMockAdapter([{ ok: true, data: mockData }]);
+			const service = new QueueStorageService(baseUrl, adapter);
+			await service.createQueue('my_queue');
+			expect(calls[0].options.telemetry?.name).toBe('agentuity.queue.create');
+			expect(calls[0].options.telemetry?.attributes?.queueName).toBe('my_queue');
+		});
+
+		test('should set timeout signal', async () => {
+			const mockData = { name: 'my_queue', queue_type: 'worker' };
+			const { adapter, calls } = createMockAdapter([{ ok: true, data: mockData }]);
+			const service = new QueueStorageService(baseUrl, adapter);
+			await service.createQueue('my_queue');
+			expect(calls[0].options.signal).toBeDefined();
+		});
+	});
+
+	describe('createQueue - validation', () => {
+		test('should throw QueueValidationError for empty queue name', async () => {
+			const { adapter } = createMockAdapter([]);
+			const service = new QueueStorageService(baseUrl, adapter);
+			await expect(service.createQueue('')).rejects.toThrow(QueueValidationError);
+		});
+
+		test('should throw QueueValidationError for queue name exceeding max length', async () => {
+			const { adapter } = createMockAdapter([]);
+			const service = new QueueStorageService(baseUrl, adapter);
+			const longName = 'a'.repeat(257);
+			await expect(service.createQueue(longName)).rejects.toThrow(QueueValidationError);
+		});
+
+		test('should throw QueueValidationError for invalid queue name characters', async () => {
+			const { adapter } = createMockAdapter([]);
+			const service = new QueueStorageService(baseUrl, adapter);
+			await expect(service.createQueue('Invalid-Queue!')).rejects.toThrow(QueueValidationError);
+		});
+
+		test('should throw QueueValidationError for queue name starting with digit', async () => {
+			const { adapter } = createMockAdapter([]);
+			const service = new QueueStorageService(baseUrl, adapter);
+			await expect(service.createQueue('1queue')).rejects.toThrow(QueueValidationError);
+		});
+	});
+
+	describe('deleteQueue', () => {
+		test('should delete queue successfully', async () => {
+			const { adapter, calls } = createMockAdapter([{ ok: true, data: {} }]);
+			const service = new QueueStorageService(baseUrl, adapter);
+			await service.deleteQueue('my_queue');
+			expect(calls).toHaveLength(1);
+			expect(calls[0].url).toContain('/queue/delete/2026-01-15/my_queue');
+			expect(calls[0].options.method).toBe('DELETE');
+		});
+
+		test('should remove queue from known queues cache after delete', async () => {
+			const mockData = { name: 'my_queue', queue_type: 'worker' };
+			const { adapter, calls } = createMockAdapter<unknown>([
+				{ ok: true, data: mockData }, // createQueue response
+				{ ok: true, data: {} }, // deleteQueue response
+				{ ok: true, data: mockData }, // second createQueue response
+			]);
+			const service = new QueueStorageService(baseUrl, adapter);
+
+			// Create queue (adds to cache)
+			await service.createQueue('my_queue');
+			expect(calls).toHaveLength(1);
+
+			// Create again — should use cache
+			await service.createQueue('my_queue');
+			expect(calls).toHaveLength(1); // still 1, cached
+
+			// Delete queue (removes from cache)
+			await service.deleteQueue('my_queue');
+			expect(calls).toHaveLength(2); // now 2
+
+			// Create again — should NOT use cache (was cleared)
+			await service.createQueue('my_queue');
+			expect(calls).toHaveLength(3); // now 3, cache was cleared
+		});
+
+		test('should throw QueueNotFoundError on 404', async () => {
+			const { adapter } = createMockAdapter([{ ok: false, status: 404 }]);
+			const service = new QueueStorageService(baseUrl, adapter);
+			await expect(service.deleteQueue('nonexistent_queue')).rejects.toThrow(QueueNotFoundError);
+		});
+
+		test('should throw ServiceException on server error', async () => {
+			const { adapter } = createMockAdapter([
+				{ ok: false, status: 500, body: { error: 'Internal Server Error' } },
+			]);
+			const service = new QueueStorageService(baseUrl, adapter);
+			await expect(service.deleteQueue('my_queue')).rejects.toThrow(ServiceException);
+		});
+
+		test('should set telemetry attributes', async () => {
+			const { adapter, calls } = createMockAdapter([{ ok: true, data: {} }]);
+			const service = new QueueStorageService(baseUrl, adapter);
+			await service.deleteQueue('my_queue');
+			expect(calls[0].options.telemetry?.name).toBe('agentuity.queue.delete');
+			expect(calls[0].options.telemetry?.attributes?.queueName).toBe('my_queue');
+		});
+
+		test('should set timeout signal', async () => {
+			const { adapter, calls } = createMockAdapter([{ ok: true, data: {} }]);
+			const service = new QueueStorageService(baseUrl, adapter);
+			await service.deleteQueue('my_queue');
+			expect(calls[0].options.signal).toBeDefined();
+		});
+
+		test('should not send request body', async () => {
+			const { adapter, calls } = createMockAdapter([{ ok: true, data: {} }]);
+			const service = new QueueStorageService(baseUrl, adapter);
+			await service.deleteQueue('my_queue');
+			expect(calls[0].options.body).toBeUndefined();
+		});
+
+		test('should URL-encode queue name', async () => {
+			const { adapter, calls } = createMockAdapter([{ ok: true, data: {} }]);
+			const service = new QueueStorageService(baseUrl, adapter);
+			await service.deleteQueue('my_queue');
+			expect(calls[0].url).toContain('/queue/delete/2026-01-15/my_queue');
+		});
+	});
+
+	describe('deleteQueue - validation', () => {
+		test('should throw QueueValidationError for empty queue name', async () => {
+			const { adapter } = createMockAdapter([]);
+			const service = new QueueStorageService(baseUrl, adapter);
+			await expect(service.deleteQueue('')).rejects.toThrow(QueueValidationError);
+		});
+
+		test('should throw QueueValidationError for queue name exceeding max length', async () => {
+			const { adapter } = createMockAdapter([]);
+			const service = new QueueStorageService(baseUrl, adapter);
+			const longName = 'a'.repeat(257);
+			await expect(service.deleteQueue(longName)).rejects.toThrow(QueueValidationError);
+		});
+
+		test('should throw QueueValidationError for invalid queue name characters', async () => {
+			const { adapter } = createMockAdapter([]);
+			const service = new QueueStorageService(baseUrl, adapter);
+			await expect(service.deleteQueue('Invalid-Queue!')).rejects.toThrow(QueueValidationError);
+		});
+
+		test('should throw QueueValidationError for queue name starting with digit', async () => {
+			const { adapter } = createMockAdapter([]);
+			const service = new QueueStorageService(baseUrl, adapter);
+			await expect(service.deleteQueue('1queue')).rejects.toThrow(QueueValidationError);
+		});
+	});
 });

--- a/packages/runtime/src/services/local/queue.ts
+++ b/packages/runtime/src/services/local/queue.ts
@@ -1,5 +1,11 @@
 import type { Database } from 'bun:sqlite';
-import type { QueueService, QueuePublishParams, QueuePublishResult } from '@agentuity/core';
+import type {
+	QueueService,
+	QueuePublishParams,
+	QueuePublishResult,
+	QueueCreateParams,
+	QueueCreateResult,
+} from '@agentuity/core';
 
 export class LocalQueueStorage implements QueueService {
 	#db: Database;
@@ -123,5 +129,17 @@ export class LocalQueueStorage implements QueueService {
 		});
 
 		return publishInTransaction.immediate();
+	}
+
+	async createQueue(queueName: string, params?: QueueCreateParams): Promise<QueueCreateResult> {
+		console.debug(`[local] createQueue: ${queueName}`);
+		return {
+			name: queueName,
+			queueType: params?.queueType ?? 'worker',
+		};
+	}
+
+	async deleteQueue(_queueName: string): Promise<void> {
+		// No-op in local mode — queues don't need provisioning locally
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `createQueue` and `deleteQueue` methods to the `QueueService` interface, enabling agents to provision and tear down queues from runtime context (`ctx.queue`) without out-of-band CLI setup
- `createQueue` has idempotent semantics — 409 Conflict treated as success, with an in-memory `knownQueues` cache to skip redundant API calls on repeat invocations
- `deleteQueue` clears the cache entry so subsequent creates hit the API again

## Usage

```typescript
// Create a worker queue (idempotent — safe to call on every startup)
await ctx.queue.createQueue('task-queue');

// Create a pubsub queue with settings
await ctx.queue.createQueue('events', {
  queueType: 'pubsub',
  settings: { defaultTtlSeconds: 86400 },
});

// Delete a queue
await ctx.queue.deleteQueue('old-queue');
```

## Changes

| File | Change |
|---|---|
| `packages/core/src/services/queue.ts` | `QueueCreateParams`, `QueueCreateResult` types; extended `QueueService` interface; `createQueue` + `deleteQueue` implementations with cache, validation, telemetry |
| `packages/core/src/index.ts` | Export new types |
| `packages/core/test/queue.test.ts` | 28 new tests (60 total, all pass) |
| `packages/runtime/src/services/local/queue.ts` | `createQueue` + `deleteQueue` stubs for local dev |

## Test Results

- ✅ 60 tests pass, 0 fail, 97 expect() calls
- ✅ Build, typecheck, lint all clean

Closes #1102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced queue creation API with support for configurable queue types, descriptions, and settings to enable dynamic queue provisioning.
  * Added queue deletion functionality for complete queue lifecycle management.
  * Queue creation is now idempotent, safely handling attempts to create existing queues without errors.
  * Extended public API with new type definitions for queue creation parameters and results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->