### PR TITLE
feat(cli): add --force as alias for --confirm flag

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1224,10 +1224,14 @@ async function registerSubcommand(
 			const yesOption = cmd.createOption('--yes', 'Alias for --confirm');
 			yesOption.hideHelp();
 			cmd.addOption(yesOption);
-			// Add hidden --force option that sets confirm to true
-			const forceOption = cmd.createOption('--force', 'Alias for --confirm');
-			forceOption.hideHelp();
-			cmd.addOption(forceOption);
+			// Add hidden --force option that sets confirm to true,
+			// but only if the schema doesn't already declare its own --force option
+			const hasForceOption = parsed.some((opt) => opt.name === 'force');
+			if (!hasForceOption) {
+				const forceOption = cmd.createOption('--force', 'Alias for --confirm');
+				forceOption.hideHelp();
+				cmd.addOption(forceOption);
+			}
 		}
 	}
 

--- a/packages/cli/src/schema-parser.ts
+++ b/packages/cli/src/schema-parser.ts
@@ -444,10 +444,12 @@ export function buildValidationInput(
 			let value = rawOptions[opt.name] ?? rawOptions[camelCaseName];
 
 			// Handle --yes and --force aliases for --confirm: if confirm is not set but yes/force is, use that value
+			// Only treat --force as a --confirm alias if the schema does NOT declare a separate 'force' option
 			if (
 				opt.name === 'confirm' &&
 				value === undefined &&
-				(rawOptions.yes === true || rawOptions.force === true)
+				(rawOptions.yes === true ||
+					(rawOptions.force === true && !parsed.some((o) => o.name === 'force')))
 			) {
 				value = true;
 			}

--- a/packages/cli/test/schema-parser-confirm-alias.test.ts
+++ b/packages/cli/test/schema-parser-confirm-alias.test.ts
@@ -69,6 +69,41 @@ describe('confirm flag aliasing', () => {
 		});
 	});
 
+	describe('schema with both confirm and force options', () => {
+		const schemaWithConfirmAndForce = {
+			options: z.object({
+				confirm: z.boolean().optional().default(false).describe('Skip confirmation prompt'),
+				force: z.boolean().optional().default(false).describe('Force the operation'),
+			}),
+		};
+
+		test('--force should NOT alias confirm when schema declares its own force option', () => {
+			const input = buildValidationInput(schemaWithConfirmAndForce, [], { force: true });
+			expect(input.options.force).toBe(true);
+			expect(input.options.confirm).toBeUndefined();
+		});
+
+		test('--yes should still alias confirm even when schema has force option', () => {
+			const input = buildValidationInput(schemaWithConfirmAndForce, [], { yes: true });
+			expect(input.options.confirm).toBe(true);
+		});
+
+		test('both --force and --confirm should be independent', () => {
+			const input = buildValidationInput(schemaWithConfirmAndForce, [], {
+				force: true,
+				confirm: true,
+			});
+			expect(input.options.force).toBe(true);
+			expect(input.options.confirm).toBe(true);
+		});
+
+		test('--force without --confirm should not set confirm', () => {
+			const input = buildValidationInput(schemaWithConfirmAndForce, [], { force: true });
+			expect(input.options.force).toBe(true);
+			expect(input.options.confirm).toBeUndefined();
+		});
+	});
+
 	describe('buildValidationInputAsync', () => {
 		test('--yes flag should set confirm to true asynchronously', async () => {
 			const input = await buildValidationInputAsync(schemaWithConfirm, [], { yes: true });


### PR DESCRIPTION
## Summary

- Adds `--force` as a hidden alias for `--confirm`, matching the existing `--yes` / `-y` aliases
- Agents commonly reach for `--force` when running destructive CLI commands — this ensures it works identically to `--confirm`

## Changes

| File | What |
|------|------|
| `packages/cli/src/cli.ts` | Register hidden `--force` option on commands that have a `confirm` schema option |
| `packages/cli/src/schema-parser.ts` | Resolve `--force` → `confirm` in the option parser (same as `--yes`) |
| `packages/cli/test/schema-parser-confirm-alias.test.ts` | 4 new tests covering `--force` sync/async, precedence, and no-op on schemas without confirm |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a hidden --force alias for the --confirm option when no separate force option is declared; public help and option names unchanged. --confirm takes precedence when both are provided.
* **Tests**
  * Added comprehensive tests covering aliasing, precedence, independent force/confirm behavior, and async cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->