### PR TITLE
fix(cli): detect duplicate eval names across agent file and eval.ts at build time

### DIFF
--- a/packages/cli/src/cmd/build/vite/agent-discovery.ts
+++ b/packages/cli/src/cmd/build/vite/agent-discovery.ts
@@ -11,7 +11,13 @@ import { dirname, join, relative } from 'node:path';
 import { existsSync } from 'node:fs';
 import type { Logger } from '../../../types';
 import { formatSchemaCode } from '../format-schema';
+import { StructuredError } from '@agentuity/core';
 import { toForwardSlash } from '../../../utils/normalize-path';
+
+const DuplicateEvalNameError = StructuredError('DuplicateEvalNameError')<{
+	agent: string;
+	filename: string;
+}>();
 
 interface ASTNode {
 	type: string;
@@ -790,11 +796,14 @@ export async function discoverAgents(
 					for (const evalItem of allEvals) {
 						const prev = seen.get(evalItem.name);
 						if (prev && prev !== evalItem.filename) {
-							throw new Error(
-								`Duplicate eval name '${evalItem.name}' for agent '${agentMetadata.name}': ` +
+							throw new DuplicateEvalNameError({
+								message:
+									`Duplicate eval name '${evalItem.name}' for agent '${agentMetadata.name}': ` +
 									`defined in both '${prev}' and '${evalItem.filename}'. ` +
-									'Eval names must be unique per agent.'
-							);
+									'Eval names must be unique per agent.',
+								agent: agentMetadata.name,
+								filename: evalItem.filename,
+							});
 						}
 						seen.set(evalItem.name, evalItem.filename);
 					}


### PR DESCRIPTION
## Summary

- Adds a cross-source duplicate eval name check during agent discovery, catching the error at build time instead of letting it surface as a cryptic "A database error occurred" during deployment.

## Problem

Evals are collected from two sources per agent:
1. The agent file itself (`agent.createEval('foo', ...)`)
2. A separate `eval.ts` in the same directory

If both define an eval with the same name, they produce the same stable `identifier` (`eval_{hash(projectId, agentId, name)}`). The existing duplicate check only covered evals within a single file (`ast.ts:661-683`), so cross-file duplicates slipped through to the API which hit a unique constraint violation and returned:

```
✗ Build, Verify and Package: A database error occurred. Please try again later.
```

## Fix

After merging evals from both sources in `agent-discovery.ts`, check for duplicate names. If found, throw a clear build error:

```
Duplicate eval name 'foo' for agent 'bar': defined in both 'src/agent/bar/index.ts' and 'src/agent/bar/eval.ts'. Eval names must be unique per agent.
```

## Note

The server should also return a more specific error (e.g. `DUPLICATE_EVAL` code) instead of a generic database error, so older CLI versions still get a meaningful message. That's a separate backend change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to detect duplicate eval names defined across different sources for the same agent, and surface clear error messages identifying the conflicting definitions and their locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->