### PR TITLE
fix: use port 443 for local dev gravity URL

### DIFF
--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -99,7 +99,7 @@ export function getGravityDevModeURL(_region: string, config?: Config | null): s
 		return overrides.gravity_url;
 	}
 	if (config?.name === 'local') {
-		return 'grpc://gravity.agentuity.io:8443';
+		return 'grpc://gravity.agentuity.io:443';
 	}
 	return 'grpc://devmode-us.agentuity.com';
 }

--- a/packages/cli/src/cmd/profile/create.ts
+++ b/packages/cli/src/cmd/profile/create.ts
@@ -84,7 +84,7 @@ export const createCommand = createSubcommand({
 					vector_url: 'https://catalyst.agentuity.io',
 					catalyst_url: 'https://catalyst.agentuity.io',
 					ion_url: 'https://ion.agentuity.io',
-					gravity_url: 'grpc://gravity.agentuity.io:8443',
+					gravity_url: 'grpc://gravity.agentuity.io:443',
 				};
 				await saveConfig(localConfig, filename);
 			}


### PR DESCRIPTION
## Summary

- Fix local dev gravity URL to use port 443 instead of 8443
- Ion serves gravity gRPC via its HTTP plugin on port 443; port 8443 is not exposed in the local Docker stack
- Affects both the runtime fallback in `api.ts` and the local profile template in `profile/create.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected gravity service endpoint configuration for local development profiles during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->