### PR TITLE
fix(cli): skip confirmation prompt on explicit upgrade command

### DIFF
--- a/packages/cli/src/cmd/upgrade/index.ts
+++ b/packages/cli/src/cmd/upgrade/index.ts
@@ -3,6 +3,7 @@ import { getVersion, getCompareUrl, getReleaseUrl, toTag } from '../../version';
 import { getCommand } from '../../command-prefix';
 import { z } from 'zod';
 import { ErrorCode, createError, exitWithError } from '../../errors';
+import { isJSONMode } from '../../output';
 import * as tui from '../../tui';
 import { tmpdir } from 'node:os';
 import { getInstallationType, type InstallationType } from '../../utils/installation-type';
@@ -235,17 +236,19 @@ export const command = createCommand({
 				};
 			}
 
-			// Show version info
-			tui.info(`Current version: ${tui.muted(normalizedCurrent)}`);
-			tui.info(`Latest version:  ${tui.bold(normalizedLatest)}`);
-			tui.newline();
-			if (toTag(currentVersion) !== toTag(latestVersion)) {
-				tui.warning(
-					`What's changed:  ${tui.link(getCompareUrl(currentVersion, latestVersion))}`
-				);
+			// Show version info (suppress in JSON mode)
+			if (!isJSONMode(options)) {
+				tui.info(`Current version: ${tui.muted(normalizedCurrent)}`);
+				tui.info(`Latest version:  ${tui.bold(normalizedLatest)}`);
+				tui.newline();
+				if (toTag(currentVersion) !== toTag(latestVersion)) {
+					tui.warning(
+						`What's changed:  ${tui.link(getCompareUrl(currentVersion, latestVersion))}`
+					);
+				}
+				tui.success(`Release notes:   ${tui.link(getReleaseUrl(latestVersion))}`);
+				tui.newline();
 			}
-			tui.success(`Release notes:   ${tui.link(getReleaseUrl(latestVersion))}`);
-			tui.newline();
 
 			// Perform the upgrade using bun
 			await tui.spinner({


### PR DESCRIPTION
## Summary

- **Removes the Y/N confirmation prompt** from the explicit `agentuity upgrade` command — when a user types `upgrade`, they've already expressed intent
- **Auto-detection prompt is unchanged** — when the CLI detects a new version during normal command execution (`version-check.ts`), it still asks "Would you like to upgrade now?"
- The `--force` flag is retained for its other purpose: bypassing the "already on latest version" check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Version information, change notes, and release notes are now suppressed when running in JSON mode; they still display in interactive/non-JSON runs.
  * Removed the manual upgrade confirmation prompt — upgrades now proceed automatically and continue to verify installation and report final status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->