### PR TITLE
feat(core): add subtask_count field to TaskSchema

### DIFF
--- a/packages/core/src/services/task/service.ts
+++ b/packages/core/src/services/task/service.ts
@@ -136,6 +136,10 @@ export const TaskSchema = z.object({
 		.lazy(() => z.array(CommentSchema))
 		.optional()
 		.describe('Array of comments on this task.'),
+	subtask_count: z
+		.number()
+		.optional()
+		.describe('Number of direct child tasks (subtasks). Only included in list responses.'),
 });
 
 export type Task = z.infer<typeof TaskSchema>;


### PR DESCRIPTION
## Summary

- Add `subtask_count` optional number field to the Task Zod schema in `@agentuity/core`
- This field is populated by the Catalyst list API with the count of direct child tasks

## Changes

### `packages/core/src/services/task/service.ts`
- Add `subtask_count: z.number().optional()` to `TaskSchema` after the `comments` field

## Context
Companion PR to [ion#task-punchlist-2](https://github.com/agentuity/ion) which adds the `subtask_count` field to the Catalyst task list API. The frontend uses this to display subtask count badges without N+1 queries.

## Testing
- `bun run build` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tasks in list views now display the count of direct subtasks, providing better visibility into task hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->