### PR TITLE
fix(cli): replace blocking route migration prompt with non-interactiv…

### DIFF
--- a/packages/cli/src/utils/route-migration.ts
+++ b/packages/cli/src/utils/route-migration.ts
@@ -697,19 +697,19 @@ export function performMigration(rootDir: string, routeFiles: string[]): Migrati
  * Show the migration notice and optionally perform migration.
  *
  * Called during `dev` and `build` after dependency upgrades.
- * Only prompts in interactive TTY sessions and only once — if the user
- * dismisses the prompt, it won't be shown again.
+ * Shows an informational banner with instructions — never blocks on
+ * interactive prompts (which would hang agents and CI pipelines).
  *
  * @returns true if migration was performed, false otherwise
  */
 export async function promptRouteMigration(
 	rootDir: string,
-	logger: Logger,
+	_logger: Logger,
 	options?: { interactive?: boolean }
 ): Promise<boolean> {
 	const interactive = options?.interactive ?? process.stdin.isTTY;
 
-	// Only show the interactive migration prompt in TTY sessions
+	// Only show the migration notice in TTY sessions
 	if (!interactive) {
 		return false;
 	}
@@ -722,7 +722,7 @@ export async function promptRouteMigration(
 
 	const { routeFiles, alreadyNotified } = eligibility;
 
-	// Only prompt once — if the user has already been notified or dismissed, don't ask again
+	// Only notify once — if the user has already been notified or dismissed, don't show again
 	if (alreadyNotified) {
 		return false;
 	}
@@ -748,35 +748,10 @@ export async function promptRouteMigration(
 	);
 
 	tui.newline();
-
-	const action = await tui.confirm('Would you like to migrate to explicit routing now?', false);
-
-	if (!action) {
-		writeMigrationState(rootDir, 'dismissed');
-		tui.info(`You can migrate later by running: ${tui.muted('agentuity dev --migrate-routes')}`);
-		tui.newline();
-		return false;
-	}
-
-	// Perform migration
+	tui.info(`Migrate by running: ${tui.muted('agentuity dev --migrate-routes')}`);
 	tui.newline();
-	const result = performMigration(rootDir, routeFiles);
 
-	if (result.success) {
-		tui.success(result.message);
-		if (result.filesCreated.length > 0) {
-			tui.info(`Created: ${result.filesCreated.map((f) => tui.muted(f)).join(', ')}`);
-		}
-		if (result.filesModified.length > 0) {
-			tui.info(`Modified: ${result.filesModified.map((f) => tui.muted(f)).join(', ')}`);
-		}
-		tui.newline();
-		tui.info('Your existing route files were not changed — they already export routers.');
-		tui.newline();
-	} else {
-		tui.warning(result.message);
-		tui.newline();
-	}
+	writeMigrationState(rootDir, 'notified');
 
-	return result.success;
+	return false;
 }


### PR DESCRIPTION
…e notice

The interactive tui.confirm() prompt in promptRouteMigration would hang indefinitely when agents (Claude Code, Cursor, etc.) run 'agentuity build' or 'agentuity dev', since they allocate a pseudo-TTY but have no human to respond.

Now just shows the informational banner and directs users to run 'agentuity dev --migrate-routes' to perform the migration explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Route migration notification flow updated to display an informational banner instead of an interactive prompt; migration execution removed from this flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->