### PR TITLE
fix(cli): stop import command from asking org/region twice

### DIFF
--- a/packages/cli/src/cmd/project/import.ts
+++ b/packages/cli/src/cmd/project/import.ts
@@ -125,6 +125,8 @@ export const importSubcommand = createSubcommand({
 			logger,
 			interactive: validateOnly ? false : isTTY(),
 			validateOnly,
+			orgId,
+			region,
 		});
 
 		if (result.status === 'error') {

--- a/packages/cli/src/cmd/project/reconcile.ts
+++ b/packages/cli/src/cmd/project/reconcile.ts
@@ -40,6 +40,10 @@ export interface ReconcileOptions {
 	interactive?: boolean;
 	/** If true, skip prompts and just validate */
 	validateOnly?: boolean;
+	/** Pre-selected organization ID (skips org selection prompt) */
+	orgId?: string;
+	/** Pre-selected region (skips region selection prompt) */
+	region?: string;
 }
 
 /**
@@ -333,16 +337,21 @@ async function importExistingProject(
 		tui.newline();
 	}
 
-	// Select org
-	const orgId = await selectOrg(orgs, config, existingConfig.orgId);
+	// Select org (use pre-selected if available)
+	const orgId = opts.orgId ?? (await selectOrg(orgs, config, existingConfig.orgId));
 
-	// Fetch regions and select
-	const regions = await tui.spinner({
-		message: 'Fetching regions',
-		clearOnSuccess: true,
-		callback: () => fetchRegionsWithCache(config.name, apiClient, logger),
-	});
-	const region = await selectRegion(regions, existingConfig.region);
+	// Select region (use pre-selected if available, otherwise fetch and prompt)
+	let region: string;
+	if (opts.region) {
+		region = opts.region;
+	} else {
+		const regions = await tui.spinner({
+			message: 'Fetching regions',
+			clearOnSuccess: true,
+			callback: () => fetchRegionsWithCache(config.name, apiClient, logger),
+		});
+		region = await selectRegion(regions, existingConfig.region);
+	}
 
 	// Get project name
 	const defaultName = await getDefaultProjectName(dir);
@@ -418,27 +427,37 @@ async function createNewProject(opts: ReconcileOptions): Promise<ReconcileResult
 
 	tui.newline();
 
-	// Fetch user's orgs
-	const orgs = await tui.spinner({
-		message: 'Fetching organizations',
-		clearOnSuccess: true,
-		callback: () => listOrganizations(apiClient),
-	});
+	let orgId: string;
+	if (opts.orgId) {
+		orgId = opts.orgId;
+	} else {
+		// Fetch user's orgs
+		const orgs = await tui.spinner({
+			message: 'Fetching organizations',
+			clearOnSuccess: true,
+			callback: () => listOrganizations(apiClient),
+		});
 
-	if (orgs.length === 0) {
-		return { status: 'error', message: 'No organizations found for your account.' };
+		if (orgs.length === 0) {
+			return { status: 'error', message: 'No organizations found for your account.' };
+		}
+
+		// Select org
+		orgId = await selectOrg(orgs, config);
 	}
 
-	// Select org
-	const orgId = await selectOrg(orgs, config);
-
-	// Fetch regions and select
-	const regions = await tui.spinner({
-		message: 'Fetching regions',
-		clearOnSuccess: true,
-		callback: () => fetchRegionsWithCache(config.name, apiClient, logger),
-	});
-	const region = await selectRegion(regions);
+	let region: string;
+	if (opts.region) {
+		region = opts.region;
+	} else {
+		// Fetch regions and select
+		const regions = await tui.spinner({
+			message: 'Fetching regions',
+			clearOnSuccess: true,
+			callback: () => fetchRegionsWithCache(config.name, apiClient, logger),
+		});
+		region = await selectRegion(regions);
+	}
 
 	// Get project name from package.json or prompt
 	const defaultName = await getDefaultProjectName(dir);


### PR DESCRIPTION
## Summary

Fixes #1170 — `agentuity project import` prompted for organization and region selection twice: once by the CLI framework (via `optional: { org: true, region: true }`) and again inside the handler's `createNewProject()` / `importExistingProject()` functions.

## Changes

- **`packages/cli/src/cmd/project/import.ts`** — Pass `orgId` and `region` from `ctx` through to `runProjectImport()`
- **`packages/cli/src/cmd/project/reconcile.ts`** — Add `orgId?` and `region?` to `ReconcileOptions`; skip org/region fetch and prompt when pre-selected values are provided

## How it works

When `orgId` or `region` are already available (from the framework's optional prompt), the internal functions now use them directly instead of prompting again. When they're `undefined` (all other call sites), behavior is identical to before.

## Verification

- ✅ 23/23 reconcile tests passing
- ✅ TypeScript typecheck clean
- ✅ Build successful
- ✅ Lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The project import and reconciliation commands now accept pre-configured organization and region parameters. This enhancement enables users to bypass interactive prompts for these settings, allowing for fully automated workflows. Integration into scripted operations and batch processes is now more straightforward and efficient, eliminating the need for manual user input during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->