### PR TITLE
feat(core): add status aliases for task API (completed/closed→done, started→in_progress)

### DIFF
--- a/packages/cli/src/cmd/cloud/task/create.ts
+++ b/packages/cli/src/cmd/cloud/task/create.ts
@@ -95,7 +95,7 @@ export const createSubcommand = createCommand({
 				.optional()
 				.describe('task priority (default: none)'),
 			status: z
-				.enum(['open', 'in_progress', 'done', 'cancelled'])
+				.enum(['open', 'in_progress', 'started', 'done', 'completed', 'closed', 'cancelled'])
 				.optional()
 				.describe('initial task status (default: open)'),
 			parentId: z.string().optional().describe('parent task ID for subtasks'),

--- a/packages/cli/src/cmd/cloud/task/delete.ts
+++ b/packages/cli/src/cmd/cloud/task/delete.ts
@@ -88,7 +88,7 @@ export const deleteSubcommand = createCommand({
 		}),
 		options: z.object({
 			status: z
-				.enum(['open', 'in_progress', 'done', 'cancelled'])
+				.enum(['open', 'in_progress', 'started', 'done', 'completed', 'closed', 'cancelled'])
 				.optional()
 				.describe('filter batch delete by status'),
 			type: z

--- a/packages/cli/src/cmd/cloud/task/list.ts
+++ b/packages/cli/src/cmd/cloud/task/list.ts
@@ -107,7 +107,7 @@ export const listSubcommand = createCommand({
 	schema: {
 		options: z.object({
 			status: z
-				.enum(['open', 'in_progress', 'done', 'cancelled'])
+				.enum(['open', 'in_progress', 'started', 'done', 'completed', 'closed', 'cancelled'])
 				.optional()
 				.describe('filter by status'),
 			type: z

--- a/packages/cli/src/cmd/cloud/task/update.ts
+++ b/packages/cli/src/cmd/cloud/task/update.ts
@@ -56,7 +56,7 @@ export const updateSubcommand = createCommand({
 				.optional()
 				.describe('new task type'),
 			status: z
-				.enum(['open', 'in_progress', 'done', 'cancelled'])
+				.enum(['open', 'in_progress', 'started', 'done', 'completed', 'closed', 'cancelled'])
 				.optional()
 				.describe('new task status'),
 			assignedId: z.string().optional().describe('new assigned agent or user ID'),

--- a/packages/core/src/services/task/service.ts
+++ b/packages/core/src/services/task/service.ts
@@ -29,12 +29,39 @@ export type TaskType = z.infer<typeof TaskTypeSchema>;
  *
  * - `'open'` — Created, not yet started.
  * - `'in_progress'` — Actively being worked on.
+ * - `'started'` — Alias for `'in_progress'`.
  * - `'done'` — Work completed.
+ * - `'completed'` — Alias for `'done'`.
+ * - `'closed'` — Alias for `'done'`.
  * - `'cancelled'` — Abandoned.
  */
-export const TaskStatusSchema = z.enum(['open', 'in_progress', 'done', 'cancelled']);
+export const TaskStatusSchema = z.enum([
+	'open',
+	'in_progress',
+	'started',
+	'done',
+	'completed',
+	'closed',
+	'cancelled',
+]);
 
 export type TaskStatus = z.infer<typeof TaskStatusSchema>;
+
+/**
+ * Normalize a task status value, converting aliases to their canonical form.
+ * Maps `'completed'` → `'done'`, `'closed'` → `'done'`, `'started'` → `'in_progress'`.
+ */
+export function normalizeTaskStatus(status: TaskStatus): TaskStatus {
+	switch (status) {
+		case 'completed':
+		case 'closed':
+			return 'done';
+		case 'started':
+			return 'in_progress';
+		default:
+			return status;
+	}
+}
 
 /**
  * A lightweight reference to a user or project entity, containing just the ID
@@ -1151,20 +1178,23 @@ export class TaskStorageService implements TaskStorage {
 			throw new TaskTitleRequiredError();
 		}
 
+		const normalized = params.status
+			? { ...params, status: normalizeTaskStatus(params.status) }
+			: params;
 		const url = buildUrl(this.#baseUrl, '/task');
 		const signal = AbortSignal.timeout(30_000);
 
 		const res = await this.#adapter.invoke<TaskResponse<Task>>(url, {
 			method: 'POST',
-			body: safeStringify(params),
+			body: safeStringify(normalized),
 			contentType: 'application/json',
 			signal,
 			telemetry: {
 				name: 'agentuity.task.create',
 				attributes: {
-					type: params.type,
-					priority: params.priority ?? 'none',
-					status: params.status ?? 'open',
+					type: normalized.type,
+					priority: normalized.priority ?? 'none',
+					status: normalized.status ?? 'open',
 				},
 			},
 		});
@@ -1256,7 +1286,7 @@ export class TaskStorageService implements TaskStorage {
 	 */
 	async list(params?: ListTasksParams): Promise<ListTasksResult> {
 		const queryParams = new URLSearchParams();
-		if (params?.status) queryParams.set('status', params.status);
+		if (params?.status) queryParams.set('status', normalizeTaskStatus(params.status));
 		if (params?.type) queryParams.set('type', params.type);
 		if (params?.priority) queryParams.set('priority', params.priority);
 		if (params?.assigned_id) queryParams.set('assigned_id', params.assigned_id);
@@ -1280,7 +1310,7 @@ export class TaskStorageService implements TaskStorage {
 			telemetry: {
 				name: 'agentuity.task.list',
 				attributes: {
-					...(params?.status ? { status: params.status } : {}),
+					...(params?.status ? { status: normalizeTaskStatus(params.status) } : {}),
 					...(params?.type ? { type: params.type } : {}),
 					...(params?.priority ? { priority: params.priority } : {}),
 				},
@@ -1331,12 +1361,15 @@ export class TaskStorageService implements TaskStorage {
 			throw new TaskTitleRequiredError();
 		}
 
+		const normalized = params.status
+			? { ...params, status: normalizeTaskStatus(params.status) }
+			: params;
 		const url = buildUrl(this.#baseUrl, `/task/${encodeURIComponent(id)}`);
 		const signal = AbortSignal.timeout(30_000);
 
 		const res = await this.#adapter.invoke<TaskResponse<Task>>(url, {
 			method: 'PATCH',
-			body: safeStringify(params),
+			body: safeStringify(normalized),
 			contentType: 'application/json',
 			signal,
 			telemetry: {
@@ -1542,7 +1575,7 @@ export class TaskStorageService implements TaskStorage {
 		const signal = AbortSignal.timeout(60_000);
 
 		const body: Record<string, unknown> = {};
-		if (params.status) body.status = params.status;
+		if (params.status) body.status = normalizeTaskStatus(params.status);
 		if (params.type) body.type = params.type;
 		if (params.priority) body.priority = params.priority;
 		if (params.parent_id) body.parent_id = params.parent_id;
@@ -1558,7 +1591,7 @@ export class TaskStorageService implements TaskStorage {
 			telemetry: {
 				name: 'agentuity.task.batchDelete',
 				attributes: {
-					...(params.status ? { status: params.status } : {}),
+					...(params.status ? { status: normalizeTaskStatus(params.status) } : {}),
 					...(params.type ? { type: params.type } : {}),
 					...(params.older_than ? { older_than: params.older_than } : {}),
 				},

--- a/packages/runtime/src/services/local/task.ts
+++ b/packages/runtime/src/services/local/task.ts
@@ -29,7 +29,7 @@ import type {
 	UserEntityRef,
 	EntityRef,
 } from '@agentuity/core';
-import { StructuredError } from '@agentuity/core';
+import { StructuredError, normalizeTaskStatus } from '@agentuity/core';
 import { now } from './_util';
 
 const TaskTitleRequiredError = StructuredError(
@@ -257,7 +257,7 @@ export class LocalTaskStorage implements TaskStorage {
 
 		const id = generateTaskId();
 		const timestamp = now();
-		const status: TaskStatus = params.status ?? 'open';
+		const status: TaskStatus = params.status ? normalizeTaskStatus(params.status) : 'open';
 		const priority: TaskPriority = params.priority ?? 'none';
 		const openDate = status === 'open' ? new Date(timestamp).toISOString() : null;
 		const inProgressDate = status === 'in_progress' ? new Date(timestamp).toISOString() : null;
@@ -366,7 +366,7 @@ export class LocalTaskStorage implements TaskStorage {
 
 		if (params?.status) {
 			filters.push('status = ?');
-			values.push(params.status);
+			values.push(normalizeTaskStatus(params.status));
 		}
 		if (params?.type) {
 			filters.push('type = ?');
@@ -467,6 +467,7 @@ export class LocalTaskStorage implements TaskStorage {
 			}
 			const timestamp = now();
 			const nowIso = new Date(timestamp).toISOString();
+			const normalizedStatus = params.status ? normalizeTaskStatus(params.status) : undefined;
 
 			const updated: TaskRow = {
 				...existing,
@@ -482,21 +483,21 @@ export class LocalTaskStorage implements TaskStorage {
 				priority: params.priority ?? existing.priority,
 				parent_id: params.parent_id !== undefined ? params.parent_id : existing.parent_id,
 				type: params.type ?? existing.type,
-				status: params.status ?? existing.status,
+				status: normalizedStatus ?? existing.status,
 				assigned_id:
 					params.assigned_id !== undefined ? params.assigned_id : existing.assigned_id,
 				closed_id: params.closed_id !== undefined ? params.closed_id : existing.closed_id,
 				updated_at: timestamp,
 			};
 
-			if (params.status && params.status !== existing.status) {
-				if (params.status === 'open' && !existing.open_date) {
+			if (normalizedStatus && normalizedStatus !== existing.status) {
+				if (normalizedStatus === 'open' && !existing.open_date) {
 					updated.open_date = nowIso;
 				}
-				if (params.status === 'in_progress' && !existing.in_progress_date) {
+				if (normalizedStatus === 'in_progress' && !existing.in_progress_date) {
 					updated.in_progress_date = nowIso;
 				}
-				if (params.status === 'done' && !existing.closed_date) {
+				if (normalizedStatus === 'done' && !existing.closed_date) {
 					updated.closed_date = nowIso;
 				}
 			}
@@ -531,7 +532,7 @@ export class LocalTaskStorage implements TaskStorage {
 			if (params.type !== undefined) {
 				compare('type', existing.type, updated.type);
 			}
-			if (params.status !== undefined) {
+			if (normalizedStatus !== undefined) {
 				compare('status', existing.status, updated.status);
 			}
 			if (params.assigned_id !== undefined) {
@@ -774,7 +775,7 @@ export class LocalTaskStorage implements TaskStorage {
 
 		if (params.status) {
 			conditions.push('status = ?');
-			args.push(params.status);
+			args.push(normalizeTaskStatus(params.status));
 		}
 		if (params.type) {
 			conditions.push('type = ?');


### PR DESCRIPTION
## Summary

- Adds friendly task status aliases that normalize to canonical API values before sending: `completed`/`closed` → `done`, `started` → `in_progress`
- Adds `normalizeTaskStatus()` helper in `@agentuity/core` called at all entry points (create, update, list, batchDelete) in both remote service and local runtime
- Updates all CLI task commands (create, update, list, delete) to accept the new aliases

## Alias Mapping

| Input | Normalized |
|---|---|
| `open` | `open` |
| `in_progress` | `in_progress` |
| `started` | `in_progress` |
| `done` | `done` |
| `completed` | `done` |
| `closed` | `done` |
| `cancelled` | `cancelled` |

## Changed Files

- `packages/core/src/services/task/service.ts` — `TaskStatusSchema` enum, `normalizeTaskStatus()` export, normalization in `create()`, `update()`, `list()`, `batchDelete()`
- `packages/runtime/src/services/local/task.ts` — imports `normalizeTaskStatus`, applies in local `create()`, `update()`, `list()`, `batchDelete()`
- `packages/cli/src/cmd/cloud/task/{create,update,list,delete}.ts` — expanded status enums to include aliases