### PR TITLE
fix(cli): route DevMode tunnel traffic through the front-door proxy

### DIFF
--- a/packages/cli/src/cmd/dev/index.ts
+++ b/packages/cli/src/cmd/dev/index.ts
@@ -952,7 +952,10 @@ export const command = createCommand({
 							'--endpoint-id',
 							devmode.id,
 							'--port',
-							vitePort.toString(),
+							// Gravity must target the user-facing front-door proxy, not Vite's
+							// internal port. HTTP can reach Bun through Vite's proxy, but public
+							// WebSocket upgrades to /api/* only reach Bun through ws-proxy.
+							opts.port.toString(),
 							'--url',
 							gravityURL,
 							'--log-level',


### PR DESCRIPTION
**NOTE** - I'm not convinced this is the actual solution but it does unblock the issue ive been running in to of the websocket in a sandbox not being able to hit the public tunnel.  so leaving this here as an example.

---

## Summary
- point the DevMode Gravity tunnel at the user-facing front-door proxy port instead of Vite's internal port
- restore public `/api/*` websocket routing through `ws-proxy` to the Bun backend
- fix sandbox driver bootstrap failures in DevMode public URLs

## Root Cause
DevMode starts three listeners:
- front-door proxy on `opts.port`
- Bun backend on `opts.port + 1`
- Vite on `opts.port + 2`

The tunnel process was started with `--port vitePort`, which sent public traffic directly to Vite instead of the front-door proxy.

That produced a misleading partial failure mode:
- public HTTP `/api/*` still worked because Vite proxies normal HTTP requests to Bun
- public websocket `/api/*` failed because backend websocket upgrades are **not** proxied by Vite; they are only routed correctly by `ws-proxy`

In practice this meant:
- deployed environments worked
- local direct websocket connections worked
- public DevMode websocket connections to `/api/ws` opened but never received `init`
- sandbox drivers timed out waiting for bootstrap and exited before connect

## Fix
Start Gravity against `opts.port`, the user-facing front-door proxy, rather than `vitePort`.

## Verification
- `bun test packages/cli/test/cmd/dev/ws-proxy.test.ts`
- manual live verification against Coder DevMode:
  - public raw `wss://<tunnel>/api/ws` returned `init` after the change
  - a real public sandbox session reached `leadConnected: true` and `driverConnected: true`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected development server port routing to ensure proper proxy connectivity and WebSocket handling during development sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->