### PR TITLE
fix(ci): improve CI build reliability and remove memory detection from SDK

### DIFF
--- a/packages/cli/src/cmd/build/ci.ts
+++ b/packages/cli/src/cmd/build/ci.ts
@@ -22,44 +22,18 @@ export interface CIBuildOptions {
 	logsUrl?: string;
 }
 
-async function streamProcessOutput(proc: ReturnType<typeof spawn>): Promise<void> {
-	const forwardStream = async (
-		stream: ReadableStream<Uint8Array> | number | undefined,
-		isStderr: boolean
-	) => {
-		if (typeof stream === 'number') return;
-		if (!stream) return;
-		const reader = stream.getReader();
-		const target = isStderr ? process.stderr : process.stdout;
-
-		while (true) {
-			const { done, value } = await reader.read();
-			if (done) break;
-			target.write(value);
-		}
-	};
-
-	await Promise.all([
-		forwardStream(proc.stdout, false),
-		forwardStream(proc.stderr, true),
-		proc.exited,
-	]);
-}
-
 async function runCommand(cmd: string[], cwd: string): Promise<number> {
 	const proc = spawn({
 		cmd,
 		cwd,
 		env: { ...process.env, CI: 'true' },
 		stdin: 'ignore',
-		stdout: 'pipe',
-		stderr: 'pipe',
+		stdout: 'inherit',
+		stderr: 'inherit',
 	});
-
-	await streamProcessOutput(proc);
+	await proc.exited;
 	return proc.exitCode ?? 1;
 }
-
 async function downloadSource(url: string, targetPath: string): Promise<void> {
 	let lastError: unknown;
 

--- a/packages/cli/src/cmd/build/vite/vite-builder.ts
+++ b/packages/cli/src/cmd/build/vite/vite-builder.ts
@@ -116,77 +116,6 @@ async function drainSubprocessStream(
  * Reads cgroup v2/v1 max and current usage to compute free memory.
  * Falls back to os.freemem() if cgroup files aren't available.
  */
-async function detectAvailableMemory(
-	logger: Logger,
-	label: string
-): Promise<Record<string, string>> {
-	let cgroupMaxBytes = 0;
-	let cgroupCurrentBytes = 0;
-	let availableBytes = 0;
-	try {
-		if (process.platform === 'linux') {
-			// Try cgroup v2
-			const cgroupMax = Bun.file('/sys/fs/cgroup/memory.max');
-			const cgroupCurrent = Bun.file('/sys/fs/cgroup/memory.current');
-			if ((await cgroupMax.exists()) && (await cgroupCurrent.exists())) {
-				const maxStr = (await cgroupMax.text()).trim();
-				const currentStr = (await cgroupCurrent.text()).trim();
-				// "max" means unlimited — use total system memory
-				if (maxStr === 'max') {
-					const { totalmem } = await import('node:os');
-					cgroupMaxBytes = totalmem();
-				} else if (/^\d+$/.test(maxStr)) {
-					cgroupMaxBytes = Number(maxStr);
-				}
-				if (/^\d+$/.test(currentStr)) {
-					cgroupCurrentBytes = Number(currentStr);
-				}
-				if (cgroupMaxBytes > 0) {
-					availableBytes =
-						cgroupCurrentBytes > 0 ? cgroupMaxBytes - cgroupCurrentBytes : cgroupMaxBytes;
-				}
-			}
-			// Fallback to cgroup v1
-			if (!availableBytes) {
-				const v1Limit = Bun.file('/sys/fs/cgroup/memory/memory.limit_in_bytes');
-				const v1Usage = Bun.file('/sys/fs/cgroup/memory/memory.usage_in_bytes');
-				if ((await v1Limit.exists()) && (await v1Usage.exists())) {
-					const limitStr = (await v1Limit.text()).trim();
-					const usageStr = (await v1Usage.text()).trim();
-					if (/^\d+$/.test(limitStr) && /^\d+$/.test(usageStr)) {
-						cgroupMaxBytes = Number(limitStr);
-						cgroupCurrentBytes = Number(usageStr);
-						availableBytes = cgroupMaxBytes - cgroupCurrentBytes;
-					}
-				}
-			}
-		}
-		if (!availableBytes) {
-			const { freemem } = await import('node:os');
-			availableBytes = freemem();
-		}
-	} catch {
-		// If detection fails, let JSC use its own defaults
-	}
-
-	const jscEnv: Record<string, string> = {};
-	if (availableBytes > 0) {
-		const maxMb = Math.round(cgroupMaxBytes / 1024 / 1024);
-		const usedMb = Math.round(cgroupCurrentBytes / 1024 / 1024);
-		const availMb = Math.round(availableBytes / 1024 / 1024);
-		const maxHeap = Math.round(availableBytes * 0.8);
-		const maxHeapMb = Math.round(maxHeap / 1024 / 1024);
-		jscEnv.BUN_JSC_forceRAMSize = String(availableBytes);
-		jscEnv.BUN_JSC_gcMaxHeapSize = String(maxHeap);
-		logger.debug(
-			`[${label}] Memory: cgroup max=${maxMb} MiB, used=${usedMb} MiB, available=${availMb} MiB, gcMaxHeapSize=${maxHeapMb} MiB`
-		);
-	} else {
-		logger.debug(`[${label}] Could not detect available memory, using JSC defaults`);
-	}
-	return jscEnv;
-}
-
 function resolveWorkerScript(name: string): string {
 	const tsPath = fileURLToPath(new URL(`./${name}.ts`, import.meta.url));
 	const jsPath = fileURLToPath(new URL(`./${name}.js`, import.meta.url));
@@ -210,12 +139,11 @@ async function spawnIsolatedWorker(opts: {
 
 	try {
 		await Bun.write(optionsPath, JSON.stringify(optionsJson));
-		const jscEnv = await detectAvailableMemory(logger, label);
 
 		const proc = Bun.spawn({
 			cmd: [process.execPath, workerScript, optionsPath],
 			cwd,
-			env: { ...process.env, ...jscEnv },
+			env: process.env,
 			stdin: 'ignore',
 			stdout: 'pipe',
 			stderr: 'pipe',

--- a/packages/core/src/services/schedule/service.ts
+++ b/packages/core/src/services/schedule/service.ts
@@ -68,7 +68,7 @@ export const ScheduleSchema = z.object({
 	internal: z
 		.boolean()
 		.describe(
-			'Whether this is a system-managed schedule. Internal schedules cannot be modified or deleted by users.'
+			'Whether this is a system-managed schedule. Internal schedules cannot be modified or deleted users.'
 		),
 });
 


### PR DESCRIPTION
## Summary
- Simplified `runCommand` in CI build to use `stdout/stderr: inherit` instead of manual stream piping
- Removed memory detection logic from vite-builder (now handled by hadron)
- Removed `BUN_JSC_forceRAMSize` and `BUN_JSC_gcMaxHeapSize` env vars from SDK side (these should only be set by hadron based on container cgroup limits)

## Context
Memory env vars should be set by hadron (the container orchestrator) based on cgroup limits, not by the SDK. This was causing conflicts and incorrect memory settings in containers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized subprocess output handling during the build process.
  * Removed automatic memory optimization tuning for isolated build workers.
* **Data Model Updates**
  * Schedule objects now include an `internal` field to distinguish system-managed schedules from user-created ones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->