### PR TITLE
fix(cli): follow up coder hub review comments

### DIFF
--- a/packages/cli/src/cmd/coder/hub-url.ts
+++ b/packages/cli/src/cmd/coder/hub-url.ts
@@ -7,6 +7,8 @@
  *   3. AGENTUITY_DEVMODE_URL env var (dev tunnel URL)
  */
 
+import { getVersion } from '../../version';
+
 /**
  * Resolve the Hub HTTP base URL for REST API calls.
  * Converts ws:// URLs to http:// automatically.
@@ -96,6 +98,7 @@ export function resolveApiKey(): string | null {
  */
 export function hubFetchHeaders(extra?: Record<string, string>): Record<string, string> {
 	const headers: Record<string, string> = { ...extra };
+	headers['User-Agent'] = `Agentuity Coder/${getVersion()}`;
 	const apiKey = resolveApiKey();
 	if (apiKey) headers['x-agentuity-auth-api-key'] = apiKey;
 	return headers;

--- a/packages/cli/src/cmd/coder/inspect.ts
+++ b/packages/cli/src/cmd/coder/inspect.ts
@@ -34,18 +34,18 @@ export const inspectSubcommand = createSubcommand({
 	tags: ['read-only', 'fast', 'requires-auth'],
 	examples: [
 		{
-			command: getCommand('coder inspect ses_abc123'),
+			command: getCommand('coder inspect codesess_abc123'),
 			description: 'Inspect a session by ID',
 		},
 		{
-			command: getCommand('coder inspect ses_abc123 --json'),
+			command: getCommand('coder inspect codesess_abc123 --json'),
 			description: 'Get session details as JSON',
 		},
 	],
 	idempotent: true,
 	schema: {
 		args: z.object({
-			session_id: z.string().describe('Session ID to inspect'),
+			session_id: z.string().describe('Coder session ID to inspect'),
 		}),
 		options: z.object({
 			hubUrl: z.string().optional().describe('Hub URL override'),
@@ -103,13 +103,10 @@ export const inspectSubcommand = createSubcommand({
 		};
 
 		try {
-			const controller = new AbortController();
-			const timeout = setTimeout(() => controller.abort(), 10_000);
 			const resp = await fetch(`${hubUrl}/api/hub/session/${encodeURIComponent(sessionId)}`, {
 				headers: hubFetchHeaders(),
-				signal: controller.signal,
+				signal: AbortSignal.timeout(10_000),
 			});
-			clearTimeout(timeout);
 			if (resp.status === 404) {
 				tui.fatal(`Session not found: ${sessionId}`, ErrorCode.RESOURCE_NOT_FOUND);
 				return;

--- a/packages/cli/src/cmd/coder/list.ts
+++ b/packages/cli/src/cmd/coder/list.ts
@@ -84,13 +84,10 @@ export const listSubcommand = createSubcommand({
 		};
 
 		try {
-			const controller = new AbortController();
-			const timeout = setTimeout(() => controller.abort(), 10_000);
 			const resp = await fetch(`${hubUrl}/api/hub/sessions`, {
 				headers: hubFetchHeaders(),
-				signal: controller.signal,
+				signal: AbortSignal.timeout(10_000),
 			});
-			clearTimeout(timeout);
 			if (!resp.ok) {
 				tui.fatal(
 					`Hub returned ${resp.status}: ${resp.statusText}. Is the Coder Hub running at ${hubUrl}?`,

--- a/packages/cli/src/cmd/coder/start.ts
+++ b/packages/cli/src/cmd/coder/start.ts
@@ -86,7 +86,7 @@ export const startSubcommand = createSubcommand({
 			description: 'Start as a specific agent role',
 		},
 		{
-			command: getCommand('coder start --remote sess_abc123'),
+			command: getCommand('coder start --remote codesess_abc123'),
 			description: 'Connect to an existing sandbox session remotely',
 		},
 		{
@@ -177,13 +177,10 @@ export const startSubcommand = createSubcommand({
 					const sessions = await tui.spinner({
 						message: 'Fetching connectable sessions…',
 						callback: async () => {
-							const controller = new AbortController();
-							const timeout = setTimeout(() => controller.abort(), 10_000);
 							const resp = await fetch(`${hubHttpUrl}/api/hub/sessions/connectable`, {
 								headers: hubFetchHeaders(),
-								signal: controller.signal,
+								signal: AbortSignal.timeout(10_000),
 							});
-							clearTimeout(timeout);
 							if (!resp.ok) {
 								throw new Error(`${resp.status} ${resp.statusText}`);
 							}
@@ -280,15 +277,12 @@ export const startSubcommand = createSubcommand({
 
 			let sessionId: string;
 			try {
-				const createController = new AbortController();
-				const createTimeout = setTimeout(() => createController.abort(), 10_000);
 				const resp = await fetch(`${hubHttpUrl}/api/hub/session`, {
 					method: 'POST',
 					headers: hubFetchHeaders({ 'Content-Type': 'application/json' }),
 					body: JSON.stringify(body),
-					signal: createController.signal,
+					signal: AbortSignal.timeout(10_000),
 				});
-				clearTimeout(createTimeout);
 				if (!resp.ok) {
 					const errText = await resp.text();
 					tui.fatal(
@@ -319,13 +313,10 @@ export const startSubcommand = createSubcommand({
 			while (Date.now() - pollStart < POLL_TIMEOUT) {
 				await new Promise((r) => setTimeout(r, POLL_INTERVAL));
 				try {
-					const pollController = new AbortController();
-					const pollTimeout = setTimeout(() => pollController.abort(), 5_000);
 					const pollResp = await fetch(`${hubHttpUrl}/api/hub/session/${sessionId}`, {
 						headers: hubFetchHeaders(),
-						signal: pollController.signal,
+						signal: AbortSignal.timeout(5_000),
 					});
-					clearTimeout(pollTimeout);
 					if (pollResp.ok) {
 						const data = (await pollResp.json()) as {
 							participants?: Array<{ role: string }>;


### PR DESCRIPTION
## Summary
- add an `Agentuity Coder/<version>` user-agent to shared Hub REST request headers
- replace manual fetch timeout wiring in coder CLI commands with `AbortSignal.timeout(...)`
- update coder session help text/examples to use the planned `codesess_...` prefix

## Notes
- this only updates the user-facing examples/help text for the `codesess_` prefix
- the actual server-side Hub session ID generation still needs to switch prefixes separately

## Verification
- `bunx biome format --write packages/cli/src/cmd/coder/hub-url.ts packages/cli/src/cmd/coder/inspect.ts packages/cli/src/cmd/coder/list.ts packages/cli/src/cmd/coder/start.ts`
- `bunx biome lint packages/cli/src/cmd/coder/hub-url.ts packages/cli/src/cmd/coder/inspect.ts packages/cli/src/cmd/coder/list.ts packages/cli/src/cmd/coder/start.ts`
- `bun run --filter='./packages/cli' typecheck`
- `bun run --filter='./packages/cli' build`
- `bun run --filter='./packages/cli' test`

## Review Context
Follow-up to jhaynie comments on merged PR #1077:
- https://github.com/agentuity/sdk/pull/1077#discussion_r2897348929
- https://github.com/agentuity/sdk/pull/1077#discussion_r2897353114
- https://github.com/agentuity/sdk/pull/1077#discussion_r2897356954


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI example commands to reference correct session ID format.
  * Clarified session ID parameter descriptions for better user guidance.

* **Improvements**
  * Enhanced timeout handling mechanism across CLI operations for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->