### PR TITLE
feat(cli): add --org as hidden alias for --org-id

### DIFF
--- a/packages/cli/bin/cli.ts
+++ b/packages/cli/bin/cli.ts
@@ -153,6 +153,10 @@ if (!hasHelp) {
 	parsedOperands = parsed.operands;
 }
 const earlyOpts = program.opts();
+// Normalize --org alias → orgId (agents prefer --org over --org-id)
+if (earlyOpts.org !== undefined && earlyOpts.orgId === undefined) {
+	earlyOpts.orgId = earlyOpts.org;
+}
 
 // Set JSON error format early, BEFORE any code that might throw,
 // so that startup failures also use the JSON error formatter.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -541,6 +541,11 @@ export async function createCLI(version: string): Promise<Command> {
 			'Filter JSON output to specified fields (comma-separated, dot notation for nested)'
 		);
 
+	// Add hidden --org alias for --org-id (agents prefer --org over --org-id)
+	const orgIdAlias = program.createOption('--org <id>', 'Alias for --org-id');
+	orgIdAlias.hideHelp();
+	program.addOption(orgIdAlias);
+
 	const skipVersionCheckOption = program.createOption(
 		'--skip-version-check',
 		'Skip version compatibility check (dev only)'
@@ -1292,6 +1297,16 @@ async function registerSubcommand(
 	// Add --org-id if command requires/optional org and doesn't define it in schema
 	if (_deferOrgIdFlag && !hasOrgIdInSchema) {
 		cmd.option('--org-id <id>', 'organization ID');
+		// Add hidden --org alias, but only if schema doesn't define its own --org option
+		// (e.g., env commands use --org for "org scope" which is different from --org-id)
+		const schemaDefinesOrg = subcommand.schema?.options
+			? parseOptionsSchema(subcommand.schema.options).some((o) => o.name === 'org')
+			: false;
+		if (!schemaDefinesOrg) {
+			const orgAlias = cmd.createOption('--org <id>', 'Alias for --org-id');
+			orgAlias.hideHelp();
+			cmd.addOption(orgAlias);
+		}
 	}
 
 	// Add --project-id if command requires/optional project and doesn't define it in schema
@@ -1331,7 +1346,10 @@ async function registerSubcommand(
 		// so subcommand-level options may not have them. Only merge when the user
 		// explicitly passed the flag on the CLI (not from env var defaults).
 		const argv = process.argv;
-		const hasExplicitOrgId = argv.some((a) => a === '--org-id' || a.startsWith('--org-id='));
+		const hasExplicitOrgId = argv.some(
+			(a) =>
+				a === '--org-id' || a.startsWith('--org-id=') || a === '--org' || a.startsWith('--org=')
+		);
 		const hasExplicitProjectId = argv.some(
 			(a) => a === '--project-id' || a.startsWith('--project-id=')
 		);

--- a/packages/cli/src/schema-generator.ts
+++ b/packages/cli/src/schema-generator.ts
@@ -358,7 +358,7 @@ export function generateCLISchema(
 				name: 'org-id',
 				type: 'string',
 				required: false,
-				description: 'Use a specific organization when performing operations',
+				description: 'Use a specific organization when performing operations (alias: --org)',
 			},
 			{
 				name: 'color-scheme',

--- a/packages/cli/src/schema-parser.ts
+++ b/packages/cli/src/schema-parser.ts
@@ -454,6 +454,17 @@ export function buildValidationInput(
 				value = true;
 			}
 
+			// Handle --org alias for --org-id: if orgId is not set but org is, use that value
+			// Only treat --org as an --org-id alias if the schema does NOT declare a separate 'org' option
+			if (
+				(opt.name === 'orgId' || opt.name === 'org-id') &&
+				value === undefined &&
+				rawOptions.org !== undefined &&
+				!parsed.some((o) => o.name === 'org')
+			) {
+				value = rawOptions.org;
+			}
+
 			if (value !== undefined) {
 				result.options[opt.name] = value;
 			}


### PR DESCRIPTION
## Summary

- Adds `--org` as a hidden alias for `--org-id` across the CLI — agents consistently prefer `--org` over `--org-id`
- Follows the existing `--yes`/`--force` → `--confirm` alias pattern in `schema-parser.ts`
- Guards against conflicts with env commands (`cloud env set/get/list/delete/import/pull/push`) which define their own `--org` schema option for org-scope selection

## Changes

| File | Change |
|------|--------|
| `packages/cli/src/cli.ts` | Hidden global `--org <id>` on `program`; hidden per-subcommand `--org` when auto-adding `--org-id` (with schema guard); argv detection updated |
| `packages/cli/bin/cli.ts` | Global options normalization: `org` → `orgId` |
| `packages/cli/src/schema-parser.ts` | `--org` → `orgId` mapping in `buildValidationInput` (mirrors `--yes`/`--force` → `--confirm` pattern) |
| `packages/cli/src/schema-generator.ts` | Updated `org-id` description to surface `(alias: --org)` in schema output |

## Testing

Verified locally with `AGENTUITY_PROFILE=production`:

- `--org` hidden from `--help` output ✅
- `auth whoami --org X` identical to `--org-id X` ✅
- `cloud sandbox list --org org_xxx` returns same data as `--org-id` ✅
- `--org=org_xxx` equals syntax works ✅
- `cloud env list --org` still works as env's own org-scope flag ✅
- `cloud env set --help` shows its own `--org [org]` — no conflict ✅
- Build and typecheck pass ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--org` as a shorthand alias for the `--org-id` CLI flag, providing an alternative and more concise way to specify organization parameters across CLI commands while maintaining full backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->