### PR TITLE
Remove old fallback for gateway url

### DIFF
--- a/packages/cli/src/cmd/build/patch/_util.ts
+++ b/packages/cli/src/cmd/build/patch/_util.ts
@@ -49,7 +49,7 @@ export function generateGatewayEnvGuard(
 ): string {
 	return `{
     const _agentuity_sdk_key = process.env.AGENTUITY_SDK_KEY;
-    const _agentuity_url = process.env.AGENTUITY_AIGATEWAY_URL || process.env.AGENTUITY_TRANSPORT_URL || (_agentuity_sdk_key ? 'https://agentuity.ai' : '');
+    const _agentuity_url = process.env.AGENTUITY_AIGATEWAY_URL || process.env.AGENTUITY_TRANSPORT_URL || (_agentuity_sdk_key ? 'https://catalyst.agentuity.cloud' : '');
     if (_agentuity_url && _agentuity_sdk_key) {
         process.env.${apikey} = _agentuity_sdk_key;
         process.env.${apibase} = _agentuity_url + '/gateway/${provider}';

--- a/packages/runtime/src/dev-patches/gateway.ts
+++ b/packages/runtime/src/dev-patches/gateway.ts
@@ -48,7 +48,7 @@ export function applyGatewayPatches(): void {
 	const gatewayUrl =
 		process.env.AGENTUITY_AIGATEWAY_URL ||
 		process.env.AGENTUITY_TRANSPORT_URL ||
-		(sdkKey ? 'https://agentuity.ai' : '');
+		(sdkKey ? 'https://catalyst.agentuity.cloud' : '');
 
 	for (const config of GATEWAY_CONFIGS) {
 		const currentKey = process.env[config.apiKeyEnv];

--- a/packages/runtime/src/workbench.ts
+++ b/packages/runtime/src/workbench.ts
@@ -396,14 +396,14 @@ export const createWorkbenchSampleRoute = (): Handler => {
 			const gatewayUrl =
 				process.env.AGENTUITY_AIGATEWAY_URL ||
 				process.env.AGENTUITY_TRANSPORT_URL ||
-				(sdkKey ? 'https://agentuity.ai' : '');
+				(sdkKey ? 'https://catalyst.agentuity.cloud' : '');
 
 			if (!sdkKey || !gatewayUrl) {
 				return ctx.json(
 					{
 						error: 'AGENTUITY_SDK_KEY and gateway URL must be configured',
 						message:
-							'Set AGENTUITY_SDK_KEY and either AGENTUITY_AIGATEWAY_URL, AGENTUITY_TRANSPORT_URL, or use https://agentuity.ai',
+							'Set AGENTUITY_SDK_KEY and either AGENTUITY_AIGATEWAY_URL or AGENTUITY_TRANSPORT_URL',
 					},
 					{ status: 500 }
 				);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default AI Gateway endpoint URL to catalyst.agentuity.cloud for SDK configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->