### PR TITLE
fix: pass cron schedule expression through route metadata pipeline (#…

### DIFF
--- a/packages/cli/src/cmd/build/vite/route-discovery.ts
+++ b/packages/cli/src/cmd/build/vite/route-discovery.ts
@@ -180,6 +180,13 @@ export async function discoverRoutes(
 					version
 				);
 
+				// Extract type-specific config from route metadata
+				const meta =
+					typeof route.handler === 'function'
+						? (route.handler as any)[Symbol.for('agentuity:route-meta')]
+						: undefined;
+				const config = meta?.schedule ? { expression: meta.schedule } : undefined;
+
 				routes.push({
 					id,
 					filename: toForwardSlash(relative(rootDir, mount.routerFile)),
@@ -187,6 +194,7 @@ export async function discoverRoutes(
 					method,
 					version,
 					type: routeType,
+					config,
 				});
 			}
 

--- a/packages/runtime/src/handlers/_route-meta.ts
+++ b/packages/runtime/src/handlers/_route-meta.ts
@@ -10,6 +10,8 @@ export const ROUTE_META = Symbol.for('agentuity:route-meta');
 
 export interface RouteMeta {
 	type: 'websocket' | 'sse' | 'stream' | 'cron';
+	/** Cron schedule expression (only for type: 'cron') */
+	schedule?: string;
 }
 
 /**

--- a/packages/runtime/src/handlers/cron.ts
+++ b/packages/runtime/src/handlers/cron.ts
@@ -129,7 +129,7 @@ export function cron<E extends Env = Env>(
 		return returnResponse(c, result);
 	};
 
-	return tagRoute(cronHandler, { type: 'cron' });
+	return tagRoute(cronHandler, { type: 'cron', schedule: _schedule });
 }
 
 /**

--- a/packages/runtime/test/cron.test.ts
+++ b/packages/runtime/test/cron.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for the cron() route handler.
+ *
+ * Verifies that:
+ * - cron() returns a handler tagged with route-meta symbol
+ * - The schedule expression is preserved in route metadata
+ * - Both overloads (with and without options) work correctly
+ * - POST-only enforcement works
+ * - Auth verification works when enabled
+ */
+
+import { test, expect, describe } from 'bun:test';
+import { Hono } from 'hono';
+import { cron } from '../src/handlers/cron';
+import { ROUTE_META, getRouteMeta } from '../src/handlers/_route-meta';
+
+describe('cron() handler', () => {
+	describe('route metadata tagging', () => {
+		test('tags handler with type "cron" and schedule expression', () => {
+			const handler = cron('0 9 * * 1', { auth: false }, async (c) => {
+				return c.text('OK');
+			});
+
+			const meta = (handler as any)[ROUTE_META];
+			expect(meta).toBeDefined();
+			expect(meta.type).toBe('cron');
+			expect(meta.schedule).toBe('0 9 * * 1');
+		});
+
+		test('preserves complex cron expressions', () => {
+			const handler = cron('*/5 * * * *', { auth: false }, async (c) => {
+				return c.text('OK');
+			});
+
+			const meta = (handler as any)[ROUTE_META];
+			expect(meta.schedule).toBe('*/5 * * * *');
+		});
+
+		test('preserves daily-at-midnight expression', () => {
+			const handler = cron('0 0 * * *', { auth: true }, async (c) => {
+				return c.text('OK');
+			});
+
+			const meta = (handler as any)[ROUTE_META];
+			expect(meta.type).toBe('cron');
+			expect(meta.schedule).toBe('0 0 * * *');
+		});
+
+		test('deprecated overload (no options) also tags schedule', () => {
+			const handler = cron('30 2 * * 0', async (c) => {
+				return c.text('OK');
+			});
+
+			const meta = (handler as any)[ROUTE_META];
+			expect(meta).toBeDefined();
+			expect(meta.type).toBe('cron');
+			expect(meta.schedule).toBe('30 2 * * 0');
+		});
+
+		test('getRouteMeta() returns schedule from cron handler', () => {
+			const handler = cron('0 12 * * *', { auth: false }, async (c) => {
+				return c.text('OK');
+			});
+
+			const meta = getRouteMeta(handler);
+			expect(meta).toBeDefined();
+			expect(meta!.type).toBe('cron');
+			expect(meta!.schedule).toBe('0 12 * * *');
+		});
+	});
+
+	describe('handler behavior', () => {
+		test('handler executes on POST request', async () => {
+			const app = new Hono();
+			app.post(
+				'/scheduled',
+				cron('0 9 * * 1', { auth: false }, async (c) => {
+					return c.json({ status: 'executed' });
+				})
+			);
+
+			const res = await app.request('/scheduled', { method: 'POST' });
+			expect(res.status).toBe(200);
+			const data = await res.json();
+			expect(data).toEqual({ status: 'executed' });
+		});
+
+		test('handler rejects non-POST methods', async () => {
+			const app = new Hono();
+			// Register on ALL methods so the route matches GET
+			app.all(
+				'/scheduled',
+				cron('0 9 * * 1', { auth: false }, async (c) => {
+					return c.text('OK');
+				})
+			);
+
+			const res = await app.request('/scheduled', { method: 'GET' });
+			// The handler throws an error for non-POST, which Hono converts to 500
+			expect(res.status).toBe(500);
+		});
+	});
+
+	describe('route discovery integration', () => {
+		test('schedule is readable from Hono router.routes', () => {
+			const app = new Hono();
+			app.post(
+				'/daily',
+				cron('0 0 * * *', { auth: true }, async (c) => {
+					return c.text('OK');
+				})
+			);
+
+			// Simulate what route-discovery.ts does: iterate router.routes
+			// and read the route-meta symbol from each handler
+			const cronRoutes = app.routes
+				.filter((r) => {
+					const meta = (r.handler as any)[Symbol.for('agentuity:route-meta')];
+					return meta?.type === 'cron';
+				})
+				.map((r) => {
+					const meta = (r.handler as any)[Symbol.for('agentuity:route-meta')];
+					return {
+						path: r.path,
+						method: r.method,
+						type: meta.type,
+						schedule: meta.schedule,
+					};
+				});
+
+			expect(cronRoutes).toHaveLength(1);
+			expect(cronRoutes[0]).toEqual({
+				path: '/daily',
+				method: 'POST',
+				type: 'cron',
+				schedule: '0 0 * * *',
+			});
+		});
+
+		test('schedule produces correct config.expression for metadata', () => {
+			const handler = cron('0 9 * * 1', { auth: true }, async (c) => {
+				return c.text('OK');
+			});
+
+			// Simulate what route-discovery.ts does when building config
+			const meta = (handler as any)[Symbol.for('agentuity:route-meta')];
+			const config = meta?.schedule ? { expression: meta.schedule } : undefined;
+
+			expect(config).toEqual({ expression: '0 9 * * 1' });
+		});
+	});
+});


### PR DESCRIPTION
…1328)

The cron() handler was tagging routes with { type: 'cron' } but discarding the schedule expression. The platform expects config.expression for cron routes, causing deployment to fail with 'expected config.expression for cron route'.

Three-point fix across the metadata pipeline:

1. _route-meta.ts: Add optional 'schedule' field to RouteMeta interface
2. cron.ts: Include schedule in tagRoute() call instead of discarding it
3. route-discovery.ts: Extract schedule from route meta into config.expression when building route metadata

Also adds cron.test.ts with 9 tests covering metadata tagging, both overloads, handler behavior, and route discovery integration.

Closes #1328

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for cron scheduled routes with configurable schedule expressions.
  * Routes now extract and include schedule configuration metadata during discovery.

* **Tests**
  * Added comprehensive test coverage for cron route handlers and metadata extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->