### PR TITLE
Fix SDK streaming handshake contract

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4383,7 +4383,41 @@
 
     "@agentuity/auth/@types/react": ["@types/react@18.3.28", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.2.2" } }, "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw=="],
 
+    "@agentuity/core/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+
+    "@agentuity/core/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
+    "@agentuity/drizzle/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+
+    "@agentuity/drizzle/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
     "@agentuity/drizzle/drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
+
+    "@agentuity/frontend/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+
+    "@agentuity/frontend/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
+    "@agentuity/postgres/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+
+    "@agentuity/postgres/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
+    "@agentuity/react/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+
+    "@agentuity/react/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
+    "@agentuity/runtime/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+
+    "@agentuity/runtime/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
+    "@agentuity/schema/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+
+    "@agentuity/schema/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
+    "@agentuity/server/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+
+    "@agentuity/server/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
+    "@agentuity/test-utils/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "@agentuity/workbench/@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 

--- a/packages/cli/src/cmd/coder/start.ts
+++ b/packages/cli/src/cmd/coder/start.ts
@@ -388,6 +388,7 @@ export const startSubcommand = createSubcommand({
 			AGENTUITY_CODER_HUB_URL: hubWsUrl,
 		};
 		env.AGENTUITY_CODER_API_KEY = ctx.auth.apiKey;
+		env.AGENTUITY_ORGID = ctx.orgId;
 
 		if (opts?.agent) {
 			env.AGENTUITY_CODER_AGENT = opts.agent;

--- a/packages/cli/src/cmd/coder/workspace/create.ts
+++ b/packages/cli/src/cmd/coder/workspace/create.ts
@@ -1,29 +1,46 @@
 import { z } from 'zod';
-import { CoderClient, type CoderCreateWorkspaceRequest } from '@agentuity/core/coder';
-import { ValidationOutputError } from '@agentuity/core';
+import { APIError, ValidationInputError, ValidationOutputError } from '@agentuity/core';
+import {
+	CoderClient,
+	CoderCreateWorkspaceRequestSchema,
+	type CoderCreateWorkspaceRequest,
+} from '@agentuity/core/coder';
 import { createSubcommand } from '../../../types';
 import * as tui from '../../../tui';
 import { getCommand } from '../../../command-prefix';
 import { ErrorCode } from '../../../errors';
 import { resolveGitHubRepo } from '../resolve-repo';
 
+const EMPTY_WORKSPACE_ERROR =
+	'A workspace needs at least one repo, saved skill, skill bucket, or agent';
+
+function hasWorkspaceSelections(input: CoderCreateWorkspaceRequest): boolean {
+	return (
+		(input.repos?.length ?? 0) > 0 ||
+		(input.savedSkillIds?.length ?? 0) > 0 ||
+		(input.skillBucketIds?.length ?? 0) > 0 ||
+		(input.enabledAgents?.length ?? 0) > 0
+	);
+}
+
+function formatWorkspaceValidationMessage(issues: Array<{ message: string }>): string {
+	const messages = [...new Set(issues.map((issue) => issue.message).filter(Boolean))];
+	if (messages.length === 0) {
+		return 'Invalid workspace configuration';
+	}
+	if (messages.includes(EMPTY_WORKSPACE_ERROR)) {
+		return `${EMPTY_WORKSPACE_ERROR}. Use --repo or --enabled-agents.`;
+	}
+	return messages.join('; ');
+}
+
 export const createWorkspaceSubcommand = createSubcommand({
 	name: 'create',
 	aliases: ['new', 'add'],
-	description: 'Create a new Coder workspace',
+	description: 'Create a new Coder workspace with at least one repo or agent',
 	tags: ['mutating', 'requires-auth'],
 	requires: { auth: true, org: true },
 	examples: [
-		{
-			command: getCommand('coder workspace create "My Workspace"'),
-			description: 'Create a workspace with a name',
-		},
-		{
-			command: getCommand(
-				'coder workspace create "My Workspace" --description "For frontend work" --scope org'
-			),
-			description: 'Create an org-scoped workspace with description',
-		},
 		{
 			command: getCommand(
 				'coder workspace create "My Workspace" --repo https://github.com/org/repo --repo-branch main'
@@ -31,7 +48,19 @@ export const createWorkspaceSubcommand = createSubcommand({
 			description: 'Create a workspace with a repository',
 		},
 		{
-			command: getCommand('coder workspace create "My Workspace" --json'),
+			command: getCommand(
+				'coder workspace create "My Workspace" --enabled-agents code-review --description "For frontend work" --scope org'
+			),
+			description: 'Create an org-scoped workspace with description and agents',
+		},
+		{
+			command: getCommand('coder workspace create "My Workspace" --enabled-agents code-review'),
+			description: 'Create a workspace with an agent roster',
+		},
+		{
+			command: getCommand(
+				'coder workspace create "My Workspace" --enabled-agents code-review --json'
+			),
 			description: 'Create a workspace and return JSON output',
 		},
 	],
@@ -59,9 +88,7 @@ export const createWorkspaceSubcommand = createSubcommand({
 			orgId: ctx.orgId,
 		});
 
-		const body: CoderCreateWorkspaceRequest & {
-			enabledAgents?: string[];
-		} = {
+		const body: CoderCreateWorkspaceRequest = {
 			name: args.name,
 			...(opts?.description && { description: opts.description }),
 			...(opts?.scope && { scope: opts.scope as 'user' | 'org' }),
@@ -84,9 +111,27 @@ export const createWorkspaceSubcommand = createSubcommand({
 				.map((name) => name.trim())
 				.filter(Boolean);
 		}
+		if (!hasWorkspaceSelections(body)) {
+			tui.fatal(
+				`Failed to create workspace: ${EMPTY_WORKSPACE_ERROR}. Use --repo or --enabled-agents.`,
+				ErrorCode.VALIDATION_FAILED
+			);
+		}
+
+		const validationResult = CoderCreateWorkspaceRequestSchema.safeParse(body);
+		if (!validationResult.success) {
+			ctx.logger.trace(
+				'Validation issues: %s',
+				JSON.stringify(validationResult.error.issues, null, 2)
+			);
+			tui.fatal(
+				`Failed to create workspace: ${formatWorkspaceValidationMessage(validationResult.error.issues)}`,
+				ErrorCode.VALIDATION_FAILED
+			);
+		}
 
 		try {
-			const created = await client.createWorkspace(body);
+			const created = await client.createWorkspace(validationResult.data);
 			const createdEnabledAgents = Array.isArray(created.enabledAgents)
 				? created.enabledAgents.filter((name): name is string => typeof name === 'string')
 				: [];
@@ -110,9 +155,15 @@ export const createWorkspaceSubcommand = createSubcommand({
 
 			return created;
 		} catch (err) {
-			if (err instanceof ValidationOutputError) {
+			if (err instanceof ValidationInputError || err instanceof ValidationOutputError) {
 				ctx.logger.trace('Validation response URL: %s', err.url ?? 'unknown');
 				ctx.logger.trace('Validation issues: %s', JSON.stringify(err.issues, null, 2));
+				tui.fatal(
+					`Failed to create workspace: ${formatWorkspaceValidationMessage(err.issues)}`,
+					ErrorCode.VALIDATION_FAILED
+				);
+			}
+			if (err instanceof APIError && err.status >= 400 && err.status < 500) {
 				tui.fatal(`Failed to create workspace: ${err.message}`, ErrorCode.VALIDATION_FAILED);
 			}
 			const msg = err instanceof Error ? err.message : String(err);

--- a/packages/cli/src/cmd/coder/workspace/index.ts
+++ b/packages/cli/src/cmd/coder/workspace/index.ts
@@ -17,7 +17,9 @@ export const workspaceCommand = createCommand({
 			description: 'List all workspaces',
 		},
 		{
-			command: getCommand('coder workspace create "My Workspace"'),
+			command: getCommand(
+				'coder workspace create "My Workspace" --repo https://github.com/org/repo'
+			),
 			description: 'Create a new workspace',
 		},
 		{

--- a/packages/cli/test/cmd/coder/workspace.test.ts
+++ b/packages/cli/test/cmd/coder/workspace.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { workspaceCommand } from '../../../src/cmd/coder/workspace';
+import { createWorkspaceSubcommand } from '../../../src/cmd/coder/workspace/create';
+import { ErrorCode, getExitCode } from '../../../src/errors';
+
+const ORIGINAL_EXIT = process.exit;
+const ORIGINAL_STDERR_WRITE = process.stderr.write;
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function makeContext(opts: Record<string, unknown> = {}) {
+	return {
+		args: { name: 'My Workspace' },
+		opts: {
+			url: 'https://coder.example',
+			...opts,
+		},
+		options: { json: false },
+		auth: { apiKey: 'ag_test' },
+		orgId: 'org_test',
+		config: null,
+		logger: {
+			trace() {},
+		},
+		getExecutingAgent: () => 'codex',
+	} as any;
+}
+
+function interceptFatal() {
+	let stderr = '';
+	let exitCode: number | undefined;
+
+	process.stderr.write = ((chunk: string | Uint8Array) => {
+		stderr += String(chunk);
+		return true;
+	}) as typeof process.stderr.write;
+	process.exit = ((code?: number) => {
+		exitCode = code;
+		throw new Error('__EXIT__');
+	}) as typeof process.exit;
+
+	return {
+		get stderr() {
+			return stderr;
+		},
+		get exitCode() {
+			return exitCode;
+		},
+	};
+}
+
+describe('coder workspace commands', () => {
+	beforeEach(() => {
+		globalThis.fetch = ORIGINAL_FETCH;
+	});
+
+	afterEach(() => {
+		process.exit = ORIGINAL_EXIT;
+		process.stderr.write = ORIGINAL_STDERR_WRITE;
+		globalThis.fetch = ORIGINAL_FETCH;
+	});
+
+	test('create examples only advertise valid non-empty workspaces', () => {
+		const rootCreateExamples =
+			workspaceCommand.examples?.filter((example) =>
+				example.command.includes('workspace create')
+			) ?? [];
+		const createExamples = createWorkspaceSubcommand.examples ?? [];
+
+		expect(rootCreateExamples).toHaveLength(1);
+		for (const example of [...rootCreateExamples, ...createExamples]) {
+			expect(
+				example.command.includes('--repo') || example.command.includes('--enabled-agents')
+			).toBe(true);
+		}
+		expect(createExamples.some((example) => example.command.includes('--enabled-agents'))).toBe(
+			true
+		);
+	});
+
+	test('create handler fails locally before fetch when no selections are provided', async () => {
+		const requestedUrls: string[] = [];
+		globalThis.fetch = (async (url: string) => {
+			requestedUrls.push(String(url));
+			throw new Error('unexpected fetch');
+		}) as typeof globalThis.fetch;
+		const fatal = interceptFatal();
+
+		await expect(createWorkspaceSubcommand.handler(makeContext())).rejects.toThrow('__EXIT__');
+
+		expect(requestedUrls).toEqual([]);
+		expect(fatal.stderr).toContain(
+			'Failed to create workspace: A workspace needs at least one repo, saved skill, skill bucket, or agent. Use --repo or --enabled-agents.'
+		);
+		expect(fatal.exitCode).toBe(getExitCode(ErrorCode.VALIDATION_FAILED));
+	});
+});

--- a/packages/coder-tui/src/auth.ts
+++ b/packages/coder-tui/src/auth.ts
@@ -1,0 +1,57 @@
+const API_KEY_HEADER = 'x-agentuity-auth-api-key';
+const AUTHORIZATION_HEADER = 'Authorization';
+const ORG_HEADER = 'x-agentuity-orgid';
+
+function normalizeApiKey(apiKey?: string | null): string | null {
+	const trimmed = apiKey?.trim();
+	return trimmed ? trimmed : null;
+}
+
+function normalizeOrgId(orgId?: string | null): string | null {
+	const trimmed = orgId?.trim();
+	return trimmed ? trimmed : null;
+}
+
+export function isHubApiKey(apiKey?: string | null): boolean {
+	const token = normalizeApiKey(apiKey);
+	return token?.startsWith('agc_') ?? false;
+}
+
+export function applyCoderAuthHeaders(
+	headers: Record<string, string>,
+	apiKey?: string | null,
+	orgId?: string | null
+): Record<string, string> {
+	const token = normalizeApiKey(apiKey);
+	const normalizedOrgId = normalizeOrgId(orgId);
+	if (normalizedOrgId) {
+		headers[ORG_HEADER] = normalizedOrgId;
+	}
+	if (!token) return headers;
+
+	if (isHubApiKey(token)) {
+		headers[API_KEY_HEADER] = token;
+		return headers;
+	}
+
+	headers[AUTHORIZATION_HEADER] = `Bearer ${token}`;
+	return headers;
+}
+
+export function getCoderAuthCurlArgs(apiKey?: string | null, orgId?: string | null): string[] {
+	const token = normalizeApiKey(apiKey);
+	const args: string[] = [];
+	const normalizedOrgId = normalizeOrgId(orgId);
+	if (normalizedOrgId) {
+		args.push('-H', `${ORG_HEADER}: ${normalizedOrgId}`);
+	}
+	if (!token) return args;
+
+	if (isHubApiKey(token)) {
+		args.push('-H', `${API_KEY_HEADER}: ${token}`);
+		return args;
+	}
+
+	args.push('-H', `${AUTHORIZATION_HEADER}: Bearer ${token}`);
+	return args;
+}

--- a/packages/coder-tui/src/auth.ts
+++ b/packages/coder-tui/src/auth.ts
@@ -41,18 +41,19 @@ export function applyCoderAuthHeaders(
 ): Record<string, string> {
 	const token = normalizeApiKey(apiKey);
 	const normalizedOrgId = resolveCoderOrgId(orgId);
+	const nextHeaders: Record<string, string> = { ...headers };
 	if (normalizedOrgId) {
-		headers[ORG_HEADER] = normalizedOrgId;
+		nextHeaders[ORG_HEADER] = normalizedOrgId;
 	}
-	if (!token) return headers;
+	if (!token) return nextHeaders;
 
 	if (isHubApiKey(token)) {
-		headers[API_KEY_HEADER] = token;
-		return headers;
+		nextHeaders[API_KEY_HEADER] = token;
+		return nextHeaders;
 	}
 
-	headers[AUTHORIZATION_HEADER] = `Bearer ${token}`;
-	return headers;
+	nextHeaders[AUTHORIZATION_HEADER] = `Bearer ${token}`;
+	return nextHeaders;
 }
 
 export function getCoderAuthCurlArgs(apiKey?: string | null, orgId?: string | null): string[] {

--- a/packages/coder-tui/src/auth.ts
+++ b/packages/coder-tui/src/auth.ts
@@ -1,6 +1,7 @@
 const API_KEY_HEADER = 'x-agentuity-auth-api-key';
 const AUTHORIZATION_HEADER = 'Authorization';
 const ORG_HEADER = 'x-agentuity-orgid';
+const DEFAULT_ORG_ID_ENV_VARS = ['AGENTUITY_ORGID', 'AGENTUITY_CLOUD_ORG_ID'] as const;
 
 function normalizeApiKey(apiKey?: string | null): string | null {
 	const trimmed = apiKey?.trim();
@@ -10,6 +11,22 @@ function normalizeApiKey(apiKey?: string | null): string | null {
 function normalizeOrgId(orgId?: string | null): string | null {
 	const trimmed = orgId?.trim();
 	return trimmed ? trimmed : null;
+}
+
+export function resolveCoderOrgId(orgId?: string | null): string | null {
+	const explicitOrgId = normalizeOrgId(orgId);
+	if (explicitOrgId) {
+		return explicitOrgId;
+	}
+
+	for (const envName of DEFAULT_ORG_ID_ENV_VARS) {
+		const envOrgId = normalizeOrgId(process.env[envName]);
+		if (envOrgId) {
+			return envOrgId;
+		}
+	}
+
+	return null;
 }
 
 export function isHubApiKey(apiKey?: string | null): boolean {
@@ -23,7 +40,7 @@ export function applyCoderAuthHeaders(
 	orgId?: string | null
 ): Record<string, string> {
 	const token = normalizeApiKey(apiKey);
-	const normalizedOrgId = normalizeOrgId(orgId);
+	const normalizedOrgId = resolveCoderOrgId(orgId);
 	if (normalizedOrgId) {
 		headers[ORG_HEADER] = normalizedOrgId;
 	}
@@ -41,7 +58,7 @@ export function applyCoderAuthHeaders(
 export function getCoderAuthCurlArgs(apiKey?: string | null, orgId?: string | null): string[] {
 	const token = normalizeApiKey(apiKey);
 	const args: string[] = [];
-	const normalizedOrgId = normalizeOrgId(orgId);
+	const normalizedOrgId = resolveCoderOrgId(orgId);
 	if (normalizedOrgId) {
 		args.push('-H', `${ORG_HEADER}: ${normalizedOrgId}`);
 	}

--- a/packages/coder-tui/src/client.ts
+++ b/packages/coder-tui/src/client.ts
@@ -1,4 +1,5 @@
 import type { HubClientMessage, HubRequest, HubResponse, InitMessage } from './protocol.ts';
+import { applyCoderAuthHeaders } from './auth.ts';
 
 /** How long to wait for a response before rejecting the pending promise (ms). */
 const SEND_TIMEOUT_MS = 30_000;
@@ -67,8 +68,7 @@ export class HubClient {
 	/** Called when an unsolicited server message arrives (broadcast, presence, hydration). */
 	public onServerMessage?: (message: Record<string, unknown>) => void;
 
-	/** API key for Hub authentication (sent as x-agentuity-auth-api-key header) */
-	// TODO: Remove/Change when we get Agentuity service level auth enabled, this is just temporary
+	/** Hub auth token from the CLI environment. */
 	public apiKey: string | null = null;
 
 	private setConnectionState(state: ConnectionState): void {
@@ -259,11 +259,11 @@ export class HubClient {
 
 	private async connectInternal(url: string, isReconnect = false): Promise<InitMessage> {
 		const wsUrl = this.buildWebSocketUrl(url);
-		// TODO: Remove/Change when we get Agentuity service level auth enabled, this is just temporary
+		const orgId = process.env.AGENTUITY_ORGID;
 		// Bun extension: custom headers on WebSocket upgrade request
-		const ws = this.apiKey
-			? new WebSocket(wsUrl, { headers: { 'x-agentuity-auth-api-key': this.apiKey } })
-			: new WebSocket(wsUrl);
+		const headers = applyCoderAuthHeaders({}, this.apiKey, orgId);
+		const ws =
+			Object.keys(headers).length > 0 ? new WebSocket(wsUrl, { headers }) : new WebSocket(wsUrl);
 		this.ws = ws;
 
 		return new Promise((resolve, reject) => {

--- a/packages/coder-tui/src/hub-overlay.ts
+++ b/packages/coder-tui/src/hub-overlay.ts
@@ -9,6 +9,7 @@ import {
 	type StreamProjection,
 	type StreamProjectionSource,
 } from './hub-overlay-state.ts';
+import { applyCoderAuthHeaders } from './auth.ts';
 import { truncateToWidth } from './renderers.ts';
 import type {
 	ConversationEntry as HubConversationEntry,
@@ -1155,15 +1156,15 @@ export class HubOverlay implements Component, Focusable {
 		const controller = new AbortController();
 		const timeout = setTimeout(() => controller.abort(), timeoutMs);
 		try {
-			// TODO: Remove/Change when we get Agentuity service level auth enabled, this is just temporary
 			const apiKey = process.env.AGENTUITY_CODER_API_KEY;
+			const orgId = process.env.AGENTUITY_ORGID;
 			const headers: Record<string, string> = {
 				accept: 'application/json',
 				...(init?.headers && typeof init.headers === 'object'
 					? (init.headers as Record<string, string>)
 					: {}),
 			};
-			if (apiKey) headers['x-agentuity-auth-api-key'] = apiKey;
+			applyCoderAuthHeaders(headers, apiKey, orgId);
 			const signal = init?.signal
 				? AbortSignal.any([controller.signal, init.signal])
 				: controller.signal;
@@ -1764,10 +1765,10 @@ export class HubOverlay implements Component, Focusable {
 		const subscribe = mode === 'full' ? '*' : 'session_*,task_*,agent_*';
 
 		try {
-			// TODO: Remove/Change when we get Agentuity service level auth enabled, this is just temporary
 			const apiKey = process.env.AGENTUITY_CODER_API_KEY;
+			const orgId = process.env.AGENTUITY_ORGID;
 			const sseHeaders: Record<string, string> = { accept: 'text/event-stream' };
-			if (apiKey) sseHeaders['x-agentuity-auth-api-key'] = apiKey;
+			applyCoderAuthHeaders(sseHeaders, apiKey, orgId);
 			const response = await fetch(
 				`${this.baseUrl}/api/hub/session/${encodeURIComponent(sessionId)}/events?subscribe=${encodeURIComponent(subscribe)}`,
 				{

--- a/packages/coder-tui/src/hub-overlay.ts
+++ b/packages/coder-tui/src/hub-overlay.ts
@@ -1158,13 +1158,16 @@ export class HubOverlay implements Component, Focusable {
 		try {
 			const apiKey = process.env.AGENTUITY_CODER_API_KEY;
 			const orgId = process.env.AGENTUITY_ORGID;
-			const headers: Record<string, string> = {
-				accept: 'application/json',
-				...(init?.headers && typeof init.headers === 'object'
-					? (init.headers as Record<string, string>)
-					: {}),
-			};
-			applyCoderAuthHeaders(headers, apiKey, orgId);
+			const headers = applyCoderAuthHeaders(
+				{
+					accept: 'application/json',
+					...(init?.headers && typeof init.headers === 'object'
+						? (init.headers as Record<string, string>)
+						: {}),
+				},
+				apiKey,
+				orgId
+			);
 			const signal = init?.signal
 				? AbortSignal.any([controller.signal, init.signal])
 				: controller.signal;
@@ -1767,8 +1770,7 @@ export class HubOverlay implements Component, Focusable {
 		try {
 			const apiKey = process.env.AGENTUITY_CODER_API_KEY;
 			const orgId = process.env.AGENTUITY_ORGID;
-			const sseHeaders: Record<string, string> = { accept: 'text/event-stream' };
-			applyCoderAuthHeaders(sseHeaders, apiKey, orgId);
+			const sseHeaders = applyCoderAuthHeaders({ accept: 'text/event-stream' }, apiKey, orgId);
 			const response = await fetch(
 				`${this.baseUrl}/api/hub/session/${encodeURIComponent(sessionId)}/events?subscribe=${encodeURIComponent(subscribe)}`,
 				{

--- a/packages/coder-tui/src/index.ts
+++ b/packages/coder-tui/src/index.ts
@@ -21,6 +21,7 @@ import { OutputViewerOverlay, type StoredResult } from './output-viewer.ts';
 import { setNativeRemoteExtensionContext } from './native-remote-ui-context.ts';
 import { handleRemoteUiRequest } from './remote-ui-handler.ts';
 import { buildInboundRpcPromptText, getInboundRpcDeliverAs } from './inbound-rpc.ts';
+import { applyCoderAuthHeaders, getCoderAuthCurlArgs } from './auth.ts';
 import type {
 	HubAction,
 	HubResponse,
@@ -43,9 +44,8 @@ const HUB_URL_ENV = 'AGENTUITY_CODER_HUB_URL';
 const AGENT_ENV = 'AGENTUITY_CODER_AGENT';
 const REMOTE_SESSION_ENV = 'AGENTUITY_CODER_REMOTE_SESSION';
 const NATIVE_REMOTE_ENV = 'AGENTUITY_CODER_NATIVE_REMOTE';
-// TODO: Remove/Change when we get Agentuity service level auth enabled, this is just temporary
+// Populated by `agentuity coder start` for hub bootstrap and runtime auth.
 const API_KEY_ENV = 'AGENTUITY_CODER_API_KEY';
-const API_KEY_HEADER = 'x-agentuity-auth-api-key';
 const RECONNECT_WAIT_TIMEOUT_MS = 120_000;
 
 type HubUiStatus = 'connected' | 'reconnecting' | 'offline';
@@ -117,12 +117,11 @@ function log(msg: string): void {
 }
 
 /** Build headers object with API key if available. Merges with any existing headers. */
-// TODO: Remove/Change when we get Agentuity service level auth enabled, this is just temporary
 function authHeaders(extra?: Record<string, string>): Record<string, string> {
 	const apiKey = process.env[API_KEY_ENV];
+	const orgId = process.env.AGENTUITY_ORGID;
 	const headers: Record<string, string> = { ...extra };
-	if (apiKey) headers[API_KEY_HEADER] = apiKey;
-	return headers;
+	return applyCoderAuthHeaders(headers, apiKey, orgId);
 }
 
 // ══════════════════════════════════════════════
@@ -173,9 +172,9 @@ function fetchInitMessageSync(hubUrl: string, agentRole?: string): InitMessage |
 			'node:child_process'
 		) as typeof import('node:child_process');
 		const apiKey = process.env[API_KEY_ENV];
+		const orgId = process.env.AGENTUITY_ORGID;
 		const curlArgs = ['-s', '--connect-timeout', '3', '--max-time', '5'];
-		// TODO: Remove/Change when we get Agentuity service level auth enabled, this is just temporary
-		if (apiKey) curlArgs.push('-H', `${API_KEY_HEADER}: ${apiKey}`);
+		curlArgs.push(...getCoderAuthCurlArgs(apiKey, orgId));
 		curlArgs.push(httpUrl);
 		const result = execFileSync('curl', curlArgs, { encoding: 'utf-8' });
 
@@ -417,7 +416,6 @@ export function agentuityCoderHub(pi: ExtensionAPI) {
 	// ══════════════════════════════════════════════
 
 	const client = new HubClient();
-	// TODO: Remove/Change when we get Agentuity service level auth enabled, this is just temporary
 	client.apiKey = process.env[API_KEY_ENV] || null;
 	let cachedInitMessage: InitMessage | null = initMsg;
 	let currentSessionId: string | null = initMsg.sessionId ?? null;

--- a/packages/coder-tui/src/remote-session.ts
+++ b/packages/coder-tui/src/remote-session.ts
@@ -22,6 +22,7 @@ import {
 	syncRemoteLifecycleWorkingMessage,
 	type RemoteLifecycleState,
 } from './remote-lifecycle.ts';
+import { resolveCoderOrgId } from './auth.ts';
 
 const DEBUG = !!process.env['AGENTUITY_DEBUG'];
 
@@ -267,9 +268,10 @@ export class RemoteSession {
 					wsHeaders['Authorization'] = `Bearer ${this.apiKey}`;
 				}
 			}
-			if (this.orgId) {
-				url.searchParams.set('orgId', this.orgId);
-				wsHeaders['x-agentuity-orgid'] = this.orgId;
+			const orgId = resolveCoderOrgId(this.orgId);
+			if (orgId) {
+				url.searchParams.set('orgId', orgId);
+				wsHeaders['x-agentuity-orgid'] = orgId;
 			}
 
 			log(`${isReconnect ? 'Reconnecting' : 'Connecting'} to ${url.toString()}`);

--- a/packages/coder-tui/test/auth.test.ts
+++ b/packages/coder-tui/test/auth.test.ts
@@ -1,7 +1,29 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { applyCoderAuthHeaders, getCoderAuthCurlArgs } from '../src/auth.ts';
 
+const ORIGINAL_AGENTUITY_ORGID = process.env.AGENTUITY_ORGID;
+const ORIGINAL_AGENTUITY_CLOUD_ORG_ID = process.env.AGENTUITY_CLOUD_ORG_ID;
+
 describe('coder auth helpers', () => {
+	beforeEach(() => {
+		delete process.env.AGENTUITY_ORGID;
+		delete process.env.AGENTUITY_CLOUD_ORG_ID;
+	});
+
+	afterEach(() => {
+		if (ORIGINAL_AGENTUITY_ORGID === undefined) {
+			delete process.env.AGENTUITY_ORGID;
+		} else {
+			process.env.AGENTUITY_ORGID = ORIGINAL_AGENTUITY_ORGID;
+		}
+
+		if (ORIGINAL_AGENTUITY_CLOUD_ORG_ID === undefined) {
+			delete process.env.AGENTUITY_CLOUD_ORG_ID;
+		} else {
+			process.env.AGENTUITY_CLOUD_ORG_ID = ORIGINAL_AGENTUITY_CLOUD_ORG_ID;
+		}
+	});
+
 	it('sends hub API keys via x-agentuity-auth-api-key', () => {
 		expect(applyCoderAuthHeaders({}, 'agc_test_key')).toEqual({
 			'x-agentuity-auth-api-key': 'agc_test_key',
@@ -17,6 +39,21 @@ describe('coder auth helpers', () => {
 			Authorization: 'Bearer ck_live_test_token',
 		});
 		expect(getCoderAuthCurlArgs('ck_live_test_token')).toEqual([
+			'-H',
+			'Authorization: Bearer ck_live_test_token',
+		]);
+	});
+
+	it('falls back to AGENTUITY_CLOUD_ORG_ID when AGENTUITY_ORGID is unset', () => {
+		process.env.AGENTUITY_CLOUD_ORG_ID = 'org_cloud';
+
+		expect(applyCoderAuthHeaders({}, 'ck_live_test_token')).toEqual({
+			Authorization: 'Bearer ck_live_test_token',
+			'x-agentuity-orgid': 'org_cloud',
+		});
+		expect(getCoderAuthCurlArgs('ck_live_test_token')).toEqual([
+			'-H',
+			'x-agentuity-orgid: org_cloud',
 			'-H',
 			'Authorization: Bearer ck_live_test_token',
 		]);

--- a/packages/coder-tui/test/auth.test.ts
+++ b/packages/coder-tui/test/auth.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'bun:test';
+import { applyCoderAuthHeaders, getCoderAuthCurlArgs } from '../src/auth.ts';
+
+describe('coder auth helpers', () => {
+	it('sends hub API keys via x-agentuity-auth-api-key', () => {
+		expect(applyCoderAuthHeaders({}, 'agc_test_key')).toEqual({
+			'x-agentuity-auth-api-key': 'agc_test_key',
+		});
+		expect(getCoderAuthCurlArgs('agc_test_key')).toEqual([
+			'-H',
+			'x-agentuity-auth-api-key: agc_test_key',
+		]);
+	});
+
+	it('sends CLI auth tokens via Authorization bearer', () => {
+		expect(applyCoderAuthHeaders({}, 'ck_live_test_token')).toEqual({
+			Authorization: 'Bearer ck_live_test_token',
+		});
+		expect(getCoderAuthCurlArgs('ck_live_test_token')).toEqual([
+			'-H',
+			'Authorization: Bearer ck_live_test_token',
+		]);
+	});
+
+	it('includes org headers when present', () => {
+		expect(applyCoderAuthHeaders({}, 'ck_live_test_token', 'org_test')).toEqual({
+			Authorization: 'Bearer ck_live_test_token',
+			'x-agentuity-orgid': 'org_test',
+		});
+		expect(getCoderAuthCurlArgs('ck_live_test_token', 'org_test')).toEqual([
+			'-H',
+			'x-agentuity-orgid: org_test',
+			'-H',
+			'Authorization: Bearer ck_live_test_token',
+		]);
+	});
+
+	it('leaves headers unchanged when no auth token is available', () => {
+		expect(applyCoderAuthHeaders({ accept: 'application/json' })).toEqual({
+			accept: 'application/json',
+		});
+		expect(getCoderAuthCurlArgs()).toEqual([]);
+	});
+});

--- a/packages/coder-tui/test/auth.test.ts
+++ b/packages/coder-tui/test/auth.test.ts
@@ -44,6 +44,21 @@ describe('coder auth helpers', () => {
 		]);
 	});
 
+	it('returns a new headers object without mutating the caller input', () => {
+		const originalHeaders = { accept: 'application/json' };
+		const result = applyCoderAuthHeaders(originalHeaders, 'agc_test_key', 'org_test');
+
+		expect(result).toEqual({
+			accept: 'application/json',
+			'x-agentuity-auth-api-key': 'agc_test_key',
+			'x-agentuity-orgid': 'org_test',
+		});
+		expect(originalHeaders).toEqual({
+			accept: 'application/json',
+		});
+		expect(result).not.toBe(originalHeaders);
+	});
+
 	it('falls back to AGENTUITY_CLOUD_ORG_ID when AGENTUITY_ORGID is unset', () => {
 		process.env.AGENTUITY_CLOUD_ORG_ID = 'org_cloud';
 

--- a/packages/coder-tui/test/remote-session.test.ts
+++ b/packages/coder-tui/test/remote-session.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { RemoteSession } from '../src/remote-session.ts';
 
 const OriginalWebSocket = globalThis.WebSocket;
+const ORIGINAL_AGENTUITY_ORGID = process.env.AGENTUITY_ORGID;
+const ORIGINAL_AGENTUITY_CLOUD_ORG_ID = process.env.AGENTUITY_CLOUD_ORG_ID;
 
 class MockWebSocket {
 	static CONNECTING = 0;
@@ -53,11 +55,23 @@ describe('RemoteSession', () => {
 	beforeEach(() => {
 		MockWebSocket.instances = [];
 		globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+		delete process.env.AGENTUITY_ORGID;
+		delete process.env.AGENTUITY_CLOUD_ORG_ID;
 	});
 
 	afterEach(() => {
 		globalThis.WebSocket = OriginalWebSocket;
 		MockWebSocket.instances = [];
+		if (ORIGINAL_AGENTUITY_ORGID === undefined) {
+			delete process.env.AGENTUITY_ORGID;
+		} else {
+			process.env.AGENTUITY_ORGID = ORIGINAL_AGENTUITY_ORGID;
+		}
+		if (ORIGINAL_AGENTUITY_CLOUD_ORG_ID === undefined) {
+			delete process.env.AGENTUITY_CLOUD_ORG_ID;
+		} else {
+			process.env.AGENTUITY_CLOUD_ORG_ID = ORIGINAL_AGENTUITY_CLOUD_ORG_ID;
+		}
 	});
 
 	it('connects as a controller, sends bootstrap_ready, and hydrates into paused state when the lead is disconnected', async () => {
@@ -132,5 +146,29 @@ describe('RemoteSession', () => {
 			sessionId: 'sess_protocol_error',
 			lastError: 'bootstrap timeout',
 		});
+	});
+
+	it('falls back to AGENTUITY_CLOUD_ORG_ID for controller auth when AGENTUITY_ORGID is unset', async () => {
+		process.env.AGENTUITY_CLOUD_ORG_ID = 'org_cloud';
+
+		const remote = new RemoteSession('sess_env_org');
+		remote.apiKey = 'agc_test_key';
+
+		const connectPromise = remote.connect('ws://hub.example/api/ws');
+		const socket = MockWebSocket.instances[0];
+		expect(socket).toBeDefined();
+		expect(decodeURIComponent(socket!.url)).toContain('orgId=org_cloud');
+		expect((socket!.options as { headers?: Record<string, string> }).headers).toEqual({
+			'x-agentuity-auth-api-key': 'agc_test_key',
+			'x-agentuity-orgid': 'org_cloud',
+		});
+
+		socket!.open();
+		socket!.receive({
+			type: 'init',
+			sessionId: 'sess_env_org',
+		});
+
+		await connectPromise;
 	});
 });

--- a/packages/core/src/services/api.ts
+++ b/packages/core/src/services/api.ts
@@ -66,7 +66,7 @@ const toIssues = (issues: z.core.$ZodIssue[]): IssuesType => {
 
 export const APIErrorSchema = z
 	.object({
-		success: z.boolean().describe('Whether the API request was successful.'),
+		success: z.boolean().optional().describe('Whether the API request was successful.'),
 		code: z.string().optional().describe('Machine-readable error code.'),
 		message: z.string().optional().describe('Human-readable error message.'),
 		error: z
@@ -698,16 +698,15 @@ export class APIClient {
 						});
 					}
 
+					const apiErrorMessage =
+						typeof errorData?.error === 'string' ? errorData.error : errorData?.message;
+
 					// Throw with message from API if available
-					if (errorData?.message) {
+					if (apiErrorMessage) {
 						throw new APIError({
 							url,
 							status: response.status,
-							message:
-								typeof errorData.error === 'string'
-									? errorData.error
-									: (errorData.message ??
-										'The API encountered an unexpected error attempting to reach the service.'),
+							message: apiErrorMessage,
 							sessionId,
 						});
 					}

--- a/packages/core/src/services/coder/protocol.ts
+++ b/packages/core/src/services/coder/protocol.ts
@@ -22,7 +22,7 @@ import { z } from 'zod/v4';
 
 /** Connection role assigned by the server in the init message */
 export const CoderHubInitRoleSchema = z
-	.enum(['lead', 'sub_agent', 'controller'])
+	.enum(['lead', 'sub_agent', 'observer', 'controller'])
 	.describe(
 		'Role assigned to a connecting client, determining its permissions and message routing.'
 	);
@@ -215,10 +215,20 @@ export const CoderHubControllerInitMessageSchema = BaseCoderHubInitMessageSchema
 );
 export type CoderHubControllerInitMessage = z.infer<typeof CoderHubControllerInitMessageSchema>;
 
+export const CoderHubObserverInitMessageSchema = BaseCoderHubInitMessageSchema.extend({
+	role: z
+		.literal('observer')
+		.describe('Indicates this client is connecting as a read-only observer.'),
+}).describe(
+	'Initialization message sent by an observer client when the server chooses to send an explicit init frame.'
+);
+export type CoderHubObserverInitMessage = z.infer<typeof CoderHubObserverInitMessageSchema>;
+
 export const CoderHubInitMessageSchema = z
 	.discriminatedUnion('role', [
 		CoderHubLeadInitMessageSchema,
 		CoderHubSubAgentInitMessageSchema,
+		CoderHubObserverInitMessageSchema,
 		CoderHubControllerInitMessageSchema,
 	])
 	.describe('Union of all initialization messages, discriminated by the client role.');
@@ -743,6 +753,22 @@ export const BootstrapReadyMessageSchema = z
 	);
 export type BootstrapReadyMessage = z.infer<typeof BootstrapReadyMessageSchema>;
 
+export const ObserverSubscribeMessageSchema = z
+	.object({
+		type: z
+			.literal('subscribe')
+			.describe('Discriminator indicating an observer subscription update.'),
+		patterns: z
+			.array(z.string())
+			.describe(
+				'Event filters to receive, including categories, exact names, wildcard prefixes, or "*".'
+			),
+	})
+	.describe(
+		'Client message updating the observer event filters for a live Coder Hub WebSocket connection.'
+	);
+export type ObserverSubscribeMessage = z.infer<typeof ObserverSubscribeMessageSchema>;
+
 export const SessionEntryMessageSchema = z
 	.object({
 		type: z
@@ -978,6 +1004,7 @@ export const ClientMessageSchema = z
 		SessionEntryMessageSchema,
 		SessionWriteMessageSchema,
 		BootstrapReadyMessageSchema,
+		ObserverSubscribeMessageSchema,
 		RpcCommandMessageSchema,
 		RpcUiResponseMessageSchema,
 		PingMessageSchema,
@@ -993,7 +1020,7 @@ export type ClientMessage = z.infer<typeof ClientMessageSchema>;
  * Messages the Coder Hub server can send to connected clients.
  */
 export const ServerMessageSchema = z
-	.discriminatedUnion('type', [
+	.union([
 		CoderHubInitMessageSchema,
 		CoderHubResponseSchema,
 		CoderHubHydrationMessageSchema,
@@ -1129,6 +1156,10 @@ export const ConnectionParamsSchema = z
 			.enum(['lead', 'observer', 'controller'])
 			.optional()
 			.describe('Requested session role; the server may override based on permissions.'),
+		subscribe: z
+			.string()
+			.optional()
+			.describe('Comma-separated event filters requested during observer connection bootstrap.'),
 		coordJobId: z
 			.string()
 			.optional()

--- a/packages/core/src/services/coder/types.ts
+++ b/packages/core/src/services/coder/types.ts
@@ -322,6 +322,20 @@ export const CoderWorkspaceListResponseSchema = z
 	.describe('Response payload for listing workspaces');
 export type CoderWorkspaceListResponse = z.infer<typeof CoderWorkspaceListResponseSchema>;
 
+function hasWorkspaceSelections(input: {
+	repos?: unknown[];
+	savedSkillIds?: unknown[];
+	skillBucketIds?: unknown[];
+	enabledAgents?: unknown[];
+}): boolean {
+	return (
+		(input.repos?.length ?? 0) > 0 ||
+		(input.savedSkillIds?.length ?? 0) > 0 ||
+		(input.skillBucketIds?.length ?? 0) > 0 ||
+		(input.enabledAgents?.length ?? 0) > 0
+	);
+}
+
 export const CoderCreateWorkspaceRequestSchema = z
 	.object({
 		name: z.string().describe('Workspace name'),
@@ -330,7 +344,13 @@ export const CoderCreateWorkspaceRequestSchema = z
 		repos: z.array(CoderSessionRepositoryRefSchema).optional().describe('Repositories'),
 		savedSkillIds: z.array(z.string()).optional().describe('Saved skill IDs'),
 		skillBucketIds: z.array(z.string()).optional().describe('Skill bucket IDs'),
-		enabledAgents: z.array(z.string()).optional().describe('Effective agent roster to store on the workspace'),
+		enabledAgents: z
+			.array(z.string())
+			.optional()
+			.describe('Effective agent roster to store on the workspace'),
+	})
+	.refine(hasWorkspaceSelections, {
+		message: 'A workspace needs at least one repo, saved skill, skill bucket, or agent',
 	})
 	.describe('Request body for creating a workspace');
 export type CoderCreateWorkspaceRequest = z.infer<typeof CoderCreateWorkspaceRequestSchema>;

--- a/packages/core/src/services/coder/websocket.ts
+++ b/packages/core/src/services/coder/websocket.ts
@@ -835,17 +835,19 @@ export class CoderHubWebSocketClient {
 			this.#clearTimers();
 			this.#setState('closed');
 
+			const wasAuthenticated = this.#authenticated;
+			const hadTerminalError = this.#intentionallyClosed;
+			const terminalClose = isTerminalCloseCode(event.code);
+
 			// Clear auth state for clean reconnect
 			this.#authenticated = false;
 			this.#initMessage = null;
-			const hadTerminalError = this.#intentionallyClosed;
-			const terminalClose = isTerminalCloseCode(event.code);
 
 			if (terminalClose) {
 				this.#intentionallyClosed = true;
 			}
 
-			if (!this.#authenticated && terminalClose && !hadTerminalError) {
+			if (!wasAuthenticated && terminalClose && !hadTerminalError) {
 				this.#options.onError(
 					this.#buildHandshakeError({
 						code: 'connection_error',

--- a/packages/core/src/services/coder/websocket.ts
+++ b/packages/core/src/services/coder/websocket.ts
@@ -712,12 +712,14 @@ export class CoderHubWebSocketClient {
 			if (ws !== this.#ws) return;
 			this.#setState('authenticating');
 			if (this.#options.apiKey || this.#options.orgId) {
-				ws.send(
-					JSON.stringify({
-						authorization: this.#options.apiKey,
-						org_id: this.#options.orgId,
-					})
-				);
+				const bootstrapPayload: { authorization?: string; org_id?: string } = {};
+				if (this.#options.apiKey) {
+					bootstrapPayload.authorization = this.#options.apiKey;
+				}
+				if (this.#options.orgId) {
+					bootstrapPayload.org_id = this.#options.orgId;
+				}
+				ws.send(JSON.stringify(bootstrapPayload));
 			}
 		};
 

--- a/packages/core/src/services/coder/websocket.ts
+++ b/packages/core/src/services/coder/websocket.ts
@@ -70,7 +70,7 @@ import type {
 	ConnectionParams,
 	ServerMessage,
 } from './protocol.ts';
-import { CoderHubInitMessageSchema } from './protocol.ts';
+import { CoderHubInitMessageSchema, parseServerMessage } from './protocol.ts';
 import { normalizeCoderUrl } from './util.ts';
 
 /**
@@ -118,6 +118,11 @@ export const CoderHubWebSocketOptionsSchema = z.object({
 	task: z.string().optional().describe('Initial task for driver mode'),
 	/** Human-readable session label */
 	label: z.string().optional().describe('Session label'),
+	/** Observer event filters to request during the initial connection. */
+	subscribe: z
+		.array(z.string())
+		.optional()
+		.describe('Observer event filters to request during connection setup'),
 	/** Client origin (web, desktop, tui, sdk) */
 	origin: z.enum(['web', 'desktop', 'tui', 'sdk']).optional().describe('Client origin'),
 	/** Driver mode: 'rpc' for RPC bridge driver */
@@ -270,6 +275,7 @@ export class CoderHubWebSocketClient {
 		parentSessionId: string;
 		task: string;
 		label: string;
+		subscribe: string[];
 		origin: 'web' | 'desktop' | 'tui' | 'sdk';
 		driverMode: 'rpc' | undefined;
 		driverInstanceId: string;
@@ -317,6 +323,7 @@ export class CoderHubWebSocketClient {
 			parentSessionId: options.parentSessionId ?? '',
 			task: options.task ?? '',
 			label: options.label ?? '',
+			subscribe: options.subscribe ?? [],
 			origin: options.origin ?? 'sdk',
 			driverMode: options.driverMode,
 			driverInstanceId: options.driverInstanceId ?? '',
@@ -522,6 +529,36 @@ export class CoderHubWebSocketClient {
 		return `${Date.now()}-${++this.#messageId}`;
 	}
 
+	#markReady(input?: {
+		initMessage?: CoderHubInitMessage;
+		firstMessage?: ServerMessage;
+		sendBootstrapReady?: boolean;
+	}): void {
+		this.#authenticated = true;
+		this.#initMessage = input?.initMessage ?? null;
+		this.#sessionId =
+			input?.initMessage?.sessionId ??
+			(input?.firstMessage && 'sessionId' in input.firstMessage
+				? input.firstMessage.sessionId
+				: undefined) ??
+			this.#options.sessionId ??
+			null;
+		this.#reconnectAttempts = 0;
+		this.#setState('connected');
+		this.#startHeartbeat();
+		if (input?.initMessage) {
+			this.#options.onInit(input.initMessage);
+		}
+		if (input?.sendBootstrapReady && this.#ws?.readyState === WebSocket.OPEN) {
+			this.#ws.send(JSON.stringify({ type: 'bootstrap_ready' }));
+		}
+		this.#flushMessageQueue();
+		this.#options.onOpen();
+		if (input?.firstMessage) {
+			this.#options.onMessage(input.firstMessage);
+		}
+	}
+
 	#setState(state: CoderHubWebSocketState): void {
 		if (this.#state !== state) {
 			this.#state = state;
@@ -589,6 +626,8 @@ export class CoderHubWebSocketClient {
 			parent: this.#options.parentSessionId || undefined,
 			task: this.#options.task || undefined,
 			label: this.#options.label || undefined,
+			subscribe:
+				this.#options.subscribe.length > 0 ? this.#options.subscribe.join(',') : undefined,
 			orgId: this.#options.orgId || undefined,
 			origin: this.#options.origin || undefined,
 			driverMode: this.#options.driverMode || undefined,
@@ -600,6 +639,9 @@ export class CoderHubWebSocketClient {
 			if (value !== undefined && value !== '') {
 				params.set(key, String(value));
 			}
+		}
+		if (this.#options.apiKey) {
+			params.set('api_key', this.#options.apiKey);
 		}
 
 		const queryString = params.toString();
@@ -642,12 +684,14 @@ export class CoderHubWebSocketClient {
 		ws.onopen = () => {
 			if (ws !== this.#ws) return;
 			this.#setState('authenticating');
-			ws.send(
-				JSON.stringify({
-					authorization: this.#options.apiKey,
-					org_id: this.#options.orgId,
-				})
-			);
+			if (this.#options.apiKey || this.#options.orgId) {
+				ws.send(
+					JSON.stringify({
+						authorization: this.#options.apiKey,
+						org_id: this.#options.orgId,
+					})
+				);
+			}
 		};
 
 		ws.onmessage = (event: MessageEvent) => {
@@ -700,15 +744,18 @@ export class CoderHubWebSocketClient {
 				const initResult = CoderHubInitMessageSchema.safeParse(parsed);
 				if (initResult.success) {
 					const initMsg = initResult.data;
-					this.#authenticated = true;
-					this.#initMessage = initMsg;
-					this.#sessionId = initMsg.sessionId ?? this.#options.sessionId ?? null;
-					this.#reconnectAttempts = 0;
-					this.#setState('connected');
-					this.#startHeartbeat();
-					this.#flushMessageQueue();
-					this.#options.onInit(initMsg);
-					this.#options.onOpen();
+					this.#markReady({
+						initMessage: initMsg,
+						sendBootstrapReady: this.#options.role === 'controller',
+					});
+					return;
+				}
+
+				if (this.#options.role === 'observer') {
+					const firstObserverMessage = parseServerMessage(parsed);
+					if (firstObserverMessage) {
+						this.#markReady({ firstMessage: firstObserverMessage });
+					}
 				}
 				return;
 			}

--- a/packages/core/src/services/coder/websocket.ts
+++ b/packages/core/src/services/coder/websocket.ts
@@ -203,7 +203,13 @@ export const CoderHubWebSocketError = StructuredError('CoderHubWebSocketError')<
 		| 'response_timeout'
 		| 'invalid_response';
 	sessionId?: string;
+	serverCode?: string;
+	serverMessage?: string;
+	serverMessageType?: 'connection_rejected' | 'protocol_error';
+	closeCode?: number;
+	closeReason?: string;
 }>();
+export type CoderHubWebSocketErrorInstance = InstanceType<typeof CoderHubWebSocketError>;
 
 interface PendingRequest {
 	resolve: (response: CoderHubResponse) => void;
@@ -529,6 +535,27 @@ export class CoderHubWebSocketClient {
 		return `${Date.now()}-${++this.#messageId}`;
 	}
 
+	#buildHandshakeError(input: {
+		code: 'auth_failed' | 'connection_error';
+		message: string;
+		serverCode?: string;
+		serverMessage?: string;
+		serverMessageType?: 'connection_rejected' | 'protocol_error';
+		closeCode?: number;
+		closeReason?: string;
+	}): CoderHubWebSocketErrorInstance {
+		return new CoderHubWebSocketError({
+			code: input.code,
+			message: input.message,
+			sessionId: this.sessionId,
+			serverCode: input.serverCode,
+			serverMessage: input.serverMessage,
+			serverMessageType: input.serverMessageType,
+			closeCode: input.closeCode,
+			closeReason: input.closeReason,
+		});
+	}
+
 	#markReady(input?: {
 		initMessage?: CoderHubInitMessage;
 		firstMessage?: ServerMessage;
@@ -729,10 +756,12 @@ export class CoderHubWebSocketClient {
 					if (msg.type === 'connection_rejected' || msg.type === 'protocol_error') {
 						this.#setState('closed');
 						this.#options.onError(
-							new CoderHubWebSocketError({
-								message: `Connection rejected: ${msg.message ?? msg.code ?? 'Unknown error'}`,
+							this.#buildHandshakeError({
 								code: 'auth_failed',
-								sessionId: this.sessionId,
+								message: `Connection rejected: ${msg.message ?? msg.code ?? 'Unknown error'}`,
+								serverCode: msg.code,
+								serverMessage: msg.message,
+								serverMessageType: msg.type,
 							})
 						);
 						this.#intentionallyClosed = true;
@@ -809,9 +838,24 @@ export class CoderHubWebSocketClient {
 			// Clear auth state for clean reconnect
 			this.#authenticated = false;
 			this.#initMessage = null;
+			const hadTerminalError = this.#intentionallyClosed;
+			const terminalClose = isTerminalCloseCode(event.code);
 
-			if (isTerminalCloseCode(event.code)) {
+			if (terminalClose) {
 				this.#intentionallyClosed = true;
+			}
+
+			if (!this.#authenticated && terminalClose && !hadTerminalError) {
+				this.#options.onError(
+					this.#buildHandshakeError({
+						code: 'connection_error',
+						message: `WebSocket closed before connection was ready (code ${event.code})${
+							event.reason ? `: ${event.reason}` : ''
+						}`,
+						closeCode: event.code,
+						closeReason: event.reason || undefined,
+					})
+				);
 			}
 
 			this.#options.onClose(event.code, event.reason);
@@ -943,7 +987,11 @@ export async function* subscribeToCoderHub(
 		onError: (error) => {
 			if (
 				error instanceof CoderHubWebSocketError &&
-				(error.code === 'max_reconnects_exceeded' || error.code === 'auth_failed')
+				(error.code === 'max_reconnects_exceeded' ||
+					error.code === 'auth_failed' ||
+					(error.code === 'connection_error' &&
+						typeof error.closeCode === 'number' &&
+						isTerminalCloseCode(error.closeCode)))
 			) {
 				terminalError = error;
 				done = true;

--- a/packages/core/test/coder-client.test.ts
+++ b/packages/core/test/coder-client.test.ts
@@ -54,6 +54,25 @@ function makeCustomAgent(overrides: Record<string, unknown> = {}) {
 	};
 }
 
+function makeWorkspace(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 'hworkspace_test123',
+		name: 'Workspace Test',
+		description: 'Workspace description',
+		scope: 'org',
+		ownerUserId: 'user_test',
+		repos: [],
+		repoCount: 0,
+		savedSkillIds: [],
+		skillBucketIds: [],
+		enabledAgents: [],
+		selectionCount: 0,
+		createdAt: '2026-04-08T00:00:00.000Z',
+		updatedAt: '2026-04-08T00:00:00.000Z',
+		...overrides,
+	};
+}
+
 describe('CoderClient remote attach helpers', () => {
 	beforeEach(() => {
 		globalThis.fetch = ORIGINAL_FETCH;
@@ -355,6 +374,197 @@ describe('CoderClient remote attach helpers', () => {
 		expect(response.limit).toBe(0);
 		expect(response.offset).toBe(0);
 		expect(response.total).toBe(2);
+	});
+});
+
+describe('CoderClient enabled agent roster contract', () => {
+	beforeEach(() => {
+		globalThis.fetch = ORIGINAL_FETCH;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = ORIGINAL_FETCH;
+	});
+
+	test('session and workspace request types accept enabledAgents', () => {
+		const createSessionBody: Parameters<CoderClient['createSession']>[0] = {
+			task: 'Review this change',
+			enabledAgents: ['code-review'],
+		};
+		const updateSessionBody: Parameters<CoderClient['updateSession']>[1] = {
+			enabledAgents: ['code-review'],
+		};
+		const createWorkspaceBody: Parameters<CoderClient['createWorkspace']>[0] = {
+			name: 'My Workspace',
+			enabledAgents: ['code-review'],
+		};
+
+		expect(createSessionBody.enabledAgents).toEqual(['code-review']);
+		expect(updateSessionBody.enabledAgents).toEqual(['code-review']);
+		expect(createWorkspaceBody.enabledAgents).toEqual(['code-review']);
+	});
+
+	test('createSession sends enabledAgents in the request body', async () => {
+		mockFetch(async (url, init) => {
+			expect(url).toBe('https://coder.example/api/hub/session');
+			expect(init?.method).toBe('POST');
+			expect(init?.body).toContain('"enabledAgents":["code-review","qa-team"]');
+			return new Response(
+				JSON.stringify({
+					sessionId: 'codesess_enabled_create',
+					status: 'active',
+				}),
+				{
+					status: 201,
+					headers: { 'content-type': 'application/json' },
+				}
+			);
+		});
+
+		const client = new CoderClient({
+			apiKey: 'ag_test',
+			url: 'https://coder.example',
+			orgId: 'org_test',
+		});
+
+		await expect(
+			client.createSession({
+				task: 'Review this change',
+				enabledAgents: ['code-review', 'qa-team'],
+			})
+		).resolves.toMatchObject({
+			sessionId: 'codesess_enabled_create',
+			status: 'active',
+		});
+	});
+
+	test('updateSession sends enabledAgents in the request body', async () => {
+		mockFetch(async (url, init) => {
+			expect(url).toBe('https://coder.example/api/hub/session/codesess_enabled_update');
+			expect(init?.method).toBe('PATCH');
+			expect(init?.body).toContain('"enabledAgents":["code-review"]');
+			return new Response(
+				JSON.stringify({
+					sessionId: 'codesess_enabled_update',
+				}),
+				{
+					status: 200,
+					headers: { 'content-type': 'application/json' },
+				}
+			);
+		});
+
+		const client = new CoderClient({
+			apiKey: 'ag_test',
+			url: 'https://coder.example',
+			orgId: 'org_test',
+		});
+
+		await expect(
+			client.updateSession('codesess_enabled_update', {
+				enabledAgents: ['code-review'],
+			})
+		).resolves.toMatchObject({
+			sessionId: 'codesess_enabled_update',
+		});
+	});
+
+	test('createWorkspace sends enabledAgents in the request body', async () => {
+		mockFetch(async (url, init) => {
+			expect(url).toBe('https://coder.example/api/hub/workspaces');
+			expect(init?.method).toBe('POST');
+			expect(init?.body).toContain('"enabledAgents":["code-review","qa-team"]');
+			return new Response(
+				JSON.stringify({
+					workspace: makeWorkspace({
+						id: 'hworkspace_enabled_create',
+						enabledAgents: ['code-review', 'qa-team'],
+						selectionCount: 2,
+					}),
+				}),
+				{
+					status: 201,
+					headers: { 'content-type': 'application/json' },
+				}
+			);
+		});
+
+		const client = new CoderClient({
+			apiKey: 'ag_test',
+			url: 'https://coder.example',
+			orgId: 'org_test',
+		});
+
+		await expect(
+			client.createWorkspace({
+				name: 'My Workspace',
+				enabledAgents: ['code-review', 'qa-team'],
+			})
+		).resolves.toMatchObject({
+			id: 'hworkspace_enabled_create',
+			enabledAgents: ['code-review', 'qa-team'],
+		});
+	});
+
+	test('getSession preserves enabledAgents from the hub response', async () => {
+		mockFetch(async (url, init) => {
+			expect(url).toBe('https://coder.example/api/hub/session/codesess_enabled_read');
+			expect(init?.method).toBe('GET');
+			return new Response(
+				JSON.stringify(
+					makeSession({
+						sessionId: 'codesess_enabled_read',
+						enabledAgents: ['code-review', 'qa-team'],
+					})
+				),
+				{
+					status: 200,
+					headers: { 'content-type': 'application/json' },
+				}
+			);
+		});
+
+		const client = new CoderClient({
+			apiKey: 'ag_test',
+			url: 'https://coder.example',
+			orgId: 'org_test',
+		});
+
+		const session = await client.getSession('codesess_enabled_read');
+		expect(session.enabledAgents).toEqual(['code-review', 'qa-team']);
+		expect('agentSlugs' in session).toBe(false);
+	});
+
+	test('getWorkspace preserves enabledAgents from the hub response', async () => {
+		mockFetch(async (url, init) => {
+			expect(url).toBe('https://coder.example/api/hub/workspaces/hworkspace_enabled_read');
+			expect(init?.method).toBe('GET');
+			return new Response(
+				JSON.stringify({
+					workspace: makeWorkspace({
+						id: 'hworkspace_enabled_read',
+						selectedEnabledAgents: ['code-review'],
+						enabledAgents: ['code-review', 'qa-team'],
+						selectionCount: 2,
+					}),
+				}),
+				{
+					status: 200,
+					headers: { 'content-type': 'application/json' },
+				}
+			);
+		});
+
+		const client = new CoderClient({
+			apiKey: 'ag_test',
+			url: 'https://coder.example',
+			orgId: 'org_test',
+		});
+
+		const workspace = await client.getWorkspace('hworkspace_enabled_read');
+		expect(workspace.enabledAgents).toEqual(['code-review', 'qa-team']);
+		expect(workspace.selectedEnabledAgents).toEqual(['code-review']);
+		expect('agentSlugs' in workspace).toBe(false);
 	});
 });
 

--- a/packages/core/test/coder-client.test.ts
+++ b/packages/core/test/coder-client.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mockFetch } from '@agentuity/test-utils';
 import { CoderClient } from '../src/services/coder/client.ts';
+import { APIError, ValidationInputError } from '../src/services/api.ts';
+import { CoderCreateWorkspaceRequestSchema } from '../src/services/coder/types.ts';
 
 const ORIGINAL_FETCH = globalThis.fetch;
 
@@ -404,6 +406,55 @@ describe('CoderClient enabled agent roster contract', () => {
 		expect(createWorkspaceBody.enabledAgents).toEqual(['code-review']);
 	});
 
+	test('workspace create schema rejects a name-only request', () => {
+		const result = CoderCreateWorkspaceRequestSchema.safeParse({
+			name: 'My Workspace',
+		});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						message:
+							'A workspace needs at least one repo, saved skill, skill bucket, or agent',
+					}),
+				])
+			);
+		}
+	});
+
+	test('createWorkspace rejects an empty workspace body before sending a request', async () => {
+		const fetchMock = mockFetch(async () => {
+			throw new Error('unexpected fetch');
+		});
+
+		const client = new CoderClient({
+			apiKey: 'ag_test',
+			url: 'https://coder.example',
+			orgId: 'org_test',
+		});
+
+		let error: unknown;
+		try {
+			await client.createWorkspace({
+				name: 'My Workspace',
+			});
+		} catch (ex) {
+			error = ex;
+		}
+
+		expect(error).toBeInstanceOf(ValidationInputError);
+		expect(error).toMatchObject({
+			issues: expect.arrayContaining([
+				expect.objectContaining({
+					message: 'A workspace needs at least one repo, saved skill, skill bucket, or agent',
+				}),
+			]),
+		});
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
 	test('createSession sends enabledAgents in the request body', async () => {
 		mockFetch(async (url, init) => {
 			expect(url).toBe('https://coder.example/api/hub/session');
@@ -503,6 +554,44 @@ describe('CoderClient enabled agent roster contract', () => {
 		).resolves.toMatchObject({
 			id: 'hworkspace_enabled_create',
 			enabledAgents: ['code-review', 'qa-team'],
+		});
+	});
+
+	test('createWorkspace preserves server validation text returned in the error field', async () => {
+		mockFetch(async (url, init) => {
+			expect(url).toBe('https://coder.example/api/hub/workspaces');
+			expect(init?.method).toBe('POST');
+			return new Response(
+				JSON.stringify({
+					error: 'One or more selected saved skills do not exist.',
+				}),
+				{
+					status: 400,
+					headers: { 'content-type': 'application/json' },
+				}
+			);
+		});
+
+		const client = new CoderClient({
+			apiKey: 'ag_test',
+			url: 'https://coder.example',
+			orgId: 'org_test',
+		});
+
+		let error: unknown;
+		try {
+			await client.createWorkspace({
+				name: 'My Workspace',
+				enabledAgents: ['code-review'],
+			});
+		} catch (ex) {
+			error = ex;
+		}
+
+		expect(error).toBeInstanceOf(APIError);
+		expect(error).toMatchObject({
+			status: 400,
+			message: 'One or more selected saved skills do not exist.',
 		});
 	});
 

--- a/packages/core/test/coder-sse.test.ts
+++ b/packages/core/test/coder-sse.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { CoderSSEClient, streamCoderSessionSSE } from '../src/services/coder/sse.ts';
+
+const OriginalEventSource = globalThis.EventSource;
+
+type MockListener = (event: Event) => void;
+
+class MockEventSource {
+	static CONNECTING = 0;
+	static OPEN = 1;
+	static CLOSED = 2;
+	static instances: MockEventSource[] = [];
+
+	readyState = MockEventSource.CONNECTING;
+	onopen: ((event: Event) => void) | null = null;
+	onerror: ((event: Event) => void) | null = null;
+	readonly url: string;
+	readonly listeners = new Map<string, MockListener[]>();
+
+	constructor(url: string) {
+		this.url = url;
+		MockEventSource.instances.push(this);
+	}
+
+	addEventListener(eventName: string, listener: MockListener) {
+		const existing = this.listeners.get(eventName) ?? [];
+		existing.push(listener);
+		this.listeners.set(eventName, existing);
+	}
+
+	close() {
+		this.readyState = MockEventSource.CLOSED;
+	}
+
+	open() {
+		this.readyState = MockEventSource.OPEN;
+		this.onopen?.(new Event('open'));
+	}
+
+	emit(eventName: string, payload: unknown) {
+		const listeners = this.listeners.get(eventName) ?? [];
+		const event = {
+			data: JSON.stringify(payload),
+		} as MessageEvent;
+		for (const listener of listeners) {
+			listener(event);
+		}
+	}
+}
+
+async function flushAsyncWork() {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+describe('Coder SSE observer clients', () => {
+	beforeEach(() => {
+		MockEventSource.instances = [];
+		globalThis.EventSource = MockEventSource as unknown as typeof EventSource;
+	});
+
+	afterEach(() => {
+		globalThis.EventSource = OriginalEventSource;
+		MockEventSource.instances = [];
+	});
+
+	it('uses default observer subscriptions unless explicit filters are provided', async () => {
+		let openCount = 0;
+		const client = new CoderSSEClient({
+			apiKey: 'ag_test',
+			orgId: 'org_test',
+			url: 'https://hub.example',
+			sessionId: 'codesess_sse_default',
+			reconnect: false,
+			onOpen: () => {
+				openCount += 1;
+			},
+		});
+
+		client.connect();
+		await flushAsyncWork();
+
+		const eventSource = MockEventSource.instances[0];
+		expect(eventSource).toBeDefined();
+		expect(decodeURIComponent(eventSource!.url)).toContain(
+			'/api/hub/session/codesess_sse_default/events'
+		);
+		expect(decodeURIComponent(eventSource!.url)).toContain('api_key=ag_test');
+		expect(decodeURIComponent(eventSource!.url)).toContain('org_id=org_test');
+		expect(decodeURIComponent(eventSource!.url)).not.toContain('subscribe=');
+
+		eventSource!.open();
+		expect(client.state).toBe('connected');
+		expect(openCount).toBe(1);
+	});
+
+	it('streams broadcast events when explicit raw-event subscriptions are requested', async () => {
+		const eventsPromise = (async () => {
+			const seen = [];
+			for await (const event of streamCoderSessionSSE({
+				url: 'https://hub.example',
+				sessionId: 'codesess_sse_stream',
+				subscribe: ['*'],
+				reconnect: false,
+			})) {
+				seen.push(event);
+				break;
+			}
+			return seen;
+		})();
+
+		await flushAsyncWork();
+
+		const eventSource = MockEventSource.instances[0];
+		expect(eventSource).toBeDefined();
+		expect(decodeURIComponent(eventSource!.url)).toContain('subscribe=*');
+
+		eventSource!.open();
+		eventSource!.emit('broadcast', {
+			event: 'message_update',
+			data: {
+				assistantMessageEvent: {
+					type: 'text_delta',
+					delta: 'hello from SSE',
+				},
+			},
+			category: 'streaming',
+			sessionId: 'codesess_sse_stream',
+			timestamp: Date.now(),
+		});
+
+		const events = await eventsPromise;
+		expect(events).toHaveLength(1);
+		expect(events[0]).toMatchObject({
+			event: 'broadcast',
+			data: {
+				type: 'broadcast',
+				event: 'message_update',
+				category: 'streaming',
+				sessionId: 'codesess_sse_stream',
+			},
+		});
+		expect(eventSource!.readyState).toBe(MockEventSource.CLOSED);
+	});
+});

--- a/packages/core/test/coder-websocket.test.ts
+++ b/packages/core/test/coder-websocket.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { parseClientMessage } from '../src/services/coder/protocol.ts';
+import { CoderHubWebSocketClient } from '../src/services/coder/websocket.ts';
+
+const OriginalWebSocket = globalThis.WebSocket;
+
+class MockWebSocket {
+	static CONNECTING = 0;
+	static OPEN = 1;
+	static CLOSED = 3;
+	static instances: MockWebSocket[] = [];
+
+	readyState = MockWebSocket.CONNECTING;
+	onopen: ((event: Event) => void) | null = null;
+	onmessage: ((event: MessageEvent) => void) | null = null;
+	onerror: ((event: Event) => void) | null = null;
+	onclose: ((event: CloseEvent) => void) | null = null;
+	readonly sent: string[] = [];
+	readonly url: string;
+
+	constructor(url: string) {
+		this.url = url;
+		MockWebSocket.instances.push(this);
+	}
+
+	send(data: string) {
+		this.sent.push(data);
+	}
+
+	close(code = 1000, reason = '') {
+		this.readyState = MockWebSocket.CLOSED;
+		this.onclose?.({
+			code,
+			reason,
+			wasClean: true,
+		} as CloseEvent);
+	}
+
+	open() {
+		this.readyState = MockWebSocket.OPEN;
+		this.onopen?.(new Event('open'));
+	}
+
+	receive(payload: unknown) {
+		this.onmessage?.({
+			data: JSON.stringify(payload),
+		} as MessageEvent);
+	}
+}
+
+async function flushAsyncWork() {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+describe('CoderHubWebSocketClient', () => {
+	beforeEach(() => {
+		MockWebSocket.instances = [];
+		globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+	});
+
+	afterEach(() => {
+		globalThis.WebSocket = OriginalWebSocket;
+		MockWebSocket.instances = [];
+	});
+
+	it('treats observer hydration as the ready signal and preserves the first server message', async () => {
+		const seenMessages: Array<Record<string, unknown>> = [];
+		let openCount = 0;
+
+		const client = new CoderHubWebSocketClient({
+			apiKey: 'ag_test',
+			orgId: 'org_test',
+			url: 'ws://hub.example/api/ws',
+			role: 'observer',
+			sessionId: 'codesess_obs',
+			subscribe: ['streaming', 'content'],
+			autoReconnect: false,
+			onOpen: () => {
+				openCount += 1;
+			},
+			onMessage: (message) => {
+				seenMessages.push(message as unknown as Record<string, unknown>);
+			},
+		});
+
+		client.connect();
+		await flushAsyncWork();
+
+		const socket = MockWebSocket.instances[0];
+		expect(socket).toBeDefined();
+		expect(decodeURIComponent(socket!.url)).toContain('role=observer');
+		expect(decodeURIComponent(socket!.url)).toContain('sessionId=codesess_obs');
+		expect(decodeURIComponent(socket!.url)).toContain('subscribe=streaming,content');
+		expect(decodeURIComponent(socket!.url)).toContain('api_key=ag_test');
+
+		socket!.open();
+		socket!.receive({
+			type: 'session_hydration',
+			sessionId: 'codesess_obs',
+			resumedAt: Date.now(),
+			entries: [],
+			tasks: [],
+			stream: { output: 'hello', thinking: '', tasks: {} },
+			leadConnected: true,
+			streamingState: { isStreaming: true },
+		});
+
+		expect(client.state).toBe('connected');
+		expect(openCount).toBe(1);
+		expect(seenMessages).toHaveLength(1);
+		expect(seenMessages[0]).toMatchObject({
+			type: 'session_hydration',
+			sessionId: 'codesess_obs',
+		});
+	});
+
+	it('sends bootstrap_ready before flushing queued controller messages', async () => {
+		const initMessages: Array<Record<string, unknown>> = [];
+		const client = new CoderHubWebSocketClient({
+			url: 'ws://hub.example/api/ws',
+			role: 'controller',
+			sessionId: 'codesess_ctrl',
+			autoReconnect: false,
+			onInit: (message) => {
+				initMessages.push(message as unknown as Record<string, unknown>);
+			},
+		});
+
+		client.send({
+			type: 'ping',
+			timestamp: 123,
+		});
+		client.connect();
+		await flushAsyncWork();
+
+		const socket = MockWebSocket.instances[0];
+		expect(socket).toBeDefined();
+		socket!.open();
+		socket!.receive({
+			type: 'init',
+			role: 'controller',
+			sessionId: 'codesess_ctrl',
+		});
+
+		expect(client.state).toBe('connected');
+		expect(initMessages).toHaveLength(1);
+		const typedMessages = socket!.sent
+			.map((payload) => JSON.parse(payload) as Record<string, unknown>)
+			.filter((payload) => typeof payload.type === 'string');
+		expect(typedMessages).toEqual([
+			{ type: 'bootstrap_ready' },
+			{ type: 'ping', timestamp: 123 },
+		]);
+	});
+});
+
+describe('Coder Hub protocol', () => {
+	it('accepts typed observer subscribe messages', () => {
+		expect(
+			parseClientMessage({
+				type: 'subscribe',
+				patterns: ['streaming', 'content'],
+			})
+		).toEqual({
+			type: 'subscribe',
+			patterns: ['streaming', 'content'],
+		});
+	});
+});

--- a/packages/core/test/coder-websocket.test.ts
+++ b/packages/core/test/coder-websocket.test.ts
@@ -222,6 +222,44 @@ describe('CoderHubWebSocketClient', () => {
 			closeReason: 'Session not found',
 		});
 	});
+
+	it('does not misreport terminal closes after ready as handshake failures', async () => {
+		const seenErrors: CoderHubWebSocketErrorInstance[] = [];
+		const client = new CoderHubWebSocketClient({
+			url: 'ws://hub.example/api/ws',
+			role: 'observer',
+			sessionId: 'codesess_live',
+			autoReconnect: false,
+			onError: (error) => {
+				if (error instanceof CoderHubWebSocketError) {
+					seenErrors.push(error);
+				}
+			},
+		});
+
+		client.connect();
+		await flushAsyncWork();
+
+		const socket = MockWebSocket.instances[0];
+		expect(socket).toBeDefined();
+		socket!.open();
+		socket!.receive({
+			type: 'session_hydration',
+			sessionId: 'codesess_live',
+			resumedAt: Date.now(),
+			entries: [],
+			tasks: [],
+			stream: { output: '', thinking: '', tasks: {} },
+			leadConnected: true,
+			streamingState: { isStreaming: false },
+		});
+
+		expect(client.state).toBe('connected');
+
+		socket!.close(4404, 'Session not found');
+
+		expect(seenErrors).toHaveLength(0);
+	});
 });
 
 describe('Coder Hub protocol', () => {

--- a/packages/core/test/coder-websocket.test.ts
+++ b/packages/core/test/coder-websocket.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { parseClientMessage } from '../src/services/coder/protocol.ts';
-import { CoderHubWebSocketClient } from '../src/services/coder/websocket.ts';
+import {
+	CoderHubWebSocketClient,
+	CoderHubWebSocketError,
+	type CoderHubWebSocketErrorInstance,
+} from '../src/services/coder/websocket.ts';
 
 const OriginalWebSocket = globalThis.WebSocket;
 
@@ -152,6 +156,71 @@ describe('CoderHubWebSocketClient', () => {
 			{ type: 'bootstrap_ready' },
 			{ type: 'ping', timestamp: 123 },
 		]);
+	});
+
+	it('preserves server rejection details for pre-ready protocol failures', async () => {
+		const seenErrors: CoderHubWebSocketErrorInstance[] = [];
+		const client = new CoderHubWebSocketClient({
+			url: 'ws://hub.example/api/ws',
+			role: 'observer',
+			sessionId: 'codesess_rejected',
+			autoReconnect: false,
+			onError: (error) => {
+				if (error instanceof CoderHubWebSocketError) {
+					seenErrors.push(error);
+				}
+			},
+		});
+
+		client.connect();
+		await flushAsyncWork();
+
+		const socket = MockWebSocket.instances[0];
+		expect(socket).toBeDefined();
+		socket!.open();
+		socket!.receive({
+			type: 'connection_rejected',
+			code: 'observer_forbidden',
+			message: 'You do not have access to session: codesess_rejected',
+		});
+
+		expect(seenErrors).toHaveLength(1);
+		expect(seenErrors[0]).toMatchObject({
+			code: 'auth_failed',
+			serverCode: 'observer_forbidden',
+			serverMessageType: 'connection_rejected',
+			serverMessage: 'You do not have access to session: codesess_rejected',
+		});
+	});
+
+	it('surfaces terminal close details when the socket closes before ready', async () => {
+		const seenErrors: CoderHubWebSocketErrorInstance[] = [];
+		const client = new CoderHubWebSocketClient({
+			url: 'ws://hub.example/api/ws',
+			role: 'observer',
+			sessionId: 'codesess_missing',
+			autoReconnect: false,
+			onError: (error) => {
+				if (error instanceof CoderHubWebSocketError) {
+					seenErrors.push(error);
+				}
+			},
+		});
+
+		client.connect();
+		await flushAsyncWork();
+
+		const socket = MockWebSocket.instances[0];
+		expect(socket).toBeDefined();
+		socket!.open();
+		socket!.close(4404, 'Session not found');
+
+		expect(seenErrors).toHaveLength(1);
+		expect(seenErrors[0]).toMatchObject({
+			code: 'connection_error',
+			closeCode: 4404,
+			closeReason: 'Session not found',
+		});
 	});
 });
 

--- a/packages/core/test/coder-websocket.test.ts
+++ b/packages/core/test/coder-websocket.test.ts
@@ -158,6 +158,29 @@ describe('CoderHubWebSocketClient', () => {
 		]);
 	});
 
+	it('omits authorization from org-only bootstrap payloads', async () => {
+		const client = new CoderHubWebSocketClient({
+			apiKey: '',
+			orgId: 'org_test',
+			url: 'ws://hub.example/api/ws',
+			role: 'observer',
+			sessionId: 'codesess_org_only',
+			autoReconnect: false,
+		});
+
+		client.connect();
+		await flushAsyncWork();
+
+		const socket = MockWebSocket.instances[0];
+		expect(socket).toBeDefined();
+		socket!.open();
+
+		expect(socket!.sent).toHaveLength(1);
+		expect(JSON.parse(socket!.sent[0]!)).toEqual({
+			org_id: 'org_test',
+		});
+	});
+
 	it('preserves server rejection details for pre-ready protocol failures', async () => {
 		const seenErrors: CoderHubWebSocketErrorInstance[] = [];
 		const client = new CoderHubWebSocketClient({


### PR DESCRIPTION
## Summary
- align the public Coder WebSocket client with the Hub observer/controller handshake
- add observer subscription support to the WS protocol and connection params
- add WebSocket and SSE regression coverage for streaming-related observer behavior
- preserve structured server rejection details and terminal close information for SDK callers

## Additional Work
- tighten `coder workspace create` so empty workspaces fail locally instead of reaching the Hub
- align the shared workspace-create SDK schema with the Hub requirement that at least one repo, saved skill, skill bucket, or agent be selected
- stop advertising name-only workspace creation in CLI help/examples
- preserve Hub `{ error: "..." }` validation messages instead of collapsing them into a generic HTTP 400
- add SDK regression coverage for the empty-workspace contract and validation-message path

## Issue Coverage
- fixes agentuity/coder#34 by aligning observer WebSocket auth/readiness with the current Hub contract
- addresses agentuity/sdk#1375 for the empty-workspace CLI/SDK contract drift

## Notes
- this branch may receive additional follow-up commits
- the PR intentionally includes the current branch state


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization ID is now supported across CLI and client connections.
  * Added an observer role with optional event subscription filters.
  * Workspace creation now enforces at least one repo/saved skill/skill bucket/enabled agent.

* **Bug Fixes**
  * Clearer validation messages and richer connection/handshake error details.
  * More consistent authentication headers and CLI curl argument generation.

* **Tests**
  * New tests for workspace validation, auth helpers, SSE, WebSocket, remote-session, and CLI workspace commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->