### PR TITLE
fix(cli): allow sandbox get and events for terminated/deleted sandboxes

### DIFF
--- a/packages/cli/src/cmd/cloud/sandbox/get.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/get.ts
@@ -79,6 +79,7 @@ export const getSubcommand = createCommand({
 		const result = await sandboxGet(client, {
 			sandboxId: args.sandboxId,
 			orgId: sandboxInfo.orgId,
+			includeDeleted: true,
 		});
 
 		// Cache the region for future lookups

--- a/packages/cli/src/cmd/cloud/sandbox/util.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/util.ts
@@ -41,7 +41,7 @@ export async function getSandboxRegion(
 		config
 	);
 
-	const sandbox = await sandboxGet(globalClient, { sandboxId, orgId });
+	const sandbox = await sandboxGet(globalClient, { sandboxId, orgId, includeDeleted: true });
 	if (!sandbox.region) {
 		tui.fatal(`Sandbox '${sandboxId}' has no region information`, ErrorCode.RESOURCE_NOT_FOUND);
 	}


### PR DESCRIPTION
## Summary

- Pass `includeDeleted: true` when resolving sandbox region and fetching sandbox info so that read-only CLI commands work after a sandbox has been terminated or deleted
- Fixes `sandbox events` and `sandbox get` returning 404 for terminated sandboxes

## Root Cause

Both `sandbox events` and `sandbox get` need to resolve the sandbox's region before querying the region-specific catalyst endpoint. This resolution calls `sandboxGet()` which hits `GET /sandbox/{sandboxId}` — a handler that filters `WHERE deleted = FALSE` by default. Once a sandbox is terminated/deleted, this returns no rows → 404.

The actual endpoints (e.g. the events handler) already use `GetSandboxByIdAndOrgIncludeDeleted` and would work fine — the request just never gets there because the region lookup fails first.

## Changes

| File | Change |
|------|--------|
| `packages/cli/src/cmd/cloud/sandbox/util.ts` | `getSandboxRegion()` now passes `includeDeleted: true` to `sandboxGet` — fixes `sandbox events`, `execution list`, and any other command using this region resolver |
| `packages/cli/src/cmd/cloud/sandbox/get.ts` | `sandbox get` handler now passes `includeDeleted: true` to `sandboxGet` |

No backend changes needed — the catalyst API already supports the `includeDeleted` query parameter; the CLI just wasn't using it for these read-only paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Sandbox retrieval operations now include deleted items alongside active ones, ensuring complete visibility across all sandbox states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->