### PR TITLE
fix(cli): guard cursor restoration with TTY check to prevent ANSI pollution

### DIFF
--- a/packages/cli/src/tui.ts
+++ b/packages/cli/src/tui.ts
@@ -25,6 +25,12 @@ function ensureCursorRestoration(): void {
 	exitHandlerInstalled = true;
 
 	const restoreCursor = () => {
+		// Only write ANSI escape sequences when stderr is a real terminal.
+		// Writing to non-TTY streams (pipes, command substitution, etc.)
+		// pollutes captured output with invisible control characters.
+		if (!process.stderr.isTTY) {
+			return;
+		}
 		// Skip cursor restoration in CI - terminals don't support these sequences
 		if (process.env.CI) {
 			return;


### PR DESCRIPTION
## Summary

- The global exit handler in `tui.ts` writes `\x1b[?25h` (ANSI "show cursor") to stderr on every CLI process exit
- When scripts capture CLI output via `2>&1` (e.g., `GOT=$(agentuity cloud sandbox exec ... 2>&1)`), this 7-byte escape sequence contaminates the captured string
- Exact string comparisons fail even though the visible output looks identical — the invisible `\n\x1b[?25h` suffix causes mismatches
- This caused **32 false test failures** in the hadron checkpoint regression test suite

## Root Cause

```
Expected: 68656c6c6f20776f726c64              = "hello world" (11 bytes)
Got:      68656c6c6f20776f726c640a1b5b3f323568 = "hello world\n\x1b[?25h" (18 bytes)
```

The `ensureCursorRestoration()` handler fires on every exit but only checked for `CI` and `getExecutingAgent()` — not whether stderr is actually a terminal.

## Fix

Add `!process.stderr.isTTY` as the first guard. ANSI escape sequences should never be written to non-TTY streams (pipes, command substitution, redirects, etc.).

The existing CI and agent-detection guards are kept for explicitness.

## Testing

- Ran full checkpoint regression test group 1 (12/12 passed) after the fix
- Typecheck passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cursor handling to prevent issues when output is piped or redirected to non-terminal environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->