### PR TITLE
fix(cli): output JSON-formatted errors when --json flag is used

### DIFF
--- a/packages/cli/bin/cli.ts
+++ b/packages/cli/bin/cli.ts
@@ -26,6 +26,7 @@ import type { GlobalOptions } from '../src/types';
 import { ensureBunOnPath } from '../src/bun-path';
 import { checkForUpdates } from '../src/version-check';
 import { closeDatabase } from '../src/cache';
+import { ErrorCode, createError, formatErrorJSON } from '../src/errors';
 import { createInternalLogger } from '../src/internal-logger';
 import { createCompositeLogger } from '../src/composite-logger';
 import { getAuth } from '../src/config';
@@ -342,21 +343,52 @@ try {
 		((errorWithMessage._tag === 'ServiceException' && errorWithMessage.statusCode === 402) ||
 			errorWithMessage._tag === 'PaymentRequiredError')
 	) {
-		const { errorBox, link, newline } = await import('../src/tui');
-		const overrides = config?.overrides as { app_url?: string } | undefined;
-		const appBaseUrl = getAppBaseURL(undefined, overrides);
-		const billingUrl = `${appBaseUrl}/billing`;
-		newline();
-		errorBox(
-			'Out of Credit',
-			`Your organization is out of credit.\n\nPlease add more here:\n${link(billingUrl)}`,
-			false // standalone box, not connected to a guide
-		);
+		if (earlyOpts.errorFormat === 'json') {
+			console.error(
+				formatErrorJSON(
+					createError(
+						ErrorCode.PAYMENT_REQUIRED,
+						'Your organization is out of credit. Please visit your billing page to add credit.'
+					)
+				)
+			);
+		} else {
+			const { errorBox, link, newline } = await import('../src/tui');
+			const overrides = config?.overrides as { app_url?: string } | undefined;
+			const appBaseUrl = getAppBaseURL(undefined, overrides);
+			const billingUrl = `${appBaseUrl}/billing`;
+			newline();
+			errorBox(
+				'Out of Credit',
+				`Your organization is out of credit.\n\nPlease add more here:\n${link(billingUrl)}`,
+				false // standalone box, not connected to a guide
+			);
+		}
 		closeDatabase();
 		exit(1);
 	}
 
-	if (isStructuredError(error)) {
+	if (earlyOpts.errorFormat === 'json') {
+		const message = errorWithMessage?.message ?? String(error);
+		const code = isStructuredError(error) ? ErrorCode.API_ERROR : ErrorCode.INTERNAL_ERROR;
+		const details: Record<string, unknown> = {};
+		if (isStructuredError(error) && errorWithMessage._tag) {
+			details.tag = errorWithMessage._tag;
+		}
+		if (
+			typeof error === 'object' &&
+			error !== null &&
+			'status' in error &&
+			typeof (error as any).status === 'number'
+		) {
+			details.status = (error as any).status;
+		}
+		console.error(
+			formatErrorJSON(
+				createError(code, message, Object.keys(details).length > 0 ? details : undefined)
+			)
+		);
+	} else if (isStructuredError(error)) {
 		logger.error(error);
 	} else {
 		logger.error(


### PR DESCRIPTION
## Summary

- Fixes CLI outputting non-JSON stack traces when `--json` flag is used by routing all top-level errors through `formatErrorJSON` when `errorFormat === 'json'`
- Covers payment-required (402) errors, API errors (`APIErrorResponse`), and generic/unknown errors
- Non-JSON behavior remains completely unchanged

## Problem

When running CLI commands with `--json` (e.g., `agentuity cloud sandbox pause <id> --json`), API errors produced human-readable output with stack traces:

```
[ERROR] APIErrorResponse: Internal Server Error
  stack trace:
    at #makeRequest (...)
```

This broke machine parsing of CLI output.

## Fix

The `earlyOpts.errorFormat` was already correctly set to `'json'` when `--json` is used (line 274-276), but the top-level catch block in `bin/cli.ts` never consulted it. The fix adds JSON error branching in two places:

1. **Payment required handler** — outputs `{"error": {"code": "PAYMENT_REQUIRED", ...}}` to stderr
2. **General error handler** — outputs `{"error": {"code": "API_ERROR"|"INTERNAL_ERROR", "message": "...", ...}}` to stderr with optional `tag` and `status` details

Uses existing `formatErrorJSON`/`createError`/`ErrorCode` utilities from `errors.ts` — no new infrastructure needed.

## Verification

- ✅ Build passes
- ✅ Typecheck passes
- ✅ Biome lint/format clean
- ✅ Tests: 1067 pass, 7 fail (all pre-existing, zero new failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI now supports JSON-formatted error output for payment and general errors, providing structured error information including codes, messages, and details for improved programmatic error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->