### PR TITLE
feat(schedule): add internal field to CreateScheduleParams

### DIFF
--- a/packages/core/src/services/schedule/service.ts
+++ b/packages/core/src/services/schedule/service.ts
@@ -217,6 +217,14 @@ export const CreateScheduleParamsSchema = z.object({
 	expression: z.string().describe('Cron expression defining when the schedule fires'),
 
 	/**
+	 * Whether this is a system-managed schedule.
+	 *
+	 * @remarks Internal schedules are created by the system for workflows and cannot
+	 * be modified or deleted directly by users.
+	 */
+	internal: z.boolean().optional().describe('Whether this is a system-managed schedule.'),
+
+	/**
 	 * Optional array of destinations to create alongside the schedule.
 	 *
 	 * @remarks Destinations are created atomically with the schedule — if any destination


### PR DESCRIPTION
## Summary
- Add optional `internal` boolean to `CreateScheduleParamsSchema`
- Allows creation of system-managed schedules that are created by workflows
- Internal schedules cannot be modified or deleted directly by users

## Context
This change supports the multi-destination workflow feature where schedules created as sources for workflows need to be marked as internal for proper filtering in the UI (User vs System tabs) and cleanup when workflows are deleted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Schedules can now be optionally marked as internal when created, providing a way to distinguish between different types of schedules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->