### PR TITLE
fix(coder): upgrade Pi integration to 0.64.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -607,16 +607,17 @@
       "name": "@agentuity/coder",
       "version": "2.0.7",
       "devDependencies": {
-        "@mariozechner/pi-coding-agent": "^0.58.1",
-        "@mariozechner/pi-tui": "^0.58.1",
+        "@mariozechner/pi-ai": "^0.64.0",
+        "@mariozechner/pi-coding-agent": "^0.64.0",
+        "@mariozechner/pi-tui": "^0.64.0",
         "@sinclair/typebox": "^0.34.48",
         "@types/bun": "^1.3.9",
         "bun-types": "^1.3.9",
         "typescript": "^5.9.0",
       },
       "peerDependencies": {
-        "@mariozechner/pi-coding-agent": "^0.58.1",
-        "@mariozechner/pi-tui": "^0.58.1",
+        "@mariozechner/pi-coding-agent": "^0.64.0",
+        "@mariozechner/pi-tui": "^0.64.0",
         "@sinclair/typebox": "^0.34.48",
       },
     },
@@ -1538,13 +1539,13 @@
 
     "@mariozechner/jiti": ["@mariozechner/jiti@2.6.5", "", { "dependencies": { "std-env": "^3.10.0", "yoctocolors": "^2.1.2" }, "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw=="],
 
-    "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.58.4", "", { "dependencies": { "@mariozechner/pi-ai": "^0.58.4" } }, "sha512-I2tVUcFzxGAS7dRpmZHKqetIAAz4Q/loupgUBQ9RxOMldUsBoQf5Pj9WWu7cGrGEFztPQ27QKPKbU1jSd2scjw=="],
+    "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.64.0", "", { "dependencies": { "@mariozechner/pi-ai": "^0.64.0" } }, "sha512-IN/sIxWOD0v1OFVXHB605SGiZhO5XdEWG5dO8EAV08n3jz/p12o4OuYGvhGXmHhU28WXa/FGWC+FO5xiIih8Uw=="],
 
-    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.58.4", "", { "dependencies": { "@anthropic-ai/sdk": "^0.73.0", "@aws-sdk/client-bedrock-runtime": "^3.983.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "1.14.1", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-yQT8H3nTHHw925DDLatQ/F5xx0ThK9wF+JTUHlzfXvrfclKDBp1+e8bvxdGK3AbbWuvWNlwZ3qbWgsZQ8/YZtQ=="],
+    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.64.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.73.0", "@aws-sdk/client-bedrock-runtime": "^3.983.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "1.14.1", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-Z/Jnf+JSVDPLRcxJsa8XhYTJKIqKekNueaCpBLGQHgizL1F9RQ1Rur3rIfZpfXkt2cLu/AIPtOs223ueuoWaWg=="],
 
-    "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.58.4", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.58.4", "@mariozechner/pi-ai": "^0.58.4", "@mariozechner/pi-tui": "^0.58.4", "@silvia-odwyer/photon-node": "^0.3.4", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "strip-ansi": "^7.1.0", "undici": "^7.19.1", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-hMU/LX9lFPoCpLYnL3yjWU4t26wkPIlDIlMRyjMihxKNqqEtW9slAc520OdARkAU3wmGgvA1sMVFER1ff+fuAA=="],
+    "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.64.0", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.64.0", "@mariozechner/pi-ai": "^0.64.0", "@mariozechner/pi-tui": "^0.64.0", "@silvia-odwyer/photon-node": "^0.3.4", "ajv": "^8.17.1", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "strip-ansi": "^7.1.0", "undici": "^7.19.1", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-Q4tcqSqFGQtOgCtRyIp1D80Nv2if13Q2pfbnrOlaT/mix90mLcZGML9jKVnT1jGSy5GMYudU1HsS7cx53kxb0g=="],
 
-    "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.58.4", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" }, "optionalDependencies": { "koffi": "^2.9.0" } }, "sha512-EVju7Baj8H7F8dOx3pTKHvQ7i1FW2cR8v9DhSfOdELrdDepkl7v20ufO5lBkuJm+nkRJHbplN861lAI7cwM7gw=="],
+    "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.64.0", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" }, "optionalDependencies": { "koffi": "^2.9.0" } }, "sha512-W1qLry9MAuN/V3YJmMv/BJa0VaYv721NkXPg/DGItdqWxuDc+1VdNbyAnRwxblNkIpXVUWL26x64BlyFXpxmkg=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
@@ -3392,7 +3393,7 @@
 
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
-    "lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
+    "lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
     "lru.min": ["lru.min@1.1.4", "", {}, "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA=="],
 
@@ -4384,6 +4385,10 @@
 
     "@antfu/install-pkg/tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
 
+    "@asamuzakjp/css-color/lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
+
+    "@asamuzakjp/dom-selector/lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
+
     "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
     "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
@@ -4608,6 +4613,8 @@
 
     "create-agentuity/@agentuity/cli": ["@agentuity/cli@2.0.6", "", { "dependencies": { "@agentuity/auth": "2.0.6", "@agentuity/core": "2.0.6", "@agentuity/frontend": "2.0.6", "@agentuity/server": "2.0.6", "@datasert/cronjs-parser": "^1.4.0", "@vitejs/plugin-react": "^5.1.2", "acorn-loose": "^8.5.2", "adm-zip": "^0.5.16", "archiver": "^7.0.1", "astring": "^1.9.0", "cli-table3": "^0.6.5", "commander": "^14.0.2", "enquirer": "^2.4.1", "git-url-parse": "^16.1.0", "json-colorizer": "^3.0.1", "tar": "^7.5.2", "tar-fs": "^3.1.1", "typescript": "^5.9.0", "vite": "^7.2.7", "zod": "^4.3.5" }, "bin": { "agentuity": "bin/cli.ts" } }, "sha512-TdM/yMpwywRG/sYCKP8atvFq2bjA3b98P6rdfPmm081kCSVVjbtBh84SY6dv7WCmkj5DRlNw2anOD6Cdug+E/w=="],
 
+    "cssstyle/lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
+
     "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
 
     "d3-dsv/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
@@ -4655,6 +4662,8 @@
     "hast-util-from-html/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "hast-util-raw/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "hosted-git-info/lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
     "integration-suite/@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
@@ -4706,11 +4715,11 @@
 
     "parse5-parser-stream/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
+    "path-scurry/lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
+
     "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "prebuild-install/tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
-
-    "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
     "radix-ui/@radix-ui/react-aspect-ratio": ["@radix-ui/react-aspect-ratio@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g=="],
 

--- a/packages/coder/package.json
+++ b/packages/coder/package.json
@@ -25,13 +25,14 @@
 		"prepublishOnly": "bun run clean && bun run build"
 	},
 	"peerDependencies": {
-		"@mariozechner/pi-coding-agent": "^0.58.1",
-		"@mariozechner/pi-tui": "^0.58.1",
+		"@mariozechner/pi-coding-agent": "^0.64.0",
+		"@mariozechner/pi-tui": "^0.64.0",
 		"@sinclair/typebox": "^0.34.48"
 	},
 	"devDependencies": {
-		"@mariozechner/pi-coding-agent": "^0.58.1",
-		"@mariozechner/pi-tui": "^0.58.1",
+		"@mariozechner/pi-ai": "^0.64.0",
+		"@mariozechner/pi-coding-agent": "^0.64.0",
+		"@mariozechner/pi-tui": "^0.64.0",
 		"@sinclair/typebox": "^0.34.48",
 		"@types/bun": "^1.3.9",
 		"bun-types": "^1.3.9",

--- a/packages/coder/src/inbound-rpc.ts
+++ b/packages/coder/src/inbound-rpc.ts
@@ -1,0 +1,35 @@
+export function buildInboundRpcPromptText(command: Record<string, unknown>): string | null {
+	const rawText =
+		typeof command.message === 'string'
+			? command.message
+			: typeof command.text === 'string'
+				? command.text
+				: '';
+	const promptText = rawText.trim();
+	if (!promptText) return null;
+
+	const targetAgent =
+		typeof command.agent === 'string'
+			? command.agent.trim()
+			: typeof command.targetAgent === 'string'
+				? command.targetAgent.trim()
+				: '';
+	if (targetAgent && targetAgent !== 'lead') {
+		return `@${targetAgent} ${promptText}`;
+	}
+
+	return promptText;
+}
+
+export function getInboundRpcDeliverAs(
+	commandType: string,
+	isIdle: boolean
+): 'steer' | 'followUp' | undefined {
+	if (commandType === 'steer') {
+		return isIdle ? undefined : 'steer';
+	}
+	if (commandType === 'prompt' || commandType === 'follow_up') {
+		return isIdle ? undefined : 'followUp';
+	}
+	return undefined;
+}

--- a/packages/coder/src/index.ts
+++ b/packages/coder/src/index.ts
@@ -20,6 +20,7 @@ import { HubOverlay } from './hub-overlay.ts';
 import { OutputViewerOverlay, type StoredResult } from './output-viewer.ts';
 import { setNativeRemoteExtensionContext } from './native-remote-ui-context.ts';
 import { handleRemoteUiRequest } from './remote-ui-handler.ts';
+import { buildInboundRpcPromptText, getInboundRpcDeliverAs } from './inbound-rpc.ts';
 import type {
 	HubAction,
 	HubResponse,
@@ -478,39 +479,6 @@ export function agentuityCoderHub(pi: ExtensionAPI) {
 		}
 	};
 
-	function buildInboundRpcPromptText(command: Record<string, unknown>): string | null {
-		const rawText =
-			typeof command.message === 'string'
-				? command.message
-				: typeof command.text === 'string'
-					? command.text
-					: '';
-		const promptText = rawText.trim();
-		if (!promptText) return null;
-
-		const targetAgent =
-			typeof command.agent === 'string'
-				? command.agent.trim()
-				: typeof command.targetAgent === 'string'
-					? command.targetAgent.trim()
-					: '';
-		if (targetAgent && targetAgent !== 'lead') {
-			return `@${targetAgent} ${promptText}`;
-		}
-		return promptText;
-	}
-
-	function getInboundRpcDeliverAs(commandType: string): 'steer' | 'followUp' | undefined {
-		const isIdle = footerCtx?.isIdle() ?? true;
-		if (commandType === 'steer') {
-			return isIdle ? undefined : 'steer';
-		}
-		if (commandType === 'prompt' || commandType === 'follow_up') {
-			return isIdle ? undefined : 'followUp';
-		}
-		return undefined;
-	}
-
 	function handleInboundRpcCommand(message: Record<string, unknown>): void {
 		const command = message.command as Record<string, unknown> | undefined;
 		if (!command) {
@@ -544,7 +512,7 @@ export function agentuityCoderHub(pi: ExtensionAPI) {
 			log(`Inbound rpc ${commandType} included attachments; native TUI forwarding text only`);
 		}
 
-		const deliverAs = getInboundRpcDeliverAs(commandType);
+		const deliverAs = getInboundRpcDeliverAs(commandType, footerCtx?.isIdle() ?? true);
 		try {
 			if (deliverAs) {
 				pi.sendUserMessage(promptText, { deliverAs });
@@ -1692,7 +1660,6 @@ async function loadPiSdk(): Promise<{ piSdk: unknown; piAi: unknown }> {
 	// Try direct import first (works if packages are in module resolution path)
 	try {
 		const piSdk = await import('@mariozechner/pi-coding-agent');
-		// @ts-expect-error pi-ai is a runtime dependency available inside Pi's process
 		const piAi = await import('@mariozechner/pi-ai');
 		_piSdkCache = { piSdk, piAi };
 		return _piSdkCache;

--- a/packages/coder/test/inbound-rpc.test.ts
+++ b/packages/coder/test/inbound-rpc.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'bun:test';
+import { buildInboundRpcPromptText, getInboundRpcDeliverAs } from '../src/inbound-rpc.ts';
+
+describe('inbound rpc helpers', () => {
+	it('prefixes non-lead targeted prompts with the agent mention', () => {
+		expect(
+			buildInboundRpcPromptText({
+				type: 'prompt',
+				message: 'Review this diff',
+				targetAgent: 'reviewer',
+			})
+		).toBe('@reviewer Review this diff');
+
+		expect(
+			buildInboundRpcPromptText({
+				type: 'prompt',
+				message: 'Handle orchestration',
+				targetAgent: 'lead',
+			})
+		).toBe('Handle orchestration');
+	});
+
+	it('routes active prompt and follow-up commands as followUp deliveries', () => {
+		expect(getInboundRpcDeliverAs('prompt', false)).toBe('followUp');
+		expect(getInboundRpcDeliverAs('follow_up', false)).toBe('followUp');
+		expect(getInboundRpcDeliverAs('prompt', true)).toBeUndefined();
+	});
+
+	it('routes active steer commands as steer deliveries', () => {
+		expect(getInboundRpcDeliverAs('steer', false)).toBe('steer');
+		expect(getInboundRpcDeliverAs('steer', true)).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary
- upgrade `@agentuity/coder` Pi peer/dev targets to `^0.64.0`
- add the local `@mariozechner/pi-ai` dev dependency needed for SDK typecheck/build
- remove the stale Pi SDK suppression and add targeted tests for inbound RPC follow-up routing

## Validation
- `bun run --filter='./packages/coder' typecheck`
- `bun run --filter='./packages/coder' build`
- `bun test` (in `packages/coder`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Updated package dependencies to version ^0.64.0.

* **Improvements**
  * Enhanced command state detection for more accurate routing based on idle/active status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->