### PR TITLE
ci: optimize CI workflows and Playwright tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,6 +34,13 @@ jobs:
          - uses: actions/checkout@v4
          - name: Setup Bun
            uses: oven-sh/setup-bun@v2
+         - name: Cache Bun dependencies
+           uses: actions/cache@v4
+           with:
+              path: ~/.bun/install/cache
+              key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+              restore-keys: |
+                 ${{ runner.os }}-bun-
          - name: Install dependencies
            run: |
               set -eou pipefail

--- a/.github/workflows/package-smoke-test.yaml
+++ b/.github/workflows/package-smoke-test.yaml
@@ -24,6 +24,14 @@ jobs:
          - name: Setup Bun
            uses: oven-sh/setup-bun@v2
 
+         - name: Cache Bun dependencies
+           uses: actions/cache@v4
+           with:
+              path: ~/.bun/install/cache
+              key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+              restore-keys: |
+                 ${{ runner.os }}-bun-
+
          - name: Install dependencies
            run: bun install
 
@@ -39,6 +47,14 @@ jobs:
 
          - name: Setup Bun
            uses: oven-sh/setup-bun@v2
+
+         - name: Cache Bun dependencies
+           uses: actions/cache@v4
+           with:
+              path: ~/.bun/install/cache
+              key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+              restore-keys: |
+                 ${{ runner.os }}-bun-
 
          - name: Install dependencies
            run: bun install
@@ -75,6 +91,14 @@ jobs:
          - name: Setup Bun
            uses: oven-sh/setup-bun@v2
 
+         - name: Cache Bun dependencies
+           uses: actions/cache@v4
+           with:
+              path: ~/.bun/install/cache
+              key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+              restore-keys: |
+                 ${{ runner.os }}-bun-
+
          - name: Install dependencies
            run: bun install
 
@@ -98,6 +122,14 @@ jobs:
 
          - name: Setup Bun
            uses: oven-sh/setup-bun@v2
+
+         - name: Cache Bun dependencies
+           uses: actions/cache@v4
+           with:
+              path: ~/.bun/install/cache
+              key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+              restore-keys: |
+                 ${{ runner.os }}-bun-
 
          - name: Install dependencies
            run: bun install
@@ -146,6 +178,14 @@ jobs:
 
          - name: Setup Bun
            uses: oven-sh/setup-bun@v2
+
+         - name: Cache Bun dependencies
+           uses: actions/cache@v4
+           with:
+              path: ~/.bun/install/cache
+              key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+              restore-keys: |
+                 ${{ runner.os }}-bun-
 
          - name: Install dependencies
            run: bun install
@@ -215,6 +255,14 @@ jobs:
          - name: Setup Bun
            uses: oven-sh/setup-bun@v2
 
+         - name: Cache Bun dependencies
+           uses: actions/cache@v4
+           with:
+              path: ~/.bun/install/cache
+              key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+              restore-keys: |
+                 ${{ runner.os }}-bun-
+
          - name: Install dependencies
            run: bun install
 
@@ -238,6 +286,14 @@ jobs:
 
          - name: Setup Bun
            uses: oven-sh/setup-bun@v2
+
+         - name: Cache Bun dependencies
+           uses: actions/cache@v4
+           with:
+              path: ~/.bun/install/cache
+              key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+              restore-keys: |
+                 ${{ runner.os }}-bun-
 
          - name: Install dependencies
            run: bun install
@@ -270,6 +326,14 @@ jobs:
          - name: Setup Bun
            uses: oven-sh/setup-bun@v2
 
+         - name: Cache Bun dependencies
+           uses: actions/cache@v4
+           with:
+              path: ~/.bun/install/cache
+              key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+              restore-keys: |
+                 ${{ runner.os }}-bun-
+
          - name: Install dependencies
            run: bun install
 
@@ -301,6 +365,14 @@ jobs:
          - name: Setup Bun
            uses: oven-sh/setup-bun@v2
 
+         - name: Cache Bun dependencies
+           uses: actions/cache@v4
+           with:
+              path: ~/.bun/install/cache
+              key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+              restore-keys: |
+                 ${{ runner.os }}-bun-
+
          - name: Install dependencies
            run: bun install
 
@@ -330,6 +402,14 @@ jobs:
          - name: Setup Bun
            uses: oven-sh/setup-bun@v2
 
+         - name: Cache Bun dependencies
+           uses: actions/cache@v4
+           with:
+              path: ~/.bun/install/cache
+              key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+              restore-keys: |
+                 ${{ runner.os }}-bun-
+
          - name: Install dependencies
            run: bun install
 
@@ -356,10 +436,28 @@ jobs:
          - name: Setup Bun
            uses: oven-sh/setup-bun@v2
 
+         - name: Cache Bun dependencies
+           uses: actions/cache@v4
+           with:
+              path: ~/.bun/install/cache
+              key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+              restore-keys: |
+                 ${{ runner.os }}-bun-
+
          - name: Install dependencies
            run: bun install
 
+         - name: Cache Playwright browsers
+           id: playwright-cache
+           uses: actions/cache@v4
+           with:
+              path: ~/.cache/ms-playwright
+              key: ${{ runner.os }}-playwright-${{ hashFiles('**/bun.lockb') }}
+              restore-keys: |
+                 ${{ runner.os }}-playwright-
+
          - name: Install Playwright browsers
+           if: steps.playwright-cache.outputs.cache-hit != 'true'
            run: bunx playwright install --with-deps chromium
 
          - name: Prepare SDK for testing
@@ -394,10 +492,28 @@ jobs:
          - name: Setup Bun
            uses: oven-sh/setup-bun@v2
 
+         - name: Cache Bun dependencies
+           uses: actions/cache@v4
+           with:
+              path: ~/.bun/install/cache
+              key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+              restore-keys: |
+                 ${{ runner.os }}-bun-
+
          - name: Install dependencies
            run: bun install
 
+         - name: Cache Playwright browsers
+           id: playwright-cache
+           uses: actions/cache@v4
+           with:
+              path: ~/.cache/ms-playwright
+              key: ${{ runner.os }}-playwright-${{ hashFiles('**/bun.lockb') }}
+              restore-keys: |
+                 ${{ runner.os }}-playwright-
+
          - name: Install Playwright browsers
+           if: steps.playwright-cache.outputs.cache-hit != 'true'
            run: bunx playwright install --with-deps chromium
 
          - name: Prepare SDK for testing

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -9,7 +9,7 @@
 import { execSync } from 'node:child_process';
 import { join } from 'node:path';
 
-const MAX_RETRIES = 60;
+const MAX_RETRIES = 30;
 const RETRY_DELAY = 1000;
 
 async function globalSetup(): Promise<void> {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,8 +8,8 @@ export default defineConfig({
 	testIgnore: ['**/frameworks/**'],
 	fullyParallel: true,
 	forbidOnly: !!process.env.CI,
-	retries: process.env.CI ? 2 : 0,
-	workers: process.env.CI ? 4 : undefined, // CI runner has 4 vCPUs, tests use unique room IDs so can run in parallel
+	retries: process.env.CI ? 1 : 0,
+	workers: process.env.CI ? Number(process.env.PLAYWRIGHT_WORKERS) || undefined : undefined, // Auto-detect based on CPUs, or override via PLAYWRIGHT_WORKERS
 	reporter: 'html',
 	use: {
 		baseURL: 'http://localhost:3500',

--- a/playwright.frameworks.config.ts
+++ b/playwright.frameworks.config.ts
@@ -7,10 +7,10 @@ import { defineConfig, devices } from '@playwright/test';
 export default defineConfig({
 	testDir: './e2e/frameworks',
 	testMatch: '**/*.pw.ts',
-	fullyParallel: false,
+	fullyParallel: true,
 	forbidOnly: !!process.env.CI,
-	retries: process.env.CI ? 2 : 0,
-	workers: 1,
+	retries: process.env.CI ? 1 : 0,
+	workers: process.env.CI ? Number(process.env.PLAYWRIGHT_WORKERS) || undefined : undefined, // Auto-detect based on CPUs, or override via PLAYWRIGHT_WORKERS
 	reporter: 'html',
 	timeout: 60000,
 	use: {

--- a/scripts/test-framework-demos.sh
+++ b/scripts/test-framework-demos.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Framework Demo Tests - Playwright E2E Tests for TanStack, Next.js, and Vite RSC Integration
 # Tests the frontend framework integration demos with Agentuity
+#
+# Optimized: Starts all servers in parallel, then runs all tests in parallel
 
 set -e
 
@@ -51,22 +53,16 @@ done
 cleanup() {
 	echo ""
 	echo "Cleaning up..."
-	if [ -n "$TANSTACK_PID" ]; then
-		kill $TANSTACK_PID 2>/dev/null || true
-	fi
-	if [ -n "$NEXTJS_PID" ]; then
-		kill $NEXTJS_PID 2>/dev/null || true
-	fi
-	if [ -n "$VITE_RSC_PID" ]; then
-		kill $VITE_RSC_PID 2>/dev/null || true
-	fi
+	# Kill all server PIDs
+	for pid in $TANSTACK_PID $NEXTJS_PID $VITE_RSC_PID; do
+		if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+			kill "$pid" 2>/dev/null || true
+		fi
+	done
 	# Kill any remaining processes on the ports
-	lsof -ti:3000 | xargs kill -9 2>/dev/null || true
-	lsof -ti:3001 | xargs kill -9 2>/dev/null || true
-	lsof -ti:3002 | xargs kill -9 2>/dev/null || true
-	lsof -ti:3500 | xargs kill -9 2>/dev/null || true
-	lsof -ti:3501 | xargs kill -9 2>/dev/null || true
-	lsof -ti:3502 | xargs kill -9 2>/dev/null || true
+	for port in 3000 3001 3002 3500 3501 3502; do
+		lsof -ti:$port | xargs kill -9 2>/dev/null || true
+	done
 }
 trap cleanup EXIT
 
@@ -77,14 +73,13 @@ if [ "$SKIP_BUILD" = false ]; then
 	echo ""
 fi
 
-# Function to wait for server
+# Function to wait for server (with timeout)
 wait_for_server() {
 	local url=$1
 	local name=$2
-	local max_attempts=60
+	local max_attempts=${3:-60}
 	local attempt=0
 	
-	echo "Waiting for $name at $url..."
 	while [ $attempt -lt $max_attempts ]; do
 		if curl -s "$url" > /dev/null 2>&1; then
 			echo "✓ $name is ready"
@@ -97,109 +92,98 @@ wait_for_server() {
 	return 1
 }
 
-# Run TanStack tests
+# Build list of projects to test
+PROJECTS=()
 if [ "$RUN_TANSTACK" = true ]; then
-	echo "═══════════════════════════════════════════════"
-	echo "  Testing TanStack Start + Agentuity"
-	echo "═══════════════════════════════════════════════"
-	echo ""
-	
-	# Start TanStack app
-	echo "Starting TanStack app..."
+	PROJECTS+=("tanstack")
+fi
+if [ "$RUN_NEXTJS" = true ]; then
+	PROJECTS+=("nextjs")
+fi
+if [ "$RUN_VITE_RSC" = true ]; then
+	PROJECTS+=("vite-rsc")
+fi
+
+if [ ${#PROJECTS[@]} -eq 0 ]; then
+	echo "No projects selected for testing"
+	exit 1
+fi
+
+echo "Projects to test: ${PROJECTS[*]}"
+echo ""
+
+# Step 2: Start all servers in parallel
+echo "Step 2: Starting all dev servers in parallel..."
+
+if [ "$RUN_TANSTACK" = true ]; then
+	echo "  Starting TanStack app..."
 	cd "$SDK_ROOT/apps/testing/tanstack-start"
 	bun run dev &
 	TANSTACK_PID=$!
-	
-	# Wait for both web and agent servers
-	wait_for_server "http://localhost:3000" "TanStack web (3000)"
-	wait_for_server "http://localhost:3500" "TanStack agent (3500)"
-	
-	# Run Playwright tests for TanStack
-	echo ""
-	echo "Running Playwright tests for TanStack..."
 	cd "$SDK_ROOT"
-	bun run playwright test --config=playwright.frameworks.config.ts --project=tanstack
-	
-	# Stop TanStack
-	kill $TANSTACK_PID 2>/dev/null || true
-	TANSTACK_PID=""
-	lsof -ti:3000 | xargs kill -9 2>/dev/null || true
-	lsof -ti:3500 | xargs kill -9 2>/dev/null || true
-	sleep 2
-	
-	echo ""
-	echo "✓ TanStack tests completed"
-	echo ""
 fi
 
-# Run Next.js tests
 if [ "$RUN_NEXTJS" = true ]; then
-	echo "═══════════════════════════════════════════════"
-	echo "  Testing Next.js + Agentuity"
-	echo "═══════════════════════════════════════════════"
-	echo ""
-	
-	# Start Next.js app
-	echo "Starting Next.js app..."
+	echo "  Starting Next.js app..."
 	cd "$SDK_ROOT/apps/testing/nextjs-app"
 	bun run dev &
 	NEXTJS_PID=$!
-	
-	# Wait for both web and agent servers
-	wait_for_server "http://localhost:3001" "Next.js web (3001)"
-	wait_for_server "http://localhost:3501" "Next.js agent (3501)"
-	
-	# Run Playwright tests for Next.js
-	echo ""
-	echo "Running Playwright tests for Next.js..."
 	cd "$SDK_ROOT"
-	bun run playwright test --config=playwright.frameworks.config.ts --project=nextjs
-	
-	# Stop Next.js
-	kill $NEXTJS_PID 2>/dev/null || true
-	NEXTJS_PID=""
-	lsof -ti:3001 | xargs kill -9 2>/dev/null || true
-	lsof -ti:3501 | xargs kill -9 2>/dev/null || true
-	
-	echo ""
-	echo "✓ Next.js tests completed"
-	echo ""
 fi
 
-# Run Vite RSC tests
 if [ "$RUN_VITE_RSC" = true ]; then
-	echo "═══════════════════════════════════════════════"
-	echo "  Testing Vite RSC + Agentuity"
-	echo "═══════════════════════════════════════════════"
-	echo ""
-	
-	# Start Vite RSC app
-	echo "Starting Vite RSC app..."
+	echo "  Starting Vite RSC app..."
 	cd "$SDK_ROOT/apps/testing/vite-rsc-app"
 	bun run dev &
 	VITE_RSC_PID=$!
-	
-	# Wait for both web and agent servers
-	wait_for_server "http://localhost:3002" "Vite RSC web (3002)"
-	wait_for_server "http://localhost:3502" "Vite RSC agent (3502)"
-	
-	# Run Playwright tests for Vite RSC
-	echo ""
-	echo "Running Playwright tests for Vite RSC..."
 	cd "$SDK_ROOT"
-	bun run playwright test --config=playwright.frameworks.config.ts --project=vite-rsc
-	
-	# Stop Vite RSC
-	kill $VITE_RSC_PID 2>/dev/null || true
-	VITE_RSC_PID=""
-	lsof -ti:3002 | xargs kill -9 2>/dev/null || true
-	lsof -ti:3502 | xargs kill -9 2>/dev/null || true
-	
-	echo ""
-	echo "✓ Vite RSC tests completed"
-	echo ""
 fi
 
+echo ""
+echo "Waiting for all servers to be ready..."
+
+# Wait for all servers in parallel (print status as they become ready)
+WAIT_FAILURE=0
+
+if [ "$RUN_TANSTACK" = true ]; then
+	wait_for_server "http://localhost:3000" "TanStack web (3000)" 90 || WAIT_FAILURE=1
+	wait_for_server "http://localhost:3500" "TanStack agent (3500)" 30 || WAIT_FAILURE=1
+fi
+
+if [ "$RUN_NEXTJS" = true ]; then
+	wait_for_server "http://localhost:3001" "Next.js web (3001)" 90 || WAIT_FAILURE=1
+	wait_for_server "http://localhost:3501" "Next.js agent (3501)" 30 || WAIT_FAILURE=1
+fi
+
+if [ "$RUN_VITE_RSC" = true ]; then
+	wait_for_server "http://localhost:3002" "Vite RSC web (3002)" 90 || WAIT_FAILURE=1
+	wait_for_server "http://localhost:3502" "Vite RSC agent (3502)" 30 || WAIT_FAILURE=1
+fi
+
+if [ $WAIT_FAILURE -eq 1 ]; then
+	echo ""
+	echo "✗ One or more servers failed to start"
+	exit 1
+fi
+
+echo ""
+echo "✓ All servers are ready"
+echo ""
+
+# Step 3: Run Playwright tests for all projects in one command
+# Playwright will run projects in parallel based on config (workers: 3)
+echo "Step 3: Running Playwright tests for all projects..."
+echo ""
+
+PROJECT_ARGS=""
+for proj in "${PROJECTS[@]}"; do
+	PROJECT_ARGS="$PROJECT_ARGS --project=$proj"
+done
+
+cd "$SDK_ROOT"
+bun run playwright test --config=playwright.frameworks.config.ts $PROJECT_ARGS
+
+echo ""
 echo "╔════════════════════════════════════════════════╗"
 echo "║  ✅ Framework Demo Tests Complete              ║"
 echo "╚════════════════════════════════════════════════╝"


### PR DESCRIPTION
- Add Bun dependency caching to all workflow jobs (~30-60s per job)
- Add Playwright browser caching with conditional install (~30-45s per job)
- Reduce Playwright retries from 2 to 1 (10-20% test time savings)
- Enable full parallelism for framework tests (was sequential)
- Start all framework demo servers in parallel instead of sequentially
- Reduce global-setup retries from 60 to 30 for faster failure detection
- Make Playwright workers configurable via PLAYWRIGHT_WORKERS env var

Expected overall CI time reduction: ~15-20%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added dependency and build artifact caching to CI workflows for faster build times.
  * Enabled parallel test execution and optimized test configuration for improved CI efficiency.
  * Reduced retry attempts in CI tests from 2 to 1 and made worker count configurable.
  * Streamlined test framework demo script execution to run servers concurrently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->