### PR TITLE
feat: extend KV max TTL to 365 days and document TTL=0 for no expiration

### DIFF
--- a/apps/docs/src/agent/kv/agent.ts
+++ b/apps/docs/src/agent/kv/agent.ts
@@ -10,7 +10,7 @@
  * - ctx.kv.set(bucket, key, value, { ttl }) - Store with optional expiration
  * - ctx.kv.getKeys(bucket) - List all keys in a bucket
  *
- * TTL (time-to-live) is in seconds, minimum 60s. Great for caching.
+ * TTL (time-to-live) is in seconds, minimum 60s (0 for no expiration). Great for caching.
  *
  * Docs: https://agentuity.dev/Services/Storage/key-value
  */

--- a/apps/docs/src/web/code-examples.ts
+++ b/apps/docs/src/web/code-examples.ts
@@ -92,7 +92,7 @@ const sessionData = {
 
 ctx.logger.info("Setting key", { key });
 
-// SET: store data with optional TTL (minimum 60 seconds)
+// SET: store data with optional TTL (minimum 60 seconds, 0 for no expiration)
 await ctx.kv.set(bucket, key, sessionData, { ttl: 300 });
 
 ctx.logger.info("Getting key", { key });

--- a/apps/docs/src/web/content/services/storage/key-value.mdx
+++ b/apps/docs/src/web/content/services/storage/key-value.mdx
@@ -44,7 +44,7 @@ import { createAgent } from '@agentuity/runtime';
 
 const agent = createAgent('CacheManager', {
   handler: async (ctx, input) => {
-    // Store with custom TTL (minimum 60 seconds, maximum 90 days)
+    // Store with custom TTL (minimum 60 seconds, maximum 365 days)
     await ctx.kv.set('cache', 'api-response', responseData, {
       ttl: 3600,  // expires in 1 hour
       contentType: 'application/json',
@@ -193,10 +193,10 @@ const agent = createAgent('NamespaceManager', {
 |-------|----------|
 | `undefined` | Keys expire after 7 days (default) |
 | `null` or `0` | Keys never expire |
-| `>= 60` | Custom TTL in seconds (minimum 60 seconds, maximum 90 days) |
+| `>= 60` | Custom TTL in seconds (minimum 60 seconds, maximum 365 days) |
 
 <Callout type="info" title="TTL Limits">
-The minimum TTL is 60 seconds. The maximum is 90 days (7,776,000 seconds). Values outside this range will be rejected.
+The minimum TTL is 60 seconds. The maximum is 365 days (31,536,000 seconds). Values outside this range will be clamped to valid bounds. A TTL of 0 means the key never expires.
 </Callout>
 
 <Callout type="info" title="Sliding Expiration">

--- a/packages/core/src/services/keyvalue/service.ts
+++ b/packages/core/src/services/keyvalue/service.ts
@@ -9,9 +9,9 @@ import { z } from 'zod';
 export const KV_MIN_TTL_SECONDS = 60;
 
 /**
- * Maximum TTL value in seconds (90 days)
+ * Maximum TTL value in seconds (365 days)
  */
-export const KV_MAX_TTL_SECONDS = 7776000;
+export const KV_MAX_TTL_SECONDS = 31536000;
 
 /**
  * Default TTL value in seconds (7 days) - used when namespace is auto-created or no TTL specified
@@ -88,11 +88,11 @@ export const KeyValueStorageSetParamsSchema = z.object({
 	 * Time-to-live in seconds for the key. Controls when the key expires and is automatically deleted.
 	 * - `undefined` (not provided): Key inherits the namespace's default TTL (7 days if not configured)
 	 * - `null` or `0`: Key never expires
-	 * - positive number (≥60): Key expires after the specified number of seconds (max 90 days)
+	 * - positive number (≥60): Key expires after the specified number of seconds (max 365 days)
 	 *
 	 * @remarks
 	 * TTL values below 60 seconds are clamped to 60 seconds by the server.
-	 * TTL values above 7,776,000 seconds (90 days) are clamped to 90 days.
+	 * TTL values above 31,536,000 seconds (365 days) are clamped to 365 days.
 	 */
 	ttl: z
 		.number()
@@ -117,7 +117,7 @@ export const CreateNamespaceParamsSchema = z.object({
 	 * Default TTL for keys in this namespace (in seconds).
 	 * - If undefined/omitted: uses server default (7 days / 604,800 seconds)
 	 * - If 0: keys will not expire by default
-	 * - If 60-7,776,000: custom TTL in seconds (1 minute to 90 days)
+	 * - If 60-31,536,000: custom TTL in seconds (1 minute to 365 days)
 	 *
 	 * Keys can override this default by specifying TTL in the set() call.
 	 * Active keys are automatically extended (sliding expiration) when read
@@ -444,7 +444,7 @@ export class KeyValueStorageService implements KeyValueStorage {
 	 * - If TTL is null or 0, the key will not expire
 	 * - If TTL is a positive number, the key expires after that many seconds
 	 * - TTL values below 60 seconds are clamped to 60 seconds by the server
-	 * - TTL values above 7,776,000 seconds (90 days) are clamped to 90 days
+	 * - TTL values above 31,536,000 seconds (365 days) are clamped to 365 days
 	 * - If the namespace doesn't exist, it is auto-created with a 7-day default TTL
 	 */
 	async set<T = unknown>(

--- a/packages/opencode/src/plugin/plugin.ts
+++ b/packages/opencode/src/plugin/plugin.ts
@@ -664,7 +664,7 @@ Returns the public URL that can be copied and used anywhere.`,
 			ttl_seconds: s
 				.number()
 				.optional()
-				.describe('TTL in seconds (60-7776000, or omit for 30-day default)'),
+				.describe('TTL in seconds (60-31536000, or omit for 30-day default)'),
 			content_type: s.string().optional().describe('Content type (default: text/markdown)'),
 			metadata: s
 				.record(s.string(), s.string())


### PR DESCRIPTION
## Summary

- Updates `KV_MAX_TTL_SECONDS` from 7,776,000 (90 days) to 31,536,000 (365 days)
- Updates all JSDoc, documentation, and code comments to reflect the new 365-day max
- Documents TTL=0 semantics ("no expiration") in docs and code examples

## Changes

### Core package (`packages/core`)
- `KV_MAX_TTL_SECONDS` constant: 7776000 → 31536000
- Updated `KeyValueStorageSetParamsSchema` JSDoc (max and clamping comments)
- Updated `CreateNamespaceParamsSchema` JSDoc (valid range)
- Updated `set()` method remarks

### OpenCode plugin
- Updated TTL range description from `60-7776000` to `60-31536000`

### Documentation
- `key-value.mdx`: Updated TTL table, callout (new max + TTL=0 note), code example
- `code-examples.ts`: Added "0 for no expiration" to SET comment
- `agent/kv/agent.ts`: Added "0 for no expiration" to TTL description

## Files Changed
| File | Change |
|------|--------|
| `packages/core/src/services/keyvalue/service.ts` | Constant + all JSDoc updates |
| `packages/opencode/src/plugin/plugin.ts` | TTL range description |
| `apps/docs/.../key-value.mdx` | Docs TTL table, callout, code example |
| `apps/docs/src/web/code-examples.ts` | SET comment |
| `apps/docs/src/agent/kv/agent.ts` | TTL description |

## Testing
- `bun run build` passes in `packages/core`

## Related
- Ion PR: https://github.com/agentuity/ion/pull — backend changes (validation fix, DB migration, constants)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified key-value storage TTL semantics: TTL is specified in seconds, with 0 indicating no expiration.
  * Increased maximum TTL limit from 90 days to 365 days (1 year) across documentation and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->