### PR TITLE
Add `Coder` cookbook examples

### DIFF
--- a/apps/docs/scripts/generate-api-reference.ts
+++ b/apps/docs/scripts/generate-api-reference.ts
@@ -420,6 +420,7 @@ async function main() {
 		JSON.stringify(
 			{
 				title: 'API Reference',
+				sort: 'title',
 				pages: services.map((service) => service.slug).sort(),
 			},
 			null,

--- a/apps/docs/scripts/generate-api-reference.ts
+++ b/apps/docs/scripts/generate-api-reference.ts
@@ -259,7 +259,7 @@ Access any Agentuity Platform Service directly via REST APIs, the TypeScript SDK
   <CardLink
     href="/reference/api/coder"
     title="Coder"
-    description="Manage Coder sessions, session data, loop state, and known users through the HTTP API"
+    description="Manage Coder sessions, custom agents, session data, loop state, and known users through the REST API"
     icon={<BrainCircuit className="size-5" />}
   />
   <CardLink

--- a/apps/docs/scripts/generate-nav-data.ts
+++ b/apps/docs/scripts/generate-nav-data.ts
@@ -36,6 +36,7 @@ interface MetaJson {
 	title?: string;
 	sections?: string[];
 	pages?: string[];
+	sort?: 'title';
 }
 
 // ---------------------------------------------------------------------------
@@ -214,6 +215,10 @@ async function processDirectory(dirPath: string, urlPrefix: string): Promise<Nav
 		} else {
 			console.warn(`Warning: No directory or .mdx file for "${slug}" in ${dirPath}`);
 		}
+	}
+
+	if (meta.sort === 'title') {
+		items.sort((a, b) => a.title.localeCompare(b.title, undefined, { numeric: true }));
 	}
 
 	return items;

--- a/apps/docs/scripts/generate-nav-data.ts
+++ b/apps/docs/scripts/generate-nav-data.ts
@@ -9,6 +9,7 @@
 
 import { readFile, stat } from 'node:fs/promises';
 import { join } from 'node:path';
+import { StructuredError } from '@agentuity/core';
 import matter from 'gray-matter';
 
 const CONTENT_DIR = join(import.meta.dir, '../src/web/content');
@@ -43,6 +44,11 @@ interface MetaJson {
 		sort?: 'title';
 	}>;
 }
+
+const NavMetaValidationError = StructuredError('NavMetaValidationError')<{
+	slug: string;
+	dirPath: string;
+}>();
 
 // ---------------------------------------------------------------------------
 // SDK Explorer (hardcoded — demo routes, not content pages)
@@ -220,8 +226,11 @@ async function buildNavItemForSlug(
 		return item;
 	}
 
-	console.warn(`Warning: No directory or .mdx file for "${slug}" in ${dirPath}`);
-	return null;
+	throw new NavMetaValidationError({
+		slug,
+		dirPath,
+		message: `meta.json references "${slug}", but no matching directory or .mdx file exists in ${dirPath}`,
+	});
 }
 
 async function processDirectory(dirPath: string, urlPrefix: string): Promise<NavItem[]> {
@@ -320,11 +329,15 @@ function serializeSection(section: NavSection, indent: number): string {
 	if (section.hideItems) {
 		out += `${ind(indent + 1)}hideItems: true,\n`;
 	}
-	out += `${ind(indent + 1)}items: [\n`;
-	for (const item of section.items) {
-		out += serializeItem(item, indent + 2);
+	if (section.items.length === 0) {
+		out += `${ind(indent + 1)}items: [],\n`;
+	} else {
+		out += `${ind(indent + 1)}items: [\n`;
+		for (const item of section.items) {
+			out += serializeItem(item, indent + 2);
+		}
+		out += `${ind(indent + 1)}],\n`;
 	}
-	out += `${ind(indent + 1)}],\n`;
 	out += `${ind(indent)}},\n`;
 	return out;
 }

--- a/apps/docs/scripts/generate-nav-data.ts
+++ b/apps/docs/scripts/generate-nav-data.ts
@@ -37,6 +37,11 @@ interface MetaJson {
 	sections?: string[];
 	pages?: string[];
 	sort?: 'title';
+	groups?: Array<{
+		title: string;
+		pages: string[];
+		sort?: 'title';
+	}>;
 }
 
 // ---------------------------------------------------------------------------
@@ -187,34 +192,66 @@ async function readFrontmatter(mdxPath: string): Promise<{ title: string; descri
 // Content processing
 // ---------------------------------------------------------------------------
 
+async function buildNavItemForSlug(
+	dirPath: string,
+	urlPrefix: string,
+	slug: string
+): Promise<NavItem | null> {
+	if (slug === 'index') return null;
+
+	const subDirPath = join(dirPath, slug);
+	const mdxPath = join(dirPath, `${slug}.mdx`);
+
+	if (await isDirectory(subDirPath)) {
+		const subMeta = await readMetaJson(subDirPath);
+		const hasIndex = await fileExists(join(subDirPath, 'index.mdx'));
+		const subItems = await processDirectory(subDirPath, `${urlPrefix}/${slug}`);
+
+		const item: NavItem = { title: subMeta.title || slug };
+		if (hasIndex) item.url = `${urlPrefix}/${slug}`;
+		if (subItems.length > 0) item.items = subItems;
+		return item;
+	}
+
+	if (await fileExists(mdxPath)) {
+		const fm = await readFrontmatter(mdxPath);
+		const item: NavItem = { title: fm.title, url: `${urlPrefix}/${slug}` };
+		if (fm.description) item.description = fm.description;
+		return item;
+	}
+
+	console.warn(`Warning: No directory or .mdx file for "${slug}" in ${dirPath}`);
+	return null;
+}
+
 async function processDirectory(dirPath: string, urlPrefix: string): Promise<NavItem[]> {
 	const meta = await readMetaJson(dirPath);
 	const pages = meta.pages || [];
 	const items: NavItem[] = [];
+	const groupedPages = new Set<string>();
+
+	for (const group of meta.groups || []) {
+		const groupItems: NavItem[] = [];
+
+		for (const slug of group.pages) {
+			groupedPages.add(slug);
+			const item = await buildNavItemForSlug(dirPath, urlPrefix, slug);
+			if (item) groupItems.push(item);
+		}
+
+		if (group.sort === 'title') {
+			groupItems.sort((a, b) => a.title.localeCompare(b.title, undefined, { numeric: true }));
+		}
+
+		if (groupItems.length > 0) {
+			items.push({ title: group.title, items: groupItems });
+		}
+	}
 
 	for (const slug of pages) {
-		if (slug === 'index') continue;
-
-		const subDirPath = join(dirPath, slug);
-		const mdxPath = join(dirPath, `${slug}.mdx`);
-
-		if (await isDirectory(subDirPath)) {
-			const subMeta = await readMetaJson(subDirPath);
-			const hasIndex = await fileExists(join(subDirPath, 'index.mdx'));
-			const subItems = await processDirectory(subDirPath, `${urlPrefix}/${slug}`);
-
-			const item: NavItem = { title: subMeta.title || slug };
-			if (hasIndex) item.url = `${urlPrefix}/${slug}`;
-			if (subItems.length > 0) item.items = subItems;
-			items.push(item);
-		} else if (await fileExists(mdxPath)) {
-			const fm = await readFrontmatter(mdxPath);
-			const item: NavItem = { title: fm.title, url: `${urlPrefix}/${slug}` };
-			if (fm.description) item.description = fm.description;
-			items.push(item);
-		} else {
-			console.warn(`Warning: No directory or .mdx file for "${slug}" in ${dirPath}`);
-		}
+		if (groupedPages.has(slug)) continue;
+		const item = await buildNavItemForSlug(dirPath, urlPrefix, slug);
+		if (item) items.push(item);
 	}
 
 	if (meta.sort === 'title') {

--- a/apps/docs/scripts/generate-nav-data.ts
+++ b/apps/docs/scripts/generate-nav-data.ts
@@ -9,7 +9,6 @@
 
 import { readFile, stat } from 'node:fs/promises';
 import { join } from 'node:path';
-import { StructuredError } from '@agentuity/core';
 import matter from 'gray-matter';
 
 const CONTENT_DIR = join(import.meta.dir, '../src/web/content');
@@ -44,11 +43,6 @@ interface MetaJson {
 		sort?: 'title';
 	}>;
 }
-
-const NavMetaValidationError = StructuredError('NavMetaValidationError')<{
-	slug: string;
-	dirPath: string;
-}>();
 
 // ---------------------------------------------------------------------------
 // SDK Explorer (hardcoded — demo routes, not content pages)
@@ -226,11 +220,9 @@ async function buildNavItemForSlug(
 		return item;
 	}
 
-	throw new NavMetaValidationError({
-		slug,
-		dirPath,
-		message: `meta.json references "${slug}", but no matching directory or .mdx file exists in ${dirPath}`,
-	});
+	throw new Error(
+		`Invalid docs meta.json entry: "${slug}" has no matching directory or .mdx file in ${dirPath}`
+	);
 }
 
 async function processDirectory(dirPath: string, urlPrefix: string): Promise<NavItem[]> {

--- a/apps/docs/src/web/components/docs/nav-data.ts
+++ b/apps/docs/src/web/components/docs/nav-data.ts
@@ -405,7 +405,8 @@ export const navData: NavSection[] = [
 			{
 				title: 'Coder',
 				url: '/services/coder',
-				description: 'Run AI coding sessions in managed sandboxes with real-time collaboration',
+				description:
+					'Manage AI coding sessions that run in cloud sandboxes with full lifecycle, replay, and reconnect support',
 			},
 			{
 				title: 'Observability',
@@ -477,6 +478,48 @@ export const navData: NavSection[] = [
 			{
 				title: 'Patterns',
 				items: [
+					{
+						title: 'Manage Coder Sessions',
+						url: '/cookbook/patterns/creating-coder-sessions-with-sdk',
+						description:
+							'Create a Coder session, read its state, and manage its lifecycle with CoderClient',
+					},
+					{
+						title: 'Loop-Mode Sessions',
+						url: '/cookbook/patterns/creating-loop-mode-coder-sessions',
+						description:
+							'Create a loop-mode Coder session and inspect its workflow state with getLoopState',
+					},
+					{
+						title: 'Built-In Agents',
+						url: '/cookbook/patterns/choosing-built-in-agents-for-a-coder-session',
+						description:
+							'Use agentSlugs and defaultAgent to choose which built-in Coder agents are available in a session',
+					},
+					{
+						title: 'Attach Skills',
+						url: '/cookbook/patterns/attaching-skills-to-a-coder-session',
+						description:
+							'Save skills, group them into buckets, and attach them to a Coder session with CoderClient',
+					},
+					{
+						title: 'Use Workspaces',
+						url: '/cookbook/patterns/using-workspaces-to-reuse-repos-skills-and-agent-selection',
+						description:
+							'Store reusable Coder selections in a workspace and attach them to sessions with workspaceId',
+					},
+					{
+						title: 'Reconnect Sessions',
+						url: '/cookbook/patterns/preparing-coder-sessions-for-remote-attach',
+						description:
+							'Use listConnectableSessions and prepareSessionForRemoteAttach to find sessions you can still reconnect to',
+					},
+					{
+						title: 'Observe Sessions',
+						url: '/cookbook/patterns/observing-a-coder-session-through-the-hub',
+						description:
+							"Subscribe to a session's live event stream, page through its event history, and hydrate a client from the durable replay stream",
+					},
 					{
 						title: 'Autonomous Research Agent',
 						url: '/cookbook/patterns/autonomous-research',
@@ -624,17 +667,12 @@ export const navData: NavSection[] = [
 						title: 'Coder',
 						url: '/reference/api/coder',
 						description:
-							'Manage Coder sessions, session data, loop state, and known users through the HTTP API',
+							'Manage Coder sessions, custom agents, session data, loop state, and known users through the REST API',
 					},
 					{
 						title: 'Databases',
 						url: '/reference/api/database',
 						description: 'Execute queries, inspect tables, and monitor database performance',
-					},
-					{
-						title: 'Durable Streams',
-						url: '/reference/api/streams',
-						description: 'Create durable, resumable data streams with public URLs',
 					},
 					{
 						title: 'Emails',
@@ -656,12 +694,6 @@ export const navData: NavSection[] = [
 						title: 'Machines',
 						url: '/reference/api/machines',
 						description: 'Manage compute nodes and organization authentication enrollment',
-					},
-					{
-						title: 'Message Queues',
-						url: '/reference/api/queues',
-						description:
-							'Publish, consume, and manage messages with worker and pub/sub queues',
 					},
 					{
 						title: 'OAuth Applications',
@@ -687,6 +719,12 @@ export const navData: NavSection[] = [
 							'Full project lifecycle management including deployments, agents, environment variables, and hostnames',
 					},
 					{
+						title: 'Message Queues',
+						url: '/reference/api/queues',
+						description:
+							'Publish, consume, and manage messages with worker and pub/sub queues',
+					},
+					{
 						title: 'Regions',
 						url: '/reference/api/regions',
 						description: 'List available cloud regions and manage per-region resources',
@@ -708,6 +746,11 @@ export const navData: NavSection[] = [
 						url: '/reference/api/sessions',
 						description:
 							'View agent execution sessions with timing, cost, and observability data',
+					},
+					{
+						title: 'Durable Streams',
+						url: '/reference/api/streams',
+						description: 'Create durable, resumable data streams with public URLs',
 					},
 					{
 						title: 'Tasks',

--- a/apps/docs/src/web/components/docs/nav-data.ts
+++ b/apps/docs/src/web/components/docs/nav-data.ts
@@ -23,8 +23,7 @@ export const navData: NavSection[] = [
 		title: 'Home',
 		url: '/',
 		hideItems: true,
-		items: [
-		],
+		items: [],
 	},
 	{
 		title: 'SDK Explorer',

--- a/apps/docs/src/web/components/docs/nav-data.ts
+++ b/apps/docs/src/web/components/docs/nav-data.ts
@@ -632,6 +632,11 @@ export const navData: NavSection[] = [
 						description: 'Execute queries, inspect tables, and monitor database performance',
 					},
 					{
+						title: 'Durable Streams',
+						url: '/reference/api/streams',
+						description: 'Create durable, resumable data streams with public URLs',
+					},
+					{
 						title: 'Emails',
 						url: '/reference/api/email',
 						description:
@@ -651,6 +656,12 @@ export const navData: NavSection[] = [
 						title: 'Machines',
 						url: '/reference/api/machines',
 						description: 'Manage compute nodes and organization authentication enrollment',
+					},
+					{
+						title: 'Message Queues',
+						url: '/reference/api/queues',
+						description:
+							'Publish, consume, and manage messages with worker and pub/sub queues',
 					},
 					{
 						title: 'OAuth Applications',
@@ -676,12 +687,6 @@ export const navData: NavSection[] = [
 							'Full project lifecycle management including deployments, agents, environment variables, and hostnames',
 					},
 					{
-						title: 'Message Queues',
-						url: '/reference/api/queues',
-						description:
-							'Publish, consume, and manage messages with worker and pub/sub queues',
-					},
-					{
 						title: 'Regions',
 						url: '/reference/api/regions',
 						description: 'List available cloud regions and manage per-region resources',
@@ -703,11 +708,6 @@ export const navData: NavSection[] = [
 						url: '/reference/api/sessions',
 						description:
 							'View agent execution sessions with timing, cost, and observability data',
-					},
-					{
-						title: 'Durable Streams',
-						url: '/reference/api/streams',
-						description: 'Create durable, resumable data streams with public URLs',
 					},
 					{
 						title: 'Tasks',
@@ -743,16 +743,10 @@ export const navData: NavSection[] = [
 				url: '/reference/cli',
 				items: [
 					{
-						title: 'Getting Started',
-						url: '/reference/cli/getting-started',
+						title: 'AI Commands',
+						url: '/reference/cli/ai-commands',
 						description:
-							'Install the Agentuity CLI and authenticate to start building agents.',
-					},
-					{
-						title: 'Development',
-						url: '/reference/cli/development',
-						description:
-							'Run the development server with hot reload, local mode, and the interactive Workbench.',
+							'CLI commands for AI agents, IDE integration, and schema inspection.',
 					},
 					{
 						title: 'Build Configuration',
@@ -761,27 +755,15 @@ export const navData: NavSection[] = [
 							'Customize the build process with Vite plugins and build-time constants',
 					},
 					{
-						title: 'Deployment',
-						url: '/reference/cli/deployment',
+						title: 'Claude Code Plugin',
+						url: '/reference/cli/claude-code-plugin',
 						description:
-							'Deploy your agents to Agentuity Cloud with automatic infrastructure provisioning.',
+							'Install the Agentuity plugin for Claude Code to get auto-activated skills for deploying and building on Agentuity.',
 					},
 					{
-						title: 'Git Integration',
-						url: '/reference/cli/git-integration',
-						description:
-							'Link your GitHub account and repositories to enable preview deployments and CI/CD.',
-					},
-					{
-						title: 'Storage',
-						url: '/reference/cli/storage',
-						description:
-							'Manage Key-Value, S3, Vector, Database, and Stream storage from the CLI.',
-					},
-					{
-						title: 'Sandbox',
-						url: '/reference/cli/sandbox',
-						description: 'Create and manage isolated execution environments from the CLI',
+						title: 'Coder',
+						url: '/reference/cli/coder',
+						description: 'Start and manage AI coding sessions connected to the Coder Hub',
 					},
 					{
 						title: 'Configuration',
@@ -795,16 +777,28 @@ export const navData: NavSection[] = [
 							'SSH into containers, inspect sessions, and troubleshoot issues in your deployed agents.',
 					},
 					{
-						title: 'AI Commands',
-						url: '/reference/cli/ai-commands',
+						title: 'Deployment',
+						url: '/reference/cli/deployment',
 						description:
-							'CLI commands for AI agents, IDE integration, and schema inspection.',
+							'Deploy your agents to Agentuity Cloud with automatic infrastructure provisioning.',
 					},
 					{
-						title: 'Managing OAuth Applications',
-						url: '/reference/cli/oauth',
+						title: 'Development',
+						url: '/reference/cli/development',
 						description:
-							'Create and manage OAuth/OIDC applications for third-party integrations from the CLI',
+							'Run the development server with hot reload, local mode, and the interactive Workbench.',
+					},
+					{
+						title: 'Getting Started',
+						url: '/reference/cli/getting-started',
+						description:
+							'Install the Agentuity CLI and authenticate to start building agents.',
+					},
+					{
+						title: 'Git Integration',
+						url: '/reference/cli/git-integration',
+						description:
+							'Link your GitHub account and repositories to enable preview deployments and CI/CD.',
 					},
 					{
 						title: 'Infrastructure Monitoring',
@@ -813,21 +807,27 @@ export const navData: NavSection[] = [
 							'Monitor machine health and resource usage from the CLI in real time or as a snapshot',
 					},
 					{
-						title: 'Coder',
-						url: '/reference/cli/coder',
-						description: 'Start and manage AI coding sessions connected to the Coder Hub',
-					},
-					{
-						title: 'Claude Code Plugin',
-						url: '/reference/cli/claude-code-plugin',
+						title: 'Managing OAuth Applications',
+						url: '/reference/cli/oauth',
 						description:
-							'Install the Agentuity plugin for Claude Code to get auto-activated skills for deploying and building on Agentuity.',
+							'Create and manage OAuth/OIDC applications for third-party integrations from the CLI',
 					},
 					{
 						title: 'OpenCode Plugin',
 						url: '/reference/cli/opencode-plugin',
 						description:
 							'Install the Agentuity plugin for OpenCode to enable AI-assisted development with specialized agents',
+					},
+					{
+						title: 'Sandbox',
+						url: '/reference/cli/sandbox',
+						description: 'Create and manage isolated execution environments from the CLI',
+					},
+					{
+						title: 'Storage',
+						url: '/reference/cli/storage',
+						description:
+							'Manage Key-Value, S3, Vector, Database, and Stream storage from the CLI.',
 					},
 				],
 			},
@@ -836,66 +836,16 @@ export const navData: NavSection[] = [
 				url: '/reference/sdk-reference',
 				items: [
 					{
-						title: 'Application Entry',
-						url: '/reference/sdk-reference/application-entry',
-						description:
-							'Initialize your Agentuity app with createApp() and configure the runtime entry file',
-					},
-					{
 						title: 'Agents',
 						url: '/reference/sdk-reference/agents',
 						description:
 							'Define agents with createAgent(), configure schemas, and write handlers',
 					},
 					{
-						title: 'Schema',
-						url: '/reference/sdk-reference/schema',
-						description: 'Type-safe runtime validation with StandardSchema support',
-					},
-					{
-						title: 'Context API',
-						url: '/reference/sdk-reference/context-api',
-						description: 'Storage, logging, and services available via the ctx.* object',
-					},
-					{
-						title: 'Router',
-						url: '/reference/sdk-reference/router',
-						description: 'HTTP endpoints, middleware, WebSocket, SSE, and cron handlers',
-					},
-					{
-						title: 'Communication',
-						url: '/reference/sdk-reference/communication',
-						description: 'Call agents from routes or other agents with type-safe imports',
-					},
-					{
-						title: 'Storage',
-						url: '/reference/sdk-reference/storage',
-						description: 'KV, Vector, Database, Object, and Stream storage reference',
-					},
-					{
-						title: 'Queue Service',
-						url: '/reference/sdk-reference/queue-service',
-						description: 'Publish messages and manage queues with ctx.queue',
-					},
-					{
-						title: 'Task Service',
-						url: '/reference/sdk-reference/task-service',
-						description: 'Track work items with lifecycle management via ctx.task',
-					},
-					{
-						title: 'Email Service',
-						url: '/reference/sdk-reference/email-service',
-						description: 'Send emails and manage addresses with ctx.email',
-					},
-					{
-						title: 'Schedule Service',
-						url: '/reference/sdk-reference/schedule-service',
-						description: 'Create and manage cron-based scheduled jobs with ctx.schedule',
-					},
-					{
-						title: 'Sandbox Service',
-						url: '/reference/sdk-reference/sandbox-service',
-						description: 'Run code in isolated containers with ctx.sandbox',
+						title: 'Application Entry',
+						url: '/reference/sdk-reference/application-entry',
+						description:
+							'Initialize your Agentuity app with createApp() and configure the runtime entry file',
 					},
 					{
 						title: 'Coder',
@@ -903,10 +853,19 @@ export const navData: NavSection[] = [
 						description: 'Manage AI coding sessions, workspaces, and skills with CoderClient',
 					},
 					{
-						title: 'Observability',
-						url: '/reference/sdk-reference/observability',
-						description:
-							'Structured logging and OpenTelemetry tracing via ctx.logger and ctx.tracer',
+						title: 'Communication',
+						url: '/reference/sdk-reference/communication',
+						description: 'Call agents from routes or other agents with type-safe imports',
+					},
+					{
+						title: 'Context API',
+						url: '/reference/sdk-reference/context-api',
+						description: 'Storage, logging, and services available via the ctx.* object',
+					},
+					{
+						title: 'Email Service',
+						url: '/reference/sdk-reference/email-service',
+						description: 'Send emails and manage addresses with ctx.email',
 					},
 					{
 						title: 'Evaluations',
@@ -919,10 +878,51 @@ export const navData: NavSection[] = [
 						description: 'Lifecycle hooks for monitoring agent, session, and thread events',
 					},
 					{
+						title: 'Observability',
+						url: '/reference/sdk-reference/observability',
+						description:
+							'Structured logging and OpenTelemetry tracing via ctx.logger and ctx.tracer',
+					},
+					{
+						title: 'Queue Service',
+						url: '/reference/sdk-reference/queue-service',
+						description: 'Publish messages and manage queues with ctx.queue',
+					},
+					{
+						title: 'Router',
+						url: '/reference/sdk-reference/router',
+						description: 'HTTP endpoints, middleware, WebSocket, SSE, and cron handlers',
+					},
+					{
 						title: 'Runtime Utilities',
 						url: '/reference/sdk-reference/advanced',
 						description:
 							'File imports, standalone execution, context detection, process lifecycle, and build metadata',
+					},
+					{
+						title: 'Sandbox Service',
+						url: '/reference/sdk-reference/sandbox-service',
+						description: 'Run code in isolated containers with ctx.sandbox',
+					},
+					{
+						title: 'Schedule Service',
+						url: '/reference/sdk-reference/schedule-service',
+						description: 'Create and manage cron-based scheduled jobs with ctx.schedule',
+					},
+					{
+						title: 'Schema',
+						url: '/reference/sdk-reference/schema',
+						description: 'Type-safe runtime validation with StandardSchema support',
+					},
+					{
+						title: 'Storage',
+						url: '/reference/sdk-reference/storage',
+						description: 'KV, Vector, Database, Object, and Stream storage reference',
+					},
+					{
+						title: 'Task Service',
+						url: '/reference/sdk-reference/task-service',
+						description: 'Track work items with lifecycle management via ctx.task',
 					},
 				],
 			},

--- a/apps/docs/src/web/components/docs/nav-data.ts
+++ b/apps/docs/src/web/components/docs/nav-data.ts
@@ -23,7 +23,8 @@ export const navData: NavSection[] = [
 		title: 'Home',
 		url: '/',
 		hideItems: true,
-		items: [],
+		items: [
+		],
 	},
 	{
 		title: 'SDK Explorer',
@@ -479,49 +480,54 @@ export const navData: NavSection[] = [
 				title: 'Patterns',
 				items: [
 					{
-						title: 'Manage Coder Sessions',
-						url: '/cookbook/patterns/creating-coder-sessions-with-sdk',
-						description:
-							'Create a Coder session, read its state, and manage its lifecycle with CoderClient',
+						title: 'Coder',
+						items: [
+							{
+								title: 'Manage Sessions',
+								url: '/cookbook/patterns/creating-coder-sessions-with-sdk',
+								description:
+									'Create a Coder session, read its state, and manage its lifecycle with CoderClient',
+							},
+							{
+								title: 'Loop-Mode Sessions',
+								url: '/cookbook/patterns/creating-loop-mode-coder-sessions',
+								description:
+									'Create a loop-mode Coder session and inspect its workflow state with getLoopState',
+							},
+							{
+								title: 'Built-In Agents',
+								url: '/cookbook/patterns/choosing-built-in-agents-for-a-coder-session',
+								description:
+									'Use agentSlugs and defaultAgent to choose which built-in Coder agents are available in a session',
+							},
+							{
+								title: 'Attach Skills',
+								url: '/cookbook/patterns/attaching-skills-to-a-coder-session',
+								description:
+									'Save skills, group them into buckets, and attach them to a Coder session with CoderClient',
+							},
+							{
+								title: 'Use Workspaces',
+								url: '/cookbook/patterns/using-workspaces-to-reuse-repos-skills-and-agent-selection',
+								description:
+									'Store reusable Coder selections in a workspace and attach them to sessions with workspaceId',
+							},
+							{
+								title: 'Reconnect Sessions',
+								url: '/cookbook/patterns/preparing-coder-sessions-for-remote-attach',
+								description:
+									'Use listConnectableSessions and prepareSessionForRemoteAttach to find sessions you can still reconnect to',
+							},
+							{
+								title: 'Observe Sessions',
+								url: '/cookbook/patterns/observing-a-coder-session-through-the-hub',
+								description:
+									"Subscribe to a session's live event stream, page through its event history, and hydrate a client from the durable replay stream",
+							},
+						],
 					},
 					{
-						title: 'Loop-Mode Sessions',
-						url: '/cookbook/patterns/creating-loop-mode-coder-sessions',
-						description:
-							'Create a loop-mode Coder session and inspect its workflow state with getLoopState',
-					},
-					{
-						title: 'Built-In Agents',
-						url: '/cookbook/patterns/choosing-built-in-agents-for-a-coder-session',
-						description:
-							'Use agentSlugs and defaultAgent to choose which built-in Coder agents are available in a session',
-					},
-					{
-						title: 'Attach Skills',
-						url: '/cookbook/patterns/attaching-skills-to-a-coder-session',
-						description:
-							'Save skills, group them into buckets, and attach them to a Coder session with CoderClient',
-					},
-					{
-						title: 'Use Workspaces',
-						url: '/cookbook/patterns/using-workspaces-to-reuse-repos-skills-and-agent-selection',
-						description:
-							'Store reusable Coder selections in a workspace and attach them to sessions with workspaceId',
-					},
-					{
-						title: 'Reconnect Sessions',
-						url: '/cookbook/patterns/preparing-coder-sessions-for-remote-attach',
-						description:
-							'Use listConnectableSessions and prepareSessionForRemoteAttach to find sessions you can still reconnect to',
-					},
-					{
-						title: 'Observe Sessions',
-						url: '/cookbook/patterns/observing-a-coder-session-through-the-hub',
-						description:
-							"Subscribe to a session's live event stream, page through its event history, and hydrate a client from the durable replay stream",
-					},
-					{
-						title: 'Autonomous Research Agent',
+						title: 'Autonomous Research',
 						url: '/cookbook/patterns/autonomous-research',
 						description:
 							'Build a recursive research loop using the Anthropic SDK with native tool calling',
@@ -543,7 +549,7 @@ export const navData: NavSection[] = [
 						description: 'Cache scheduled task results in KV for later retrieval',
 					},
 					{
-						title: 'Hono RPC + TanStack Query',
+						title: 'Hono RPC + TanStack',
 						url: '/cookbook/patterns/hono-rpc-tanstack-query',
 						description:
 							'Get end-to-end type safety between your Agentuity API routes and React frontend using Hono RPC and TanStack Query',
@@ -571,7 +577,7 @@ export const navData: NavSection[] = [
 						description: 'Add Tailwind CSS styling to your Agentuity frontend',
 					},
 					{
-						title: 'Web Exploration with Sandboxes',
+						title: 'Web Exploration',
 						url: '/cookbook/patterns/web-exploration',
 						description:
 							'Run a headless browser in a sandbox to let agents browse, screenshot, and extract web content',
@@ -675,6 +681,11 @@ export const navData: NavSection[] = [
 						description: 'Execute queries, inspect tables, and monitor database performance',
 					},
 					{
+						title: 'Durable Streams',
+						url: '/reference/api/streams',
+						description: 'Create durable, resumable data streams with public URLs',
+					},
+					{
 						title: 'Emails',
 						url: '/reference/api/email',
 						description:
@@ -694,6 +705,12 @@ export const navData: NavSection[] = [
 						title: 'Machines',
 						url: '/reference/api/machines',
 						description: 'Manage compute nodes and organization authentication enrollment',
+					},
+					{
+						title: 'Message Queues',
+						url: '/reference/api/queues',
+						description:
+							'Publish, consume, and manage messages with worker and pub/sub queues',
 					},
 					{
 						title: 'OAuth Applications',
@@ -719,12 +736,6 @@ export const navData: NavSection[] = [
 							'Full project lifecycle management including deployments, agents, environment variables, and hostnames',
 					},
 					{
-						title: 'Message Queues',
-						url: '/reference/api/queues',
-						description:
-							'Publish, consume, and manage messages with worker and pub/sub queues',
-					},
-					{
 						title: 'Regions',
 						url: '/reference/api/regions',
 						description: 'List available cloud regions and manage per-region resources',
@@ -746,11 +757,6 @@ export const navData: NavSection[] = [
 						url: '/reference/api/sessions',
 						description:
 							'View agent execution sessions with timing, cost, and observability data',
-					},
-					{
-						title: 'Durable Streams',
-						url: '/reference/api/streams',
-						description: 'Create durable, resumable data streams with public URLs',
 					},
 					{
 						title: 'Tasks',
@@ -850,7 +856,7 @@ export const navData: NavSection[] = [
 							'Monitor machine health and resource usage from the CLI in real time or as a snapshot',
 					},
 					{
-						title: 'Managing OAuth Applications',
+						title: 'Managing OAuth Apps',
 						url: '/reference/cli/oauth',
 						description:
 							'Create and manage OAuth/OIDC applications for third-party integrations from the CLI',

--- a/apps/docs/src/web/content/cookbook/index.mdx
+++ b/apps/docs/src/web/content/cookbook/index.mdx
@@ -3,7 +3,7 @@ title: Cookbook
 description: Tutorials and patterns for building with Agentuity
 ---
 
-import { BookOpen, Search, Clock, MessageSquare, Timer, Scale, Server, ShoppingCart, Paintbrush, Webhook, Link, Globe } from 'lucide-react';
+import { BookOpen, Search, Clock, MessageSquare, Timer, Scale, Server, ShoppingCart, Paintbrush, Webhook, Link, Globe, Bot } from 'lucide-react';
 
 Learn common patterns and build real-world applications with these guides.
 
@@ -21,6 +21,53 @@ Learn common patterns and build real-world applications with these guides.
     title="RAG Agent"
     description="Build a retrieval-augmented generation agent"
     icon={<Search />}
+  />
+</Cards>
+
+## Coder
+
+<Cards>
+  <CardLink
+    href="/cookbook/patterns/creating-coder-sessions-with-sdk"
+    title="Manage Coder Sessions"
+    description="Create sessions, read state, and manage lifecycle from a plain script"
+    icon={<Bot />}
+  />
+  <CardLink
+    href="/cookbook/patterns/creating-loop-mode-coder-sessions"
+    title="Loop-Mode Sessions"
+    description="Create a loop-mode session and inspect workflow state with getLoopState"
+    icon={<Bot />}
+  />
+  <CardLink
+    href="/cookbook/patterns/choosing-built-in-agents-for-a-coder-session"
+    title="Built-In Agents"
+    description="Choose which built-in Coder agents are enabled for a session and set the default agent"
+    icon={<Bot />}
+  />
+  <CardLink
+    href="/cookbook/patterns/attaching-skills-to-a-coder-session"
+    title="Attach Skills"
+    description="Save skills, group them into buckets, and attach them to a Coder session"
+    icon={<Bot />}
+  />
+  <CardLink
+    href="/cookbook/patterns/using-workspaces-to-reuse-repos-skills-and-agent-selection"
+    title="Use Workspaces"
+    description="Store reusable Coder selections in a workspace and attach them to sessions"
+    icon={<Bot />}
+  />
+  <CardLink
+    href="/cookbook/patterns/preparing-coder-sessions-for-remote-attach"
+    title="Reconnect Sessions"
+    description="Find live or wakeable sessions and prepare one for remote attach"
+    icon={<Bot />}
+  />
+  <CardLink
+    href="/cookbook/patterns/observing-a-coder-session-through-the-hub"
+    title="Observe Sessions"
+    description="Subscribe to a session's live event stream, page through its event history, and hydrate a client from the durable replay stream"
+    icon={<Bot />}
   />
 </Cards>
 

--- a/apps/docs/src/web/content/cookbook/index.mdx
+++ b/apps/docs/src/web/content/cookbook/index.mdx
@@ -24,7 +24,9 @@ Learn common patterns and build real-world applications with these guides.
   />
 </Cards>
 
-## Coder
+## Patterns
+
+### Coder
 
 <Cards>
   <CardLink
@@ -71,7 +73,7 @@ Learn common patterns and build real-world applications with these guides.
   />
 </Cards>
 
-## Patterns
+### More Patterns
 
 <Cards>
   <CardLink

--- a/apps/docs/src/web/content/cookbook/patterns/attaching-skills-to-a-coder-session.mdx
+++ b/apps/docs/src/web/content/cookbook/patterns/attaching-skills-to-a-coder-session.mdx
@@ -1,0 +1,151 @@
+---
+title: Attaching Skills to a Coder Session
+short_title: Attach Skills
+description: Save skills, group them into buckets, and attach them to a Coder session with CoderClient
+---
+
+Use this page when you want a session to start with skill selections you control. The Hub already injects system skills automatically. This flow is about attaching your own saved skills and optional skill buckets on top of that base behavior.
+
+<Callout type="info" title="Use this page when you want reusable skill selections">
+Use this page when you want the same saved skills to show up across multiple sessions instead of repeating inline skill definitions each time.
+</Callout>
+
+<Callout type="tip" title="Read the session back after creation">
+`saveSkill()` and `createSkillBucket()` build the library side of the workflow. `getSession()` is still the cleanest place to confirm which skills the session actually received.
+</Callout>
+
+You can validate this from a local script: save the skill, create the session, then read the session back to confirm what attached.
+
+## The Pattern
+
+Save a skill, optionally group it into a bucket, then attach both selections when you create the session:
+
+```typescript
+import { CoderClient } from '@agentuity/coder';
+
+const DEFAULT_TASK =
+  'Review the repo and use the attached skills where they help the work move faster.';
+
+function getTask(): string {
+  const task = process.argv.slice(2).join(' ').trim();
+  return task || DEFAULT_TASK;
+}
+
+async function main(): Promise<void> {
+  const client = new CoderClient();
+  const task = getTask();
+
+  // Save the skill to your library once so any future session can attach it by id.
+  const savedSkill = await client.saveSkill({
+    repo: 'anthropics/skills',
+    skillId: 'frontend-design',
+    name: 'frontend-design',
+    description: 'Design-focused frontend implementation guidance.',
+    url: 'https://skills.sh/anthropics/skills/frontend-design',
+  });
+
+  // Buckets are a convenience for when your app usually attaches the same group of skills together.
+  const bucket = await client.createSkillBucket({
+    name: `design-bucket-${Date.now()}`,
+    description: 'Reusable design skills for Coder sessions.',
+    savedSkillIds: [savedSkill.id],
+  });
+
+  const created = await client.createSession({
+    task,
+    workflowMode: 'standard',
+    // savedSkillIds and skillBucketIds both attach to the session; buckets expand into their members.
+    savedSkillIds: [savedSkill.id], // [!code highlight]
+    skillBucketIds: [bucket.id], // [!code highlight]
+    tags: ['docs-example', 'session-skills'],
+  });
+
+  // Read the session back to confirm which skills the Hub actually attached.
+  const session = await client.getSession(created.sessionId);
+
+  // The library still holds the saved skill and bucket after session creation, so future sessions can reuse them.
+  const { skills } = await client.listSavedSkills();
+  const { buckets } = await client.listSkillBuckets();
+
+  console.log(
+    JSON.stringify(
+      {
+        sessionId: session.sessionId,
+        status: session.status,
+        bucket: session.bucket,
+        skills: session.skills.map((skill) => ({
+          repo: skill.repo,
+          skillId: skill.skillId,
+          name: skill.name,
+          url: skill.url,
+        })),
+        matchingSavedSkills: skills.filter((skill) => skill.id === savedSkill.id).length,
+        matchingBuckets: buckets.filter((bucketItem) => bucketItem.id === bucket.id).length,
+      },
+      null,
+      2
+    )
+  );
+}
+
+void main();
+```
+
+## Example Output
+
+```json
+{
+  "sessionId": "codesess_e7ec6fe0932c",
+  "status": "creating",
+  "bucket": "provisioning",
+  "skills": [
+    {
+      "repo": "anthropics/skills",
+      "skillId": "frontend-design",
+      "name": "frontend-design",
+      "url": "https://skills.sh/anthropics/skills/frontend-design"
+    }
+  ],
+  "matchingSavedSkills": 1,
+  "matchingBuckets": 1
+}
+```
+
+What this means:
+
+- the session received the saved skill selection you attached
+- the bucket exists as a reusable library selection for future sessions
+- the saved skill still lives in your skill library after the session is created
+
+## System Skills vs Saved Skills
+
+The easiest mental model is:
+
+- system skills are automatic and platform-managed
+- saved skills are your reusable library entries
+- skill buckets are just reusable groups of saved skills
+
+So if you want to control what your own app reuses, reach for `savedSkillIds` and `skillBucketIds`.
+
+## When to Use This Pattern
+
+Use this pattern when you want:
+
+- a reusable library of prompts or instructions
+- consistent skill attachments across multiple sessions
+- a small set of named buckets you can attach from a UI or internal tool
+- to keep session creation code clean while still reusing the same skills
+
+## Key Points
+
+- Attach saved skills when you want explicit, user-controlled reuse.
+- Buckets are helpful when your app usually attaches the same group of skills together.
+- `getSession()` is the cleanest confirmation surface for the effective skill selection on a session.
+- Fresh sessions can still be in `creating` or `provisioning` even when the skill selection is already visible.
+
+## See Also
+
+- [Using Workspaces to Reuse Repos, Skills, and Agent Selection](/cookbook/patterns/using-workspaces-to-reuse-repos-skills-and-agent-selection): Store the same selections once and attach them by `workspaceId`
+- [Managing Coder Sessions with the SDK](/cookbook/patterns/creating-coder-sessions-with-sdk): Start with the core create, read, archive, and delete flow
+- [Coder](/services/coder): Concepts, lifecycle, and the difference between system skills and saved skills
+- [Coder Client](/reference/sdk-reference/coder): Full `saveSkill()`, `createSkillBucket()`, and `createSession()` reference

--- a/apps/docs/src/web/content/cookbook/patterns/attaching-skills-to-a-coder-session.mdx
+++ b/apps/docs/src/web/content/cookbook/patterns/attaching-skills-to-a-coder-session.mdx
@@ -4,17 +4,11 @@ short_title: Attach Skills
 description: Save skills, group them into buckets, and attach them to a Coder session with CoderClient
 ---
 
-Use this page when you want a session to start with skill selections you control. The Hub already injects system skills automatically. This flow is about attaching your own saved skills and optional skill buckets on top of that base behavior.
-
-<Callout type="info" title="Use this page when you want reusable skill selections">
-Use this page when you want the same saved skills to show up across multiple sessions instead of repeating inline skill definitions each time.
-</Callout>
+The Hub injects system skills into every session automatically. Saved skills and skill buckets are the part your app owns. Save them to your library once, then attach them to new sessions with `savedSkillIds` or `skillBucketIds`, so you don't reship the definitions each time.
 
 <Callout type="tip" title="Read the session back after creation">
-`saveSkill()` and `createSkillBucket()` build the library side of the workflow. `getSession()` is still the cleanest place to confirm which skills the session actually received.
+`getSession()` is the simplest way to confirm a session started with the selections you passed. Skill detail appears on the session right away, so you can verify it even while the session is still `creating` or `provisioning`.
 </Callout>
-
-You can validate this from a local script: save the skill, create the session, then read the session back to confirm what attached.
 
 ## The Pattern
 
@@ -35,7 +29,7 @@ async function main(): Promise<void> {
   const client = new CoderClient();
   const task = getTask();
 
-  // Save the skill to your library once so any future session can attach it by id.
+  // Save the skill once so future sessions can attach it by id
   const savedSkill = await client.saveSkill({
     repo: 'anthropics/skills',
     skillId: 'frontend-design',
@@ -44,7 +38,7 @@ async function main(): Promise<void> {
     url: 'https://skills.sh/anthropics/skills/frontend-design',
   });
 
-  // Buckets are a convenience for when your app usually attaches the same group of skills together.
+  // Buckets group skills your app usually attaches together
   const bucket = await client.createSkillBucket({
     name: `design-bucket-${Date.now()}`,
     description: 'Reusable design skills for Coder sessions.',
@@ -54,16 +48,16 @@ async function main(): Promise<void> {
   const created = await client.createSession({
     task,
     workflowMode: 'standard',
-    // savedSkillIds and skillBucketIds both attach to the session; buckets expand into their members.
+    // savedSkillIds and skillBucketIds both attach; buckets expand into their members
     savedSkillIds: [savedSkill.id], // [!code highlight]
     skillBucketIds: [bucket.id], // [!code highlight]
     tags: ['docs-example', 'session-skills'],
   });
 
-  // Read the session back to confirm which skills the Hub actually attached.
+  // Read the session back to confirm what attached
   const session = await client.getSession(created.sessionId);
 
-  // The library still holds the saved skill and bucket after session creation, so future sessions can reuse them.
+  // The library still holds the saved skill and bucket for future sessions
   const { skills } = await client.listSavedSkills();
   const { buckets } = await client.listSkillBuckets();
 
@@ -139,9 +133,9 @@ Use this pattern when you want:
 ## Key Points
 
 - Attach saved skills when you want explicit, user-controlled reuse.
-- Buckets are helpful when your app usually attaches the same group of skills together.
-- `getSession()` is the cleanest confirmation surface for the effective skill selection on a session.
-- Fresh sessions can still be in `creating` or `provisioning` even when the skill selection is already visible.
+- Buckets help when your app usually reaches for the same group of skills.
+- `getSession()` is the simplest way to verify what a session ended up with.
+- Fresh sessions can be in `creating` or `provisioning` even when the skill selection is already visible.
 
 ## See Also
 

--- a/apps/docs/src/web/content/cookbook/patterns/autonomous-research.mdx
+++ b/apps/docs/src/web/content/cookbook/patterns/autonomous-research.mdx
@@ -1,5 +1,6 @@
 ---
 title: Autonomous Research Agent
+short_title: Autonomous Research
 description: Build a recursive research loop using the Anthropic SDK with native tool calling
 ---
 

--- a/apps/docs/src/web/content/cookbook/patterns/choosing-built-in-agents-for-a-coder-session.mdx
+++ b/apps/docs/src/web/content/cookbook/patterns/choosing-built-in-agents-for-a-coder-session.mdx
@@ -4,21 +4,15 @@ short_title: Built-In Agents
 description: Use agentSlugs and defaultAgent to choose which built-in Coder agents are available in a session
 ---
 
-Not every Coder session should expose the same agent roster. Use `agentSlugs` to choose which built-in agents are available for a session, then use `defaultAgent` when you want prompts to route to a specific built-in agent instead of the default `lead` flow.
-
-<Callout type="info" title="Use this page when you want a more opinionated session roster">
-Use this page when you want to narrow the built-in agents for a session, for example a focused builder plus reviewer workflow instead of the broader default team.
-</Callout>
+A session can start with only the built-in Coder agents you care about. Use `agentSlugs` to pick which built-ins are mounted, and `defaultAgent` to route prompts to a specific one instead of the normal `lead` flow. A builder-plus-reviewer pair is a common shape.
 
 <Callout type="tip" title="Read the session back after creation">
-`createSession()` accepts the roster. Call `getSession()` when you want to confirm the session state and the default agent.
+`getSession()` returns the session's lifecycle state and its `defaultAgent`. That's usually enough to confirm the session started the way you intended.
 </Callout>
-
-You can test the roster behavior from a small local script before wiring it into a larger app or tool.
 
 ## The Pattern
 
-Create the session with an explicit built-in roster, then inspect the session detail:
+Create the session with an explicit built-in selection, then inspect the session detail:
 
 ```typescript
 import { CoderClient } from '@agentuity/coder';
@@ -41,14 +35,14 @@ async function main(): Promise<void> {
     const created = await client.createSession({
       task,
       workflowMode: 'standard',
-      // defaultAgent: the built-in the Hub routes to when no specific agent is named.
+      // defaultAgent: the built-in the Hub routes to when no specific agent is named
       defaultAgent: DEFAULT_AGENT, // [!code highlight]
-      // agentSlugs: the only built-ins mounted for this session; others are hidden.
+      // agentSlugs: the only built-ins mounted for this session; others stay hidden
       agentSlugs: [...AGENT_SLUGS], // [!code highlight]
       tags: ['docs-example', 'built-in-agents'],
     });
 
-    // Read the session back so you can confirm the default agent and lifecycle state.
+    // Read the session back to confirm the default agent and lifecycle state
     const session = await client.getSession(created.sessionId);
 
     console.log(
@@ -89,17 +83,17 @@ void main();
 
 What this means:
 
-- `agentSlugs` limits the built-in roster attached when you create the session
-- `defaultAgent` tells the Hub which built-in agent should handle routed work by default
+- `agentSlugs` limits which built-ins are mounted when you create the session
+- `defaultAgent` tells the Hub which built-in should handle routed work by default
 - `status` and `bucket` still describe the lifecycle state of the session itself
 
 ## How Agent Selection Works
 
-The simplest mental model is:
+The simplest mental model:
 
 - `lead` is the default orchestration posture for a normal session
-- `agentSlugs` says which built-in specialists are mounted for this session
-- `defaultAgent` says which agent should be preferred when the session is not just using the normal `lead` path
+- `agentSlugs` is the set of built-in specialists mounted for this session
+- `defaultAgent` is the built-in preferred when the session isn't using the normal `lead` path
 
 So if you create a session with:
 
@@ -110,10 +104,7 @@ So if you create a session with:
 }
 ```
 
-you are effectively saying:
-
-- this session should expose `builder` and `reviewer`
-- `builder` should be the default routed specialist
+you're saying: make `builder` and `reviewer` available, and route to `builder` by default.
 
 ## When to Use This Pattern
 
@@ -121,17 +112,17 @@ Use this pattern when you want:
 
 - a focused implementation session with `builder`
 - a review-oriented session with `reviewer`
-- a tighter roster for your app instead of every available built-in agent
+- a tighter set of agents than the full default team
 - a consistent default specialist for repeated automation
 
-If you just want a normal Coder session, you can omit both fields and let the standard session behavior take over.
+If you want a normal Coder session, omit both fields.
 
 ## Key Points
 
-- Start with a small roster. It keeps the session easier to inspect.
-- Prefer `getSession()` over a list view when you need the definitive session state.
-- Use built-in agent names that actually exist in your Hub environment.
-- If you need your own reusable agent definition, that is a custom-agent flow, not a built-in roster flow.
+- Start with the built-ins you need. You can widen the selection later.
+- Prefer `getSession()` over list views when you need a definitive view of one session.
+- Use built-in names your Hub exposes.
+- For agent definitions you author yourself, switch to the custom-agent flow.
 
 ## See Also
 

--- a/apps/docs/src/web/content/cookbook/patterns/choosing-built-in-agents-for-a-coder-session.mdx
+++ b/apps/docs/src/web/content/cookbook/patterns/choosing-built-in-agents-for-a-coder-session.mdx
@@ -1,0 +1,141 @@
+---
+title: Choosing Built-In Agents for a Coder Session
+short_title: Built-In Agents
+description: Use agentSlugs and defaultAgent to choose which built-in Coder agents are available in a session
+---
+
+Not every Coder session should expose the same agent roster. Use `agentSlugs` to choose which built-in agents are available for a session, then use `defaultAgent` when you want prompts to route to a specific built-in agent instead of the default `lead` flow.
+
+<Callout type="info" title="Use this page when you want a more opinionated session roster">
+Use this page when you want to narrow the built-in agents for a session, for example a focused builder plus reviewer workflow instead of the broader default team.
+</Callout>
+
+<Callout type="tip" title="Read the session back after creation">
+`createSession()` accepts the roster. Call `getSession()` when you want to confirm the session state and the default agent.
+</Callout>
+
+You can test the roster behavior from a small local script before wiring it into a larger app or tool.
+
+## The Pattern
+
+Create the session with an explicit built-in roster, then inspect the session detail:
+
+```typescript
+import { CoderClient } from '@agentuity/coder';
+
+const DEFAULT_TASK =
+  'Inspect the repo, identify the main implementation risks, and suggest a clean next step.';
+const AGENT_SLUGS = ['builder', 'reviewer'] as const;
+const DEFAULT_AGENT = 'builder';
+
+function getTask(): string {
+  const task = process.argv.slice(2).join(' ').trim();
+  return task || DEFAULT_TASK;
+}
+
+async function main(): Promise<void> {
+  const client = new CoderClient();
+  const task = getTask();
+
+  try {
+    const created = await client.createSession({
+      task,
+      workflowMode: 'standard',
+      // defaultAgent: the built-in the Hub routes to when no specific agent is named.
+      defaultAgent: DEFAULT_AGENT, // [!code highlight]
+      // agentSlugs: the only built-ins mounted for this session; others are hidden.
+      agentSlugs: [...AGENT_SLUGS], // [!code highlight]
+      tags: ['docs-example', 'built-in-agents'],
+    });
+
+    // Read the session back so you can confirm the default agent and lifecycle state.
+    const session = await client.getSession(created.sessionId);
+
+    console.log(
+      JSON.stringify(
+        {
+          sessionId: session.sessionId,
+          workflowMode: session.workflowMode,
+          defaultAgent: session.defaultAgent,
+          status: session.status,
+          bucket: session.bucket,
+        },
+        null,
+        2
+      )
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.stack ?? error.message : String(error);
+    console.error('Failed to create a built-in agent session');
+    console.error(message);
+    process.exitCode = 1;
+  }
+}
+
+void main();
+```
+
+## Example Output
+
+```json
+{
+  "sessionId": "codesess_142090f92556",
+  "workflowMode": "standard",
+  "defaultAgent": "builder",
+  "status": "creating",
+  "bucket": "provisioning"
+}
+```
+
+What this means:
+
+- `agentSlugs` limits the built-in roster attached when you create the session
+- `defaultAgent` tells the Hub which built-in agent should handle routed work by default
+- `status` and `bucket` still describe the lifecycle state of the session itself
+
+## How Agent Selection Works
+
+The simplest mental model is:
+
+- `lead` is the default orchestration posture for a normal session
+- `agentSlugs` says which built-in specialists are mounted for this session
+- `defaultAgent` says which agent should be preferred when the session is not just using the normal `lead` path
+
+So if you create a session with:
+
+```typescript
+{
+  agentSlugs: ['builder', 'reviewer'],
+  defaultAgent: 'builder',
+}
+```
+
+you are effectively saying:
+
+- this session should expose `builder` and `reviewer`
+- `builder` should be the default routed specialist
+
+## When to Use This Pattern
+
+Use this pattern when you want:
+
+- a focused implementation session with `builder`
+- a review-oriented session with `reviewer`
+- a tighter roster for your app instead of every available built-in agent
+- a consistent default specialist for repeated automation
+
+If you just want a normal Coder session, you can omit both fields and let the standard session behavior take over.
+
+## Key Points
+
+- Start with a small roster. It keeps the session easier to inspect.
+- Prefer `getSession()` over a list view when you need the definitive session state.
+- Use built-in agent names that actually exist in your Hub environment.
+- If you need your own reusable agent definition, that is a custom-agent flow, not a built-in roster flow.
+
+## See Also
+
+- [Managing Coder Sessions with the SDK](/cookbook/patterns/creating-coder-sessions-with-sdk): Start with the core create, read, archive, and delete flow
+- [Creating Loop-Mode Coder Sessions](/cookbook/patterns/creating-loop-mode-coder-sessions): Add explicit workflow state on top of session composition
+- [Coder](/services/coder): Concepts, lifecycle, and session-state fields
+- [Coder Client](/reference/sdk-reference/coder): Full `createSession()` and `getSession()` reference

--- a/apps/docs/src/web/content/cookbook/patterns/creating-coder-sessions-with-sdk.mdx
+++ b/apps/docs/src/web/content/cookbook/patterns/creating-coder-sessions-with-sdk.mdx
@@ -1,6 +1,6 @@
 ---
 title: Managing Coder Sessions with the SDK
-short_title: Manage Coder Sessions
+short_title: Manage Sessions
 description: Create a Coder session, read its state, and manage its lifecycle with CoderClient
 ---
 
@@ -56,11 +56,11 @@ async function main(): Promise<void> {
     const resolvedUrl = await client.getUrl(); // [!code highlight]
     console.log('Connected to Coder Hub:', resolvedUrl);
 
-    const created = await client.createSession({
+    const created = await client.createSession({ // [!code highlight]
       task,
       workflowMode: 'standard',
       tags: ['architecture', 'docs-example'],
-    }); // [!code highlight]
+    });
     console.log('Created session:', created.sessionId);
 
     // Read the session back to inspect the first lifecycle state
@@ -243,10 +243,10 @@ async function main(): Promise<void> {
   const client = new CoderClient();
 
   try {
-    const { sessions, total } = await client.listSessions({
+    const { sessions, total } = await client.listSessions({ // [!code highlight]
       limit: 20,
       includeArchived: true,
-    }); // [!code highlight]
+    });
 
     console.log(
       JSON.stringify(
@@ -370,10 +370,10 @@ async function main(): Promise<void> {
 
   try {
     // updateSession is for app-level session detail, not runtime control
-    await client.updateSession(sessionId, {
+    await client.updateSession(sessionId, { // [!code highlight]
       tags: ['docs', 'follow-up'],
       visibility: 'organization',
-    }); // [!code highlight]
+    });
 
     if (action === 'delete') {
       // Delete temporary sessions when you don't need replay later

--- a/apps/docs/src/web/content/cookbook/patterns/creating-coder-sessions-with-sdk.mdx
+++ b/apps/docs/src/web/content/cookbook/patterns/creating-coder-sessions-with-sdk.mdx
@@ -289,58 +289,62 @@ When your app needs Coder to operate on a specific repository, use `listGitHubAc
 ```typescript
 import { CoderClient } from '@agentuity/coder';
 
-const client = new CoderClient();
+async function main(): Promise<void> {
+  const client = new CoderClient();
 
-let github;
-try {
-  // Sign in to Agentuity first. Without that OAuth login, the Hub returns HTTP 409
-  github = await client.listGitHubAccounts();
-} catch {
-  throw new Error(
-    'Sign in to Agentuity first. Then run this again to list the GitHub accounts available to your org.'
-  );
+  let github;
+  try {
+    // Sign in to Agentuity first. Without that OAuth login, the Hub returns HTTP 409
+    github = await client.listGitHubAccounts();
+  } catch {
+    throw new Error(
+      'Sign in to Agentuity first. Then run this again to list the GitHub accounts available to your org.'
+    );
+  }
+
+  const { connected, accounts } = github;
+  if (!connected) {
+    throw new Error('Connect GitHub in the Agentuity Console first.');
+  }
+
+  if (accounts.length === 0) {
+    throw new Error('No GitHub accounts connected. Install the Agentuity GitHub App first.');
+  }
+
+  // Pick the first account, or match by accountName in your own logic.
+  const account = accounts[0];
+  if (!account) {
+    throw new Error('No GitHub account selected.');
+  }
+
+  // List repos visible under that account
+  const { repositories } = await client.listGitHubRepos(account.accountId);
+  if (repositories.length === 0) {
+    throw new Error(`No repositories found under account ${account.accountName}`);
+  }
+
+  // Pick a repository. This example just takes the first
+  const repo = repositories[0];
+  if (!repo) {
+    throw new Error('No repository selected.');
+  }
+
+  // Create the session with the pinned repository reference
+  // CoderSessionRepositoryRef accepts owner, name, and optionally branch
+  const created = await client.createSession({
+    task: 'Review the open pull requests and summarize any security-related changes.',
+    workflowMode: 'standard',
+    repo: {
+      owner: repo.owner.login,
+      name: repo.name,
+      // branch: 'main', // optional: pin to a specific branch
+    },
+  });
+
+  console.log('Session:', created.sessionId, 'pinned to repo:', repo.fullName);
 }
 
-const { connected, accounts } = github;
-if (!connected) {
-  throw new Error('Connect GitHub in the Agentuity Console first.');
-}
-
-if (accounts.length === 0) {
-  throw new Error('No GitHub accounts connected. Install the Agentuity GitHub App first.');
-}
-
-// Pick the first account, or match by accountName in your own logic.
-const account = accounts[0];
-if (!account) {
-  throw new Error('No GitHub account selected.');
-}
-
-// List repos visible under that account
-const { repositories } = await client.listGitHubRepos(account.accountId);
-if (repositories.length === 0) {
-  throw new Error(`No repositories found under account ${account.accountName}`);
-}
-
-// Pick a repository. This example just takes the first
-const repo = repositories[0];
-if (!repo) {
-  throw new Error('No repository selected.');
-}
-
-// Create the session with the pinned repository reference
-// CoderSessionRepositoryRef accepts owner, name, and optionally branch
-const created = await client.createSession({
-  task: 'Review the open pull requests and summarize any security-related changes.',
-  workflowMode: 'standard',
-  repo: {
-    owner: repo.owner.login,
-    name: repo.name,
-    // branch: 'main', // optional: pin to a specific branch
-  },
-});
-
-console.log('Session:', created.sessionId, 'pinned to repo:', repo.fullName);
+void main();
 ```
 
 `listGitHubAccounts()` reflects the GitHub App installations active for the API key's org. If `accounts` is empty, install the Agentuity GitHub App from your org settings in the [Agentuity Console](https://app.agentuity.com) and grant it access to the repositories you need, then try again.

--- a/apps/docs/src/web/content/cookbook/patterns/creating-coder-sessions-with-sdk.mdx
+++ b/apps/docs/src/web/content/cookbook/patterns/creating-coder-sessions-with-sdk.mdx
@@ -14,7 +14,7 @@ This flow works without deploying your app. If you already created an Agentuity 
 If discovery succeeds but session calls fail with an org-level error, your API key is fine. The org just needs Coder turned on first.
 </Callout>
 
-The examples below are standalone `@agentuity/coder` snippets. They work well in a local Bun or Node script while you prove the session flow end to end.
+The examples below are standalone TypeScript `@agentuity/coder` snippets. Run them with Bun, `tsx`, `ts-node`, or another TypeScript-capable runner while you prove the session flow end to end.
 
 ## The Pattern
 
@@ -402,7 +402,7 @@ For quick local validation, deleting the session is fine:
 await client.deleteSession(sessionId);
 ```
 
-If you want to preserve session history and inspect it later, prefer `archiveSession()`:
+To keep session history for later inspection, prefer `archiveSession()`:
 
 ```typescript
 await client.archiveSession(sessionId);

--- a/apps/docs/src/web/content/cookbook/patterns/creating-coder-sessions-with-sdk.mdx
+++ b/apps/docs/src/web/content/cookbook/patterns/creating-coder-sessions-with-sdk.mdx
@@ -1,0 +1,394 @@
+---
+title: Managing Coder Sessions with the SDK
+short_title: Manage Coder Sessions
+description: Create a Coder session, read its state, and manage its lifecycle with CoderClient
+---
+
+Use this page when you want to drive Coder from your own code. It shows the basic `CoderClient` flow: create a session, read it back, then manage it over time from an app, script, or internal tool.
+
+<Callout type="tip" title="Run this locally first">
+This flow works without deploying your app. If you already created an Agentuity project, its local `.env` usually includes `AGENTUITY_SDK_KEY`, which is enough for `CoderClient` discovery mode.
+</Callout>
+
+<Callout type="info" title="Use this page when you want the core session workflow">
+Use this page when you want to start a session from code, inspect what the Hub returned, read the session later, and decide whether to archive or delete it.
+</Callout>
+
+<Callout type="warning" title="Coder must be enabled for your org">
+If discovery succeeds but session calls fail with an org-level error, your API key is probably valid and Coder just is not enabled for that org yet.
+</Callout>
+
+The examples below are standalone `@agentuity/coder` snippets. They work well in a local Bun or Node script while you prove the session flow end to end.
+
+## The Pattern
+
+Install the package:
+
+```bash
+bun add @agentuity/coder
+```
+
+Start with the smallest integration that proves discovery, session creation, and the first session read:
+
+```typescript
+import { CoderClient } from '@agentuity/coder';
+
+const DEFAULT_TASK = 'Inspect this repo and explain the current architecture.';
+function getTask(): string {
+  const task = process.argv.slice(2).join(' ').trim();
+  return task || DEFAULT_TASK;
+}
+
+async function main(): Promise<void> {
+  // Let the SDK discover the Hub from AGENTUITY_SDK_KEY.
+  const client = new CoderClient();
+  const task = getTask();
+
+  try {
+    const resolvedUrl = await client.getUrl(); // [!code highlight]
+    console.log('Connected to Coder Hub:', resolvedUrl);
+
+    const created = await client.createSession({
+      task,
+      workflowMode: 'standard',
+      tags: ['architecture', 'docs-example'],
+    }); // [!code highlight]
+    console.log('Created session:', created.sessionId);
+
+    // Read the session back so you can inspect the first lifecycle state.
+    const session = await client.getSession(created.sessionId); // [!code highlight]
+    console.log(
+      JSON.stringify(
+        {
+          sessionId: session.sessionId,
+          label: session.label,
+          status: session.status,
+          bucket: session.bucket,
+          workflowMode: session.workflowMode,
+          runtimeAvailable: session.runtimeAvailable,
+          controlAvailable: session.controlAvailable,
+          wakeAvailable: session.wakeAvailable,
+          historyOnly: session.historyOnly,
+          liveExpected: session.liveExpected,
+        },
+        null,
+        2
+      )
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.stack ?? error.message : String(error);
+    console.error('Failed to create or inspect the session');
+    console.error(message);
+    process.exitCode = 1;
+  }
+}
+
+void main();
+```
+
+This gives you two things you need right away:
+
+- a `sessionId` you can reuse in later calls or other apps
+- the first session detail from `getSession()`
+
+## What You Should See
+
+The exact values will vary, but a brand-new session usually looks like this:
+
+```json
+{
+  "sessionId": "codesess_f64101b6ad47",
+  "status": "creating",
+  "bucket": "provisioning",
+  "workflowMode": "standard",
+  "runtimeAvailable": false,
+  "controlAvailable": false,
+  "wakeAvailable": false,
+  "historyOnly": false,
+  "liveExpected": true
+}
+```
+
+The important part is not the exact `status` string. It is seeing that:
+
+- creation succeeded and you have a real `sessionId`
+- `getSession()` returns usable session detail immediately
+- the session may still be provisioning even though it already exists
+
+## Reading Session State
+
+Once you have a session ID, use the read APIs to build dashboards, internal tools, or a simple status view in another app.
+
+```typescript
+import { CoderClient } from '@agentuity/coder';
+
+const sessionId = process.argv[2];
+
+if (!sessionId) {
+  throw new Error('Pass a session ID as the first argument, for example: bun example.ts codesess_123');
+}
+
+async function main(): Promise<void> {
+  const client = new CoderClient();
+
+  try {
+    // Start with session detail. It is the cleanest overview surface.
+    const session = await client.getSession(sessionId); // [!code highlight]
+
+    // Pull related data in parallel when you need a fuller view of the session.
+    const [participants, history, replay] = await Promise.all([
+      client.listParticipants(sessionId, { limit: 20 }), // [!code highlight]
+      client.listEventHistory(sessionId, { limit: 20 }), // [!code highlight]
+      client.getReplay(sessionId, { limit: 50 }), // [!code highlight]
+    ]);
+
+    console.log(
+      JSON.stringify(
+        {
+          session: {
+            sessionId: session.sessionId,
+            label: session.label,
+            status: session.status,
+            bucket: session.bucket,
+            workflowMode: session.workflowMode,
+            historyOnly: session.historyOnly,
+            runtimeAvailable: session.runtimeAvailable,
+            controlAvailable: session.controlAvailable,
+          },
+          participantsCount: participants.participants.length,
+          historyCount: history.events.length,
+          replaySessionId: replay.sessionId,
+        },
+        null,
+        2
+      )
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.stack ?? error.message : String(error);
+    console.error('Failed to read session state');
+    console.error(message);
+    process.exitCode = 1;
+  }
+}
+
+void main();
+```
+
+Fresh or idle sessions can legitimately return empty participants, event history, or replay data. That usually means the session has not produced much activity yet.
+
+<Callout type="info" title="Replay is a hydration stream, not a transcript">
+`getReplay()` returns the durable event stream a late-joining client uses to catch up to the Hub's current state. Treat the result as the hydration payload, not as a list you enumerate in a dashboard. For a structured timeline, use `listEventHistory()` instead.
+</Callout>
+
+## Listing Sessions for Dashboards or History Views
+
+If your app needs a broader session list before it drills into one session, start with `listSessions()`.
+
+```typescript
+import { CoderClient } from '@agentuity/coder';
+
+async function main(): Promise<void> {
+  const client = new CoderClient();
+
+  try {
+    const { sessions, total } = await client.listSessions({
+      limit: 20,
+      includeArchived: true,
+    }); // [!code highlight]
+
+    console.log(
+      JSON.stringify(
+        {
+          total,
+          sessions: sessions.map((session) => ({
+            sessionId: session.sessionId,
+            label: session.label,
+            status: session.status,
+            bucket: session.bucket,
+            workflowMode: session.workflowMode,
+            historyOnly: session.historyOnly,
+          })),
+        },
+        null,
+        2
+      )
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.stack ?? error.message : String(error);
+    console.error('Failed to list sessions');
+    console.error(message);
+    process.exitCode = 1;
+  }
+}
+
+void main();
+```
+
+Use `listSessions()` when you are building a dashboard or history view. Once the user picks a session, switch back to `getSession()`, replay, participants, or lifecycle methods.
+
+## Reading Session State: List vs Get
+
+`listSessions()` returns summary items (`CoderSessionListItem`). Each item includes status, bucket, workflow mode, and tag fields, but it does not include full session detail such as the `task` prompt, `env`, `metadata`, or `updatedAt`. When another service needs to enumerate sessions and then fetch the full model for one of them, call `listSessions()` first, then `getSession()` for the chosen entry.
+
+```typescript
+import { CoderClient } from '@agentuity/coder';
+
+const client = new CoderClient();
+
+// Fetch the first page of sessions as lightweight summaries.
+const { sessions } = await client.listSessions({ limit: 20 });
+
+// Once your app has chosen a session ID, fetch the full session.
+const firstSession = sessions[0];
+if (firstSession) {
+  const detail = await client.getSession(firstSession.sessionId);
+  // detail.task, detail.env, detail.metadata, and detail.updatedAt
+  // are only present on the full session response, not the list item.
+  console.log(detail.task);
+}
+```
+
+`getSession()` is the right starting point whenever you need the cleanest single answer to "what is this session right now?" Use `listSessions()` when you need a broader view before narrowing to one.
+
+## Pinning a GitHub Repo
+
+When your app needs Coder to operate on a specific repository, use `listGitHubAccounts()` to retrieve the GitHub accounts connected via the GitHub App installation, then `listGitHubRepos(accountId)` to list repositories under that account. Pass the chosen repository to `createSession()` via the `repo` field.
+
+<Callout type="warning" title="Sign in to Agentuity before calling the GitHub APIs">
+`listGitHubAccounts()` and `listGitHubRepos()` require an Agentuity OAuth login, not just the GitHub App installation. Without the login, the Hub returns `HTTP 409` and the client throws before any account data is returned. Sign in from the [Agentuity Console](https://app.agentuity.com) (or via `agentuity auth login`) before running this flow.
+</Callout>
+
+```typescript
+import { CoderClient } from '@agentuity/coder';
+
+const client = new CoderClient();
+
+let github;
+try {
+  // Sign in to Agentuity first. Without that OAuth login, the Hub returns HTTP 409 here.
+  github = await client.listGitHubAccounts();
+} catch {
+  throw new Error(
+    'Sign in to Agentuity first. Then run this again to list the GitHub accounts available to your org.'
+  );
+}
+
+const { connected, accounts } = github;
+if (!connected) {
+  throw new Error('Connect GitHub in the Agentuity Console first.');
+}
+
+if (accounts.length === 0) {
+  throw new Error('No GitHub accounts connected. Install the Agentuity GitHub App first.');
+}
+
+// Pick the first account, or match by accountName in your own logic.
+const account = accounts[0];
+if (!account) {
+  throw new Error('No GitHub account selected.');
+}
+
+// List repos visible under that account.
+const { repositories } = await client.listGitHubRepos(account.accountId);
+if (repositories.length === 0) {
+  throw new Error(`No repositories found under account ${account.accountName}`);
+}
+
+// Pick a repository. Here we take the first; your app would apply its own selection.
+const repo = repositories[0];
+if (!repo) {
+  throw new Error('No repository selected.');
+}
+
+// Create the session with the pinned repository reference.
+// CoderSessionRepositoryRef accepts owner, name, and optionally branch.
+const created = await client.createSession({
+  task: 'Review the open pull requests and summarize any security-related changes.',
+  workflowMode: 'standard',
+  repo: {
+    owner: repo.owner.login,
+    name: repo.name,
+    // branch: 'main', // Optional: pin to a specific branch.
+  },
+});
+
+console.log('Session:', created.sessionId, 'pinned to repo:', repo.fullName);
+```
+
+`listGitHubAccounts()` reflects the GitHub App installations active for the API key's org. If `accounts` is empty, install the Agentuity GitHub App from your org settings in the [Agentuity Console](https://app.agentuity.com) and grant it access to the repositories you need, then try again.
+
+## Updating and Cleaning Up
+
+Use `updateSession()` when you want to relabel a session, retag it, or adjust its visibility. Then decide whether to archive it for later replay or delete it completely.
+
+```typescript
+import { CoderClient } from '@agentuity/coder';
+
+const sessionId = process.argv[2];
+const action = process.argv[3] ?? 'archive';
+
+if (!sessionId) {
+  throw new Error(
+    'Pass a session ID as the first argument, for example: bun example.ts codesess_123 archive'
+  );
+}
+
+async function main(): Promise<void> {
+  const client = new CoderClient();
+
+  try {
+    // updateSession is for app-level session detail, not runtime control.
+    await client.updateSession(sessionId, {
+      tags: ['docs', 'follow-up'],
+      visibility: 'organization',
+    }); // [!code highlight]
+
+    if (action === 'delete') {
+      // Delete temporary sessions when you do not need replay later.
+      await client.deleteSession(sessionId); // [!code highlight]
+      console.log(`Deleted ${sessionId}`);
+      return;
+    }
+
+    // Archive by default so session history remains available for replay and inspection.
+    const archived = await client.archiveSession(sessionId); // [!code highlight]
+    console.log(JSON.stringify({ sessionId, status: archived.status }, null, 2));
+  } catch (error) {
+    const message = error instanceof Error ? error.stack ?? error.message : String(error);
+    console.error('Failed to manage the session');
+    console.error(message);
+    process.exitCode = 1;
+  }
+}
+
+void main();
+```
+
+For quick local validation, deleting the session is fine:
+
+```typescript
+await client.deleteSession(sessionId);
+```
+
+If you want to preserve session history and inspect it later, prefer `archiveSession()`:
+
+```typescript
+await client.archiveSession(sessionId);
+```
+
+## Key Points
+
+- Keep the `sessionId` from `createSession()`. Most follow-on APIs start there.
+- Call `getSession()` first when you need the clearest answer to “what state is this session in?”
+- Use `listSessions()` for dashboards and history views, not as a substitute for session detail.
+- Use `archiveSession()` for real work sessions that you may want to inspect later.
+- Use `deleteSession()` for temporary tests, demos, and cleanup.
+- If you need to reconnect to an older session, switch to the reconnect flow instead of starting from `listSessions()`.
+
+## See Also
+
+- [Reconnecting to Existing Coder Sessions](/cookbook/patterns/preparing-coder-sessions-for-remote-attach): Find live or wakeable sessions before re-attaching
+- [Creating Loop-Mode Coder Sessions](/cookbook/patterns/creating-loop-mode-coder-sessions): Use loop workflow state instead of a standard session
+- [Coder](/services/coder): Concepts, workflow modes, and CLI entry points
+- [Coder Client](/reference/sdk-reference/coder): Full `CoderClient` method reference
+- [Coder Commands](/reference/cli/coder): CLI flows for creating and attaching to sessions

--- a/apps/docs/src/web/content/cookbook/patterns/creating-coder-sessions-with-sdk.mdx
+++ b/apps/docs/src/web/content/cookbook/patterns/creating-coder-sessions-with-sdk.mdx
@@ -351,7 +351,7 @@ void main();
 
 ## Updating and Cleaning Up
 
-Use `updateSession()` when you want to relabel a session, retag it, or adjust its visibility. Then decide whether to archive it for later replay or delete it completely.
+Use `updateSession()` to relabel a session, retag it, adjust its visibility, or patch its `metadata`. Metadata merges into the session's _existing_ metadata, so you can change one key without resending the rest. Then archive the session for later replay, or delete it.
 
 ```typescript
 import { CoderClient } from '@agentuity/coder';
@@ -373,6 +373,11 @@ async function main(): Promise<void> {
     await client.updateSession(sessionId, { // [!code highlight]
       tags: ['docs', 'follow-up'],
       visibility: 'organization',
+      // metadata is merged into the session's existing metadata, so you can patch
+      // one correlation id without resending the rest
+      metadata: {
+        reviewStage: 'follow-up',
+      },
     });
 
     if (action === 'delete') {

--- a/apps/docs/src/web/content/cookbook/patterns/creating-coder-sessions-with-sdk.mdx
+++ b/apps/docs/src/web/content/cookbook/patterns/creating-coder-sessions-with-sdk.mdx
@@ -4,18 +4,14 @@ short_title: Manage Coder Sessions
 description: Create a Coder session, read its state, and manage its lifecycle with CoderClient
 ---
 
-Use this page when you want to drive Coder from your own code. It shows the basic `CoderClient` flow: create a session, read it back, then manage it over time from an app, script, or internal tool.
+Drive Coder from your own code with `CoderClient`. Coder sessions run on a shared Hub, the real-time broadcast bus that apps, agents, and humans all subscribe to. This page covers the core client-side flow: create a session, read it back, and manage its lifecycle over time.
 
 <Callout type="tip" title="Run this locally first">
 This flow works without deploying your app. If you already created an Agentuity project, its local `.env` usually includes `AGENTUITY_SDK_KEY`, which is enough for `CoderClient` discovery mode.
 </Callout>
 
-<Callout type="info" title="Use this page when you want the core session workflow">
-Use this page when you want to start a session from code, inspect what the Hub returned, read the session later, and decide whether to archive or delete it.
-</Callout>
-
 <Callout type="warning" title="Coder must be enabled for your org">
-If discovery succeeds but session calls fail with an org-level error, your API key is probably valid and Coder just is not enabled for that org yet.
+If discovery succeeds but session calls fail with an org-level error, your API key is fine. The org just needs Coder turned on first.
 </Callout>
 
 The examples below are standalone `@agentuity/coder` snippets. They work well in a local Bun or Node script while you prove the session flow end to end.
@@ -28,7 +24,19 @@ Install the package:
 bun add @agentuity/coder
 ```
 
-Start with the smallest integration that proves discovery, session creation, and the first session read:
+If your app creates sessions from more than one place (an HTTP route, a background job, a webhook handler), construct a `CoderClient` once and share it:
+
+```typescript title="src/lib/coder.ts"
+import { CoderClient } from '@agentuity/coder';
+
+export const coder = new CoderClient();
+```
+
+With `AGENTUITY_SDK_KEY` set in your environment, this picks up your org, region, and Hub URL. Pass `orgId` or `region` explicitly when your app needs to pin a specific one.
+
+The standalone scripts on this page keep `new CoderClient()` inline so each one stays copy-pasteable. Move to a shared module once your app has more than one call site.
+
+Start with a minimal script that covers discovery, session creation, and the first session read:
 
 ```typescript
 import { CoderClient } from '@agentuity/coder';
@@ -40,7 +48,7 @@ function getTask(): string {
 }
 
 async function main(): Promise<void> {
-  // Let the SDK discover the Hub from AGENTUITY_SDK_KEY.
+  // Let the SDK discover the Hub from AGENTUITY_SDK_KEY
   const client = new CoderClient();
   const task = getTask();
 
@@ -55,7 +63,7 @@ async function main(): Promise<void> {
     }); // [!code highlight]
     console.log('Created session:', created.sessionId);
 
-    // Read the session back so you can inspect the first lifecycle state.
+    // Read the session back to inspect the first lifecycle state
     const session = await client.getSession(created.sessionId); // [!code highlight]
     console.log(
       JSON.stringify(
@@ -98,6 +106,7 @@ The exact values will vary, but a brand-new session usually looks like this:
 ```json
 {
   "sessionId": "codesess_f64101b6ad47",
+  "label": "Inspect this repo and explain the current architecture.",
   "status": "creating",
   "bucket": "provisioning",
   "workflowMode": "standard",
@@ -109,11 +118,54 @@ The exact values will vary, but a brand-new session usually looks like this:
 }
 ```
 
-The important part is not the exact `status` string. It is seeing that:
+The Hub auto-derives `label` from the `task` prompt when the caller doesn't set one, so a fresh session always has a label to show in list views.
+
+The exact `status` string varies. What matters is:
 
 - creation succeeded and you have a real `sessionId`
 - `getSession()` returns usable session detail immediately
 - the session may still be provisioning even though it already exists
+
+## Creating Sessions From Your App
+
+In app code, the shape you usually reach for adds three fields on top of `task`: `label`, `metadata`, and `env`. These cover the pieces apps actually need: a short label for list UIs, correlation ids that tie the session back to your own records, and any credentials the sandbox-side agent reads at runtime.
+
+```typescript title="src/lib/start-session.ts"
+import { coder } from './coder';
+
+type StartSessionInput = {
+  userId: string;
+  conversationId: string;
+  task: string;
+  apiToken: string;
+};
+
+export async function startSession(input: StartSessionInput) {
+  return coder.createSession({
+    task: input.task,
+    // label shows up in list UIs; falls back to the task prompt when unset
+    label: input.task.slice(0, 100),
+    // metadata is for app correlation ids and app-owned session context
+    metadata: {
+      userId: input.userId,
+      conversationId: input.conversationId,
+    },
+    // env is what the sandbox-side agent can read at runtime
+    env: {
+      API_TOKEN: input.apiToken,
+    },
+  });
+}
+```
+
+| Field | What it carries |
+|------|-----------------|
+| `task` | The prompt the agent executes, including any context you want it to act on |
+| `label` | A short human string for list UIs and dashboards |
+| `metadata` | App correlation ids and app-owned session context |
+| `env` | Credentials and runtime config the sandbox-side agent reads |
+
+When your app already resolved user or account context, the common split is: put resolved context into `task`, correlation ids into `metadata`, and integration credentials into `env`. `env` is fixed once the session is created, so prefer credentials the agent can refresh itself over short-lived access tokens.
 
 ## Reading Session State
 
@@ -132,10 +184,10 @@ async function main(): Promise<void> {
   const client = new CoderClient();
 
   try {
-    // Start with session detail. It is the cleanest overview surface.
+    // Start with session detail. It's the fullest single view
     const session = await client.getSession(sessionId); // [!code highlight]
 
-    // Pull related data in parallel when you need a fuller view of the session.
+    // Pull related data in parallel when you need more than session detail alone
     const [participants, history, replay] = await Promise.all([
       client.listParticipants(sessionId, { limit: 20 }), // [!code highlight]
       client.listEventHistory(sessionId, { limit: 20 }), // [!code highlight]
@@ -224,31 +276,7 @@ async function main(): Promise<void> {
 void main();
 ```
 
-Use `listSessions()` when you are building a dashboard or history view. Once the user picks a session, switch back to `getSession()`, replay, participants, or lifecycle methods.
-
-## Reading Session State: List vs Get
-
-`listSessions()` returns summary items (`CoderSessionListItem`). Each item includes status, bucket, workflow mode, and tag fields, but it does not include full session detail such as the `task` prompt, `env`, `metadata`, or `updatedAt`. When another service needs to enumerate sessions and then fetch the full model for one of them, call `listSessions()` first, then `getSession()` for the chosen entry.
-
-```typescript
-import { CoderClient } from '@agentuity/coder';
-
-const client = new CoderClient();
-
-// Fetch the first page of sessions as lightweight summaries.
-const { sessions } = await client.listSessions({ limit: 20 });
-
-// Once your app has chosen a session ID, fetch the full session.
-const firstSession = sessions[0];
-if (firstSession) {
-  const detail = await client.getSession(firstSession.sessionId);
-  // detail.task, detail.env, detail.metadata, and detail.updatedAt
-  // are only present on the full session response, not the list item.
-  console.log(detail.task);
-}
-```
-
-`getSession()` is the right starting point whenever you need the cleanest single answer to "what is this session right now?" Use `listSessions()` when you need a broader view before narrowing to one.
+Use `listSessions()` when you are building a dashboard or history view. Once the user picks a session, switch back to `getSession()`, replay, participants, or lifecycle methods. List items include status, bucket, workflow mode, and tags, but not the `task` prompt; that only appears on the full `getSession()` response. `total` can exceed `sessions.length` because the Hub counts a broader set than the SDK surfaces; render from `sessions` and treat `total` as a hint that more exist.
 
 ## Pinning a GitHub Repo
 
@@ -265,7 +293,7 @@ const client = new CoderClient();
 
 let github;
 try {
-  // Sign in to Agentuity first. Without that OAuth login, the Hub returns HTTP 409 here.
+  // Sign in to Agentuity first. Without that OAuth login, the Hub returns HTTP 409
   github = await client.listGitHubAccounts();
 } catch {
   throw new Error(
@@ -288,27 +316,27 @@ if (!account) {
   throw new Error('No GitHub account selected.');
 }
 
-// List repos visible under that account.
+// List repos visible under that account
 const { repositories } = await client.listGitHubRepos(account.accountId);
 if (repositories.length === 0) {
   throw new Error(`No repositories found under account ${account.accountName}`);
 }
 
-// Pick a repository. Here we take the first; your app would apply its own selection.
+// Pick a repository. This example just takes the first
 const repo = repositories[0];
 if (!repo) {
   throw new Error('No repository selected.');
 }
 
-// Create the session with the pinned repository reference.
-// CoderSessionRepositoryRef accepts owner, name, and optionally branch.
+// Create the session with the pinned repository reference
+// CoderSessionRepositoryRef accepts owner, name, and optionally branch
 const created = await client.createSession({
   task: 'Review the open pull requests and summarize any security-related changes.',
   workflowMode: 'standard',
   repo: {
     owner: repo.owner.login,
     name: repo.name,
-    // branch: 'main', // Optional: pin to a specific branch.
+    // branch: 'main', // optional: pin to a specific branch
   },
 });
 
@@ -337,20 +365,20 @@ async function main(): Promise<void> {
   const client = new CoderClient();
 
   try {
-    // updateSession is for app-level session detail, not runtime control.
+    // updateSession is for app-level session detail, not runtime control
     await client.updateSession(sessionId, {
       tags: ['docs', 'follow-up'],
       visibility: 'organization',
     }); // [!code highlight]
 
     if (action === 'delete') {
-      // Delete temporary sessions when you do not need replay later.
+      // Delete temporary sessions when you don't need replay later
       await client.deleteSession(sessionId); // [!code highlight]
       console.log(`Deleted ${sessionId}`);
       return;
     }
 
-    // Archive by default so session history remains available for replay and inspection.
+    // Archive by default so session history remains available for replay
     const archived = await client.archiveSession(sessionId); // [!code highlight]
     console.log(JSON.stringify({ sessionId, status: archived.status }, null, 2));
   } catch (error) {
@@ -379,11 +407,10 @@ await client.archiveSession(sessionId);
 ## Key Points
 
 - Keep the `sessionId` from `createSession()`. Most follow-on APIs start there.
-- Call `getSession()` first when you need the clearest answer to “what state is this session in?”
-- Use `listSessions()` for dashboards and history views, not as a substitute for session detail.
-- Use `archiveSession()` for real work sessions that you may want to inspect later.
-- Use `deleteSession()` for temporary tests, demos, and cleanup.
-- If you need to reconnect to an older session, switch to the reconnect flow instead of starting from `listSessions()`.
+- In app code, pair `task` with `label` for list UIs, `metadata` for correlation ids, and `env` for credentials the sandbox-side agent reads.
+- Use `listSessions()` for dashboards and history views, then `getSession()` for the chosen entry.
+- Use `archiveSession()` for sessions you may want to inspect later, and `deleteSession()` for temporary tests and cleanup.
+- To reconnect to an older session, switch to the reconnect flow instead of starting from `listSessions()`.
 
 ## See Also
 

--- a/apps/docs/src/web/content/cookbook/patterns/creating-coder-sessions-with-sdk.mdx
+++ b/apps/docs/src/web/content/cookbook/patterns/creating-coder-sessions-with-sdk.mdx
@@ -14,7 +14,7 @@ This flow works without deploying your app. If you already created an Agentuity 
 If discovery succeeds but session calls fail with an org-level error, your API key is fine. The org just needs Coder turned on first.
 </Callout>
 
-The examples below are standalone TypeScript `@agentuity/coder` snippets. Run them with Bun, `tsx`, `ts-node`, or another TypeScript-capable runner while you prove the session flow end to end.
+The examples below are standalone `@agentuity/coder` TypeScript snippets. Bun is the quickest way to run them locally. If you prefer Node, use `tsx` or another TypeScript runner.
 
 ## The Pattern
 
@@ -402,7 +402,7 @@ For quick local validation, deleting the session is fine:
 await client.deleteSession(sessionId);
 ```
 
-To keep session history for later inspection, prefer `archiveSession()`:
+Archive the session instead when you want to inspect its history later:
 
 ```typescript
 await client.archiveSession(sessionId);

--- a/apps/docs/src/web/content/cookbook/patterns/creating-loop-mode-coder-sessions.mdx
+++ b/apps/docs/src/web/content/cookbook/patterns/creating-loop-mode-coder-sessions.mdx
@@ -1,0 +1,206 @@
+---
+title: Creating Loop-Mode Coder Sessions
+short_title: Loop-Mode Sessions
+description: Create a loop-mode Coder session and inspect its workflow state with getLoopState
+---
+
+Use loop mode when you want a session to carry explicit workflow state across iterations. This is different from a normal interactive session: the session has a goal, iteration state, and loop-specific status that you can inspect separately from the standard session detail.
+
+<Callout type="info" title="Use this page when your workflow is iteration-aware">
+Use this page when your app needs more than a standard interactive session, for example review loops, bounded research loops, or workflows that need explicit iteration and pause state.
+</Callout>
+
+This is easiest to explore from a small local script so you can create the session and inspect its loop state right away.
+
+## The Pattern
+
+Create the session with `workflowMode: 'loop'`, then call `getLoopState()` to read the workflow state back.
+
+```typescript
+import { CoderClient } from '@agentuity/coder';
+
+async function main(): Promise<void> {
+  const client = new CoderClient();
+
+  try {
+    const created = await client.createSession({
+      task: 'Review the repository and suggest the next documentation steps.',
+      // Opt into loop workflow state; standard sessions do not expose loop fields.
+      workflowMode: 'loop', // [!code highlight]
+      loop: {
+        goal: 'Produce a concise docs plan',
+        maxIterations: 3,
+        // Default to supervised advancement; flip to true for unattended loops.
+        autoContinue: false,
+        allowDetached: false,
+      },
+      tags: ['docs', 'loop-example'],
+    });
+
+    // getSession gives you lifecycle state; getLoopState is the only place loop fields live.
+    const session = await client.getSession(created.sessionId);
+    const loopState = await client.getLoopState(created.sessionId); // [!code highlight]
+
+    console.log(
+      JSON.stringify(
+        {
+          session: {
+            sessionId: session.sessionId,
+            status: session.status,
+            bucket: session.bucket,
+            workflowMode: session.workflowMode,
+          },
+          loopState,
+        },
+        null,
+        2
+      )
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.stack ?? error.message : String(error);
+    console.error('Failed to create or inspect the loop-mode session');
+    console.error(message);
+    process.exitCode = 1;
+  }
+}
+
+void main();
+```
+
+## Example Output
+
+```json
+{
+  "session": {
+    "sessionId": "codesess_6727f29e6086",
+    "status": "creating",
+    "bucket": "provisioning",
+    "workflowMode": "loop"
+  },
+  "loopState": {
+    "sessionId": "codesess_6727f29e6086",
+    "workflowMode": "loop",
+    "loop": {
+      "status": "starting",
+      "iteration": 0,
+      "maxIterations": 3,
+      "goal": "Produce a concise docs plan",
+      "startedAt": 1776110497864,
+      "updatedAt": 1776110497864,
+      "autoContinue": false,
+      "allowDetached": false
+    }
+  }
+}
+```
+
+## What to Inspect
+
+Treat `getSession()` and `getLoopState()` as two related but different views:
+
+- `getSession()` tells you the overall lifecycle state of the session
+- `getLoopState()` tells you the workflow state inside a loop-mode session
+
+The most important loop fields are:
+
+- `status`: where the loop currently is, such as `starting`, `running`, or `paused`
+- `iteration`: the current loop iteration
+- `maxIterations`: the configured upper bound
+- `goal`: the high-level goal you gave the loop
+- `autoContinue`: whether the loop advances without manual approval
+- `allowDetached`: whether the loop is allowed to continue without an attached client
+
+## Polling a Loop to Completion
+
+For headless, unattended runs, configure the loop with `autoContinue: true` and `allowDetached: true`, then poll `getLoopState()` until the loop reaches a terminal status. This lets your app dispatch the work and check back at a controlled interval rather than staying connected.
+
+The terminal statuses from `CoderLoopStatusSchema` are `completed`, `cancelled`, and `blocked`. The status `awaiting_input` is a non-terminal pause: the loop stopped and is waiting for external input before it can continue. All other statuses (`idle`, `starting`, `running`, `paused`) indicate the loop is still in progress.
+
+```typescript
+import { CoderClient } from '@agentuity/coder';
+import type { CoderLoopStatus } from '@agentuity/coder';
+
+const TERMINAL: ReadonlySet<CoderLoopStatus> = new Set(['completed', 'cancelled', 'blocked']);
+const POLL_MS = 5_000;
+const MAX_WAIT_MS = 10 * 60 * 1_000; // 10-minute wall-clock ceiling
+
+async function main(): Promise<void> {
+  const client = new CoderClient();
+
+  const created = await client.createSession({
+    task: 'Audit the repository for outdated dependencies and open a summary issue.',
+    workflowMode: 'loop',
+    loop: {
+      goal: 'Identify and report all packages more than two major versions behind.',
+      maxIterations: 10,
+      autoContinue: true,   // advance each iteration without manual approval
+      allowDetached: true,  // continue even when no client is attached
+    },
+    tags: ['deps', 'audit'],
+  });
+
+  console.log('Session created:', created.sessionId);
+
+  const deadline = Date.now() + MAX_WAIT_MS;
+
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS));
+
+    const { loop } = await client.getLoopState(created.sessionId);
+
+    if (!loop) {
+      // Loop state is not initialized yet; the session is still starting.
+      continue;
+    }
+
+    const { status, iteration, maxIterations } = loop;
+    console.log(`iteration ${iteration}/${maxIterations ?? '?'}: ${status}`);
+
+    if (TERMINAL.has(status)) {
+      console.log('Loop finished with status:', status);
+      if (loop.summary) {
+        console.log('Summary:', loop.summary);
+      }
+      return;
+    }
+
+    if (status === 'awaiting_input') {
+      // The loop paused and is waiting for external input before it can continue.
+      // Your app would handle this, for example by prompting the user or injecting
+      // a response via the Hub WebSocket or REST API.
+      console.log('Loop is awaiting input. Exiting poll loop.');
+      return;
+    }
+  }
+
+  console.error('Timed out waiting for loop to complete.');
+  process.exitCode = 1;
+}
+
+void main();
+```
+
+The `loop.summary` and `loop.nextAction` fields are populated by the Hub as the loop progresses. They are useful for surfacing progress in a UI or feeding into a downstream step.
+
+## When to Use This Pattern
+
+Use loop mode when your app needs explicit iteration-aware workflow state, not just a long-running session.
+
+- structured review or planning flows
+- bounded research or implementation loops
+- apps that need to display loop progress separately from normal session status
+
+If you only need a normal interactive coding session, stick with `workflowMode: 'standard'`.
+
+## Key Points
+
+- Loop mode is explicit. Sessions do not become loop-mode sessions automatically.
+- `getLoopState()` is the right place to inspect loop progress. Do not infer it only from top-level session status.
+- Keep the loop goal concrete. It becomes part of the state your app can show to users.
+- Start with `autoContinue: false` unless you specifically want unattended advancement.
+
+## See Also
+
+- [Managing Coder Sessions with the SDK](/cookbook/patterns/creating-coder-sessions-with-sdk): Start with the standard session flow and core lifecycle
+- [Reconnecting to Existing Coder Sessions](/cookbook/patterns/preparing-coder-sessions-for-remote-attach): Resume or inspect sessions that may still be live
+- [Coder Client](/reference/sdk-reference/coder): Full method reference for `createSession()` and `getLoopState()`

--- a/apps/docs/src/web/content/cookbook/patterns/creating-loop-mode-coder-sessions.mdx
+++ b/apps/docs/src/web/content/cookbook/patterns/creating-loop-mode-coder-sessions.mdx
@@ -4,13 +4,7 @@ short_title: Loop-Mode Sessions
 description: Create a loop-mode Coder session and inspect its workflow state with getLoopState
 ---
 
-Use loop mode when you want a session to carry explicit workflow state across iterations. This is different from a normal interactive session: the session has a goal, iteration state, and loop-specific status that you can inspect separately from the standard session detail.
-
-<Callout type="info" title="Use this page when your workflow is iteration-aware">
-Use this page when your app needs more than a standard interactive session, for example review loops, bounded research loops, or workflows that need explicit iteration and pause state.
-</Callout>
-
-This is easiest to explore from a small local script so you can create the session and inspect its loop state right away.
+Loop mode gives a session explicit workflow state across iterations: a goal, iteration counters, and loop-specific status you can inspect separately from the standard session detail. It's the shape you want for review loops, bounded research, or any iteration-aware workflow that needs explicit pause and resume state.
 
 ## The Pattern
 
@@ -25,19 +19,19 @@ async function main(): Promise<void> {
   try {
     const created = await client.createSession({
       task: 'Review the repository and suggest the next documentation steps.',
-      // Opt into loop workflow state; standard sessions do not expose loop fields.
+      // Opt into loop workflow state; standard sessions don't expose loop fields
       workflowMode: 'loop', // [!code highlight]
       loop: {
         goal: 'Produce a concise docs plan',
         maxIterations: 3,
-        // Default to supervised advancement; flip to true for unattended loops.
+        // Default to supervised advancement; flip to true for unattended loops
         autoContinue: false,
         allowDetached: false,
       },
       tags: ['docs', 'loop-example'],
     });
 
-    // getSession gives you lifecycle state; getLoopState is the only place loop fields live.
+    // getSession is for lifecycle state; getLoopState is the only place loop fields live
     const session = await client.getSession(created.sessionId);
     const loopState = await client.getLoopState(created.sessionId); // [!code highlight]
 
@@ -96,19 +90,12 @@ void main();
 
 ## What to Inspect
 
-Treat `getSession()` and `getLoopState()` as two related but different views:
+`getSession()` returns the session's lifecycle state. `getLoopState()` returns the workflow state inside a loop-mode run. When you read loop state, the fields that usually matter:
 
-- `getSession()` tells you the overall lifecycle state of the session
-- `getLoopState()` tells you the workflow state inside a loop-mode session
-
-The most important loop fields are:
-
-- `status`: where the loop currently is, such as `starting`, `running`, or `paused`
-- `iteration`: the current loop iteration
-- `maxIterations`: the configured upper bound
+- `status`: where the loop currently is (`starting`, `running`, `paused`, or a terminal status)
+- `iteration` and `maxIterations`: how far the loop has advanced and its upper bound
 - `goal`: the high-level goal you gave the loop
-- `autoContinue`: whether the loop advances without manual approval
-- `allowDetached`: whether the loop is allowed to continue without an attached client
+- `autoContinue` and `allowDetached`: whether the loop can advance and keep running without a manual step or an attached client
 
 ## Polling a Loop to Completion
 
@@ -149,7 +136,7 @@ async function main(): Promise<void> {
     const { loop } = await client.getLoopState(created.sessionId);
 
     if (!loop) {
-      // Loop state is not initialized yet; the session is still starting.
+      // Loop state isn't initialized yet. The session is still starting
       continue;
     }
 
@@ -165,9 +152,8 @@ async function main(): Promise<void> {
     }
 
     if (status === 'awaiting_input') {
-      // The loop paused and is waiting for external input before it can continue.
-      // Your app would handle this, for example by prompting the user or injecting
-      // a response via the Hub WebSocket or REST API.
+      // The loop paused and is waiting for external input. Your app would handle this
+      // by prompting the user or sending a response through the Hub WebSocket or REST API
       console.log('Loop is awaiting input. Exiting poll loop.');
       return;
     }
@@ -180,7 +166,7 @@ async function main(): Promise<void> {
 void main();
 ```
 
-The `loop.summary` and `loop.nextAction` fields are populated by the Hub as the loop progresses. They are useful for surfacing progress in a UI or feeding into a downstream step.
+The Hub broadcasts `loop.summary` and `loop.nextAction` as the loop progresses, so your UI or downstream step can pick them up without holding a live controller socket.
 
 ## When to Use This Pattern
 

--- a/apps/docs/src/web/content/cookbook/patterns/hono-rpc-tanstack-query.mdx
+++ b/apps/docs/src/web/content/cookbook/patterns/hono-rpc-tanstack-query.mdx
@@ -1,6 +1,6 @@
 ---
 title: Type-Safe API Calls with Hono RPC and TanStack Query
-short_title: Hono RPC + TanStack Query
+short_title: Hono RPC + TanStack
 description: Get end-to-end type safety between your Agentuity API routes and React frontend using Hono RPC and TanStack Query
 ---
 

--- a/apps/docs/src/web/content/cookbook/patterns/meta.json
+++ b/apps/docs/src/web/content/cookbook/patterns/meta.json
@@ -1,6 +1,13 @@
 {
 	"title": "Patterns",
 	"pages": [
+		"creating-coder-sessions-with-sdk",
+		"creating-loop-mode-coder-sessions",
+		"choosing-built-in-agents-for-a-coder-session",
+		"attaching-skills-to-a-coder-session",
+		"using-workspaces-to-reuse-repos-skills-and-agent-selection",
+		"preparing-coder-sessions-for-remote-attach",
+		"observing-a-coder-session-through-the-hub",
 		"autonomous-research",
 		"background-tasks",
 		"chat-with-history",

--- a/apps/docs/src/web/content/cookbook/patterns/meta.json
+++ b/apps/docs/src/web/content/cookbook/patterns/meta.json
@@ -1,13 +1,20 @@
 {
 	"title": "Patterns",
+	"groups": [
+		{
+			"title": "Coder",
+			"pages": [
+				"creating-coder-sessions-with-sdk",
+				"creating-loop-mode-coder-sessions",
+				"choosing-built-in-agents-for-a-coder-session",
+				"attaching-skills-to-a-coder-session",
+				"using-workspaces-to-reuse-repos-skills-and-agent-selection",
+				"preparing-coder-sessions-for-remote-attach",
+				"observing-a-coder-session-through-the-hub"
+			]
+		}
+	],
 	"pages": [
-		"creating-coder-sessions-with-sdk",
-		"creating-loop-mode-coder-sessions",
-		"choosing-built-in-agents-for-a-coder-session",
-		"attaching-skills-to-a-coder-session",
-		"using-workspaces-to-reuse-repos-skills-and-agent-selection",
-		"preparing-coder-sessions-for-remote-attach",
-		"observing-a-coder-session-through-the-hub",
 		"autonomous-research",
 		"background-tasks",
 		"chat-with-history",

--- a/apps/docs/src/web/content/cookbook/patterns/observing-a-coder-session-through-the-hub.mdx
+++ b/apps/docs/src/web/content/cookbook/patterns/observing-a-coder-session-through-the-hub.mdx
@@ -1,0 +1,145 @@
+---
+title: Observing a Coder Session through the Hub
+short_title: Observe Sessions
+description: Subscribe to a session's live event stream, page through its event history, and hydrate a client from the durable replay stream
+---
+
+The Hub is Coder's real-time broadcast bus. Any client that subscribes to it receives the same stream: the running terminal UI, a web viewer, a CLI, or your own app or automation. Every event the session produces flows through the Hub and is available both live and from the durable stream that accumulates as the session runs.
+
+Three mechanisms cover the most common integration shapes:
+
+- **WebSocket (`subscribeToCoderHub`)** for live observation, dashboards, or real-time monitors
+- **Event history (`listEventHistory`)** for structured, paginated inspection of what the session emitted
+- **Replay (`getReplay`)** for a client that attaches after the session has started and needs to catch up to current state
+
+## Live Observation with `subscribeToCoderHub`
+
+`subscribeToCoderHub` is an async iterator that yields server messages as the Hub broadcasts them. Use it from Bun or another runtime that already exposes a global `WebSocket`.
+
+<Callout type="warning" title="Start with a live session">
+Use this after `getSession()` shows a live runtime. A newly created session may not emit observer traffic until its runtime is live.
+</Callout>
+
+```typescript
+import { subscribeToCoderHub } from '@agentuity/coder';
+
+const sessionId = process.argv[2];
+if (!sessionId) {
+  throw new Error('Pass a session ID: bun observe.ts codesess_123');
+}
+
+let stop = false;
+
+// Flip the flag on Ctrl-C so the for-await loop exits cleanly.
+process.once('SIGINT', () => {
+  stop = true;
+});
+
+// Optional: stop after a wall-clock ceiling so a stray observer does not run forever.
+const timeoutId = setTimeout(() => {
+  stop = true;
+}, 5 * 60 * 1_000);
+
+try {
+  for await (const message of subscribeToCoderHub({
+    sessionId,
+    // Observer role is read-only: it receives broadcasts without driving the session.
+    role: 'observer',
+  })) {
+    if (stop) break;
+
+    // Only a subset of messages carry a `type` field; skip the rest before branching.
+    if (!('type' in message)) continue;
+
+    if (message.type === 'broadcast') {
+      // Broadcast carries the event name and the payload the session emitted.
+      console.log('Broadcast event:', message.event);
+    } else if (message.type === 'presence') {
+      // Presence fires when a participant joins or leaves the session.
+      console.log('Presence:', message.event);
+    }
+  }
+} finally {
+  clearTimeout(timeoutId);
+}
+```
+
+The client handles the WebSocket handshake and heartbeat for you. Break out of the loop, or let your stop flag fire, when your app no longer needs the stream.
+
+## Structured Audit with Event History
+
+`listEventHistory` returns the events the session has emitted so far, sorted and paginated. Use `limit` and `offset` to page through large sessions without loading all events at once.
+
+```typescript
+import { CoderClient } from '@agentuity/coder';
+
+const sessionId = process.argv[2];
+if (!sessionId) {
+  throw new Error('Pass a session ID: bun history.ts codesess_123');
+}
+
+const client = new CoderClient();
+const PAGE = 50;
+let offset = 0;
+let fetched = 0;
+
+// Page through all events, stopping when a page returns fewer items than requested.
+while (true) {
+  const { events, total } = await client.listEventHistory(sessionId, {
+    limit: PAGE,
+    offset,
+  });
+
+  for (const ev of events) {
+    // Each event carries: id, event (name), category, agent, taskId, occurredAt, payload.
+    console.log(`[${ev.occurredAt}] ${ev.category ?? '-'} / ${ev.event} (agent: ${ev.agent ?? 'none'})`);
+  }
+
+  fetched += events.length;
+  offset += PAGE;
+
+  if (events.length < PAGE || fetched >= (total ?? fetched)) {
+    break;
+  }
+}
+```
+
+This is the right approach when you need structured records: feeding an evaluator, writing an audit log, or building a session timeline in a UI. It is not a real-time feed, so for live observation use `subscribeToCoderHub` instead.
+
+## Hydration with getReplay
+
+When a client attaches to a session that is already running, it needs to catch up to the current state before processing new events. `getReplay` returns the durable stream accumulated by the Hub, which the client uses to rehydrate its local view.
+
+```typescript
+import { CoderClient } from '@agentuity/coder';
+
+const sessionId = process.argv[2];
+if (!sessionId) {
+  throw new Error('Pass a session ID: bun replay.ts codesess_123');
+}
+
+const client = new CoderClient();
+const replay = await client.getReplay(sessionId);
+
+// The replay payload is the accumulated hydration stream for this session.
+// A late-joining client consumes it to match the Hub's current state before
+// switching over to the live subscription for new events.
+console.log(`Rehydrated replay for session ${replay.sessionId}`);
+```
+
+Frame `getReplay` as hydration, not narrative review. A newly attached client calls it once so its local state matches the Hub's accumulated stream, then it switches to `subscribeToCoderHub` for the live feed going forward.
+
+## When to Use Each
+
+| Mechanism | When to use |
+|-----------|-------------|
+| `subscribeToCoderHub` | Live observation: dashboards, monitors, real-time UIs |
+| `listEventHistory` | Structured audit: evaluators, audit logs, session timelines |
+| `getReplay` | Client hydration: a late-joining client catching up to current session state |
+
+## See Also
+
+- [Managing Coder Sessions with the SDK](/cookbook/patterns/creating-coder-sessions-with-sdk): Create sessions, read state, and manage lifecycle
+- [Creating Loop-Mode Coder Sessions](/cookbook/patterns/creating-loop-mode-coder-sessions): Poll loop state for headless autonomous runs
+- [Coder Client](/reference/sdk-reference/coder): Full method reference for `@agentuity/coder`
+- [Coder](/services/coder): Concepts, workflow modes, and the Hub model

--- a/apps/docs/src/web/content/cookbook/patterns/preparing-coder-sessions-for-remote-attach.mdx
+++ b/apps/docs/src/web/content/cookbook/patterns/preparing-coder-sessions-for-remote-attach.mdx
@@ -4,17 +4,11 @@ short_title: Reconnect Sessions
 description: Use listConnectableSessions and prepareSessionForRemoteAttach to find sessions you can still reconnect to
 ---
 
-If your app offers a “resume session” or “attach to session” flow, do not start from the full session list. Use `listConnectableSessions()` to narrow the choices, then use `prepareSessionForRemoteAttach()` to decide whether the selected session is live, wakeable, or already history-only.
+For a "resume session" or "attach to session" flow, don't start from the full session list. Use `listConnectableSessions()` to narrow the choices, then `prepareSessionForRemoteAttach()` to decide whether the selected session is live, wakeable, or already history-only.
 
 <Callout type="info" title="This page stops before opening a live transport">
-These methods help you decide whether a session can still be reconnected to or should fall back to replay. They do not open a controller socket for you.
+These methods tell you whether a session can still be reconnected to or should fall back to replay. They don't open a controller socket for you.
 </Callout>
-
-<Callout type="info" title="Use this page when you already have existing sessions">
-Use this page when your app needs a “resume recent session” picker, a reconnect button, or logic that decides whether to re-attach or fall back to replay.
-</Callout>
-
-These examples work well as small local utilities while you build a reconnect picker or attach flow.
 
 ## The Pattern
 
@@ -29,7 +23,7 @@ async function main(): Promise<void> {
   const client = new CoderClient();
 
   try {
-    // listConnectableSessions filters out history-only sessions so your picker starts from resumable candidates.
+    // listConnectableSessions filters out history-only sessions so your picker starts from resumable candidates
     const { sessions } = await client.listConnectableSessions({ limit: 20 }); // [!code highlight]
 
     console.log(
@@ -57,7 +51,7 @@ async function main(): Promise<void> {
 void main();
 ```
 
-If this list is empty, that is expected in most cases. Sessions in `bucket: 'provisioning'` are intentionally excluded until they reach `running` or `paused`; a session you just created will not appear here yet. Other sessions may be absent because they are already history-only or no longer live enough to resume.
+An empty list is common. Sessions in `bucket: 'provisioning'` are intentionally excluded until they reach `running` or `paused`, so a session you just created won't show up yet. Others may be absent because they're already history-only or no longer in a resumable state.
 
 ### Preparing One Session for Reconnect
 
@@ -78,21 +72,21 @@ async function main(): Promise<void> {
       );
     }
 
-    // Polls the session state until it is attachable, wakeable, or clearly history-only.
-    // The returned session carries the live flags your UI should branch on below.
+    // Polls until the session is attachable, wakeable, or history-only
+    // The returned session carries the live flags your UI branches on below
     const session = await client.prepareSessionForRemoteAttach(sessionId, {
       timeoutMs: 30_000,
       pollIntervalMs: 1_000,
     }); // [!code highlight]
 
     if (session.historyOnly) {
-      // The live runtime is gone. Show replay or a read-only view instead.
+      // The live runtime is gone. Hydrate from replay or a read-only view instead
       console.log('Session is history-only. Use replay or session detail instead of re-attaching.');
       return;
     }
 
     if (session.runtimeAvailable) {
-      // Attaching before the runtime is up will fail; this check confirms it is ready.
+      // Attaching before the runtime is up fails; this check confirms it's ready
       console.log('Session is attachable.');
       console.log(
         JSON.stringify(
@@ -109,9 +103,8 @@ async function main(): Promise<void> {
       return;
     }
 
-    // wakeAvailable is false here, so prepareSessionForRemoteAttach returned immediately
-    // rather than polling. This happens for provisioning-bucket sessions that have not
-    // yet reached a state where a wake attempt would make sense.
+    // wakeAvailable is false, so prepareSessionForRemoteAttach returned immediately
+    // without polling. Typical for provisioning-bucket sessions that aren't yet wakeable
     console.log('Session is not attachable yet.');
     console.log(
       JSON.stringify(
@@ -140,15 +133,17 @@ void main();
 
 ## What to Look For
 
-These two methods solve different parts of the reconnect story:
+The two methods solve different parts of the reconnect story:
 
-- `listConnectableSessions()` helps you build a clean picker or “resume recent work” list
-- `prepareSessionForRemoteAttach()` handles the state check for one chosen session
+- `listConnectableSessions()` builds a clean picker or "resume recent work" list
+- `prepareSessionForRemoteAttach()` runs the state check for one chosen session
 - `runtimeAvailable: true` means the runtime is ready for a controller client
-- `historyOnly: true` means the live runtime is gone, so you should fall back to replay or read-only views
-- `wakeAvailable: true` means the session may be resumable, even if it is not live yet
+- `historyOnly: true` means the live runtime is gone, so fall back to the replay hydration stream or `listEventHistory()`
+- `wakeAvailable: true` means the session may be resumable, even if it isn't live yet
 
-Use `listConnectableSessions()` instead of `listSessions()` here. It filters out sessions that are already history-only, so your UI starts from sessions that still have a reconnect path.
+Use `listConnectableSessions()` instead of `listSessions()` here. It already filters out history-only sessions, so your UI starts from sessions that still have a reconnect path.
+
+In app code, call `prepareSessionForRemoteAttach()` right before your app opens a live connection to the session, whether that's to send messages to the agent or stream its events. It returns the current session detail so your app can branch on `runtimeAvailable`, `wakeAvailable`, and `historyOnly`. A thrown error usually means the underlying `getSession()` or `resumeSession()` call failed, so handle it like any other SDK error.
 
 ## Example Output
 
@@ -179,9 +174,9 @@ A session that can no longer be re-attached falls back to session history or sto
 ## Key Points
 
 - Use `listConnectableSessions()` for chooser UIs, resume commands, and recent-session pickers.
-- Call `prepareSessionForRemoteAttach()` only after the user picks a session or your app already knows the session ID.
+- Call `prepareSessionForRemoteAttach()` right before your app opens its live connection to the session, and branch on `runtimeAvailable`, `wakeAvailable`, and `historyOnly` to decide the next step.
 - If the timeout expires, you still get the latest session detail, which is useful for your own retry logic.
-- If a session becomes `historyOnly`, switch to replay, event history, or other read-only session data.
+- Once a session is `historyOnly`, switch to the replay hydration stream or `listEventHistory()` for a structured timeline.
 - For the CLI flow, `agentuity coder tui --remote` builds on the same reconnect idea.
 
 ## See Also

--- a/apps/docs/src/web/content/cookbook/patterns/preparing-coder-sessions-for-remote-attach.mdx
+++ b/apps/docs/src/web/content/cookbook/patterns/preparing-coder-sessions-for-remote-attach.mdx
@@ -1,0 +1,191 @@
+---
+title: Reconnecting to Existing Coder Sessions
+short_title: Reconnect Sessions
+description: Use listConnectableSessions and prepareSessionForRemoteAttach to find sessions you can still reconnect to
+---
+
+If your app offers a “resume session” or “attach to session” flow, do not start from the full session list. Use `listConnectableSessions()` to narrow the choices, then use `prepareSessionForRemoteAttach()` to decide whether the selected session is live, wakeable, or already history-only.
+
+<Callout type="info" title="This page stops before opening a live transport">
+These methods help you decide whether a session can still be reconnected to or should fall back to replay. They do not open a controller socket for you.
+</Callout>
+
+<Callout type="info" title="Use this page when you already have existing sessions">
+Use this page when your app needs a “resume recent session” picker, a reconnect button, or logic that decides whether to re-attach or fall back to replay.
+</Callout>
+
+These examples work well as small local utilities while you build a reconnect picker or attach flow.
+
+## The Pattern
+
+### Listing Reconnectable Sessions
+
+Use `listConnectableSessions()` when you want to show only sessions that still have a reconnect story.
+
+```typescript
+import { CoderClient } from '@agentuity/coder';
+
+async function main(): Promise<void> {
+  const client = new CoderClient();
+
+  try {
+    // listConnectableSessions filters out history-only sessions so your picker starts from resumable candidates.
+    const { sessions } = await client.listConnectableSessions({ limit: 20 }); // [!code highlight]
+
+    console.log(
+      JSON.stringify(
+        sessions.map((session) => ({
+          sessionId: session.sessionId,
+          label: session.label,
+          status: session.status,
+          bucket: session.bucket,
+          runtimeAvailable: session.runtimeAvailable,
+          wakeAvailable: session.wakeAvailable,
+        })),
+        null,
+        2
+      )
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.stack ?? error.message : String(error);
+    console.error('Failed to list reconnectable sessions');
+    console.error(message);
+    process.exitCode = 1;
+  }
+}
+
+void main();
+```
+
+If this list is empty, that is expected in most cases. Sessions in `bucket: 'provisioning'` are intentionally excluded until they reach `running` or `paused`; a session you just created will not appear here yet. Other sessions may be absent because they are already history-only or no longer live enough to resume.
+
+### Preparing One Session for Reconnect
+
+Once a user picks a session, use `prepareSessionForRemoteAttach()` to check whether it is live, wakeable, or already read-only.
+
+```typescript
+import { CoderClient } from '@agentuity/coder';
+
+const sessionId = process.argv[2];
+
+async function main(): Promise<void> {
+  const client = new CoderClient();
+
+  try {
+    if (!sessionId) {
+      throw new Error(
+        'Pass a session ID as the first argument, for example: bun example.ts codesess_123'
+      );
+    }
+
+    // Polls the session state until it is attachable, wakeable, or clearly history-only.
+    // The returned session carries the live flags your UI should branch on below.
+    const session = await client.prepareSessionForRemoteAttach(sessionId, {
+      timeoutMs: 30_000,
+      pollIntervalMs: 1_000,
+    }); // [!code highlight]
+
+    if (session.historyOnly) {
+      // The live runtime is gone. Show replay or a read-only view instead.
+      console.log('Session is history-only. Use replay or session detail instead of re-attaching.');
+      return;
+    }
+
+    if (session.runtimeAvailable) {
+      // Attaching before the runtime is up will fail; this check confirms it is ready.
+      console.log('Session is attachable.');
+      console.log(
+        JSON.stringify(
+          {
+            sessionId: session.sessionId,
+            status: session.status,
+            bucket: session.bucket,
+            runtimeAvailable: session.runtimeAvailable,
+          },
+          null,
+          2
+        )
+      );
+      return;
+    }
+
+    // wakeAvailable is false here, so prepareSessionForRemoteAttach returned immediately
+    // rather than polling. This happens for provisioning-bucket sessions that have not
+    // yet reached a state where a wake attempt would make sense.
+    console.log('Session is not attachable yet.');
+    console.log(
+      JSON.stringify(
+        {
+          sessionId: session.sessionId,
+          status: session.status,
+          bucket: session.bucket,
+          runtimeAvailable: session.runtimeAvailable,
+          wakeAvailable: session.wakeAvailable,
+          historyOnly: session.historyOnly,
+        },
+        null,
+        2
+      )
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.stack ?? error.message : String(error);
+    console.error('Failed to prepare the session for remote attach');
+    console.error(message);
+    process.exitCode = 1;
+  }
+}
+
+void main();
+```
+
+## What to Look For
+
+These two methods solve different parts of the reconnect story:
+
+- `listConnectableSessions()` helps you build a clean picker or “resume recent work” list
+- `prepareSessionForRemoteAttach()` handles the state check for one chosen session
+- `runtimeAvailable: true` means the runtime is ready for a controller client
+- `historyOnly: true` means the live runtime is gone, so you should fall back to replay or read-only views
+- `wakeAvailable: true` means the session may be resumable, even if it is not live yet
+
+Use `listConnectableSessions()` instead of `listSessions()` here. It filters out sessions that are already history-only, so your UI starts from sessions that still have a reconnect path.
+
+## Example Output
+
+An attachable session may look like this:
+
+```json
+{
+  "sessionId": "codesess_abc123",
+  "status": "active",
+  "bucket": "running",
+  "runtimeAvailable": true
+}
+```
+
+A session that can no longer be re-attached falls back to session history or stored session data instead:
+
+```json
+{
+  "sessionId": "codesess_def456",
+  "status": "archived",
+  "bucket": "history",
+  "runtimeAvailable": false,
+  "wakeAvailable": false,
+  "historyOnly": true
+}
+```
+
+## Key Points
+
+- Use `listConnectableSessions()` for chooser UIs, resume commands, and recent-session pickers.
+- Call `prepareSessionForRemoteAttach()` only after the user picks a session or your app already knows the session ID.
+- If the timeout expires, you still get the latest session detail, which is useful for your own retry logic.
+- If a session becomes `historyOnly`, switch to replay, event history, or other read-only session data.
+- For the CLI flow, `agentuity coder tui --remote` builds on the same reconnect idea.
+
+## See Also
+
+- [Managing Coder Sessions with the SDK](/cookbook/patterns/creating-coder-sessions-with-sdk): Create sessions, read state, and manage lifecycle from code
+- [Creating Loop-Mode Coder Sessions](/cookbook/patterns/creating-loop-mode-coder-sessions): Create loop workflows and inspect loop state
+- [Coder Commands](/reference/cli/coder): Use `agentuity coder tui --remote` when you want the CLI remote-attach flow

--- a/apps/docs/src/web/content/cookbook/patterns/preparing-coder-sessions-for-remote-attach.mdx
+++ b/apps/docs/src/web/content/cookbook/patterns/preparing-coder-sessions-for-remote-attach.mdx
@@ -74,10 +74,10 @@ async function main(): Promise<void> {
 
     // Polls until the session is attachable, wakeable, or history-only
     // The returned session carries the live flags your UI branches on below
-    const session = await client.prepareSessionForRemoteAttach(sessionId, {
+    const session = await client.prepareSessionForRemoteAttach(sessionId, { // [!code highlight]
       timeoutMs: 30_000,
       pollIntervalMs: 1_000,
-    }); // [!code highlight]
+    });
 
     if (session.historyOnly) {
       // The live runtime is gone. Hydrate from replay or a read-only view instead

--- a/apps/docs/src/web/content/cookbook/patterns/using-workspaces-to-reuse-repos-skills-and-agent-selection.mdx
+++ b/apps/docs/src/web/content/cookbook/patterns/using-workspaces-to-reuse-repos-skills-and-agent-selection.mdx
@@ -1,0 +1,150 @@
+---
+title: Using Workspaces to Reuse Repos, Skills, and Agent Selection
+short_title: Use Workspaces
+description: Store reusable Coder selections in a workspace and attach them to sessions with workspaceId
+---
+
+Use this page when you want to save a session setup once and reuse it with `workspaceId`. Start with the pieces you repeat most often: saved skills and agent selection. Add repositories when your app already knows which repos belong there.
+
+<Callout type="info" title="Use this page when you want reusable session composition">
+Use this page when your app keeps reaching for the same skills and agent roster and you want one saved workspace instead of repeating those selections on every `createSession()` call.
+</Callout>
+
+<Callout type="tip" title="Start with selections, then add repos when your app already has them">
+This example stores a saved skill and an agent roster, then reuses both from the workspace. You can add repositories to the same workspace later.
+</Callout>
+
+This works well as a local script while you shape the workspace contents and inspect the session it produces.
+
+## The Pattern
+
+Create a workspace, then create a session that points at it:
+
+```typescript
+import { CoderClient } from '@agentuity/coder';
+
+const DEFAULT_TASK =
+  'Use the workspace selections to review the repo, identify the biggest implementation risk, and recommend a focused next step.';
+
+function getTask(): string {
+  const task = process.argv.slice(2).join(' ').trim();
+  return task || DEFAULT_TASK;
+}
+
+async function main(): Promise<void> {
+  const client = new CoderClient();
+  const task = getTask();
+
+  // Save the skill into the library first so the workspace can own it by id.
+  const savedSkill = await client.saveSkill({
+    repo: 'anthropics/skills',
+    skillId: 'frontend-design',
+    name: 'frontend-design',
+    description: 'Design-focused frontend implementation guidance.',
+    url: 'https://skills.sh/anthropics/skills/frontend-design',
+  });
+
+  // Workspaces bundle reusable selections (skills, agents, repos) behind a single id.
+  const workspace = await client.createWorkspace({
+    name: `workspace-${Date.now()}`,
+    description: 'Reusable selections for review-oriented sessions.',
+    savedSkillIds: [savedSkill.id],
+    agentSlugs: ['builder', 'reviewer'], // [!code highlight]
+  });
+
+  // Passing workspaceId is enough; the session inherits the workspace's selections.
+  const created = await client.createSession({
+    task,
+    workflowMode: 'standard',
+    workspaceId: workspace.id, // [!code highlight]
+    // defaultAgent can still be set per session even when a workspace supplies the roster.
+    defaultAgent: 'builder',
+  });
+
+  // Read the session back so you can confirm the workspace selections took effect
+  // and the session started with the defaults you expect.
+  const session = await client.getSession(created.sessionId);
+
+  console.log(
+    JSON.stringify(
+      {
+        workspaceId: workspace.id,
+        sessionId: session.sessionId,
+        defaultAgent: session.defaultAgent,
+        skills: session.skills.map((skill) => ({
+          repo: skill.repo,
+          skillId: skill.skillId,
+          name: skill.name,
+        })),
+      },
+      null,
+      2
+    )
+  );
+}
+
+void main();
+```
+
+## Example Output
+
+```json
+{
+  "workspaceId": "ws_956cc248e682",
+  "sessionId": "codesess_2f3af05751fb",
+  "defaultAgent": "builder",
+  "skills": [
+    {
+      "repo": "anthropics/skills",
+      "skillId": "frontend-design",
+      "name": "frontend-design"
+    }
+  ]
+}
+```
+
+What this means:
+
+- the workspace stored the reusable selections
+- `workspaceId` carried those selections into the session
+- you can still set a default agent like `builder` when you create the session
+
+## Where Repositories Fit
+
+Workspaces are also where repository reuse belongs. When your app already has a valid `CoderSessionRepositoryRef`, add it to the workspace the same way:
+
+```typescript
+// Store repo, skill, and agent selections together so later createSession calls need only workspaceId.
+const workspace = await client.createWorkspace({
+  name: 'review-workspace',
+  repos: [repoRef], // Repository ref your app already resolved
+  savedSkillIds: [savedSkill.id],
+  agentSlugs: ['builder', 'reviewer'],
+});
+```
+
+That keeps repo selection, skill selection, and agent selection in one reusable object. If your app does not already have repository refs, start with skills and agent selection first, then add repo reuse later.
+
+## When to Use This Pattern
+
+Use this pattern when you want:
+
+- one saved setup reused across multiple sessions
+- less duplication in your session creation code
+- a stable place to store reusable skill and agent selections
+- session creation that starts from a named workspace instead of a long config object
+
+## Key Points
+
+- Workspaces are a composition tool. They are most helpful once you already know the selections your app reuses.
+- A workspace cannot be empty. Include at least one repo, saved skill, skill bucket, or agent selection.
+- `workspaceId` does not replace normal session lifecycle APIs. You still create, inspect, archive, and delete sessions the same way.
+- Start with saved skills and agent selection. Add repos when your app already has repository refs to store or resolve elsewhere.
+- Reading the session back after creation is the cleanest way to verify that the workspace produced the session you expected.
+
+## See Also
+
+- [Attaching Skills to a Coder Session](/cookbook/patterns/attaching-skills-to-a-coder-session): Attach saved skills directly without first creating a workspace
+- [Choosing Built-In Agents for a Coder Session](/cookbook/patterns/choosing-built-in-agents-for-a-coder-session): Set the built-in roster without introducing a workspace
+- [Managing Coder Sessions with the SDK](/cookbook/patterns/creating-coder-sessions-with-sdk): Core session lifecycle flow
+- [Coder Client](/reference/sdk-reference/coder): Full `createWorkspace()` and `createSession()` reference

--- a/apps/docs/src/web/content/cookbook/patterns/using-workspaces-to-reuse-repos-skills-and-agent-selection.mdx
+++ b/apps/docs/src/web/content/cookbook/patterns/using-workspaces-to-reuse-repos-skills-and-agent-selection.mdx
@@ -4,17 +4,11 @@ short_title: Use Workspaces
 description: Store reusable Coder selections in a workspace and attach them to sessions with workspaceId
 ---
 
-Use this page when you want to save a session setup once and reuse it with `workspaceId`. Start with the pieces you repeat most often: saved skills and agent selection. Add repositories when your app already knows which repos belong there.
+Workspaces save a session setup once and reuse it everywhere by `workspaceId`. They hold the selections your app repeats most often: saved skills, agent selection, and (once your app has them) repository refs. That means you aren't re-listing those on every `createSession()` call.
 
-<Callout type="info" title="Use this page when you want reusable session composition">
-Use this page when your app keeps reaching for the same skills and agent roster and you want one saved workspace instead of repeating those selections on every `createSession()` call.
+<Callout type="tip" title="Start with what you already repeat">
+This example stores a saved skill and an agent selection, then pulls both in by `workspaceId`. Repositories can join the same workspace later.
 </Callout>
-
-<Callout type="tip" title="Start with selections, then add repos when your app already has them">
-This example stores a saved skill and an agent roster, then reuses both from the workspace. You can add repositories to the same workspace later.
-</Callout>
-
-This works well as a local script while you shape the workspace contents and inspect the session it produces.
 
 ## The Pattern
 
@@ -35,7 +29,7 @@ async function main(): Promise<void> {
   const client = new CoderClient();
   const task = getTask();
 
-  // Save the skill into the library first so the workspace can own it by id.
+  // Save the skill into the library first so the workspace can own it by id
   const savedSkill = await client.saveSkill({
     repo: 'anthropics/skills',
     skillId: 'frontend-design',
@@ -44,7 +38,7 @@ async function main(): Promise<void> {
     url: 'https://skills.sh/anthropics/skills/frontend-design',
   });
 
-  // Workspaces bundle reusable selections (skills, agents, repos) behind a single id.
+  // Workspaces bundle reusable selections (skills, agents, repos) behind a single id
   const workspace = await client.createWorkspace({
     name: `workspace-${Date.now()}`,
     description: 'Reusable selections for review-oriented sessions.',
@@ -52,17 +46,16 @@ async function main(): Promise<void> {
     agentSlugs: ['builder', 'reviewer'], // [!code highlight]
   });
 
-  // Passing workspaceId is enough; the session inherits the workspace's selections.
+  // Passing workspaceId is enough; the session inherits the workspace selections
   const created = await client.createSession({
     task,
     workflowMode: 'standard',
     workspaceId: workspace.id, // [!code highlight]
-    // defaultAgent can still be set per session even when a workspace supplies the roster.
+    // defaultAgent can still be set per session even when a workspace supplies the agent list
     defaultAgent: 'builder',
   });
 
-  // Read the session back so you can confirm the workspace selections took effect
-  // and the session started with the defaults you expect.
+  // Read the session back to confirm the workspace selections took effect
   const session = await client.getSession(created.sessionId);
 
   console.log(
@@ -111,10 +104,10 @@ What this means:
 
 ## Where Repositories Fit
 
-Workspaces are also where repository reuse belongs. When your app already has a valid `CoderSessionRepositoryRef`, add it to the workspace the same way:
+Once your app has a valid `CoderSessionRepositoryRef`, add it to the same workspace:
 
 ```typescript
-// Store repo, skill, and agent selections together so later createSession calls need only workspaceId.
+// Store repo, skill, and agent selections together so later createSession calls need only workspaceId
 const workspace = await client.createWorkspace({
   name: 'review-workspace',
   repos: [repoRef], // Repository ref your app already resolved
@@ -123,7 +116,7 @@ const workspace = await client.createWorkspace({
 });
 ```
 
-That keeps repo selection, skill selection, and agent selection in one reusable object. If your app does not already have repository refs, start with skills and agent selection first, then add repo reuse later.
+That keeps repo, skill, and agent selections in one reusable object. If your app doesn't have repository refs yet, start with skills and agents and layer repositories in later.
 
 ## When to Use This Pattern
 
@@ -136,11 +129,10 @@ Use this pattern when you want:
 
 ## Key Points
 
-- Workspaces are a composition tool. They are most helpful once you already know the selections your app reuses.
-- A workspace cannot be empty. Include at least one repo, saved skill, skill bucket, or agent selection.
-- `workspaceId` does not replace normal session lifecycle APIs. You still create, inspect, archive, and delete sessions the same way.
-- Start with saved skills and agent selection. Add repos when your app already has repository refs to store or resolve elsewhere.
-- Reading the session back after creation is the cleanest way to verify that the workspace produced the session you expected.
+- Workspaces pay off when the same selections repeat across sessions.
+- A workspace can't be empty. Include at least one repo, saved skill, skill bucket, or agent selection.
+- `workspaceId` doesn't replace the normal session lifecycle APIs; create, inspect, archive, and delete sessions the same way.
+- Read the session back after creation to confirm the workspace selections flowed through.
 
 ## See Also
 

--- a/apps/docs/src/web/content/cookbook/patterns/web-exploration.mdx
+++ b/apps/docs/src/web/content/cookbook/patterns/web-exploration.mdx
@@ -1,5 +1,6 @@
 ---
 title: Web Exploration with Sandboxes
+short_title: Web Exploration
 description: Run a headless browser in a sandbox to let agents browse, screenshot, and extract web content
 ---
 

--- a/apps/docs/src/web/content/reference/api/coder.mdx
+++ b/apps/docs/src/web/content/reference/api/coder.mdx
@@ -1,7 +1,7 @@
 ---
 title: Coder API
 short_title: Coder
-description: Manage Coder sessions, session data, loop state, and known users through the HTTP API
+description: Manage Coder sessions, custom agents, session data, loop state, and known users through the REST API
 ---
 
 {/* This file is auto-generated from Zod schemas. Do not edit manually. Run scripts/generate-api-reference.ts to regenerate. */}
@@ -100,6 +100,12 @@ Session creation payload.
     "required": false
   },
   {
+    "name": "defaultAgent",
+    "type": "string",
+    "description": "Preferred default agent identifier for routing session prompts",
+    "required": false
+  },
+  {
     "name": "visibility",
     "type": "string",
     "description": "Session visibility setting",
@@ -145,6 +151,12 @@ Session creation payload.
     "name": "tags",
     "type": "string[]",
     "description": "Tags applied to the session for filtering",
+    "required": false
+  },
+  {
+    "name": "enabledAgents",
+    "type": "string[]",
+    "description": "Enabled agent roster to include in the session",
     "required": false
   },
   {
@@ -811,6 +823,11 @@ Returns a session list.
     "description": "Canonical URL for the skill repository or page"
   },
   {
+    "name": "sessions.websocket[].enabledAgents",
+    "type": "string[]",
+    "description": "Enabled agent roster attached to the session"
+  },
+  {
     "name": "sessions.websocket[].defaultAgent",
     "type": "string",
     "description": "Default agent assigned to session operations"
@@ -1209,6 +1226,11 @@ Returns the full session object.
     "name": "skills[].url",
     "type": "string",
     "description": "Canonical URL for the skill repository or page"
+  },
+  {
+    "name": "enabledAgents",
+    "type": "string[]",
+    "description": "Enabled agent roster attached to the session"
   },
   {
     "name": "defaultAgent",
@@ -2065,5 +2087,831 @@ Returns session event history.
 #### Example
 
 <ApiExample method="GET" path="/hub/session/sess_123/events/history?limit=50&beforeId=1234" />
+
+---
+
+## Agents
+
+### List Custom Agents
+
+Lists custom agents visible to the caller.
+
+<ApiEndpoint method="GET" path="/hub/agents" />
+
+#### Parameters
+
+<ParamTable params={[
+  {
+    "name": "includeArchived",
+    "type": "boolean",
+    "in": "query",
+    "required": false,
+    "description": "Include archived custom agents"
+  },
+  {
+    "name": "orgId",
+    "type": "string",
+    "in": "query",
+    "required": false,
+    "description": "Organization ID"
+  }
+]} />
+
+#### Response
+
+Returns custom agents visible to the caller.
+
+| Status | Description |
+|--------|-------------|
+| 200 | Custom agents returned |
+| 401 | Unauthorized — invalid or missing API key |
+
+#### Response Fields
+
+<ResponseFields fields={[
+  {
+    "name": "agents",
+    "type": "object[]",
+    "description": "Custom agents returned by coder hub"
+  },
+  {
+    "name": "agents[].slug",
+    "type": "string",
+    "description": "Stable custom agent slug"
+  },
+  {
+    "name": "agents[].displayName",
+    "type": "string",
+    "description": "Human-readable custom agent name"
+  },
+  {
+    "name": "agents[].description",
+    "type": "string",
+    "description": "Optional custom agent description"
+  },
+  {
+    "name": "agents[].instructions",
+    "type": "string",
+    "description": "Standalone custom-agent system prompt"
+  },
+  {
+    "name": "agents[].model",
+    "type": "string",
+    "description": "Optional model override"
+  },
+  {
+    "name": "agents[].thinkingLevel",
+    "type": "string",
+    "description": "Optional thinking level override"
+  },
+  {
+    "name": "agents[].headlessCompatible",
+    "type": "boolean",
+    "description": "Whether the custom agent is safe for non-interactive callers"
+  },
+  {
+    "name": "agents[].tools",
+    "type": "string[]",
+    "description": "Workspace tools granted to the custom agent"
+  },
+  {
+    "name": "agents[].serviceTools",
+    "type": "string[]",
+    "description": "Service tools granted to the custom agent"
+  },
+  {
+    "name": "agents[].savedSkills",
+    "type": "object[]",
+    "description": "Frozen saved-skill refs attached to the custom agent snapshot"
+  },
+  {
+    "name": "agents[].savedSkills[].skillId",
+    "type": "string",
+    "description": "Unique skill identifier"
+  },
+  {
+    "name": "agents[].savedSkills[].repo",
+    "type": "string",
+    "description": "Repository slug for the skill source"
+  },
+  {
+    "name": "agents[].savedSkills[].name",
+    "type": "string",
+    "description": "Human-readable skill name"
+  },
+  {
+    "name": "agents[].savedSkills[].url",
+    "type": "string",
+    "description": "Canonical URL for the skill repository or page"
+  },
+  {
+    "name": "agents[].companionAgents",
+    "type": "string[]",
+    "description": "Companion agents auto-included alongside this custom agent"
+  },
+  {
+    "name": "agents[].id",
+    "type": "string",
+    "description": "Custom agent record identifier"
+  },
+  {
+    "name": "agents[].ownerUserId",
+    "type": "string",
+    "description": "Owner user identifier"
+  },
+  {
+    "name": "agents[].lifecycle",
+    "type": "string",
+    "description": "Current lifecycle state for the custom agent"
+  },
+  {
+    "name": "agents[].visibility",
+    "type": "string",
+    "description": "Visibility tier for the custom agent"
+  },
+  {
+    "name": "agents[].createdAt",
+    "type": "string",
+    "description": "Creation timestamp (ISO-8601)"
+  },
+  {
+    "name": "agents[].updatedAt",
+    "type": "string",
+    "description": "Last update timestamp (ISO-8601)"
+  },
+  {
+    "name": "agents[].hasPublishedVersion",
+    "type": "boolean",
+    "description": "Whether the agent has at least one published version"
+  },
+  {
+    "name": "agents[].hasUnpublishedChanges",
+    "type": "boolean",
+    "description": "Whether the current draft differs from the latest published version"
+  },
+  {
+    "name": "agents[].latestPublishedVersion",
+    "type": "number",
+    "description": "Latest published version number"
+  },
+  {
+    "name": "agents[].latestPublishedAt",
+    "type": "string",
+    "description": "Latest published timestamp (ISO-8601)"
+  },
+  {
+    "name": "agents[].published",
+    "type": "object",
+    "description": "Latest published version snapshot"
+  },
+  {
+    "name": "agents[].published.slug",
+    "type": "string",
+    "description": "Stable custom agent slug"
+  },
+  {
+    "name": "agents[].published.displayName",
+    "type": "string",
+    "description": "Human-readable custom agent name"
+  },
+  {
+    "name": "agents[].published.description",
+    "type": "string",
+    "description": "Optional custom agent description"
+  },
+  {
+    "name": "agents[].published.instructions",
+    "type": "string",
+    "description": "Standalone custom-agent system prompt"
+  },
+  {
+    "name": "agents[].published.model",
+    "type": "string",
+    "description": "Optional model override"
+  },
+  {
+    "name": "agents[].published.thinkingLevel",
+    "type": "string",
+    "description": "Optional thinking level override"
+  },
+  {
+    "name": "agents[].published.headlessCompatible",
+    "type": "boolean",
+    "description": "Whether the custom agent is safe for non-interactive callers"
+  },
+  {
+    "name": "agents[].published.tools",
+    "type": "string[]",
+    "description": "Workspace tools granted to the custom agent"
+  },
+  {
+    "name": "agents[].published.serviceTools",
+    "type": "string[]",
+    "description": "Service tools granted to the custom agent"
+  },
+  {
+    "name": "agents[].published.savedSkills",
+    "type": "object[]",
+    "description": "Frozen saved-skill refs attached to the custom agent snapshot"
+  },
+  {
+    "name": "agents[].published.savedSkills[].skillId",
+    "type": "string",
+    "description": "Unique skill identifier"
+  },
+  {
+    "name": "agents[].published.savedSkills[].repo",
+    "type": "string",
+    "description": "Repository slug for the skill source"
+  },
+  {
+    "name": "agents[].published.savedSkills[].name",
+    "type": "string",
+    "description": "Human-readable skill name"
+  },
+  {
+    "name": "agents[].published.savedSkills[].url",
+    "type": "string",
+    "description": "Canonical URL for the skill repository or page"
+  },
+  {
+    "name": "agents[].published.companionAgents",
+    "type": "string[]",
+    "description": "Companion agents auto-included alongside this custom agent"
+  },
+  {
+    "name": "agents[].published.id",
+    "type": "string",
+    "description": "Published custom agent version identifier"
+  },
+  {
+    "name": "agents[].published.agentId",
+    "type": "string",
+    "description": "Parent custom agent identifier"
+  },
+  {
+    "name": "agents[].published.version",
+    "type": "number",
+    "description": "Published version number"
+  },
+  {
+    "name": "agents[].published.createdByUserId",
+    "type": "string",
+    "description": "User who published the version"
+  },
+  {
+    "name": "agents[].published.createdAt",
+    "type": "string",
+    "description": "Version creation timestamp (ISO-8601)"
+  },
+  {
+    "name": "agents[].draft",
+    "type": "object",
+    "description": "Owner-visible draft snapshot"
+  },
+  {
+    "name": "agents[].draft.slug",
+    "type": "string",
+    "description": "Stable custom agent slug"
+  },
+  {
+    "name": "agents[].draft.displayName",
+    "type": "string",
+    "description": "Human-readable custom agent name"
+  },
+  {
+    "name": "agents[].draft.description",
+    "type": "string",
+    "description": "Optional custom agent description"
+  },
+  {
+    "name": "agents[].draft.instructions",
+    "type": "string",
+    "description": "Standalone custom-agent system prompt"
+  },
+  {
+    "name": "agents[].draft.model",
+    "type": "string",
+    "description": "Optional model override"
+  },
+  {
+    "name": "agents[].draft.thinkingLevel",
+    "type": "string",
+    "description": "Optional thinking level override"
+  },
+  {
+    "name": "agents[].draft.headlessCompatible",
+    "type": "boolean",
+    "description": "Whether the custom agent is safe for non-interactive callers"
+  },
+  {
+    "name": "agents[].draft.tools",
+    "type": "string[]",
+    "description": "Workspace tools granted to the custom agent"
+  },
+  {
+    "name": "agents[].draft.serviceTools",
+    "type": "string[]",
+    "description": "Service tools granted to the custom agent"
+  },
+  {
+    "name": "agents[].draft.savedSkills",
+    "type": "object[]",
+    "description": "Frozen saved-skill refs attached to the custom agent snapshot"
+  },
+  {
+    "name": "agents[].draft.savedSkills[].skillId",
+    "type": "string",
+    "description": "Unique skill identifier"
+  },
+  {
+    "name": "agents[].draft.savedSkills[].repo",
+    "type": "string",
+    "description": "Repository slug for the skill source"
+  },
+  {
+    "name": "agents[].draft.savedSkills[].name",
+    "type": "string",
+    "description": "Human-readable skill name"
+  },
+  {
+    "name": "agents[].draft.savedSkills[].url",
+    "type": "string",
+    "description": "Canonical URL for the skill repository or page"
+  },
+  {
+    "name": "agents[].draft.companionAgents",
+    "type": "string[]",
+    "description": "Companion agents auto-included alongside this custom agent"
+  }
+]} />
+
+#### Example
+
+<ApiExample method="GET" path="/hub/agents?includeArchived=true" />
+
+---
+
+### Create Custom Agent
+
+Creates a new custom-agent draft.
+
+<ApiEndpoint method="POST" path="/hub/agents" />
+
+#### Parameters
+
+<ParamTable params={[
+  {
+    "name": "orgId",
+    "type": "string",
+    "in": "query",
+    "required": false,
+    "description": "Organization ID"
+  }
+]} />
+
+#### Request Body
+
+Custom-agent creation payload.
+
+<ResponseFields fields={[
+  {
+    "name": "slug",
+    "type": "string",
+    "description": "Stable custom agent slug",
+    "required": true
+  },
+  {
+    "name": "displayName",
+    "type": "string",
+    "description": "Human-readable custom agent name",
+    "required": true
+  },
+  {
+    "name": "description",
+    "type": "string",
+    "description": "Optional custom agent description",
+    "required": false
+  },
+  {
+    "name": "instructions",
+    "type": "string",
+    "description": "Standalone custom-agent system prompt",
+    "required": true
+  },
+  {
+    "name": "model",
+    "type": "string",
+    "description": "Optional model override",
+    "required": false
+  },
+  {
+    "name": "thinkingLevel",
+    "type": "string",
+    "description": "Optional thinking level override",
+    "required": false
+  },
+  {
+    "name": "headlessCompatible",
+    "type": "boolean",
+    "description": "Whether the custom agent is safe for non-interactive callers",
+    "required": false
+  },
+  {
+    "name": "tools",
+    "type": "string[]",
+    "description": "Workspace tools to grant to the custom agent",
+    "required": false
+  },
+  {
+    "name": "serviceTools",
+    "type": "string[]",
+    "description": "Service tools to grant to the custom agent",
+    "required": false
+  },
+  {
+    "name": "savedSkillIds",
+    "type": "string[]",
+    "description": "Saved skill row ids to snapshot onto the custom agent",
+    "required": false
+  },
+  {
+    "name": "companionAgents",
+    "type": "string[]",
+    "description": "Agent names to auto-include alongside this custom agent",
+    "required": false
+  }
+]} />
+
+#### Response
+
+Returns the created custom agent.
+
+| Status | Description |
+|--------|-------------|
+| 201 | Custom agent created |
+| 401 | Unauthorized — invalid or missing API key |
+
+#### Example
+
+<ApiExample method="POST" path="/hub/agents" body={{
+  "slug": "code-review",
+  "displayName": "Code Review",
+  "instructions": "Focus on correctness, regressions, and missing tests.",
+  "tools": [
+    "read",
+    "grep",
+    "ls"
+  ],
+  "serviceTools": [
+    "session_todo_list",
+    "session_todo_update"
+  ]
+}} />
+
+---
+
+### Get Custom Agent
+
+Fetches a custom agent by id or slug.
+
+<ApiEndpoint method="GET" path="/hub/agents/{agentIdOrSlug}" />
+
+#### Parameters
+
+<ParamTable params={[
+  {
+    "name": "agentIdOrSlug",
+    "type": "string",
+    "in": "path",
+    "required": true,
+    "description": "Custom agent id or slug"
+  },
+  {
+    "name": "orgId",
+    "type": "string",
+    "in": "query",
+    "required": false,
+    "description": "Organization ID"
+  }
+]} />
+
+#### Response
+
+Returns the requested custom agent.
+
+| Status | Description |
+|--------|-------------|
+| 200 | Custom agent returned |
+| 404 | Custom agent not found |
+
+#### Example
+
+<ApiExample method="GET" path="/hub/agents/code-review" />
+
+---
+
+### Update Custom Agent
+
+Updates an owned custom-agent draft.
+
+<ApiEndpoint method="PATCH" path="/hub/agents/{agentIdOrSlug}" />
+
+#### Parameters
+
+<ParamTable params={[
+  {
+    "name": "agentIdOrSlug",
+    "type": "string",
+    "in": "path",
+    "required": true,
+    "description": "Custom agent id or slug"
+  },
+  {
+    "name": "orgId",
+    "type": "string",
+    "in": "query",
+    "required": false,
+    "description": "Organization ID"
+  }
+]} />
+
+#### Request Body
+
+Custom-agent update payload.
+
+<ResponseFields fields={[
+  {
+    "name": "slug",
+    "type": "string",
+    "description": "Stable custom agent slug",
+    "required": false
+  },
+  {
+    "name": "displayName",
+    "type": "string",
+    "description": "Human-readable custom agent name",
+    "required": false
+  },
+  {
+    "name": "description",
+    "type": "string | null",
+    "description": "Optional custom agent description",
+    "required": false
+  },
+  {
+    "name": "instructions",
+    "type": "string",
+    "description": "Standalone custom-agent system prompt",
+    "required": false
+  },
+  {
+    "name": "model",
+    "type": "string | null",
+    "description": "Optional model override",
+    "required": false
+  },
+  {
+    "name": "thinkingLevel",
+    "type": "string | null",
+    "description": "Optional thinking level override",
+    "required": false
+  },
+  {
+    "name": "headlessCompatible",
+    "type": "boolean",
+    "description": "Whether the custom agent is safe for non-interactive callers",
+    "required": false
+  },
+  {
+    "name": "tools",
+    "type": "string[]",
+    "description": "Workspace tools to grant to the custom agent",
+    "required": false
+  },
+  {
+    "name": "serviceTools",
+    "type": "string[]",
+    "description": "Service tools to grant to the custom agent",
+    "required": false
+  },
+  {
+    "name": "savedSkillIds",
+    "type": "string[]",
+    "description": "Saved skill row ids to snapshot onto the custom agent",
+    "required": false
+  },
+  {
+    "name": "companionAgents",
+    "type": "string[]",
+    "description": "Agent names to auto-include alongside this custom agent",
+    "required": false
+  }
+]} />
+
+#### Response
+
+Returns the updated custom agent.
+
+| Status | Description |
+|--------|-------------|
+| 200 | Custom agent updated |
+| 404 | Custom agent not found |
+
+#### Example
+
+<ApiExample method="PATCH" path="/hub/agents/code-review" body={{
+  "displayName": "Code Review Draft"
+}} />
+
+---
+
+### Custom Agent Lifecycle Endpoints
+
+Publishes or archives an owned custom agent.
+
+<ApiEndpoint method="POST" path="/hub/agents/{agentIdOrSlug}/(publish|archive)" />
+
+#### Parameters
+
+<ParamTable params={[
+  {
+    "name": "agentIdOrSlug",
+    "type": "string",
+    "in": "path",
+    "required": true,
+    "description": "Custom agent id or slug"
+  },
+  {
+    "name": "orgId",
+    "type": "string",
+    "in": "query",
+    "required": false,
+    "description": "Organization ID"
+  }
+]} />
+
+#### Response
+
+Returns the updated custom agent.
+
+| Status | Description |
+|--------|-------------|
+| 200 | Lifecycle action applied |
+| 404 | Custom agent not found |
+
+#### Example
+
+<ApiExample method="POST" path="/hub/agents/code-review/publish" />
+
+---
+
+### List Custom Agent Versions
+
+Lists immutable published versions for a custom agent.
+
+<ApiEndpoint method="GET" path="/hub/agents/{agentIdOrSlug}/versions" />
+
+#### Parameters
+
+<ParamTable params={[
+  {
+    "name": "agentIdOrSlug",
+    "type": "string",
+    "in": "path",
+    "required": true,
+    "description": "Custom agent id or slug"
+  },
+  {
+    "name": "orgId",
+    "type": "string",
+    "in": "query",
+    "required": false,
+    "description": "Organization ID"
+  }
+]} />
+
+#### Response
+
+Returns published versions for the custom agent.
+
+| Status | Description |
+|--------|-------------|
+| 200 | Custom agent versions returned |
+| 404 | Custom agent not found |
+
+#### Response Fields
+
+<ResponseFields fields={[
+  {
+    "name": "versions",
+    "type": "object[]",
+    "description": "Published custom agent versions returned by coder hub"
+  },
+  {
+    "name": "versions[].slug",
+    "type": "string",
+    "description": "Stable custom agent slug"
+  },
+  {
+    "name": "versions[].displayName",
+    "type": "string",
+    "description": "Human-readable custom agent name"
+  },
+  {
+    "name": "versions[].description",
+    "type": "string",
+    "description": "Optional custom agent description"
+  },
+  {
+    "name": "versions[].instructions",
+    "type": "string",
+    "description": "Standalone custom-agent system prompt"
+  },
+  {
+    "name": "versions[].model",
+    "type": "string",
+    "description": "Optional model override"
+  },
+  {
+    "name": "versions[].thinkingLevel",
+    "type": "string",
+    "description": "Optional thinking level override"
+  },
+  {
+    "name": "versions[].headlessCompatible",
+    "type": "boolean",
+    "description": "Whether the custom agent is safe for non-interactive callers"
+  },
+  {
+    "name": "versions[].tools",
+    "type": "string[]",
+    "description": "Workspace tools granted to the custom agent"
+  },
+  {
+    "name": "versions[].serviceTools",
+    "type": "string[]",
+    "description": "Service tools granted to the custom agent"
+  },
+  {
+    "name": "versions[].savedSkills",
+    "type": "object[]",
+    "description": "Frozen saved-skill refs attached to the custom agent snapshot"
+  },
+  {
+    "name": "versions[].savedSkills[].skillId",
+    "type": "string",
+    "description": "Unique skill identifier"
+  },
+  {
+    "name": "versions[].savedSkills[].repo",
+    "type": "string",
+    "description": "Repository slug for the skill source"
+  },
+  {
+    "name": "versions[].savedSkills[].name",
+    "type": "string",
+    "description": "Human-readable skill name"
+  },
+  {
+    "name": "versions[].savedSkills[].url",
+    "type": "string",
+    "description": "Canonical URL for the skill repository or page"
+  },
+  {
+    "name": "versions[].companionAgents",
+    "type": "string[]",
+    "description": "Companion agents auto-included alongside this custom agent"
+  },
+  {
+    "name": "versions[].id",
+    "type": "string",
+    "description": "Published custom agent version identifier"
+  },
+  {
+    "name": "versions[].agentId",
+    "type": "string",
+    "description": "Parent custom agent identifier"
+  },
+  {
+    "name": "versions[].version",
+    "type": "number",
+    "description": "Published version number"
+  },
+  {
+    "name": "versions[].createdByUserId",
+    "type": "string",
+    "description": "User who published the version"
+  },
+  {
+    "name": "versions[].createdAt",
+    "type": "string",
+    "description": "Version creation timestamp (ISO-8601)"
+  }
+]} />
+
+#### Example
+
+<ApiExample method="GET" path="/hub/agents/code-review/versions" />
 
 ---

--- a/apps/docs/src/web/content/reference/api/coder.mdx
+++ b/apps/docs/src/web/content/reference/api/coder.mdx
@@ -1343,6 +1343,18 @@ Session update payload.
     "required": false
   },
   {
+    "name": "defaultAgent",
+    "type": "string",
+    "description": "Updated preferred default agent identifier",
+    "required": false
+  },
+  {
+    "name": "enabledAgents",
+    "type": "string[]",
+    "description": "Updated enabled agent roster for the session",
+    "required": false
+  },
+  {
     "name": "visibility",
     "type": "string",
     "description": "Updated visibility setting",
@@ -1382,6 +1394,18 @@ Session update payload.
     "name": "skills[].url",
     "type": "string",
     "description": "Canonical URL for the skill repository or page",
+    "required": false
+  },
+  {
+    "name": "savedSkillIds",
+    "type": "string[]",
+    "description": "Updated saved skill ids",
+    "required": false
+  },
+  {
+    "name": "skillBucketIds",
+    "type": "string[]",
+    "description": "Updated skill bucket ids",
     "required": false
   }
 ]} />
@@ -1427,6 +1451,11 @@ Returns the updated session fields.
     "name": "defaultAgent",
     "type": "string | null",
     "description": "Updated default agent"
+  },
+  {
+    "name": "enabledAgents",
+    "type": "string[]",
+    "description": "Updated enabled agents"
   }
 ]} />
 
@@ -2726,11 +2755,11 @@ Returns the updated custom agent.
 
 ---
 
-### Custom Agent Lifecycle Endpoints
+### Publish Custom Agent
 
-Publishes or archives an owned custom agent.
+Publishes an owned custom agent.
 
-<ApiEndpoint method="POST" path="/hub/agents/{agentIdOrSlug}/(publish|archive)" />
+<ApiEndpoint method="POST" path="/hub/agents/{agentIdOrSlug}/publish" />
 
 #### Parameters
 
@@ -2757,12 +2786,52 @@ Returns the updated custom agent.
 
 | Status | Description |
 |--------|-------------|
-| 200 | Lifecycle action applied |
+| 200 | Custom agent published |
 | 404 | Custom agent not found |
 
 #### Example
 
 <ApiExample method="POST" path="/hub/agents/code-review/publish" />
+
+---
+
+### Archive Custom Agent
+
+Archives an owned custom agent.
+
+<ApiEndpoint method="POST" path="/hub/agents/{agentIdOrSlug}/archive" />
+
+#### Parameters
+
+<ParamTable params={[
+  {
+    "name": "agentIdOrSlug",
+    "type": "string",
+    "in": "path",
+    "required": true,
+    "description": "Custom agent id or slug"
+  },
+  {
+    "name": "orgId",
+    "type": "string",
+    "in": "query",
+    "required": false,
+    "description": "Organization ID"
+  }
+]} />
+
+#### Response
+
+Returns the updated custom agent.
+
+| Status | Description |
+|--------|-------------|
+| 200 | Custom agent archived |
+| 404 | Custom agent not found |
+
+#### Example
+
+<ApiExample method="POST" path="/hub/agents/code-review/archive" />
 
 ---
 

--- a/apps/docs/src/web/content/reference/api/coder.mdx
+++ b/apps/docs/src/web/content/reference/api/coder.mdx
@@ -1397,6 +1397,12 @@ Session update payload.
     "required": false
   },
   {
+    "name": "metadata",
+    "type": "object",
+    "description": "Updated arbitrary metadata associated with the session",
+    "required": false
+  },
+  {
     "name": "savedSkillIds",
     "type": "string[]",
     "description": "Updated saved skill ids",
@@ -1456,6 +1462,11 @@ Returns the updated session fields.
     "name": "enabledAgents",
     "type": "string[]",
     "description": "Updated enabled agents"
+  },
+  {
+    "name": "metadata",
+    "type": "object",
+    "description": "Updated arbitrary metadata associated with the session"
   }
 ]} />
 

--- a/apps/docs/src/web/content/reference/api/index.mdx
+++ b/apps/docs/src/web/content/reference/api/index.mdx
@@ -19,7 +19,7 @@ Access any Agentuity Platform Service directly via REST APIs, the TypeScript SDK
   <CardLink
     href="/reference/api/coder"
     title="Coder"
-    description="Manage Coder sessions, session data, loop state, and known users through the HTTP API"
+    description="Manage Coder sessions, custom agents, session data, loop state, and known users through the REST API"
     icon={<BrainCircuit className="size-5" />}
   />
   <CardLink

--- a/apps/docs/src/web/content/reference/api/meta.json
+++ b/apps/docs/src/web/content/reference/api/meta.json
@@ -1,5 +1,6 @@
 {
 	"title": "API Reference",
+	"sort": "title",
 	"pages": [
 		"api-keys",
 		"coder",

--- a/apps/docs/src/web/content/reference/api/oauth.mdx
+++ b/apps/docs/src/web/content/reference/api/oauth.mdx
@@ -151,6 +151,12 @@ JSON array of OAuth client objects with usage statistics.
     "required": true
   },
   {
+    "name": "is_public",
+    "type": "boolean",
+    "description": "",
+    "required": true
+  },
+  {
     "name": "created_at",
     "type": "string",
     "description": "",
@@ -290,6 +296,12 @@ JSON body with the OAuth client configuration.
     "type": "string[]",
     "description": "",
     "required": false
+  },
+  {
+    "name": "is_public",
+    "type": "boolean",
+    "description": "",
+    "required": false
   }
 ]} />
 
@@ -416,6 +428,12 @@ JSON object containing the created client and its client secret.
   },
   {
     "name": "client.internal",
+    "type": "boolean",
+    "description": "",
+    "required": true
+  },
+  {
+    "name": "client.is_public",
     "type": "boolean",
     "description": "",
     "required": true
@@ -598,6 +616,12 @@ JSON object with the OAuth client details.
     "required": true
   },
   {
+    "name": "is_public",
+    "type": "boolean",
+    "description": "",
+    "required": true
+  },
+  {
     "name": "created_at",
     "type": "string",
     "description": "",
@@ -732,6 +756,11 @@ JSON body with the fields to update.
     "name": "allowed_user_ids",
     "type": "string[]",
     "description": ""
+  },
+  {
+    "name": "is_public",
+    "type": "boolean",
+    "description": ""
   }
 ]} />
 
@@ -859,6 +888,12 @@ JSON object containing the updated client. May include a new client secret if th
   },
   {
     "name": "client.internal",
+    "type": "boolean",
+    "description": "",
+    "required": true
+  },
+  {
+    "name": "client.is_public",
     "type": "boolean",
     "description": "",
     "required": true

--- a/apps/docs/src/web/content/reference/cli/coder.mdx
+++ b/apps/docs/src/web/content/reference/cli/coder.mdx
@@ -14,7 +14,7 @@ All commands accept `--json` for machine-readable output. This is a global CLI f
 
 | Command | Description |
 |---------|-------------|
-| `coder start` | Start a Pi coding session |
+| `coder tui` | Open the interactive Coder terminal session |
 | `coder create <task>` | Create a new session |
 | `coder list` | List active sessions |
 | `coder get <id>` | Show session details |
@@ -34,15 +34,15 @@ All commands accept `--json` for machine-readable output. This is a global CLI f
 - `show`, `inspect` → `get`
 - `new` → `create`
 - `rm`, `del`, `remove` → `delete`
-- `run`, `tui` → `start`
+- `run`, `start` → `tui`
 
 ## Starting a Session
 
 ```bash
-agentuity coder start
+agentuity coder tui
 ```
 
-Launches a [Pi](https://pi.dev/) coding session connected to the Coder Hub. The CLI auto-detects the Hub URL and extension path.
+Launches a [Pi](https://pi.dev/) coding session connected to the Coder Hub. The CLI auto-detects the Hub URL and extension path. `start` and `run` are aliases for `tui`.
 
 ### Options
 
@@ -61,22 +61,22 @@ Launches a [Pi](https://pi.dev/) coding session connected to the Coder Hub. The 
 
 ```bash
 # Start with auto-detection
-agentuity coder start
+agentuity coder tui
 
 # Start as a specific agent role
-agentuity coder start --agent scout
+agentuity coder tui --agent scout
 
 # Connect to an existing sandbox session
-agentuity coder start --remote codesess_abc123
+agentuity coder tui --remote codesess_abc123
 
 # Browse and select a sandbox session
-agentuity coder start --remote
+agentuity coder tui --remote
 
 # Create a new sandbox session with a task
-agentuity coder start --sandbox "Build an auth system"
+agentuity coder tui --sandbox "Build an auth system"
 
 # Create a sandbox with a git repo cloned
-agentuity coder start --sandbox "Build auth" --repo https://github.com/org/repo
+agentuity coder tui --sandbox "Build auth" --repo https://github.com/org/repo
 ```
 
 ## Creating a Session
@@ -105,6 +105,11 @@ Creates a new Coder session. Pass `--connect` to attach immediately after creati
 | `--repo-branch <branch>` | Branch to checkout |
 | `--workspace-id <id>` | Workspace to use |
 | `--tags <list>` | Comma-separated tags |
+| `--default-agent <slug>` | Preferred default built-in or custom agent |
+| `--enabled-agents <list>` | Comma-separated agent slugs to include. Built-in roles like `builder` also work. Alias: `--agent-slugs` |
+| `--saved-skill-ids <list>` | Comma-separated saved skill IDs |
+| `--skill-bucket-ids <list>` | Comma-separated skill bucket IDs |
+| `--env <pairs>` | Comma-separated `KEY=VALUE` environment variables |
 
 ## Listing Sessions
 
@@ -150,14 +155,21 @@ Shows detailed information about a specific session, including participants, tas
 
 ## Workspaces
 
-Manage reusable workspace configurations that bundle repositories and skills.
+Manage reusable workspace configurations from the CLI.
+
+From the CLI, think of a workspace as a saved setup you can reuse later. It is a good fit for repository choices and agent selection. If you want to build a workspace around saved skills or skill buckets, do that from the SDK or web app.
+
+Do not create an empty workspace. Start with at least one repository or agent selection.
 
 ```bash
 # List workspaces
 agentuity coder workspace list
 
-# Create a workspace
+# Create a repo-backed workspace
 agentuity coder workspace create "Auth System" --repo https://github.com/org/repo
+
+# Create a workspace with agent selection
+agentuity coder workspace create "Review Workspace" --enabled-agents builder
 
 # Show workspace details
 agentuity coder workspace get ws_abc123
@@ -165,6 +177,17 @@ agentuity coder workspace get ws_abc123
 # Delete a workspace
 agentuity coder workspace delete ws_abc123
 ```
+
+### Workspace Create Options
+
+| Option | Description |
+|--------|-------------|
+| `--url <url>` | Coder API URL override |
+| `--description <text>` | Workspace description |
+| `--scope <scope>` | `user` or `org` |
+| `--repo <url>` | Git repository URL to store on the workspace |
+| `--repo-branch <branch>` | Branch to associate with the repository |
+| `--enabled-agents <list>` | Comma-separated agent slugs. Built-in roles like `builder` also work. Alias: `--agent-slugs` |
 
 ## Skills
 
@@ -180,8 +203,14 @@ agentuity coder skill save --repo my-org/skills --skill-id code-review --name "C
 # List skill buckets
 agentuity coder skill buckets
 
+# Create a skill bucket
+agentuity coder skill buckets --create "Frontend Skills" --description "Reusable UI skills"
+
 # Delete a skill
 agentuity coder skill delete skill_abc123
+
+# Delete a skill bucket
+agentuity coder skill buckets --delete bucket_abc123
 ```
 
 ## URL Resolution

--- a/apps/docs/src/web/content/reference/cli/meta.json
+++ b/apps/docs/src/web/content/reference/cli/meta.json
@@ -1,5 +1,6 @@
 {
 	"title": "CLI",
+	"sort": "title",
 	"pages": [
 		"getting-started",
 		"development",

--- a/apps/docs/src/web/content/reference/cli/oauth.mdx
+++ b/apps/docs/src/web/content/reference/cli/oauth.mdx
@@ -1,5 +1,6 @@
 ---
 title: Managing OAuth Applications
+short_title: Managing OAuth Apps
 description: Create and manage OAuth/OIDC applications for third-party integrations from the CLI
 ---
 

--- a/apps/docs/src/web/content/reference/sdk-reference/coder.mdx
+++ b/apps/docs/src/web/content/reference/sdk-reference/coder.mdx
@@ -72,7 +72,7 @@ Create a new coder session.
 | `body.workflowMode` | `'standard' \| 'loop'` | no | Workflow execution mode |
 | `body.loop` | `CoderSessionLoopConfig` | no | Loop-mode configuration (`goal`, `maxIterations`, `autoContinue`, `allowDetached`) |
 | `body.tags` | `string[]` | no | Tags for filtering |
-| `body.agentSlugs` | `string[]` | no | Built-in or custom agent roster attached to the session |
+| `body.enabledAgents` | `string[]` | no | Built-in or custom agent roster attached to the session |
 | `body.savedSkillIds` | `string[]` | no | Saved skill IDs to attach |
 | `body.skillBucketIds` | `string[]` | no | Skill bucket IDs to attach |
 | `body.skills` | `CoderSkillRef[]` | no | Inline skill definitions attached to the session |
@@ -118,11 +118,10 @@ Update an existing session.
 | `body.agent` | `string` | no | Updated default agent |
 | `body.defaultAgent` | `string` | no | Updated preferred default agent identifier |
 | `body.visibility` | `'private' \| 'organization' \| 'collaborate'` | no | Updated visibility |
-| `body.workflowMode` | `'standard' \| 'loop'` | no | Updated workflow mode |
-| `body.loop` | `CoderSessionLoopConfig` | no | Updated loop configuration |
 | `body.tags` | `string[]` | no | Updated tag set |
-| `body.agentSlugs` | `string[]` | no | Updated session agent roster |
+| `body.enabledAgents` | `string[]` | no | Updated session agent roster |
 | `body.skills` | `CoderSkillRef[]` | no | Updated attached skills for the session |
+| `body.metadata` | `Record<string, string>` | no | Updated arbitrary metadata associated with the session |
 
 **Returns:** `Promise<CoderUpdateSessionResponse>`
 
@@ -299,7 +298,7 @@ Create a reusable workspace definition. A workspace cannot be empty: include at 
 | `body.repos` | `CoderSessionRepositoryRef[]` | no | Repositories to include |
 | `body.savedSkillIds` | `string[]` | no | Saved skill IDs |
 | `body.skillBucketIds` | `string[]` | no | Skill bucket IDs |
-| `body.agentSlugs` | `string[]` | no | Built-in or custom agent roster to store on the workspace |
+| `body.enabledAgents` | `string[]` | no | Built-in or custom agent roster to store on the workspace |
 
 **Returns:** `Promise<CoderWorkspaceDetail>`
 
@@ -307,7 +306,7 @@ Create a reusable workspace definition. A workspace cannot be empty: include at 
 const workspace = await client.createWorkspace({
   name: 'Auth System',
   description: 'OAuth and session management',
-  agentSlugs: ['builder', 'reviewer'],
+  enabledAgents: ['builder', 'reviewer'],
 });
 ```
 

--- a/apps/docs/src/web/content/reference/sdk-reference/coder.mdx
+++ b/apps/docs/src/web/content/reference/sdk-reference/coder.mdx
@@ -10,6 +10,8 @@ Method reference for `CoderClient` from the standalone [`@agentuity/coder`](/ref
 Coder has HTTP endpoints, but no single static base URL. `CoderClient` calls the Agentuity API to discover your org's Hub address, then routes session and workspace requests there. For concepts, session lifecycle, and workflows, see [Coder](/services/coder).
 </Callout>
 
+If you want practical examples before reading the full reference, see: [Managing Coder Sessions with the SDK](/cookbook/patterns/creating-coder-sessions-with-sdk), [Choosing Built-In Agents for a Coder Session](/cookbook/patterns/choosing-built-in-agents-for-a-coder-session), [Attaching Skills to a Coder Session](/cookbook/patterns/attaching-skills-to-a-coder-session), [Using Workspaces to Reuse Repos, Skills, and Agent Selection](/cookbook/patterns/using-workspaces-to-reuse-repos-skills-and-agent-selection), [Reconnecting to Existing Coder Sessions](/cookbook/patterns/preparing-coder-sessions-for-remote-attach), and [Creating Loop-Mode Coder Sessions](/cookbook/patterns/creating-loop-mode-coder-sessions).
+
 ## Install
 
 ```bash
@@ -42,6 +44,18 @@ The client resolves the Hub URL in this order:
 
 Most apps only need the API key. Set `AGENTUITY_SDK_KEY` and let the client discover the rest.
 
+### getUrl()
+
+Resolve the active Coder base URL. This returns the explicit `url` when you set one, otherwise it uses `AGENTUITY_CODER_URL` or discovery through the Agentuity API.
+
+**Returns:** `Promise<string>`
+
+```typescript
+const client = new CoderClient();
+const url = await client.getUrl();
+console.log(url);
+```
+
 ## Sessions
 
 ### createSession(body)
@@ -53,10 +67,12 @@ Create a new coder session.
 | `body.task` | `string` | yes | Primary task prompt for the session |
 | `body.label` | `string` | no | Human-readable session label |
 | `body.agent` | `string` | no | Default agent identifier |
+| `body.defaultAgent` | `string` | no | Preferred default agent identifier for routed session work |
 | `body.visibility` | `'private' \| 'organization' \| 'collaborate'` | no | Session visibility |
 | `body.workflowMode` | `'standard' \| 'loop'` | no | Workflow execution mode |
 | `body.loop` | `CoderSessionLoopConfig` | no | Loop-mode configuration (`goal`, `maxIterations`, `autoContinue`, `allowDetached`) |
 | `body.tags` | `string[]` | no | Tags for filtering |
+| `body.agentSlugs` | `string[]` | no | Built-in or custom agent roster attached to the session |
 | `body.savedSkillIds` | `string[]` | no | Saved skill IDs to attach |
 | `body.skillBucketIds` | `string[]` | no | Skill bucket IDs to attach |
 | `body.skills` | `CoderSkillRef[]` | no | Inline skill definitions attached to the session |
@@ -100,19 +116,20 @@ Update an existing session.
 | `sessionId` | `string` | yes | Session identifier |
 | `body.label` | `string` | no | Updated label |
 | `body.agent` | `string` | no | Updated default agent |
+| `body.defaultAgent` | `string` | no | Updated preferred default agent identifier |
 | `body.visibility` | `'private' \| 'organization' \| 'collaborate'` | no | Updated visibility |
 | `body.workflowMode` | `'standard' \| 'loop'` | no | Updated workflow mode |
 | `body.loop` | `CoderSessionLoopConfig` | no | Updated loop configuration |
 | `body.tags` | `string[]` | no | Updated tag set |
+| `body.agentSlugs` | `string[]` | no | Updated session agent roster |
 | `body.skills` | `CoderSkillRef[]` | no | Updated attached skills for the session |
-| `body.metadata` | `Record<string, string>` | no | Updated metadata |
 
 **Returns:** `Promise<CoderUpdateSessionResponse>`
 
 ```typescript
 await client.updateSession('codesess_abc123', {
-  label: 'Auth feature - phase 2',
   tags: ['auth', 'feature', 'phase-2'],
+  visibility: 'organization',
 });
 ```
 
@@ -164,7 +181,7 @@ await client.deleteSession('codesess_abc123');
 
 ### archiveSession(sessionId)
 
-Archive an active session. The transcript is preserved for replay.
+Archive an active session. Session history remains available for replay and inspection.
 
 **Returns:** `Promise<CoderLifecycleResponse>`
 
@@ -192,7 +209,7 @@ Ensure a paused remote session is attachable before opening a controller socket.
 | `options.timeoutMs` | `number` | no | Max time to wait for the runtime to come back. Default `30000` |
 | `options.pollIntervalMs` | `number` | no | Interval between `getSession` polls while waking. Default `1000` |
 
-**Returns:** `Promise<CoderSession>` — the latest session detail (which may still be detached if the timeout elapsed)
+**Returns:** `Promise<CoderSession>`. Returns the latest session detail, which may still be detached if the timeout elapsed.
 
 ```typescript
 const session = await client.prepareSessionForRemoteAttach('codesess_abc123', {
@@ -207,7 +224,7 @@ if (session.runtimeAvailable) {
 
 ### getReplay(sessionId, params?)
 
-Retrieve replay data (transcript and events) for a session.
+Retrieve the data a late-joining client uses to catch up to the session's current state.
 
 | Param | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -220,6 +237,8 @@ Retrieve replay data (transcript and events) for a session.
 ```typescript
 const replay = await client.getReplay('codesess_abc123');
 ```
+
+Use `getReplay()` when a late-joining client needs to catch up to the Hub's current state. For a structured timeline, use `listEventHistory()` instead.
 
 ### listParticipants(sessionId, params?)
 
@@ -270,6 +289,8 @@ Workspaces group repositories and skills into reusable configurations attachable
 
 ### createWorkspace(body)
 
+Create a reusable workspace definition. A workspace cannot be empty: include at least one repo, saved skill, skill bucket, or agent selection.
+
 | Param | Type | Required | Description |
 |-------|------|----------|-------------|
 | `body.name` | `string` | yes | Workspace name |
@@ -278,6 +299,7 @@ Workspaces group repositories and skills into reusable configurations attachable
 | `body.repos` | `CoderSessionRepositoryRef[]` | no | Repositories to include |
 | `body.savedSkillIds` | `string[]` | no | Saved skill IDs |
 | `body.skillBucketIds` | `string[]` | no | Skill bucket IDs |
+| `body.agentSlugs` | `string[]` | no | Built-in or custom agent roster to store on the workspace |
 
 **Returns:** `Promise<CoderWorkspaceDetail>`
 
@@ -285,6 +307,7 @@ Workspaces group repositories and skills into reusable configurations attachable
 const workspace = await client.createWorkspace({
   name: 'Auth System',
   description: 'OAuth and session management',
+  agentSlugs: ['builder', 'reviewer'],
 });
 ```
 
@@ -374,14 +397,20 @@ Delete a skill bucket.
 
 ### listGitHubAccounts()
 
-List GitHub accounts available via the caller's GitHub App installations. The response includes connection status, the connected GitHub username, and all available accounts.
+List GitHub accounts available via the caller's GitHub App installations. Sign in to Agentuity before calling this method. Without an Agentuity OAuth login, the Hub returns `HTTP 409` and the client throws before it can return account data.
 
 **Returns:** `Promise<CoderGitHubAccountListResponse>`
 
 ```typescript
-const { connected, accounts } = await client.listGitHubAccounts();
-if (!connected) {
-  console.log('Connect GitHub first');
+try {
+  const { connected, accounts } = await client.listGitHubAccounts();
+  if (!connected) {
+    console.log('Connect GitHub in the Agentuity Console first');
+  } else {
+    console.log(accounts.map((account) => account.accountName));
+  }
+} catch {
+  console.log('Sign in to Agentuity first, then call listGitHubAccounts() again');
 }
 ```
 

--- a/apps/docs/src/web/content/reference/sdk-reference/meta.json
+++ b/apps/docs/src/web/content/reference/sdk-reference/meta.json
@@ -1,5 +1,6 @@
 {
 	"title": "SDK Reference",
+	"sort": "title",
 	"pages": [
 		"application-entry",
 		"agents",

--- a/apps/docs/src/web/content/services/coder.mdx
+++ b/apps/docs/src/web/content/services/coder.mdx
@@ -98,9 +98,7 @@ Install the standalone package:
 bun add @agentuity/coder
 ```
 
-If you want the cleanest first SDK integration, start with [Managing Coder Sessions with the SDK](/cookbook/patterns/creating-coder-sessions-with-sdk). It shows the core programmatic flow for creating a session, reading state back, and managing lifecycle before you add workspaces or skill configuration.
-
-If you are shaping session composition, the main follow-on pages are [Choosing Built-In Agents for a Coder Session](/cookbook/patterns/choosing-built-in-agents-for-a-coder-session), [Attaching Skills to a Coder Session](/cookbook/patterns/attaching-skills-to-a-coder-session), and [Using Workspaces to Reuse Repos, Skills, and Agent Selection](/cookbook/patterns/using-workspaces-to-reuse-repos-skills-and-agent-selection).
+If you want the cleanest first SDK integration, start with [Managing Coder Sessions with the SDK](/cookbook/patterns/creating-coder-sessions-with-sdk). For the rest of the runnable Coder examples, see the [Coder cookbook section](/cookbook#coder), including how to branch into [Loop-Mode Sessions](/cookbook/patterns/creating-loop-mode-coder-sessions), [Attach Skills](/cookbook/patterns/attaching-skills-to-a-coder-session), [Use Workspaces](/cookbook/patterns/using-workspaces-to-reuse-repos-skills-and-agent-selection), and more.
 
 ### Creating and Listing Sessions
 

--- a/apps/docs/src/web/content/services/coder.mdx
+++ b/apps/docs/src/web/content/services/coder.mdx
@@ -1,9 +1,9 @@
 ---
 title: Coder
-description: Run AI coding sessions in managed sandboxes with real-time collaboration
+description: Manage AI coding sessions that run in cloud sandboxes with full lifecycle, replay, and reconnect support
 ---
 
-Agentuity Coder runs AI-assisted coding sessions in cloud sandboxes. Each session connects an AI agent (powered by [Pi](https://pi.dev/)) to a managed environment where it can write code, run builds, execute tests, and iterate autonomously, while you watch or collaborate in real time.
+Agentuity Coder runs AI coding sessions on a durable Hub where humans, apps, and agents all subscribe to the same event stream. Sessions carry full lifecycle state, a participant model, and a durable event log you can inspect or attach to from the SDK, CLI, or web app.
 
 <Callout type="tip" title="Standalone Package">
 Use the [`@agentuity/coder`](/reference/standalone-packages#coder) package to manage sessions from any Node.js or Bun application without the full runtime.
@@ -13,34 +13,82 @@ Use the [`@agentuity/coder`](/reference/standalone-packages#coder) package to ma
 
 | Approach | Best For |
 |----------|----------|
-| **Coder sessions** | Autonomous coding tasks in isolated sandboxes, remote pair programming with AI |
-| [Claude Code plugin](/reference/cli/claude-code-plugin) | AI-assisted development in your local project via Claude Code |
-| [OpenCode plugin](/reference/cli/opencode-plugin) | Multi-agent team for complex tasks in OpenCode |
-| [Sandbox service](/services/sandbox) | Running arbitrary code or scripts in isolated environments |
+| **Coder sessions** | Coding work that should run in a cloud sandbox and remain available as a session you can inspect, resume, or review later |
+| [Claude Code/Cowork plugin](/reference/cli/claude-code-plugin) | Agentuity skills inside Claude Code and Cowork for SDK work, cloud services, and deploys. It does not manage Coder sessions. |
+| [OpenCode plugin](/reference/cli/opencode-plugin) | Agentuity multi-agent workflows inside OpenCode with specialized agents, slash commands, and headless runs. It is separate from managed Coder session lifecycle. |
+| [Sandbox service](/services/sandbox) | One-off isolated execution when you do not need Coder session state, replay, or reconnect flows |
 
-Use Coder when you want an AI agent to work independently in a cloud sandbox: building features, fixing bugs, or exploring code, without tying up your local environment.
+Use Coder when you want the unit of work to be a session with history, lifecycle, and reconnect semantics, not just a sandbox process.
 
 ## Managing Sessions
 
 | Method | Best For |
 |--------|----------|
-| **SDK** (`CoderClient`) | Programmatic session management from agents, scripts, or external apps |
-| **CLI** (`agentuity coder`) | Interactive session management and local development |
-| **[Web App](https://app.agentuity.com)** | Observing sessions, viewing transcripts, browsing history |
+| **SDK** (`CoderClient`) | Programmatic session management from your app, automation, or internal tooling |
+| **CLI** (`agentuity coder`) | Starting, attaching to, and driving sessions from the terminal |
+| **[Web App](https://app.agentuity.com)** | Inspecting session state, replay, and history from a browser |
 
 <Callout type="info" title="Hub URL is discovered when not explicitly set">
 Coder has HTTP endpoints, but no single static base URL. If neither `url` nor `AGENTUITY_CODER_URL` is set, clients call the Agentuity API to discover your org's Hub address, then route session and workspace requests to that Hub. [`@agentuity/coder`](/reference/standalone-packages#coder) and `agentuity coder` handle discovery, auth, and routing for you.
+</Callout>
+
+<Callout type="warning" title="SDK examples do not need a deploy, but your org does need Coder enabled">
+You can validate `CoderClient` without deploying an app. If discovery works but session calls fail at the org level, Coder is probably not enabled for that org yet.
 </Callout>
 
 ## How It Works
 
 A Coder session has three components:
 
-1. **Hub**: Orchestration server that manages session lifecycle, tools, and real-time communication via WebSocket
+1. **Hub**: Real-time broadcast server where participants (humans, apps, agents) subscribe to the same event stream; also manages session lifecycle and tools
 2. **Agent**: An AI coding agent that connects to the Hub and executes tasks
 3. **Sandbox**: An isolated cloud environment where the agent writes, builds, and tests code
 
 Sessions support multiple participants: the primary agent, sub-agents that split work, and observers that stream the session transcript in real time.
+
+## Agents and Skills
+
+Coder has a few different layers that are easy to mix up:
+
+- **Built-in agents** are the built-in Coder team roles like `builder`, `reviewer`, and `scout`
+- **System skills** are Hub-managed skills that the platform injects automatically
+- **Saved skills and skill buckets** are user-managed selections you attach to sessions or workspaces
+
+If you want to choose which built-in specialists are available in a session, use `agentSlugs` and `defaultAgent`.
+
+## Reading Session State
+
+When you inspect a session from the SDK or CLI, these fields do most of the work:
+
+| Field | What It Tells You |
+|------|--------------------|
+| `status` | The current lifecycle state, such as creating, active, paused, or archived |
+| `bucket` | The broader lifecycle bucket, which is useful when grouping sessions in a UI |
+| `runtimeAvailable` | Whether the runtime is currently available for live interaction |
+| `controlAvailable` | Whether a controller client can actively drive the session |
+| `wakeAvailable` | Whether the session can be resumed or woken back up |
+| `historyOnly` | Whether the session is no longer live and should be treated as replay-only |
+| `liveExpected` | Whether the Hub still expects a live runtime to come online |
+
+In practice:
+
+- `historyOnly: true` usually means “switch to replay or a read-only session view”
+- `runtimeAvailable: true` usually means “the session is live enough to attach to”
+- `wakeAvailable: true` usually means “the session is not live now, but it may still be resumable”
+- fresh sessions often have little or no replay, event history, or participant data yet
+
+## Which Read Method to Use
+
+| Need | Start Here |
+|------|------------|
+| One session's current state | `getSession()` |
+| A dashboard or picker of many sessions | `listSessions()` |
+| Sessions available to resume | `listConnectableSessions()` |
+| Wake a paused session before attaching | `prepareSessionForRemoteAttach()` |
+| Catch a late-joining client up to current state | `getReplay()` |
+| Build a structured timeline or audit view | `listEventHistory()` |
+| See who is currently attached | `listParticipants()` |
+| Watch the live session feed | `subscribeToCoderHub()` |
 
 ## SDK Usage
 
@@ -49,6 +97,10 @@ Install the standalone package:
 ```bash
 bun add @agentuity/coder
 ```
+
+If you want the cleanest first SDK integration, start with [Managing Coder Sessions with the SDK](/cookbook/patterns/creating-coder-sessions-with-sdk). It shows the core programmatic flow for creating a session, reading state back, and managing lifecycle before you add workspaces or skill configuration.
+
+If you are shaping session composition, the main follow-on pages are [Choosing Built-In Agents for a Coder Session](/cookbook/patterns/choosing-built-in-agents-for-a-coder-session), [Attaching Skills to a Coder Session](/cookbook/patterns/attaching-skills-to-a-coder-session), and [Using Workspaces to Reuse Repos, Skills, and Agent Selection](/cookbook/patterns/using-workspaces-to-reuse-repos-skills-and-agent-selection).
 
 ### Creating and Listing Sessions
 
@@ -84,11 +136,11 @@ const session = await client.getSession('codesess_abc123');
 
 // Update a session
 await client.updateSession('codesess_abc123', {
-  label: 'Auth feature - phase 2',
   tags: ['auth', 'feature', 'phase-2'],
+  visibility: 'organization',
 });
 
-// Archive a completed session (preserves transcript for replay)
+// Archive a completed session so its history stays available for replay and inspection
 await client.archiveSession('codesess_abc123');
 
 // Resume a paused session (wakes the sandbox)
@@ -106,7 +158,7 @@ import { CoderClient } from '@agentuity/coder';
 const client = new CoderClient();
 const sessionId = 'codesess_abc123';
 
-// Get the full session replay (transcript + events)
+// Get the replay payload a late-joining client uses to catch up
 const replay = await client.getReplay(sessionId);
 
 // List participants in a session
@@ -132,6 +184,7 @@ const client = new CoderClient();
 const workspace = await client.createWorkspace({
   name: 'Auth System',
   description: 'OAuth and session management',
+  agentSlugs: ['builder', 'reviewer'],
 });
 
 // Save a reusable skill
@@ -169,7 +222,7 @@ const client = new CoderClient({
 import { CoderClient } from '@agentuity/coder';
 
 const client = new CoderClient({
-  url: 'https://coder.example.com',     // Explicit Hub URL — skips discovery
+  url: 'https://coder.example.com',     // Explicit Hub URL, skips discovery
   apiKey: 'agentuity_sk_...',
   orgId: 'org_...',
 });
@@ -186,27 +239,30 @@ Most apps only need the API key. Set `AGENTUITY_SDK_KEY` and let the client disc
 ## CLI Usage
 
 ```bash
-# Start a coding session
-agentuity coder start
+# Open the interactive terminal session
+agentuity coder tui
 
-# Start with a task in a sandbox
-agentuity coder start --sandbox "Build an auth system" --repo https://github.com/org/repo
+# Create a managed session without attaching
+agentuity coder create "Build an auth system"
+
+# Create a managed session and attach immediately
+agentuity coder create "Build an auth system" --connect
+
+# Open the interactive terminal session against an existing remote session
+agentuity coder tui --remote codesess_abc123
 
 # List active sessions
 agentuity coder list
 
 # Inspect a session
-agentuity coder inspect codesess_abc123
-
-# Connect to an existing session
-agentuity coder start --remote codesess_abc123
+agentuity coder get codesess_abc123
 ```
 
 See [Coder CLI Commands](/reference/cli/coder) for the full command reference.
 
 ### Session Modes
 
-Running `agentuity coder start` with no extra flags launches a local TUI session. Using `--sandbox <task>` creates a cloud sandbox session with the provided task description. Using `--remote <session_id>` connects to an existing remote session.
+Running `agentuity coder tui` with no extra flags launches the interactive terminal session. Using `agentuity coder tui --sandbox <task>` creates a cloud sandbox session and attaches to it. Using `agentuity coder tui --remote <session_id>` attaches to an existing remote session.
 
 | Mode | Description |
 |------|-------------|
@@ -222,19 +278,19 @@ Running `agentuity coder start` with no extra flags launches a local TUI session
 | **Active** | Agent is connected and working |
 | **Idle** | Agent has finished the current task, waiting for new instructions |
 | **Paused** | Agent disconnected, sandbox suspended. Resume with `resumeSession()` or `--remote` |
-| **Archived** | Session ended, transcript preserved for replay |
+| **Archived** | Session ended, session history remains available for replay and inspection |
 
 ## Connecting via Plugins
 
 The Claude Code and OpenCode plugins integrate with the Coder ecosystem:
 
-- **Claude Code**: The base [Agentuity plugin](/reference/cli/claude-code-plugin) (`/install agentuity`) provides skills for deploying and building with the SDK. The separate `agentuity-coder` marketplace plugin adds multi-agent teams, persistent memory, and cadence mode
-- **OpenCode**: The `@agentuity/opencode` plugin provides a multi-agent team (Lead, Scout, Builder, etc.) with background tasks and workspace integration
+- **Claude Code/Cowork**: The [Agentuity plugin](/reference/cli/claude-code-plugin) adds auto-activated Agentuity skills to Claude Code and Cowork. Use it when you want help deploying apps, managing cloud services, or building with the SDK from that editor workflow. It is not the API for creating or inspecting Coder sessions.
+- **OpenCode**: The [OpenCode plugin](/reference/cli/opencode-plugin) adds Agentuity-aware agents, slash commands, and dashboard tooling to OpenCode. Use it when you want an editor-based multi-agent workflow rather than a managed Coder session.
 
 ## Next Steps
 
+- [Managing Coder Sessions with the SDK](/cookbook/patterns/creating-coder-sessions-with-sdk): Core SDK flow for create, read, archive, and delete operations
+- [Choosing Built-In Agents for a Coder Session](/cookbook/patterns/choosing-built-in-agents-for-a-coder-session): Choose the built-in roster for a session
+- [Attaching Skills to a Coder Session](/cookbook/patterns/attaching-skills-to-a-coder-session): Attach saved skills and skill buckets from your library
 - [CoderClient Reference](/reference/sdk-reference/coder): Full method reference for `@agentuity/coder`
 - [Coder CLI Commands](/reference/cli/coder): Full command reference
-- [`@agentuity/coder` Package](/reference/standalone-packages#coder): Install and constructor overview
-- [Sandbox](/services/sandbox): Manage sandbox environments directly
-- [Claude Code Plugin](/reference/cli/claude-code-plugin): AI-assisted local development

--- a/apps/docs/src/web/routes/_docs/cookbook/patterns/attaching-skills-to-a-coder-session.tsx
+++ b/apps/docs/src/web/routes/_docs/cookbook/patterns/attaching-skills-to-a-coder-session.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { MDXPage } from '../../../../components/docs/mdx-page';
+
+export const Route = createFileRoute(
+	'/_docs/cookbook/patterns/attaching-skills-to-a-coder-session'
+)({
+	component: () => <MDXPage route="cookbook/patterns/attaching-skills-to-a-coder-session" />,
+	staticData: { crumb: 'Attach Skills' },
+});

--- a/apps/docs/src/web/routes/_docs/cookbook/patterns/choosing-built-in-agents-for-a-coder-session.tsx
+++ b/apps/docs/src/web/routes/_docs/cookbook/patterns/choosing-built-in-agents-for-a-coder-session.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { MDXPage } from '../../../../components/docs/mdx-page';
+
+export const Route = createFileRoute(
+	'/_docs/cookbook/patterns/choosing-built-in-agents-for-a-coder-session'
+)({
+	component: () => (
+		<MDXPage route="cookbook/patterns/choosing-built-in-agents-for-a-coder-session" />
+	),
+	staticData: { crumb: 'Built-In Agents' },
+});

--- a/apps/docs/src/web/routes/_docs/cookbook/patterns/creating-coder-sessions-with-sdk.tsx
+++ b/apps/docs/src/web/routes/_docs/cookbook/patterns/creating-coder-sessions-with-sdk.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { MDXPage } from '../../../../components/docs/mdx-page';
+
+export const Route = createFileRoute('/_docs/cookbook/patterns/creating-coder-sessions-with-sdk')({
+	component: () => <MDXPage route="cookbook/patterns/creating-coder-sessions-with-sdk" />,
+	staticData: { crumb: 'Manage Coder Sessions' },
+});

--- a/apps/docs/src/web/routes/_docs/cookbook/patterns/creating-loop-mode-coder-sessions.tsx
+++ b/apps/docs/src/web/routes/_docs/cookbook/patterns/creating-loop-mode-coder-sessions.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { MDXPage } from '../../../../components/docs/mdx-page';
+
+export const Route = createFileRoute('/_docs/cookbook/patterns/creating-loop-mode-coder-sessions')({
+	component: () => <MDXPage route="cookbook/patterns/creating-loop-mode-coder-sessions" />,
+	staticData: { crumb: 'Loop-Mode Sessions' },
+});

--- a/apps/docs/src/web/routes/_docs/cookbook/patterns/observing-a-coder-session-through-the-hub.tsx
+++ b/apps/docs/src/web/routes/_docs/cookbook/patterns/observing-a-coder-session-through-the-hub.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { MDXPage } from '../../../../components/docs/mdx-page';
+
+export const Route = createFileRoute(
+	'/_docs/cookbook/patterns/observing-a-coder-session-through-the-hub'
+)({
+	component: () => <MDXPage route="cookbook/patterns/observing-a-coder-session-through-the-hub" />,
+	staticData: { crumb: 'Observe Sessions' },
+});

--- a/apps/docs/src/web/routes/_docs/cookbook/patterns/preparing-coder-sessions-for-remote-attach.tsx
+++ b/apps/docs/src/web/routes/_docs/cookbook/patterns/preparing-coder-sessions-for-remote-attach.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { MDXPage } from '../../../../components/docs/mdx-page';
+
+export const Route = createFileRoute(
+	'/_docs/cookbook/patterns/preparing-coder-sessions-for-remote-attach'
+)({
+	component: () => (
+		<MDXPage route="cookbook/patterns/preparing-coder-sessions-for-remote-attach" />
+	),
+	staticData: { crumb: 'Reconnect Sessions' },
+});

--- a/apps/docs/src/web/routes/_docs/cookbook/patterns/using-workspaces-to-reuse-repos-skills-and-agent-selection.tsx
+++ b/apps/docs/src/web/routes/_docs/cookbook/patterns/using-workspaces-to-reuse-repos-skills-and-agent-selection.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { MDXPage } from '../../../../components/docs/mdx-page';
+
+export const Route = createFileRoute(
+	'/_docs/cookbook/patterns/using-workspaces-to-reuse-repos-skills-and-agent-selection'
+)({
+	component: () => (
+		<MDXPage route="cookbook/patterns/using-workspaces-to-reuse-repos-skills-and-agent-selection" />
+	),
+	staticData: { crumb: 'Use Workspaces' },
+});

--- a/packages/core/src/services/coder/api-reference.ts
+++ b/packages/core/src/services/coder/api-reference.ts
@@ -71,6 +71,7 @@ const CoderUpdateSessionRequestWireSchema = CoderUpdateSessionRequestSchema.pick
 	visibility: true,
 	tags: true,
 	skills: true,
+	metadata: true,
 })
 	.extend({
 		savedSkillIds: z.array(z.string()).optional().describe('Updated saved skill ids'),
@@ -87,6 +88,10 @@ const CoderUpdateSessionResponseWireSchema = z
 		skills: z.array(z.unknown()).optional().describe('Updated skills'),
 		defaultAgent: z.string().nullable().optional().describe('Updated default agent'),
 		enabledAgents: z.array(z.string()).optional().describe('Updated enabled agents'),
+		metadata: z
+			.record(z.string(), z.unknown())
+			.optional()
+			.describe('Updated arbitrary metadata associated with the session'),
 	})
 	.passthrough();
 

--- a/packages/core/src/services/coder/api-reference.ts
+++ b/packages/core/src/services/coder/api-reference.ts
@@ -66,10 +66,17 @@ const CoderCreateSessionResponseWireSchema = z
 const CoderUpdateSessionRequestWireSchema = CoderUpdateSessionRequestSchema.pick({
 	label: true,
 	agent: true,
+	defaultAgent: true,
+	enabledAgents: true,
 	visibility: true,
 	tags: true,
 	skills: true,
-}).describe('Request body for updating public session metadata over REST');
+})
+	.extend({
+		savedSkillIds: z.array(z.string()).optional().describe('Updated saved skill ids'),
+		skillBucketIds: z.array(z.string()).optional().describe('Updated skill bucket ids'),
+	})
+	.describe('Request body for updating public session metadata over REST');
 
 const CoderUpdateSessionResponseWireSchema = z
 	.object({
@@ -79,6 +86,7 @@ const CoderUpdateSessionResponseWireSchema = z
 		tags: z.array(z.string()).optional().describe('Updated tags'),
 		skills: z.array(z.unknown()).optional().describe('Updated skills'),
 		defaultAgent: z.string().nullable().optional().describe('Updated default agent'),
+		enabledAgents: z.array(z.string()).optional().describe('Updated enabled agents'),
 	})
 	.passthrough();
 
@@ -512,12 +520,12 @@ const service: Service = {
 			exampleBody: { displayName: 'Code Review Draft' },
 		},
 		{
-			id: 'custom-agent-lifecycle',
-			title: 'Custom Agent Lifecycle Endpoints',
+			id: 'publish-custom-agent',
+			title: 'Publish Custom Agent',
 			sectionTitle: 'Agents',
 			method: 'POST',
-			path: '/hub/agents/{agentIdOrSlug}/(publish|archive)',
-			description: 'Publishes or archives an owned custom agent.',
+			path: '/hub/agents/{agentIdOrSlug}/publish',
+			description: 'Publishes an owned custom agent.',
 			pathParams: [
 				{
 					name: 'agentIdOrSlug',
@@ -532,10 +540,36 @@ const service: Service = {
 			requestBody: null,
 			responseDescription: 'Returns the updated custom agent.',
 			statuses: [
-				{ code: 200, description: 'Lifecycle action applied' },
+				{ code: 200, description: 'Custom agent published' },
 				{ code: 404, description: 'Custom agent not found' },
 			],
 			examplePath: '/hub/agents/code-review/publish',
+		},
+		{
+			id: 'archive-custom-agent',
+			title: 'Archive Custom Agent',
+			sectionTitle: 'Agents',
+			method: 'POST',
+			path: '/hub/agents/{agentIdOrSlug}/archive',
+			description: 'Archives an owned custom agent.',
+			pathParams: [
+				{
+					name: 'agentIdOrSlug',
+					type: 'string',
+					description: 'Custom agent id or slug',
+					required: true,
+				},
+			],
+			queryParams: [
+				{ name: 'orgId', type: 'string', description: 'Organization ID', required: false },
+			],
+			requestBody: null,
+			responseDescription: 'Returns the updated custom agent.',
+			statuses: [
+				{ code: 200, description: 'Custom agent archived' },
+				{ code: 404, description: 'Custom agent not found' },
+			],
+			examplePath: '/hub/agents/code-review/archive',
 		},
 		{
 			id: 'list-custom-agent-versions',

--- a/packages/core/src/services/coder/api-reference.ts
+++ b/packages/core/src/services/coder/api-reference.ts
@@ -86,7 +86,7 @@ const service: Service = {
 	name: 'Coder',
 	slug: 'coder',
 	description:
-		'Manage Coder sessions, custom agents, session data, loop state, and known users through the HTTP API',
+		'Manage Coder sessions, custom agents, session data, loop state, and known users through the REST API',
 	hasPublicEndpoints: false,
 	endpoints: [
 		{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added seven new cookbook patterns for Coder: session management, loop-mode, built‑in agent selection, attaching skills, workspaces, remote attach/reconnect, and observing sessions.
  * Expanded API reference: added custom‑agent endpoints, new session fields/options, and changed wording to “REST API”.
  * Updated CLI and SDK docs: new flags/options for agents, skills, workspaces, and revised command examples.
  * Adjusted navigation and page ordering to surface Coder content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->