### PR TITLE
feat: add internal field to KV and Vector stats schemas

### DIFF
--- a/packages/core/src/services/keyvalue/service.ts
+++ b/packages/core/src/services/keyvalue/service.ts
@@ -145,6 +145,10 @@ export const KeyValueStatsSchema = z.object({
 		.number()
 		.optional()
 		.describe('Unix timestamp (milliseconds) when the namespace was last used.'),
+	internal: z
+		.boolean()
+		.optional()
+		.describe('Whether this namespace is system-managed (internal).'),
 });
 
 export type KeyValueStats = z.infer<typeof KeyValueStatsSchema>;

--- a/packages/core/src/services/vector/service.ts
+++ b/packages/core/src/services/vector/service.ts
@@ -341,6 +341,14 @@ export const VectorNamespaceStatsSchema = z.object({
 		.number()
 		.optional()
 		.describe('Unix timestamp (milliseconds) when the namespace was last used'),
+
+	/**
+	 * Whether this namespace is system-managed (internal)
+	 */
+	internal: z
+		.boolean()
+		.optional()
+		.describe('Whether this namespace is system-managed (internal).'),
 });
 
 export type VectorNamespaceStats = z.infer<typeof VectorNamespaceStatsSchema>;


### PR DESCRIPTION
## Summary

- Add optional `internal: z.boolean().optional()` to `KeyValueStatsSchema` in `@agentuity/core`
- Add optional `internal: z.boolean().optional()` to `VectorNamespaceStatsSchema` in `@agentuity/core`
- Uses optional boolean for backward compatibility — App can deploy before or after Ion

## Related PRs
- Ion: agentuity/ion (PR incoming) — adds `internal` column to tenant databases
- App: agentuity/app#1218 — consumes `internal` field for User/System toggle UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced KeyValue service namespace statistics with an optional internal flag to identify system-managed namespaces alongside user-created ones.
  * Enhanced Vector service namespace statistics with an optional internal flag to identify system-managed namespaces alongside user-created ones.
  * Both updates maintain full backward compatibility with existing implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->