### PR TITLE
fix: map 404 to SandboxNotFoundError in execute for clearer diagnostics

### DIFF
--- a/packages/core/src/services/sandbox/execute.ts
+++ b/packages/core/src/services/sandbox/execute.ts
@@ -1,7 +1,7 @@
 import type { ExecuteOptions, Execution, ExecutionStatus } from './types.ts';
 import { z } from 'zod';
 import type { APIClient } from '../api.ts';
-import { SandboxBusyError, throwSandboxError } from './util.ts';
+import { SandboxBusyError, SandboxNotFoundError, throwSandboxError } from './util.ts';
 
 export const ExecuteRequestSchema = z
 	.object({
@@ -114,23 +114,37 @@ export async function sandboxExecute(
 			signal ?? options.signal
 		);
 	} catch (error: unknown) {
-		// Detect 409 Conflict (sandbox busy) and throw a specific error.
-		// The sandbox API client is configured with maxRetries: 0 to fail fast
-		// when sandbox is busy (retrying wouldn't help - sandbox is still busy).
-		// Convert APIErrorResponse with status 409 to SandboxBusyError for clarity.
 		if (
 			error &&
 			typeof error === 'object' &&
 			'_tag' in error &&
 			(error as { _tag: string })._tag === 'APIErrorResponse' &&
-			'status' in error &&
-			(error as { status: number }).status === 409
+			'status' in error
 		) {
-			throw new SandboxBusyError({
-				message:
-					'Sandbox is currently busy executing another command. Please wait for the current execution to complete before submitting a new one.',
-				sandboxId,
-			});
+			const status = (error as { status: number }).status;
+
+			// Detect 404 Not Found — sandbox may not exist or may still be initializing.
+			// The server normally handles the creating→idle wait transparently, but this
+			// provides a clear typed error if a 404 reaches the SDK for any reason.
+			if (status === 404) {
+				throw new SandboxNotFoundError({
+					message:
+						'Sandbox not found. If you just created this sandbox, it may still be initializing. The server should handle this automatically — if this persists, the sandbox may have been destroyed.',
+					sandboxId,
+				});
+			}
+
+			// Detect 409 Conflict (sandbox busy) and throw a specific error.
+			// The sandbox API client is configured with maxRetries: 0 to fail fast
+			// when sandbox is busy (retrying wouldn't help - sandbox is still busy).
+			// Convert APIErrorResponse with status 409 to SandboxBusyError for clarity.
+			if (status === 409) {
+				throw new SandboxBusyError({
+					message:
+						'Sandbox is currently busy executing another command. Please wait for the current execution to complete before submitting a new one.',
+					sandboxId,
+				});
+			}
 		}
 		throw error;
 	}


### PR DESCRIPTION
## Summary

- Adds defensive 404 → `SandboxNotFoundError` mapping in `sandboxExecute()` alongside the existing 409 → `SandboxBusyError` handler
- Provides a clear typed error instead of a raw `APIErrorResponse` if a 404 reaches the SDK

## Context

The primary fix for #1252 is server-side in [agentuity/ion#328](https://github.com/agentuity/ion/pull/328) — catalyst now transparently waits for sandbox creation before forwarding execute requests. This SDK change is a belt-and-suspenders improvement that ensures any 404 from the execute endpoint produces a typed, actionable `SandboxNotFoundError` with a helpful message.

## Changes

### `packages/core/src/services/sandbox/execute.ts`
- Refactored the catch block to check `_tag` and `status` once, then branch on status code
- Added 404 handler that throws `SandboxNotFoundError` with guidance message
- Existing 409 handler preserved unchanged

Fixes #1252

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced error handling for sandbox operations to provide more specific feedback, distinguishing between scenarios when a sandbox is not found versus when it is busy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->