### PR TITLE
fix(cli): guard spinner and success output with stderr TTY check

### DIFF
--- a/packages/cli/src/tui.ts
+++ b/packages/cli/src/tui.ts
@@ -299,8 +299,13 @@ export function getSeverityColor(severity: string): (text: string) => string {
 export function success(message: string): void {
 	const color = getColor('success');
 	const reset = getColor('reset');
-	// Clear line first to ensure no leftover content from previous output
-	process.stderr.write(`\r\x1b[2K${color}${ICONS.success} ${message}${reset}\n`);
+	if (process.stderr.isTTY) {
+		// Clear line first to ensure no leftover content from previous output
+		process.stderr.write(`\r\x1b[2K${color}${ICONS.success} ${message}${reset}\n`);
+	} else {
+		// No ANSI control sequences for non-TTY streams (pipes, command substitution)
+		process.stderr.write(`${ICONS.success} ${message}\n`);
+	}
 }
 
 /**
@@ -1249,9 +1254,11 @@ export async function spinner<T>(
 	const outputOptions = getOutputOptions();
 	const noProgress = outputOptions ? shouldDisableProgress(outputOptions) : false;
 
-	// If no interactive TTY-like environment or progress disabled, just execute
-	// the callback without animation
-	if (!isTTYLike() || noProgress) {
+	// If stderr is not a real terminal or progress disabled, just execute
+	// the callback without animation. We check stderr specifically because
+	// the spinner writes ANSI sequences to stderr — isTTYLike() may return
+	// true when stdout is a TTY but stderr is piped (e.g. 2>&1 in $()).
+	if (!process.stderr.isTTY || noProgress) {
 		try {
 			const result =
 				options.type === 'progress'


### PR DESCRIPTION
## Summary

Follow-up to #1268. The original fix guarded the exit handler's cursor restoration, but the spinner and `success()` function still wrote ANSI control sequences (`\x1b[2K` erase line, cursor movement) to stderr unconditionally.

## Root Cause

`isTTYLike()` returns `true` when **either** stdout or stderr is a TTY (using `||`). When scripts capture output via `OUT=$(command 2>&1)`, stdout is a pipe but stderr may still be a terminal, causing `isTTYLike()` to return `true` and the spinner to run with full ANSI animation.

This produced `[2K` (erase line) artifacts in captured test output, visible in the hadron regression test as:
```
❌ T6.2 pause during exec blocked: [2K[OK] paused sandbox sbx_...
```

## Fix

- **Spinner entry**: Check `process.stderr.isTTY` specifically (not `isTTYLike()`) since all spinner ANSI goes to stderr
- **`success()`**: Skip `\r\x1b[2K` prefix when stderr is not a terminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI output handling for non-terminal environments. Success messages and progress spinners now correctly avoid ANSI escape codes when output is piped or redirected, ensuring cleaner logs and better compatibility with shell scripts and automation tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->