### PR TITLE
Add enabled agent roster support to the coder SDK

### DIFF
--- a/packages/cli/src/cmd/coder/create.ts
+++ b/packages/cli/src/cmd/coder/create.ts
@@ -46,9 +46,9 @@ export const createCoderSubcommand = createSubcommand({
 		},
 		{
 			command: getCommand(
-				'coder create "Review this change" --default-agent code-review --agent-slugs code-review'
+				'coder create "Review this change" --default-agent code-review --enabled-agents code-review'
 			),
-			description: 'Create with published custom agents and a custom default route target',
+			description: 'Create with a selected agent roster and a custom default route target',
 		},
 	],
 	schema: {
@@ -96,10 +96,10 @@ export const createCoderSubcommand = createSubcommand({
 			// Resources
 			workspaceId: z.string().optional().describe('Workspace ID to use'),
 			tags: z.string().optional().describe('Comma-separated tags'),
-			agentSlugs: z
+			enabledAgents: z
 				.string()
 				.optional()
-				.describe('Comma-separated published custom agent slugs to include'),
+				.describe('Comma-separated built-in/custom agents to include'),
 			env: z
 				.string()
 				.optional()
@@ -121,7 +121,7 @@ export const createCoderSubcommand = createSubcommand({
 		// Build the create session request body from flags
 		const body: CoderCreateSessionRequest & {
 			defaultAgent?: string;
-			agentSlugs?: string[];
+			enabledAgents?: string[];
 		} = {
 			task: args.task,
 			...(opts?.label && { label: opts.label }),
@@ -167,10 +167,10 @@ export const createCoderSubcommand = createSubcommand({
 				.split(',')
 				.map((t) => t.trim())
 				.filter(Boolean);
-		if (opts?.agentSlugs)
-			body.agentSlugs = opts.agentSlugs
+		if (opts?.enabledAgents)
+			body.enabledAgents = opts.enabledAgents
 				.split(',')
-				.map((slug) => slug.trim())
+				.map((name) => name.trim())
 				.filter(Boolean);
 		if (opts?.savedSkillIds)
 			body.savedSkillIds = opts.savedSkillIds

--- a/packages/cli/src/cmd/coder/update.ts
+++ b/packages/cli/src/cmd/coder/update.ts
@@ -54,10 +54,10 @@ export const updateSubcommand = createSubcommand({
 			loopAutoContinue: z.boolean().optional().describe('Auto-continue loop'),
 			loopAllowDetached: z.boolean().optional().describe('Allow detached loop execution'),
 			tags: z.string().optional().describe('Comma-separated tags (replaces existing)'),
-			agentSlugs: z
+			enabledAgents: z
 				.string()
 				.optional()
-				.describe('Comma-separated published custom agent slugs (replaces existing)'),
+				.describe('Comma-separated built-in/custom agents (replaces existing)'),
 		}),
 	},
 	async handler(ctx) {
@@ -81,10 +81,10 @@ export const updateSubcommand = createSubcommand({
 				.map((t) => t.trim())
 				.filter(Boolean);
 		}
-		if (opts?.agentSlugs) {
-			body.agentSlugs = opts.agentSlugs
+		if (opts?.enabledAgents) {
+			body.enabledAgents = opts.enabledAgents
 				.split(',')
-				.map((slug) => slug.trim())
+				.map((name) => name.trim())
 				.filter(Boolean);
 		}
 
@@ -105,7 +105,7 @@ export const updateSubcommand = createSubcommand({
 
 		if (Object.keys(body).length === 0) {
 			tui.fatal(
-				'No update fields provided. Use --label, --visibility, --tags, --agent, --default-agent, --agent-slugs, --workflow-mode, or loop options.',
+				'No update fields provided. Use --label, --visibility, --tags, --agent, --default-agent, --enabled-agents, --workflow-mode, or loop options.',
 				ErrorCode.VALIDATION_FAILED
 			);
 		}
@@ -125,7 +125,7 @@ export const updateSubcommand = createSubcommand({
 			if (opts?.tags) fields.push(`Tags: ${(body.tags as string[]).join(', ')}`);
 			if (opts?.agent) fields.push(`Agent: ${opts.agent}`);
 			if (opts?.defaultAgent) fields.push(`Default agent: ${opts.defaultAgent}`);
-			if (opts?.agentSlugs) fields.push(`Custom agents: ${opts.agentSlugs}`);
+			if (opts?.enabledAgents) fields.push(`Enabled agents: ${opts.enabledAgents}`);
 			if (opts?.workflowMode || body.loop) fields.push(`Workflow: ${body.workflowMode}`);
 
 			for (const f of fields) {

--- a/packages/cli/src/cmd/coder/workspace/create.ts
+++ b/packages/cli/src/cmd/coder/workspace/create.ts
@@ -45,10 +45,10 @@ export const createWorkspaceSubcommand = createSubcommand({
 			scope: z.string().optional().describe('Workspace scope: user or org'),
 			repo: z.string().optional().describe('Repository URL to add'),
 			repoBranch: z.string().optional().describe('Branch for the repository'),
-			agentSlugs: z
+			enabledAgents: z
 				.string()
 				.optional()
-				.describe('Comma-separated published custom agent slugs to add'),
+				.describe('Comma-separated built-in/custom agents to include'),
 		}),
 	},
 	async handler(ctx) {
@@ -60,7 +60,7 @@ export const createWorkspaceSubcommand = createSubcommand({
 		});
 
 		const body: CoderCreateWorkspaceRequest & {
-			agentSlugs?: string[];
+			enabledAgents?: string[];
 		} = {
 			name: args.name,
 			...(opts?.description && { description: opts.description }),
@@ -78,17 +78,17 @@ export const createWorkspaceSubcommand = createSubcommand({
 				return;
 			}
 		}
-		if (opts?.agentSlugs) {
-			body.agentSlugs = opts.agentSlugs
+		if (opts?.enabledAgents) {
+			body.enabledAgents = opts.enabledAgents
 				.split(',')
-				.map((slug) => slug.trim())
+				.map((name) => name.trim())
 				.filter(Boolean);
 		}
 
 		try {
 			const created = await client.createWorkspace(body);
-			const createdAgentSlugs = Array.isArray(created.agentSlugs)
-				? created.agentSlugs.filter((slug): slug is string => typeof slug === 'string')
+			const createdEnabledAgents = Array.isArray(created.enabledAgents)
+				? created.enabledAgents.filter((name): name is string => typeof name === 'string')
 				: [];
 
 			if (options.json) {
@@ -104,8 +104,8 @@ export const createWorkspaceSubcommand = createSubcommand({
 			tui.output(`  Scope:       ${created.scope}`);
 			tui.output(`  Repos:       ${created.repoCount}`);
 			tui.output(`  Selections:  ${created.selectionCount}`);
-			if (createdAgentSlugs.length > 0) {
-				tui.output(`  Agents:      ${createdAgentSlugs.join(', ')}`);
+			if (createdEnabledAgents.length > 0) {
+				tui.output(`  Agents:      ${createdEnabledAgents.join(', ')}`);
 			}
 
 			return created;

--- a/packages/coder-tui/src/protocol.ts
+++ b/packages/coder-tui/src/protocol.ts
@@ -381,7 +381,7 @@ export interface SessionListItem {
 	participantCount: number;
 	tags: string[];
 	skills: SessionSkillRef[];
-	agentSlugs: string[];
+	enabledAgents: string[];
 	defaultAgent?: string;
 	bucket: SessionBucket;
 	runtimeAvailable: boolean;
@@ -530,7 +530,7 @@ export interface SessionSnapshotMetadataExtensions {
 	product?: SessionProductProjection;
 	tags: string[];
 	skills: SessionSkillRef[];
-	agentSlugs: string[];
+	enabledAgents: string[];
 	defaultAgent?: string;
 	workers?: SessionListItem[];
 }

--- a/packages/core/src/services/coder/api-reference.ts
+++ b/packages/core/src/services/coder/api-reference.ts
@@ -451,8 +451,8 @@ const service: Service = {
 				slug: 'code-review',
 				displayName: 'Code Review',
 				instructions: 'Focus on correctness, regressions, and missing tests.',
-				piTools: ['read', 'grep', 'ls'],
-				hubToolNames: ['session_todo_list', 'session_todo_update'],
+				tools: ['read', 'grep', 'ls'],
+				serviceTools: ['session_todo_list', 'session_todo_update'],
 			},
 		},
 		{

--- a/packages/core/src/services/coder/types.ts
+++ b/packages/core/src/services/coder/types.ts
@@ -133,7 +133,7 @@ export const CoderCustomAgentThinkingLevelSchema = z
 	.describe('Thinking level override for a custom agent');
 export type CoderCustomAgentThinkingLevel = z.infer<typeof CoderCustomAgentThinkingLevelSchema>;
 
-export const CODER_CUSTOM_AGENT_PI_TOOLS = [
+export const CODER_CUSTOM_AGENT_TOOLS = [
 	'read',
 	'ls',
 	'find',
@@ -143,17 +143,17 @@ export const CODER_CUSTOM_AGENT_PI_TOOLS = [
 	'edit',
 ] as const;
 
-export const CoderCustomAgentPiToolSchema = z
-	.enum(CODER_CUSTOM_AGENT_PI_TOOLS)
+export const CoderCustomAgentToolSchema = z
+	.enum(CODER_CUSTOM_AGENT_TOOLS)
 	.describe('Workspace tool available to a standalone custom agent');
-export type CoderCustomAgentPiTool = z.infer<typeof CoderCustomAgentPiToolSchema>;
+export type CoderCustomAgentTool = z.infer<typeof CoderCustomAgentToolSchema>;
 
-export const CoderCustomAgentPiToolResponseSchema = z
-	.union([CoderCustomAgentPiToolSchema, z.string()])
-	.describe('Pi workspace tool granted to a standalone custom agent');
-export type CoderCustomAgentPiToolResponse = z.infer<typeof CoderCustomAgentPiToolResponseSchema>;
+export const CoderCustomAgentToolResponseSchema = z
+	.union([CoderCustomAgentToolSchema, z.string()])
+	.describe('Workspace tool granted to a standalone custom agent');
+export type CoderCustomAgentToolResponse = z.infer<typeof CoderCustomAgentToolResponseSchema>;
 
-export const CODER_CUSTOM_AGENT_HUB_TOOLS = [
+export const CODER_CUSTOM_AGENT_SERVICE_TOOLS = [
 	'session_dashboard',
 	'memory_service_search',
 	'memory_service_store',
@@ -198,15 +198,17 @@ export const CODER_CUSTOM_AGENT_HUB_TOOLS = [
 	'coord_spawn_workers',
 ] as const;
 
-export const CoderCustomAgentHubToolSchema = z
-	.enum(CODER_CUSTOM_AGENT_HUB_TOOLS)
-	.describe('Hub-managed tool available to a standalone custom agent');
-export type CoderCustomAgentHubTool = z.infer<typeof CoderCustomAgentHubToolSchema>;
+export const CoderCustomAgentServiceToolSchema = z
+	.enum(CODER_CUSTOM_AGENT_SERVICE_TOOLS)
+	.describe('Service tool available to a standalone custom agent');
+export type CoderCustomAgentServiceTool = z.infer<typeof CoderCustomAgentServiceToolSchema>;
 
-export const CoderCustomAgentHubToolResponseSchema = z
-	.union([CoderCustomAgentHubToolSchema, z.string()])
-	.describe('Hub-managed tool granted to a standalone custom agent');
-export type CoderCustomAgentHubToolResponse = z.infer<typeof CoderCustomAgentHubToolResponseSchema>;
+export const CoderCustomAgentServiceToolResponseSchema = z
+	.union([CoderCustomAgentServiceToolSchema, z.string()])
+	.describe('Service tool granted to a standalone custom agent');
+export type CoderCustomAgentServiceToolResponse = z.infer<
+	typeof CoderCustomAgentServiceToolResponseSchema
+>;
 
 export const CoderCustomAgentSnapshotSchema = z
 	.object({
@@ -221,12 +223,12 @@ export const CoderCustomAgentSnapshotSchema = z
 		headlessCompatible: z
 			.boolean()
 			.describe('Whether the custom agent is safe for non-interactive callers'),
-		piTools: z
-			.array(CoderCustomAgentPiToolResponseSchema)
-			.describe('Pi workspace tools granted to the custom agent'),
-		hubToolNames: z
-			.array(CoderCustomAgentHubToolResponseSchema)
-			.describe('Hub-managed tools granted to the custom agent'),
+		tools: z
+			.array(CoderCustomAgentToolResponseSchema)
+			.describe('Workspace tools granted to the custom agent'),
+		serviceTools: z
+			.array(CoderCustomAgentServiceToolResponseSchema)
+			.describe('Service tools granted to the custom agent'),
 		savedSkills: z
 			.array(CoderSkillRefSchema)
 			.describe('Frozen saved-skill refs attached to the custom agent snapshot'),
@@ -347,14 +349,14 @@ export const CoderCreateCustomAgentRequestSchema = z
 			.boolean()
 			.optional()
 			.describe('Whether the custom agent is safe for non-interactive callers'),
-		piTools: z
-			.array(CoderCustomAgentPiToolSchema)
+		tools: z
+			.array(CoderCustomAgentToolSchema)
 			.optional()
-			.describe('Pi workspace tools to grant to the custom agent'),
-		hubToolNames: z
-			.array(CoderCustomAgentHubToolSchema)
+			.describe('Workspace tools to grant to the custom agent'),
+		serviceTools: z
+			.array(CoderCustomAgentServiceToolSchema)
 			.optional()
-			.describe('Hub-managed tools to grant to the custom agent'),
+			.describe('Service tools to grant to the custom agent'),
 		savedSkillIds: z
 			.array(z.string())
 			.optional()
@@ -381,14 +383,14 @@ export const CoderUpdateCustomAgentRequestSchema = z
 			.boolean()
 			.optional()
 			.describe('Whether the custom agent is safe for non-interactive callers'),
-		piTools: z
-			.array(CoderCustomAgentPiToolSchema)
+		tools: z
+			.array(CoderCustomAgentToolSchema)
 			.optional()
-			.describe('Pi workspace tools to grant to the custom agent'),
-		hubToolNames: z
-			.array(CoderCustomAgentHubToolSchema)
+			.describe('Workspace tools to grant to the custom agent'),
+		serviceTools: z
+			.array(CoderCustomAgentServiceToolSchema)
 			.optional()
-			.describe('Hub-managed tools to grant to the custom agent'),
+			.describe('Service tools to grant to the custom agent'),
 		savedSkillIds: z
 			.array(z.string())
 			.optional()

--- a/packages/core/src/services/coder/types.ts
+++ b/packages/core/src/services/coder/types.ts
@@ -115,11 +115,11 @@ export const CoderWorkspaceDetailSchema = z
 		repoCount: z.number().describe('Number of repositories'),
 		savedSkillIds: z.array(z.string()).describe('Saved skill IDs in workspace'),
 		skillBucketIds: z.array(z.string()).describe('Skill bucket IDs in workspace'),
-		agentSlugs: z
+		enabledAgents: z
 			.array(z.string())
 			.optional()
 			.default([])
-			.describe('Published custom agent slugs in workspace'),
+			.describe('Effective agent roster stored on the workspace'),
 		selectionCount: z.number().describe('Total number of selections'),
 		createdAt: z.string().describe('Creation timestamp (ISO-8601)'),
 		updatedAt: z.string().describe('Last update timestamp (ISO-8601)'),
@@ -230,6 +230,9 @@ export const CoderCustomAgentSnapshotSchema = z
 		savedSkills: z
 			.array(CoderSkillRefSchema)
 			.describe('Frozen saved-skill refs attached to the custom agent snapshot'),
+		companionAgents: z
+			.array(z.string())
+			.describe('Companion agents auto-included alongside this custom agent'),
 	})
 	.passthrough()
 	.describe('Custom agent snapshot returned by coder hub');
@@ -324,7 +327,7 @@ export const CoderCreateWorkspaceRequestSchema = z
 		repos: z.array(CoderSessionRepositoryRefSchema).optional().describe('Repositories'),
 		savedSkillIds: z.array(z.string()).optional().describe('Saved skill IDs'),
 		skillBucketIds: z.array(z.string()).optional().describe('Skill bucket IDs'),
-		agentSlugs: z.array(z.string()).optional().describe('Published custom agent slugs'),
+		enabledAgents: z.array(z.string()).optional().describe('Effective agent roster to store on the workspace'),
 	})
 	.describe('Request body for creating a workspace');
 export type CoderCreateWorkspaceRequest = z.infer<typeof CoderCreateWorkspaceRequestSchema>;
@@ -355,6 +358,10 @@ export const CoderCreateCustomAgentRequestSchema = z
 			.array(z.string())
 			.optional()
 			.describe('Saved skill row ids to snapshot onto the custom agent'),
+		companionAgents: z
+			.array(z.string())
+			.optional()
+			.describe('Agent names to auto-include alongside this custom agent'),
 	})
 	.describe('Request body for creating a custom agent draft');
 export type CoderCreateCustomAgentRequest = z.infer<typeof CoderCreateCustomAgentRequestSchema>;
@@ -385,6 +392,10 @@ export const CoderUpdateCustomAgentRequestSchema = z
 			.array(z.string())
 			.optional()
 			.describe('Saved skill row ids to snapshot onto the custom agent'),
+		companionAgents: z
+			.array(z.string())
+			.optional()
+			.describe('Agent names to auto-include alongside this custom agent'),
 	})
 	.describe('Request body for updating a custom agent draft');
 export type CoderUpdateCustomAgentRequest = z.infer<typeof CoderUpdateCustomAgentRequestSchema>;
@@ -447,10 +458,10 @@ export const CoderCreateSessionRequestSchema = z
 		workflowMode: CoderWorkflowModeSchema.optional().describe('Workflow execution mode'),
 		loop: CoderSessionLoopConfigSchema.optional().describe('Loop mode settings for the session'),
 		tags: z.array(z.string()).optional().describe('Tags applied to the session for filtering'),
-		agentSlugs: z
+		enabledAgents: z
 			.array(z.string())
 			.optional()
-			.describe('Published custom agent slugs to include in the session'),
+			.describe('Enabled agent roster to include in the session'),
 		savedSkillIds: z
 			.array(z.string())
 			.optional()
@@ -495,10 +506,10 @@ export const CoderUpdateSessionRequestSchema = z
 		workflowMode: CoderWorkflowModeSchema.optional().describe('Updated workflow mode'),
 		loop: CoderSessionLoopConfigSchema.optional().describe('Updated loop mode configuration'),
 		tags: z.array(z.string()).optional().describe('Updated set of tags for the session'),
-		agentSlugs: z
+		enabledAgents: z
 			.array(z.string())
 			.optional()
-			.describe('Updated published custom agent slugs included in the session'),
+			.describe('Updated enabled agent roster for the session'),
 		skills: z
 			.array(CoderSkillRefSchema)
 			.optional()
@@ -580,11 +591,11 @@ export const CoderSessionListItemSchema = z
 		participantCount: z.number().describe('Total number of participants in the session'),
 		tags: z.array(z.string()).describe('Tag values attached to the session'),
 		skills: z.array(CoderSkillRefSchema).describe('Skills attached to the session'),
-		agentSlugs: z
+		enabledAgents: z
 			.array(z.string())
 			.optional()
 			.default([])
-			.describe('Published custom agent slugs attached to the session'),
+			.describe('Enabled agent roster attached to the session'),
 		defaultAgent: z.string().optional().describe('Default agent assigned to session operations'),
 		bucket: CoderSessionBucketSchema.describe('Derived bucket for session listing'),
 		runtimeAvailable: z.boolean().describe('Whether runtime is currently reachable'),

--- a/packages/core/src/services/coder/types.ts
+++ b/packages/core/src/services/coder/types.ts
@@ -232,6 +232,7 @@ export const CoderCustomAgentSnapshotSchema = z
 			.describe('Frozen saved-skill refs attached to the custom agent snapshot'),
 		companionAgents: z
 			.array(z.string())
+			.default([])
 			.describe('Companion agents auto-included alongside this custom agent'),
 	})
 	.passthrough()

--- a/packages/core/test/coder-client.test.ts
+++ b/packages/core/test/coder-client.test.ts
@@ -46,8 +46,8 @@ function makeCustomAgent(overrides: Record<string, unknown> = {}) {
 		description: 'Review changes for regressions',
 		instructions: 'Focus on correctness, regressions, and missing tests.',
 		headlessCompatible: true,
-		piTools: ['read', 'grep', 'ls'],
-		hubToolNames: ['session_todo_list', 'session_todo_update'],
+		tools: ['read', 'grep', 'ls'],
+		serviceTools: ['session_todo_list', 'session_todo_update'],
 		companionAgents: [],
 		savedSkills: [],
 		...overrides,
@@ -389,8 +389,8 @@ describe('CoderClient custom agent helpers', () => {
 				slug: 'code-review',
 				displayName: 'Code Review',
 				instructions: 'Focus on correctness, regressions, and missing tests.',
-				piTools: ['read', 'grep', 'ls'],
-				hubToolNames: ['session_todo_list', 'session_todo_update'],
+				tools: ['read', 'grep', 'ls'],
+				serviceTools: ['session_todo_list', 'session_todo_update'],
 				savedSkillIds: ['saved_1'],
 			})
 		).resolves.toMatchObject({
@@ -428,8 +428,8 @@ describe('CoderClient custom agent helpers', () => {
 				JSON.stringify({
 					agents: [
 						makeCustomAgent({
-							piTools: ['read', 'future_pi_tool'],
-							hubToolNames: ['session_todo_list', 'future_hub_tool'],
+							tools: ['read', 'future_pi_tool'],
+							serviceTools: ['session_todo_list', 'future_hub_tool'],
 						}),
 					],
 				}),
@@ -447,8 +447,8 @@ describe('CoderClient custom agent helpers', () => {
 		});
 
 		const response = await client.listCustomAgents();
-		expect(response.agents[0]?.piTools).toEqual(['read', 'future_pi_tool']);
-		expect(response.agents[0]?.hubToolNames).toEqual(['session_todo_list', 'future_hub_tool']);
+		expect(response.agents[0]?.tools).toEqual(['read', 'future_pi_tool']);
+		expect(response.agents[0]?.serviceTools).toEqual(['session_todo_list', 'future_hub_tool']);
 	});
 
 	test('listCustomAgents defaults missing companionAgents to an empty array', async () => {

--- a/packages/core/test/coder-client.test.ts
+++ b/packages/core/test/coder-client.test.ts
@@ -20,7 +20,7 @@ function makeSession(overrides: Record<string, unknown> = {}) {
 		participantCount: 0,
 		tags: [],
 		skills: [],
-		agentSlugs: [],
+		enabledAgents: [],
 		bucket: 'paused',
 		runtimeAvailable: false,
 		controlAvailable: false,
@@ -48,6 +48,7 @@ function makeCustomAgent(overrides: Record<string, unknown> = {}) {
 		headlessCompatible: true,
 		piTools: ['read', 'grep', 'ls'],
 		hubToolNames: ['session_todo_list', 'session_todo_update'],
+		companionAgents: [],
 		savedSkills: [],
 		...overrides,
 	};

--- a/packages/core/test/coder-client.test.ts
+++ b/packages/core/test/coder-client.test.ts
@@ -451,6 +451,35 @@ describe('CoderClient custom agent helpers', () => {
 		expect(response.agents[0]?.hubToolNames).toEqual(['session_todo_list', 'future_hub_tool']);
 	});
 
+	test('listCustomAgents defaults missing companionAgents to an empty array', async () => {
+		mockFetch(async (url, init) => {
+			expect(url).toBe('https://coder.example/api/hub/agents');
+			expect(init?.method).toBe('GET');
+			return new Response(
+				JSON.stringify({
+					agents: [
+						makeCustomAgent({
+							companionAgents: undefined,
+						}),
+					],
+				}),
+				{
+					status: 200,
+					headers: { 'content-type': 'application/json' },
+				}
+			);
+		});
+
+		const client = new CoderClient({
+			apiKey: 'ag_test',
+			url: 'https://coder.example',
+			orgId: 'org_test',
+		});
+
+		const response = await client.listCustomAgents();
+		expect(response.agents[0]?.companionAgents).toEqual([]);
+	});
+
 	test('publishCustomAgent posts to the publish endpoint and returns the updated agent', async () => {
 		mockFetch(async (url, init) => {
 			expect(url).toBe('https://coder.example/api/hub/agents/code-review/publish');


### PR DESCRIPTION
## Summary
- add `enabledAgents` session/workspace support and `companionAgents` custom-agent support across `packages/core`
- add first-class custom-agent client methods to the coder SDK surface
- update the CLI to use `--enabled-agents` for session/workspace roster selection
- update coder-tui protocol/session metadata to carry `enabledAgents`

Refs: https://app.agentuity.com/services/task/task_5wQmmqbG7uAEofh6?tab=subtasks
Paired Hub PR: agentuity/coder#25

## SDK functions
Core custom-agent and roster APIs on `CoderClient`:
- `listCustomAgents()`
- `getCustomAgent(agentIdOrSlug)`
- `createCustomAgent(body)`
- `updateCustomAgent(agentIdOrSlug, body)`
- `publishCustomAgent(agentIdOrSlug)`
- `archiveCustomAgent(agentIdOrSlug)`
- `listCustomAgentVersions(agentIdOrSlug)`
- `createSession({ enabledAgents, defaultAgent, ... })`
- `updateSession(sessionId, { enabledAgents, defaultAgent, ... })`
- `createWorkspace({ enabledAgents, ... })`

## TypeScript example
```ts
import { CoderClient } from '@agentuity/sdk';

const client = new CoderClient({ baseUrl: process.env.CODER_URL! });

const agent = await client.createCustomAgent({
  name: 'QA Team',
  description: 'Coordinates browser and API verification.',
  instructions: 'You are QA Team. Triage failures, coordinate testing, and summarize risk clearly.',
  tools: ['read', 'grep', 'find', 'ls', 'bash'],
  serviceTools: ['session_dashboard', 'web_search', 'sandbox_exec'],
  companionAgents: ['browser-qa', 'api-qa'],
});

await client.publishCustomAgent(agent.slug);

await client.createSession({
  task: 'Investigate the latest QA failure and summarize next steps.',
  enabledAgents: ['qa-team', 'reviewer'],
  defaultAgent: 'qa-team',
});

await client.createWorkspace({
  name: 'QA Workspace',
  enabledAgents: ['qa-team', 'reviewer'],
});
```

## CLI examples
Create a session with an explicit roster:

```bash
agentuity coder create "Investigate the latest QA failure and summarize next steps" \
  --enabled-agents qa-team,reviewer \
  --default-agent qa-team
```

Update a session roster:

```bash
agentuity coder update codesess_abc123 \
  --enabled-agents qa-team,reviewer,browser-qa \
  --default-agent qa-team
```

Create a workspace with a reusable roster:

```bash
agentuity coder workspace create "QA Workspace" \
  --enabled-agents qa-team,reviewer
```

## Hub endpoints this SDK surface covers
- `GET /api/hub/agents`
- `GET /api/hub/agents/:idOrSlug`
- `POST /api/hub/agents`
- `PATCH /api/hub/agents/:idOrSlug`
- `POST /api/hub/agents/:idOrSlug/publish`
- `POST /api/hub/agents/:idOrSlug/archive`
- `GET /api/hub/agents/:idOrSlug/versions`
- `POST /api/hub/session`
- `PATCH /api/hub/session/:id`
- `POST /api/hub/workspaces`
- `PATCH /api/hub/workspaces/:id`

## Verification
- `cd packages/core && bun run typecheck`
- `cd packages/core && bun test test/coder-client.test.ts`
- `cd packages/cli && bun run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added companion agents support for custom agents; companionAgents are normalized to an empty list when absent.

* **Refactor**
  * Renamed CLI flag `--agent-slugs` to `--enabled-agents` and updated option descriptions to reflect built-in + custom agents.
  * Renamed session/workspace/API fields from `agentSlugs` → `enabledAgents`.
  * Consolidated custom-agent tool fields: `piTools` → `tools` and `hubToolNames` → `serviceTools`, with corresponding exported name updates.

* **Tests**
  * Added unit test verifying companionAgents normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->