### PR TITLE
fix: add internal field to OAuth client schema and fix deploy upload

### DIFF
--- a/packages/cli/src/cmd/cloud/deploy.ts
+++ b/packages/cli/src/cmd/cloud/deploy.ts
@@ -801,9 +801,9 @@ export const deploySubcommand = createSubcommand({
 								ctx.logger.trace(`Upload file size: ${fileSize} bytes`);
 								const resp = await fetch(instructions.deployment, {
 									method: 'PUT',
-									duplex: 'half',
 									headers: {
 										'Content-Type': 'application/zip',
+										'Content-Length': String(fileSize),
 									},
 									body: zipfile,
 									signal: stepCtx.signal,

--- a/packages/core/src/services/oauth/types.ts
+++ b/packages/core/src/services/oauth/types.ts
@@ -19,6 +19,7 @@ export const OAuthClientSchema = z.object({
 	refresh_token_lifetime_seconds: z.number().optional(),
 	id_token_lifetime_seconds: z.number().optional(),
 	allowed_user_ids: z.array(z.string()),
+	internal: z.boolean().optional().default(false),
 	created_at: z.string(),
 	updated_at: z.string(),
 });


### PR DESCRIPTION
## Summary
- Add `internal` boolean to `OAuthClientSchema` for system-managed OAuth app support
- Fix deployment upload removing unnecessary `duplex: 'half'` and adding explicit `Content-Length`

## Details

### OAuth `internal` field
The catalyst API now returns an `internal` boolean on OAuth clients (added in agentuity/hadron#118). The frontend uses this to filter apps into User vs System tabs in Settings → OAuth Apps. Without this field in the SDK schema, the Zod parse strips it and all apps show under "User".

### Deploy upload
Removed `duplex: 'half'` from the deployment zip upload `fetch()` call and added an explicit `Content-Length` header. The `duplex: 'half'` option is unnecessary for `Bun.file()` bodies with known sizes. In some proxy environments, the combination of `duplex: 'half'` and no explicit `Content-Length` caused S3 to reject the upload with HTTP 411 `MissingContentLength`.

Supersedes #1223.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment archive upload handling by fixing request headers to properly include accurate content size information for encrypted files, enhancing overall upload reliability and stability.

* **New Features**
  * OAuth client configurations now support an internal designation flag option, enabling better classification, organization and management of different client types and use cases within your system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->