### PR TITLE
fix: apply gateway env patching before agent discovery in dev mode

### DIFF
--- a/packages/migrate/src/detect.ts
+++ b/packages/migrate/src/detect.ts
@@ -494,7 +494,7 @@ export async function detect(projectDir: string): Promise<DetectionResult> {
 					"    define: { CUSTOM: JSON.stringify('value') },\n" +
 					'    build: {\n' +
 					'      rollupOptions: {\n' +
-					"        input: join(__dirname, 'src/web/index.html'),\n" +
+					"        input: join(import.meta.dirname, 'src/web/index.html'),\n" +
 					'      },\n' +
 					'    },\n' +
 					'  });\n' +
@@ -733,7 +733,7 @@ export async function detect(projectDir: string): Promise<DetectionResult> {
 				'    plugins: [react()],\n' +
 				'    build: {\n' +
 				'      rollupOptions: {\n' +
-				"        input: join(__dirname, 'src/web/index.html'),\n" +
+				"        input: join(import.meta.dirname, 'src/web/index.html'),\n" +
 				'      },\n' +
 				'    },\n' +
 				'  });\n' +
@@ -748,7 +748,11 @@ export async function detect(projectDir: string): Promise<DetectionResult> {
 	// If vite.config.ts exists but is missing build.rollupOptions.input, warn about it
 	if (hasFrontend && hasViteConfig) {
 		const viteSrc = await Bun.file(viteConfigPath).text();
-		if (!viteSrc.includes('rollupOptions') || !viteSrc.includes('index.html')) {
+		if (
+			!viteSrc.includes('rollupOptions') ||
+			!viteSrc.includes('input') ||
+			!viteSrc.includes('src/web/index.html')
+		) {
 			findings.push({
 				id: 'vite-config-missing-rollup-input',
 				severity: 'guided',
@@ -764,7 +768,7 @@ export async function detect(projectDir: string): Promise<DetectionResult> {
 					'    // ...your existing config\n' +
 					'    build: {\n' +
 					'      rollupOptions: {\n' +
-					"        input: join(__dirname, 'src/web/index.html'),\n" +
+					"        input: join(import.meta.dirname, 'src/web/index.html'),\n" +
 					'      },\n' +
 					'    },\n' +
 					'  });',

--- a/templates/_base/vite.config.ts
+++ b/templates/_base/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
 	root: '.',
 	build: {
 		rollupOptions: {
-			input: join(__dirname, 'src/web/index.html'),
+			input: join(import.meta.dirname, 'src/web/index.html'),
 		},
 	},
 });

--- a/templates/default/vite.config.ts
+++ b/templates/default/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
 	root: '.',
 	build: {
 		rollupOptions: {
-			input: join(__dirname, 'src/web/index.html'),
+			input: join(import.meta.dirname, 'src/web/index.html'),
 		},
 	},
 });


### PR DESCRIPTION
Agent discovery imports eval files at build time, which may import LLM
SDKs (e.g. groq-sdk) at module scope. These SDKs check for API keys
like GROQ_API_KEY at import time, but the gateway env patching that
sets these keys was only running later (inside createApp → applyDevPatches).

Move SDK key loading, AGENTUITY_TRANSPORT_URL setup, and gateway env
patching (GROQ_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY) to a new
Step 0b that runs before discoverAgents(), matching the same gateway
logic from runtime/src/dev-patches/gateway.ts.

Also includes template fixes:
- Remove deprecated agentuity.config.ts
- Update vite.config.ts
- Add workbench config to app.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a default Vite configuration template with React and Tailwind pre-configured and a ready HTML entry for web apps.
* **Bug Fixes / Enhancements**
  * Improved migration detection and user guidance for incomplete Vite build configurations — now flags missing build entry settings and provides a concrete suggestion to fix them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->