### PR TITLE
fix(create-agentuity): use matching dist-tag for CLI version

### DIFF
--- a/apps/create-agentuity/bin.js
+++ b/apps/create-agentuity/bin.js
@@ -1,8 +1,24 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
 
+const require = createRequire(import.meta.url);
+const pkg = require('./package.json');
+
+// Determine the dist-tag based on create-agentuity version
+// Prerelease versions (e.g., 2.0.0-beta.1) should use @next
+// Stable versions should use @latest
+function getDistTag(version) {
+	// Check for prerelease identifiers: alpha, beta, rc, canary, next, etc.
+	if (/-([a-zA-Z]+)/.test(version)) {
+		return 'next';
+	}
+	return 'latest';
+}
+
+const distTag = getDistTag(pkg.version);
 const args = process.argv.slice(2);
-const result = spawnSync('bunx', ['@agentuity/cli@latest', 'create', ...args], {
+const result = spawnSync('bunx', [`@agentuity/cli@${distTag}`, 'create', ...args], {
 	stdio: 'inherit',
 });
 process.exit(result.status || 0);


### PR DESCRIPTION
## Problem

Previously, `bin.js` hardcoded `@agentuity/cli@latest` regardless of which version tag the user specified for `create-agentuity`. This caused a mismatch when running:

```bash
bun create agentuity@next
```

It would invoke `@agentuity/cli@latest` instead of `@next`, leading to inconsistent behavior between the create package and the CLI.

## Solution

Now reads `create-agentuity`'s own version and detects prerelease identifiers (alpha, beta, rc, etc.) to determine the appropriate dist-tag:

- **Prerelease versions** (e.g., `2.0.0-beta.1`) → `@agentuity/cli@next`
- **Stable versions** (e.g., `2.0.0`) → `@agentuity/cli@latest`

## Example Flow

```bash
# User runs:
bun create agentuity@next my-project

# create-agentuity@next is downloaded (prerelease version)
# bin.js detects prerelease → calls @agentuity/cli@next create

# User runs:
bun create agentuity my-project

# create-agentuity@latest is downloaded (stable version)
# bin.js detects stable → calls @agentuity/cli@latest create
```

## Testing

- The `getDistTag()` function uses a regex to detect prerelease identifiers: `alpha`, `beta`, `rc`, `canary`, `next`, etc.
- Works with any semver prerelease format (e.g., `2.0.0-beta.1`, `1.0.0-rc.2`, `3.0.0-alpha.0`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CLI version selection to dynamically choose between prerelease and stable releases based on the current package version. Prerelease versions now automatically use the next CLI release, while stable versions use the latest stable CLI release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->