### PR TITLE
fix(cli): save config back to correct profile when --profile flag is used

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -141,6 +141,8 @@ function expandTilde(path: string): string {
 }
 
 let cachedConfig: Config | null | undefined;
+// Track the resolved config path so saveConfig writes back to the same file
+let cachedConfigPath: string | undefined;
 
 export async function loadConfig(
 	customPath?: string,
@@ -217,6 +219,7 @@ export async function loadConfig(
 		// This ensures --config flag is respected across all commands
 		if (!skipCache) {
 			cachedConfig = result.data;
+			cachedConfigPath = configPath;
 		}
 		return result.data;
 	} catch (error) {
@@ -227,6 +230,7 @@ export async function loadConfig(
 		// Note: For long-running processes, consider time-based cache expiry for transient failures.
 		if (!skipCache) {
 			cachedConfig = null;
+			cachedConfigPath = configPath;
 		}
 		return null;
 	}
@@ -275,7 +279,10 @@ function formatYAML(obj: unknown, indent = 0): string {
 }
 
 export async function saveConfig(config: Config, customPath?: string): Promise<void> {
-	const configPath = customPath || (await getProfile());
+	// Use the path the config was originally loaded from (cachedConfigPath) so that
+	// saves go back to the correct profile even when --profile was used to load it.
+	// Falls back to getProfile() if no config has been loaded yet.
+	const configPath = customPath || cachedConfigPath || (await getProfile());
 	await ensureConfigDir();
 
 	const content = formatYAML(config);


### PR DESCRIPTION
## Summary

- Fixes update check (and any config save) writing to the wrong profile file when `--profile` flag is used
- `loadConfig` resolves the path via `getProfile("production")` but `saveConfig` called `getProfile()` without the flag, falling back to the `~/.config/agentuity/profile` pointer — which may point to a different file (e.g. `local.yaml`)
- Adds a `cachedConfigPath` module variable set by `loadConfig`, reused by `saveConfig` as the default write target

## Root Cause

When running e.g. `agentuity cloud sandbox run --profile production`, the version-check timestamp was saved to whichever profile the pointer file referenced (`local.yaml`) instead of `production.yaml`. On the next invocation with `--profile production`, the stale timestamp in `production.yaml` caused the update check to fire every time.

## Testing

- `bun run typecheck` ✅
- `bun run build` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where configuration saves were written to the wrong file when loading from a non-default profile. Configuration now correctly persists to the same file from which it was originally loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->