### PR TITLE
fix(sandbox): use nullish for nullable job fields in JobSchema

### DIFF
--- a/packages/core/src/services/sandbox/types.ts
+++ b/packages/core/src/services/sandbox/types.ts
@@ -175,12 +175,12 @@ export const JobSchema = z.object({
 	sandboxId: z.string().describe('ID of the sandbox where the job is running'),
 	command: z.array(z.string()).describe('Command and arguments being executed'),
 	status: JobStatusSchema.describe('Current status of the job'),
-	exitCode: z.number().optional().describe('Exit code of the job (set when completed)'),
-	startedAt: z.string().optional().describe('ISO timestamp when the job started'),
-	completedAt: z.string().optional().describe('ISO timestamp when the job completed'),
-	error: z.string().optional().describe('Error message if the job failed'),
-	stdoutStreamUrl: z.string().optional().describe('URL to stream stdout output'),
-	stderrStreamUrl: z.string().optional().describe('URL to stream stderr output'),
+	exitCode: z.number().nullish().describe('Exit code of the job (set when completed)'),
+	startedAt: z.string().nullish().describe('ISO timestamp when the job started'),
+	completedAt: z.string().nullish().describe('ISO timestamp when the job completed'),
+	error: z.string().nullish().describe('Error message if the job failed'),
+	stdoutStreamUrl: z.string().nullish().describe('URL to stream stdout output'),
+	stderrStreamUrl: z.string().nullish().describe('URL to stream stderr output'),
 });
 export type Job = z.infer<typeof JobSchema>;
 


### PR DESCRIPTION
## Summary

- Fixes `ValidationOutputError` when running `job list` and `job get` commands for jobs with pending/running status
- Changed `.optional()` to `.nullish()` for nullable fields in `JobSchema` to allow both `null` and `undefined` values

The Go API uses `omitempty` which can return `null` or omit fields entirely. Using `.nullish()` properly handles both cases.

## Related Issues

- task_5pdVpjCgzxP6pspe - [sandbox-fuzz] Job: list/get commands fail with ValidationOutputError - nullable fields not allowed

## Test Plan

- [x] Verified locally with `agentuity cloud sandbox job list` and `job get` commands
- [x] All tests pass (`bun run typecheck`, `bun test`, `bun run build`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated job status field handling to better distinguish between missing and explicitly null values for job completion information, improving state representation clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->