### PR TITLE
fix(cli): skip tailwind source(none) in dev mode

### DIFF
--- a/packages/cli/src/cmd/build/vite/tailwind-source-plugin.ts
+++ b/packages/cli/src/cmd/build/vite/tailwind-source-plugin.ts
@@ -3,23 +3,27 @@
  *
  * The Tailwind v4 oxide scanner (native Rust binary) can hang or fail when
  * scanning the filesystem in containerized environments. Adding source(none)
- * to @import "tailwindcss" disables the oxide filesystem scanner while still
- * allowing @tailwindcss/vite to detect class usage through Vite's module graph.
- *
- * Only applies during production builds (apply: 'build'). In dev mode, the
- * oxide scanner runs natively and source(none) would prevent Tailwind from
- * discovering utility classes since Vite's module graph is built lazily.
+ * to @import "tailwindcss" disables the oxide filesystem scanner, and an
+ * explicit @source directive pointing at the project's src/ directory tells
+ * Tailwind exactly where to find utility classes.
  *
  * @see https://github.com/tailwindlabs/tailwindcss/discussions/19661
+ * @see https://tailwindcss.com/docs/detecting-classes-in-source-files
  */
 
+import { dirname, join, relative, sep } from 'node:path';
 import type { Plugin } from 'vite';
 
 export function tailwindSourcePlugin(): Plugin {
+	let root: string;
+
 	return {
 		name: 'agentuity:tailwind-source',
 		enforce: 'pre',
-		apply: 'build',
+
+		configResolved(config) {
+			root = config.root;
+		},
 
 		transform(code, id) {
 			// Only transform CSS files
@@ -32,9 +36,19 @@ export function tailwindSourcePlugin(): Plugin {
 				return null;
 			}
 
+			// Compute relative path from CSS file to project's src/ directory
+			const cssDir = dirname(id);
+			const srcDir = join(root, 'src');
+			let relPath = relative(cssDir, srcDir).split(sep).join('/');
+			if (relPath === '') {
+				relPath = '.';
+			} else if (!relPath.startsWith('.')) {
+				relPath = './' + relPath;
+			}
+
 			// Transform @import "tailwindcss" → @import "tailwindcss" source(none)
-			// Handles both quote styles and preserves any other directives on the same statement
-			// Does NOT transform if source() is already specified
+			// and add explicit @source so Tailwind knows where to scan for classes.
+			// Does NOT transform if source() is already specified.
 			const transformed = code.replace(
 				/@import\s+(["'])tailwindcss\1([^;]*);/g,
 				(match, quote, rest) => {
@@ -42,7 +56,7 @@ export function tailwindSourcePlugin(): Plugin {
 					if (/source\s*\(/.test(rest)) {
 						return match;
 					}
-					return `@import ${quote}tailwindcss${quote}${rest} source(none);`;
+					return `@import ${quote}tailwindcss${quote}${rest} source(none);\n@source "${relPath}";`;
 				}
 			);
 


### PR DESCRIPTION
## Summary

- Restrict the `tailwindSourcePlugin` to production builds only (`apply: 'build'`) so the Tailwind v4 oxide scanner runs normally in dev mode
- In dev mode, `source(none)` was disabling the oxide filesystem scanner, leaving `@layer utilities` empty because Vite's module graph is built lazily and can't compensate
- Production builds are unaffected — the full module graph is available at build time, so `source(none)` continues to work correctly in containerized build environments

Fixes #1234

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Tailwind utility-class discovery by injecting an explicit @source "<relative-path>" directive (while preserving existing source(...) annotations) so Tailwind scans the correct src directory.
  * Transformer now only runs for .css files and only when a Tailwind import is present, reducing unintended interference with module scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->