### PR TITLE
fix: reword eval(s) to evaluations to avoid socket.dev false positive

### DIFF
--- a/packages/cli/src/cmd/dev/sync.ts
+++ b/packages/cli/src/cmd/dev/sync.ts
@@ -169,7 +169,7 @@ class DevmodeSyncService implements IDevmodeSyncService {
 					}
 				}
 			}
-			this.logger.debug('Previous metadata found with %d eval(s)', prevEvalCount);
+			this.logger.debug('Previous metadata found with %d evaluations', prevEvalCount);
 		} else {
 			this.logger.debug('No previous metadata, all evals will be treated as new');
 		}
@@ -182,7 +182,7 @@ class DevmodeSyncService implements IDevmodeSyncService {
 			if (agent.evals) {
 				currentEvalCount += agent.evals.length;
 				this.logger.debug(
-					'[CLI EVAL SYNC] Agent "%s" has %d eval(s)',
+					'[CLI EVAL SYNC] Agent "%s" has %d evaluations',
 					agent.name,
 					agent.evals.length
 				);
@@ -196,7 +196,7 @@ class DevmodeSyncService implements IDevmodeSyncService {
 				}
 			}
 		}
-		this.logger.debug('[CLI EVAL SYNC] Total current eval(s): %d', currentEvalCount);
+		this.logger.debug('[CLI EVAL SYNC] Total current evaluations: %d', currentEvalCount);
 
 		// Get agents and evals to sync using shared diff logic
 		const { create: agentsToCreate, delete: agentsToDelete } = getAgentsToSync(
@@ -241,7 +241,7 @@ class DevmodeSyncService implements IDevmodeSyncService {
 			}
 			if (evalsToCreate.length > 0 || evalsToDelete.length > 0) {
 				this.logger.debug(
-					'Successfully bulk synced %d eval(s) to create, %d eval(s) to delete',
+					'Successfully bulk synced %d evaluations to create, %d evaluations to delete',
 					evalsToCreate.length,
 					evalsToDelete.length
 				);
@@ -369,7 +369,7 @@ class MockDevmodeSyncService implements IDevmodeSyncService {
 
 		if (evalsToCreate.length > 0 || evalsToDelete.length > 0) {
 			this.logger.debug(
-				'[MOCK] Would make request: POST /cli/devmode/eval with %d eval(s) to create, %d eval(s) to delete',
+				'[MOCK] Would make request: POST /cli/devmode/eval with %d evaluations to create, %d evaluations to delete',
 				evalsToCreate.length,
 				evalsToDelete.length
 			);

--- a/packages/runtime/src/agent.ts
+++ b/packages/runtime/src/agent.ts
@@ -1949,7 +1949,7 @@ export function createAgent<
 		);
 
 		if (agentEvals && agentEvals.length > 0) {
-			internal.info(`Executing ${agentEvals.length} eval(s) after agent run`);
+			internal.info(`Executing ${agentEvals.length} evaluations after agent run`);
 
 			// Get validated input/output from context state
 			const validatedInput = ctx.state.get('_evalInput');


### PR DESCRIPTION
## Summary

Socket.dev flagged our package as risky due to a false positive match on `eval(s)` string in log messages. This PR rewords all instances of `eval(s)` (used for pluralization) to `evaluations` to avoid triggering the security scanner.

## Changes

- `packages/cli/src/cmd/dev/sync.ts` - 5 log messages updated
- `packages/runtime/src/agent.ts` - 1 log message updated

No functional changes - only log message wording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated log messages throughout the application to use consistent, clearer terminology for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->