### PR TITLE
fix(cli): eliminate ECONNREFUSED startup race in dev mode

### DIFF
--- a/packages/cli/src/cmd/build/vite/bun-dev-server.ts
+++ b/packages/cli/src/cmd/build/vite/bun-dev-server.ts
@@ -21,7 +21,7 @@ export interface BunDevServerOptions {
 	rootDir: string;
 	port?: number;
 	logger: Logger;
-	vitePort: number;
+	vitePort: number; // Kept for backward compatibility — no longer used internally
 	inspect?: boolean;
 	inspectWait?: boolean;
 	inspectBrk?: boolean;
@@ -311,9 +311,17 @@ export function buildStartupErrorMessage(
  * are re-evaluated.
  */
 export async function startBunDevServer(options: BunDevServerOptions): Promise<BunDevServerResult> {
-	const { rootDir, port = 3500, logger, vitePort, inspect, inspectWait, inspectBrk } = options;
+	const {
+		rootDir,
+		port = 3500,
+		logger,
+		vitePort: _vitePort,
+		inspect,
+		inspectWait,
+		inspectBrk,
+	} = options;
 
-	logger.debug('Starting Bun dev server (Vite already running on port %d)...', vitePort);
+	logger.debug('Starting Bun dev server (port %d)...', port);
 
 	const appPath = `${rootDir}/app.ts`;
 
@@ -452,7 +460,6 @@ export async function startBunDevServer(options: BunDevServerOptions): Promise<B
 	}
 
 	logger.debug(`Bun dev server started on http://127.0.0.1:${port} (--hot mode)`);
-	logger.debug(`Proxied to Vite:${vitePort}`);
 
 	return { bunServerPort: port };
 }

--- a/packages/cli/src/cmd/build/vite/vite-asset-server-config.ts
+++ b/packages/cli/src/cmd/build/vite/vite-asset-server-config.ts
@@ -23,6 +23,37 @@ export interface GenerateAssetServerConfigOptions {
 }
 
 /**
+ * Shared proxy configuration for backend routes.
+ *
+ * Includes `configure` callback that gracefully handles ECONNREFUSED errors
+ * when the Bun backend isn't ready yet (startup race condition or brief
+ * disconnect during --hot reload). Instead of logging noisy errors, the
+ * proxy returns 503 Service Unavailable with a retry hint.
+ */
+function backendProxyOptions(backendPort: number) {
+	return {
+		target: `http://127.0.0.1:${backendPort}`,
+		changeOrigin: true,
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		configure: (proxy: any, _options: any) => {
+			proxy.on('error', (err: Error & { code?: string }, _req: any, res: any) => {
+				if (err.code === 'ECONNREFUSED' && res && !res.writableEnded) {
+					res.statusCode = 503;
+					res.setHeader('Content-Type', 'application/json');
+					res.end(
+						JSON.stringify({
+							error: 'Backend unavailable',
+							message: 'The Bun backend is not ready yet. Retrying shortly...',
+							retry: true,
+						})
+					);
+				}
+			});
+		},
+	};
+}
+
+/**
  * Vite plugin that injects analytics scripts in dev mode.
  *
  * In production the beacon plugin handles this at build time. In dev mode
@@ -241,37 +272,19 @@ export async function generateAssetServerConfig(
 			proxy: {
 				// User-defined route mounts (from createApp({ router }))
 				...Object.fromEntries(
-					routePaths.map((routePath) => [
-						routePath,
-						{
-							target: `http://127.0.0.1:${backendPort}`,
-							changeOrigin: true,
-						},
-					])
+					routePaths.map((routePath) => [routePath, backendProxyOptions(backendPort)])
 				),
 				// Agentuity system routes (workbench API, health, analytics, etc.)
-				'/_agentuity': {
-					target: `http://127.0.0.1:${backendPort}`,
-					changeOrigin: true,
-				},
+				'/_agentuity': backendProxyOptions(backendPort),
 				// Workbench UI route (served by Bun, references /@fs/* paths handled by Vite)
 				...(workbenchPath
 					? {
-							[workbenchPath]: {
-								target: `http://127.0.0.1:${backendPort}`,
-								changeOrigin: true,
-							},
+							[workbenchPath]: backendProxyOptions(backendPort),
 						}
 					: {}),
 				// Legacy health check routes
-				'/_health': {
-					target: `http://127.0.0.1:${backendPort}`,
-					changeOrigin: true,
-				},
-				'/_idle': {
-					target: `http://127.0.0.1:${backendPort}`,
-					changeOrigin: true,
-				},
+				'/_health': backendProxyOptions(backendPort),
+				'/_idle': backendProxyOptions(backendPort),
 			},
 
 			// HMR works natively — Vite is the primary server, no proxy needed

--- a/packages/cli/src/cmd/build/vite/vite-asset-server.ts
+++ b/packages/cli/src/cmd/build/vite/vite-asset-server.ts
@@ -50,8 +50,12 @@ function isPortAvailable(port: number, host: string): Promise<boolean> {
 /**
  * Find an available port starting from the preferred port.
  * Tries incrementing ports up to maxAttempts times.
+ *
+ * Exported so the dev command can pre-resolve the Vite port before
+ * starting the Bun backend (env vars like AGENTUITY_BASE_URL need
+ * the real port before Bun initializes CORS).
  */
-async function findAvailablePort(
+export async function findAvailablePort(
 	preferredPort: number,
 	host: string = '127.0.0.1',
 	maxAttempts: number = 20

--- a/packages/cli/src/cmd/dev/index.ts
+++ b/packages/cli/src/cmd/dev/index.ts
@@ -534,95 +534,23 @@ export const command = createCommand({
 				};
 			}
 
-			// Start Vite dev server on an internal port.
-			// The user-facing port is handled by the front-door TCP proxy (ws-proxy)
-			// which routes WS upgrades to Bun and everything else to Vite.
-			let viteServer: ServerLike | null = null;
-			let vitePort: number;
-
-			// Initialize process manager to track all servers/processes
-			const procManager = initProcessManager(logger);
-
-			try {
-				logger.debug('Starting Vite dev server (internal port %d)...', viteInternalPort);
-				const viteResult = await startViteAssetServer({
-					rootDir,
-					logger,
-					workbenchPath: workbench.config?.route,
-					port: viteInternalPort,
-					backendPort: bunBackendPort,
-					routePaths,
-					liveHostname: devmode?.hostname,
-				});
-				viteServer = viteResult.server;
-				vitePort = viteResult.port;
-
-				// Register Vite server with process manager
-				procManager.registerServer({
-					id: 'vite',
-					server: viteServer,
-					description: 'Vite dev server (frontend assets)',
-					port: vitePort,
-				});
-
-				// Update dev lock with actual Vite port
-				await devLock.updatePorts({ vite: vitePort });
-
-				logger.debug(
-					`Vite dev server running on port ${vitePort} (internal, proxying backend on port ${bunBackendPort})`
-				);
-			} catch (error) {
-				tui.error(`Failed to start Vite dev server: ${error}`);
-				await procManager.cleanup('vite startup failure');
-				await devLock.release();
-				originalExit(1);
-				return;
-			}
-
-			// Start the front-door TCP proxy on the user-facing port.
-			// Routes WebSocket upgrades (for /api/*, /_agentuity/*) directly to Bun
-			// and everything else (HTTP, HMR WebSocket) to Vite.
-			// This works around Bun's broken node:http upgrade socket implementation.
-			let frontDoorServer: import('node:net').Server | null = null;
-			try {
-				const { startWsProxy } = await import('../build/vite/ws-proxy');
-				frontDoorServer = await startWsProxy({
-					port: opts.port,
-					vitePort,
-					backendPort: bunBackendPort,
-					routePaths,
-					logger,
-				});
-
-				// Register front-door proxy with process manager
-				procManager.registerServer({
-					id: 'front-door-proxy',
-					server: {
-						close: () => {
-							frontDoorServer?.close();
-						},
-					},
-					description: 'Front-door TCP proxy (WS routing)',
-					port: opts.port,
-				});
-
-				logger.debug(
-					`Front-door proxy on port ${opts.port} (Vite:${vitePort}, Bun:${bunBackendPort})`
-				);
-			} catch (error) {
-				tui.error(`Failed to start front-door proxy: ${error}`);
-				await procManager.cleanup('front-door proxy startup failure');
-				await devLock.release();
-				originalExit(1);
-				return;
-			}
-
 			// --- State for long-running processes ---
+			// Declared early so signal handlers can reference them before
+			// servers are started.
+			let viteServer: ServerLike | null = null;
+			let frontDoorServer: import('node:net').Server | null = null;
 			let gravityProcess: ProcessLike | null = null;
 			let gravityHeartbeatInterval: ReturnType<typeof setInterval> | null = null;
 			let stdinListenerRegistered = false;
 			let stdinDataHandler: ((data: Buffer | string) => void) | null = null;
 			let shutdownRequested = false;
+
+			// Initialize process manager to track all servers/processes
+			const procManager = initProcessManager(logger);
+
+			// Pre-initialize vitePort with the anticipated internal port.
+			// The actual port is confirmed after Vite starts (below) and rarely differs.
+			let vitePort: number = viteInternalPort;
 
 			/**
 			 * Centralized cleanup function for all resources.
@@ -861,6 +789,10 @@ export const command = createCommand({
 			// Note: AGENTUITY_SDK_KEY, NODE_ENV, AGENTUITY_ENV, and
 			// AGENTUITY_TRANSPORT_URL are already set in Step 0b (before
 			// agent discovery) to support gateway env patching.
+			//
+			// vitePort is pre-initialized to viteInternalPort here. If Vite
+			// ends up on a different port (rare), we update these env vars
+			// after Vite starts in Step 4.
 
 			process.env.AGENTUITY_SDK_DEV_MODE = 'true';
 			process.env.AGENTUITY_RUNTIME = 'yes';
@@ -932,7 +864,95 @@ export const command = createCommand({
 			}
 
 			// ================================================================
-			// Step 4: Start gravity tunnel (if public URL enabled)
+			// Step 4: Start Vite asset server (frontend + API proxy)
+			// ================================================================
+			// Vite starts AFTER the Bun backend so that its proxy is ready
+			// to forward API requests immediately — no ECONNREFUSED race.
+
+			try {
+				logger.debug('Starting Vite dev server (internal port %d)...', viteInternalPort);
+				const viteResult = await startViteAssetServer({
+					rootDir,
+					logger,
+					workbenchPath: workbench.config?.route,
+					port: viteInternalPort,
+					backendPort: bunBackendPort,
+					routePaths,
+					liveHostname: devmode?.hostname,
+				});
+				viteServer = viteResult.server;
+				vitePort = viteResult.port;
+
+				// If Vite ended up on a different port than anticipated, update the
+				// env vars so CORS and devmode URLs are correct. The Bun backend's
+				// --hot reload will pick up the change.
+				if (vitePort !== viteInternalPort) {
+					process.env.AGENTUITY_BASE_URL = `http://localhost:${vitePort}`;
+					if (!devmode?.hostname) {
+						process.env.AGENTUITY_DEVMODE_URL = `http://localhost:${vitePort}`;
+					}
+				}
+
+				// Register Vite server with process manager
+				procManager.registerServer({
+					id: 'vite',
+					server: viteServer,
+					description: 'Vite dev server (frontend assets)',
+					port: vitePort,
+				});
+
+				// Update dev lock with actual Vite port
+				await devLock.updatePorts({ vite: vitePort });
+
+				logger.debug(
+					`Vite dev server running on port ${vitePort} (internal, proxying backend on port ${bunBackendPort})`
+				);
+			} catch (error) {
+				tui.error(`Failed to start Vite dev server: ${error}`);
+				await cleanup(true, 1, true);
+				return;
+			}
+
+			// ================================================================
+			// Step 5: Start front-door TCP proxy (user-facing port)
+			// ================================================================
+			// Routes WebSocket upgrades (for /api/*, /_agentuity/*) directly to Bun
+			// and everything else (HTTP, HMR WebSocket) to Vite.
+			// This works around Bun's broken node:http upgrade socket implementation.
+
+			try {
+				const { startWsProxy } = await import('../build/vite/ws-proxy');
+				frontDoorServer = await startWsProxy({
+					port: opts.port,
+					vitePort,
+					backendPort: bunBackendPort,
+					routePaths,
+					logger,
+				});
+
+				// Register front-door proxy with process manager
+				procManager.registerServer({
+					id: 'front-door-proxy',
+					server: {
+						close: () => {
+							frontDoorServer?.close();
+						},
+					},
+					description: 'Front-door TCP proxy (WS routing)',
+					port: opts.port,
+				});
+
+				logger.debug(
+					`Front-door proxy on port ${opts.port} (Vite:${vitePort}, Bun:${bunBackendPort})`
+				);
+			} catch (error) {
+				tui.error(`Failed to start front-door proxy: ${error}`);
+				await cleanup(true, 1, true);
+				return;
+			}
+
+			// ================================================================
+			// Step 6: Start gravity tunnel (if public URL enabled)
 			// ================================================================
 
 			if (gravityBin && gravityURL && devmode && project) {
@@ -1049,7 +1069,7 @@ export const command = createCommand({
 			}
 
 			// ================================================================
-			// Step 5: Keyboard shortcuts + wait for shutdown
+			// Step 7: Keyboard shortcuts + wait for shutdown
 			// ================================================================
 
 			if (interactive && process.stdin.isTTY && process.stdout.isTTY) {

--- a/packages/cli/src/cmd/dev/index.ts
+++ b/packages/cli/src/cmd/dev/index.ts
@@ -548,9 +548,18 @@ export const command = createCommand({
 			// Initialize process manager to track all servers/processes
 			const procManager = initProcessManager(logger);
 
-			// Pre-initialize vitePort with the anticipated internal port.
-			// The actual port is confirmed after Vite starts (below) and rarely differs.
-			let vitePort: number = viteInternalPort;
+			// Resolve the actual Vite port BEFORE starting Bun so that env vars
+			// like AGENTUITY_BASE_URL contain the correct port. The runtime's
+			// CORS trusted-origins are built once at startup, so a late update
+			// would leave the backend with stale origins.
+			const { findAvailablePort } = await import('../build/vite/vite-asset-server');
+			const vitePort = await findAvailablePort(viteInternalPort, '127.0.0.1');
+
+			if (vitePort !== viteInternalPort) {
+				logger.info(
+					`Port ${viteInternalPort} is in use, using port ${vitePort} for Vite dev server`
+				);
+			}
 
 			/**
 			 * Centralized cleanup function for all resources.
@@ -790,9 +799,9 @@ export const command = createCommand({
 			// AGENTUITY_TRANSPORT_URL are already set in Step 0b (before
 			// agent discovery) to support gateway env patching.
 			//
-			// vitePort is pre-initialized to viteInternalPort here. If Vite
-			// ends up on a different port (rare), we update these env vars
-			// after Vite starts in Step 4.
+			// vitePort is pre-resolved (via findAvailablePort) before Bun
+			// starts, so env vars like AGENTUITY_BASE_URL are correct when
+			// the runtime builds its CORS trusted-origin set.
 
 			process.env.AGENTUITY_SDK_DEV_MODE = 'true';
 			process.env.AGENTUITY_RUNTIME = 'yes';
@@ -875,22 +884,19 @@ export const command = createCommand({
 					rootDir,
 					logger,
 					workbenchPath: workbench.config?.route,
-					port: viteInternalPort,
+					port: vitePort,
 					backendPort: bunBackendPort,
 					routePaths,
 					liveHostname: devmode?.hostname,
 				});
 				viteServer = viteResult.server;
-				vitePort = viteResult.port;
 
-				// If Vite ended up on a different port than anticipated, update the
-				// env vars so CORS and devmode URLs are correct. The Bun backend's
-				// --hot reload will pick up the change.
-				if (vitePort !== viteInternalPort) {
-					process.env.AGENTUITY_BASE_URL = `http://localhost:${vitePort}`;
-					if (!devmode?.hostname) {
-						process.env.AGENTUITY_DEVMODE_URL = `http://localhost:${vitePort}`;
-					}
+				// Verify Vite used the port we pre-resolved (should always match
+				// since strictPort:true is set and we already confirmed availability).
+				if (viteResult.port !== vitePort) {
+					logger.warn(
+						`Vite started on port ${viteResult.port} instead of expected ${vitePort} — env vars may be incorrect`
+					);
 				}
 
 				// Register Vite server with process manager

--- a/packages/cli/test/cmd/dev/backend-proxy.test.ts
+++ b/packages/cli/test/cmd/dev/backend-proxy.test.ts
@@ -1,0 +1,434 @@
+import { describe, test, expect } from 'bun:test';
+import { join } from 'node:path';
+import { createServer } from 'node:net';
+import { tmpdir } from 'node:os';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+
+const viteConfigPath = join(
+	import.meta.dir,
+	'../../../src/cmd/build/vite/vite-asset-server-config.ts'
+);
+
+/**
+ * Helper to find an available port.
+ */
+async function findAvailablePort(startPort: number): Promise<number> {
+	for (let port = startPort; port < startPort + 100; port++) {
+		const available = await new Promise<boolean>((resolve) => {
+			const server = createServer();
+			server.once('error', () => resolve(false));
+			server.listen(port, '127.0.0.1', () => {
+				server.close(() => resolve(true));
+			});
+		});
+		if (available) return port;
+	}
+	throw new Error('Could not find available port');
+}
+
+/**
+ * Extract the configure callback from a generated Vite config's proxy entry.
+ *
+ * The `generateAssetServerConfig` returns the full Vite config including
+ * `server.proxy`. We pull out the `configure` function from a proxy entry
+ * so we can test it in isolation.
+ */
+async function getProxyConfigure(routePath: string = '/api'): Promise<{
+	configure: (proxy: any, options: any) => void;
+	target: string;
+}> {
+	const { generateAssetServerConfig } = await import(viteConfigPath);
+
+	const mockLogger = {
+		debug: () => {},
+		info: () => {},
+		warn: () => {},
+		error: () => {},
+		hasErrorLogged: () => false,
+		hasWarned: false,
+		clearScreen: () => {},
+		warnOnce: () => {},
+	};
+
+	const backendPort = 39999;
+	const config = await generateAssetServerConfig({
+		rootDir: '/tmp/test',
+		logger: mockLogger as any,
+		port: 3502,
+		backendPort,
+		routePaths: [routePath],
+	});
+
+	const proxyEntry = config.server?.proxy?.[routePath] as any;
+	expect(proxyEntry).toBeDefined();
+	expect(proxyEntry.configure).toBeDefined();
+	expect(proxyEntry.target).toBe(`http://127.0.0.1:${backendPort}`);
+
+	return {
+		configure: proxyEntry.configure,
+		target: proxyEntry.target,
+	};
+}
+
+/**
+ * Simulate an http-proxy error event on a mock proxy object.
+ *
+ * Returns the response object so we can assert on its state.
+ */
+function simulateProxyError(
+	configure: (proxy: any, options: any) => void,
+	errorCode: string,
+	hasResponse: boolean = true
+): {
+	proxy: any;
+	res: Record<string, any>;
+	capturedEvents: string[];
+} {
+	const res: Record<string, any> = {
+		writableEnded: false,
+		statusCode: 200,
+		headers: {} as Record<string, string>,
+		setHeader: function (name: string, value: string) {
+			this.headers[name] = value;
+		},
+		end: function (chunk: string) {
+			this.writableEnded = true;
+			this.body = chunk;
+		},
+		body: '',
+	};
+
+	const capturedEvents: string[] = [];
+
+	// Create a mock EventEmitter-like proxy
+	const proxy = {
+		listeners: {} as Record<string, Function[]>,
+		on(event: string, handler: Function) {
+			if (!this.listeners[event]) this.listeners[event] = [];
+			this.listeners[event].push(handler);
+		},
+		emit(event: string, ...args: unknown[]) {
+			capturedEvents.push(event);
+			for (const handler of this.listeners[event] ?? []) {
+				handler(...args);
+			}
+		},
+	};
+
+	// Call configure to register the error handler
+	configure(proxy, { target: 'http://127.0.0.1:39999' });
+
+	// Emit the error event, simulating http-proxy behavior
+	const err = new Error(`connect ECONNREFUSED 127.0.0.1:39999`);
+	(err as any).code = errorCode;
+
+	proxy.emit('error', err, {}, hasResponse ? res : null);
+
+	return { proxy, res, capturedEvents };
+}
+
+describe('Backend Proxy ECONNREFUSED Handler', () => {
+	describe('backendProxyOptions configure callback', () => {
+		test('returns 503 with JSON body on ECONNREFUSED', async () => {
+			const { configure } = await getProxyConfigure('/api');
+
+			const { res } = simulateProxyError(configure, 'ECONNREFUSED');
+
+			expect(res.statusCode).toBe(503);
+			expect(res.headers['Content-Type']).toBe('application/json');
+			expect(res.writableEnded).toBe(true);
+
+			const body = JSON.parse(res.body);
+			expect(body.error).toBe('Backend unavailable');
+			expect(body.message).toContain('not ready yet');
+			expect(body.retry).toBe(true);
+		});
+
+		test('does not write response if already ended', async () => {
+			const { configure } = await getProxyConfigure('/api');
+
+			const res = {
+				writableEnded: true,
+				statusCode: 200,
+				headers: {} as Record<string, string>,
+				setHeader: function (name: string, value: string) {
+					this.headers[name] = value;
+				},
+				end: (_chunk: string) => {
+					throw new Error('Should not call end() on already-ended response');
+				},
+				body: '',
+			};
+
+			const proxy = {
+				listeners: {} as Record<string, Function[]>,
+				on(event: string, handler: Function) {
+					if (!this.listeners[event]) this.listeners[event] = [];
+					this.listeners[event].push(handler);
+				},
+				emit(event: string, ...args: unknown[]) {
+					for (const handler of this.listeners[event] ?? []) {
+						handler(...args);
+					}
+				},
+			};
+
+			configure(proxy, { target: 'http://127.0.0.1:39999' });
+
+			const err = new Error('connect ECONNREFUSED');
+			(err as any).code = 'ECONNREFUSED';
+
+			// Should NOT throw even though response is already ended
+			expect(() => proxy.emit('error', err, {}, res)).not.toThrow();
+
+			// Response should remain unchanged
+			expect(res.statusCode).toBe(200);
+		});
+
+		test('ignores non-ECONNREFUSED errors', async () => {
+			const { configure } = await getProxyConfigure('/api');
+
+			const res = {
+				writableEnded: false,
+				statusCode: 200,
+				headers: {} as Record<string, string>,
+				setHeader: function (name: string, value: string) {
+					this.headers[name] = value;
+				},
+				end: function (chunk: string) {
+					this.writableEnded = true;
+					this.body = chunk;
+				},
+				body: '',
+			};
+
+			const proxy = {
+				listeners: {} as Record<string, Function[]>,
+				on(event: string, handler: Function) {
+					if (!this.listeners[event]) this.listeners[event] = [];
+					this.listeners[event].push(handler);
+				},
+			};
+
+			configure(proxy, { target: 'http://127.0.0.1:39999' });
+
+			// Emit a non-ECONNREFUSED error (e.g., ETIMEDOUT)
+			const err = new Error('connect ETIMEDOUT');
+			(err as any).code = 'ETIMEDOUT';
+
+			const handler = proxy.listeners['error']?.[0];
+			expect(handler).toBeDefined();
+
+			// Should NOT modify the response for non-ECONNREFUSED
+			handler(err, {}, res);
+			expect(res.statusCode).toBe(200);
+			expect(res.writableEnded).toBe(false);
+		});
+
+		test('handles null/undefined response gracefully', async () => {
+			const { configure } = await getProxyConfigure('/api');
+
+			const proxy = {
+				listeners: {} as Record<string, Function[]>,
+				on(event: string, handler: Function) {
+					if (!this.listeners[event]) this.listeners[event] = [];
+					this.listeners[event].push(handler);
+				},
+			};
+
+			configure(proxy, { target: 'http://127.0.0.1:39999' });
+
+			const err = new Error('connect ECONNREFUSED');
+			(err as any).code = 'ECONNREFUSED';
+
+			const handler = proxy.listeners['error']?.[0];
+
+			// Should not throw when response is null (WebSocket upgrade has no res)
+			expect(() => handler(err, {}, null)).not.toThrow();
+			expect(() => handler(err, {}, undefined)).not.toThrow();
+		});
+	});
+
+	describe('all proxy routes have configure callback', () => {
+		test('all default proxy entries include ECONNREFUSED handler', async () => {
+			const { generateAssetServerConfig } = await import(viteConfigPath);
+
+			const mockLogger = {
+				debug: () => {},
+				info: () => {},
+				warn: () => {},
+				error: () => {},
+				hasErrorLogged: () => false,
+				hasWarned: false,
+				clearScreen: () => {},
+				warnOnce: () => {},
+			};
+
+			const backendPort = 39999;
+			const config = await generateAssetServerConfig({
+				rootDir: '/tmp/test',
+				logger: mockLogger as any,
+				port: 3502,
+				backendPort,
+				routePaths: ['/api', '/graphql'],
+				workbenchPath: '/workbench',
+			});
+
+			const proxy = config.server?.proxy as Record<string, any>;
+
+			// Every proxy entry should have the configure callback
+			for (const [key, entry] of Object.entries(proxy)) {
+				expect(
+					typeof entry.configure,
+					`Proxy entry "${key}" should have configure callback`
+				).toBe('function');
+				expect(entry.changeOrigin, `Proxy entry "${key}" should have changeOrigin`).toBe(true);
+				expect(
+					entry.target,
+					`Proxy entry "${key}" should target backend port ${backendPort}`
+				).toBe(`http://127.0.0.1:${backendPort}`);
+			}
+		});
+	});
+
+	describe('ECONNREFUSED through real HTTP proxy', () => {
+		test('Vite proxy returns 503 when backend is not listening', async () => {
+			// This is an integration-level test: spin up a real Vite dev server
+			// whose proxy target port has nothing listening, and verify the 503.
+			//
+			// We use node:http to create a minimal server that loads Vite's
+			// proxy middleware, then sends a request to it.
+
+			const { generateAssetServerConfig } = await import(viteConfigPath);
+
+			const mockLogger = {
+				debug: () => {},
+				info: () => {},
+				warn: () => {},
+				error: () => {},
+				hasErrorLogged: () => false,
+				hasWarned: false,
+				clearScreen: () => {},
+				warnOnce: () => {},
+			};
+
+			// Use a port with nothing listening as the "backend"
+			const deadBackendPort = await findAvailablePort(50000);
+
+			const vitePort = await findAvailablePort(deadBackendPort + 1);
+
+			// Create a temp dir with minimal Vite setup
+			const testDir = join(tmpdir(), `vite-proxy-test-${Date.now()}`);
+			mkdirSync(testDir, { recursive: true });
+			mkdirSync(join(testDir, 'src', 'web'), { recursive: true });
+			writeFileSync(join(testDir, 'index.html'), '<html><body></body></html>');
+
+			try {
+				const config = await generateAssetServerConfig({
+					rootDir: testDir,
+					logger: mockLogger as any,
+					port: vitePort,
+					backendPort: deadBackendPort,
+					routePaths: ['/api'],
+				});
+
+				// Dynamically import Vite from project node_modules
+				const projectRequire = require('node:module').createRequire(
+					join(testDir, 'package.json')
+				);
+
+				let viteServer: any;
+				try {
+					const { createServer } = await import(projectRequire.resolve('vite'));
+					viteServer = await createServer(config);
+					await viteServer.listen();
+				} catch {
+					// Vite not available in this test environment — skip integration test
+					return;
+				}
+
+				try {
+					// Make an HTTP request to /api/anything via Vite's proxy
+					const response = await fetch(`http://127.0.0.1:${vitePort}/api/test`, {
+						signal: AbortSignal.timeout(5000),
+					});
+
+					// Should get 503, not 500 or ECONNREFUSED crash
+					expect(response.status).toBe(503);
+
+					const body = await response.json();
+					expect(body.error).toBe('Backend unavailable');
+					expect(body.retry).toBe(true);
+				} finally {
+					await viteServer.close();
+				}
+			} finally {
+				rmSync(testDir, { recursive: true, force: true });
+			}
+		});
+	});
+});
+
+describe('Startup Order Verification', () => {
+	test('Bun backend starts before Vite in the dev command flow', async () => {
+		// Verify the dev command's step ordering by checking that
+		// startBunDevServer is imported and called before startViteAssetServer
+		// in the source code ordering.
+		//
+		// This is a source-level assertion — the actual startup order is
+		// determined by the sequential await calls in the handler.
+
+		const devIndexPath = join(import.meta.dir, '../../../src/cmd/dev/index.ts');
+		const source = await Bun.file(devIndexPath).text();
+
+		// Find step markers
+		const step3Pos = source.indexOf('Step 3: Start Bun backend');
+		const step4Pos = source.indexOf('Step 4: Start Vite asset server');
+		const step5Pos = source.indexOf('Step 5: Start front-door TCP proxy');
+
+		expect(step3Pos, 'Step 3 (Bun backend) should exist in dev/index.ts').toBeGreaterThan(0);
+		expect(step4Pos, 'Step 4 (Vite) should exist in dev/index.ts').toBeGreaterThan(0);
+		expect(step5Pos, 'Step 5 (front-door proxy) should exist in dev/index.ts').toBeGreaterThan(0);
+
+		// Bun (Step 3) must come before Vite (Step 4)
+		expect(step3Pos, 'Bun backend (Step 3) must start before Vite (Step 4)').toBeLessThan(
+			step4Pos
+		);
+
+		// Vite (Step 4) must come before front-door proxy (Step 5)
+		expect(step4Pos, 'Vite (Step 4) must start before front-door proxy (Step 5)').toBeLessThan(
+			step5Pos
+		);
+	});
+
+	test('vitePort is pre-initialized before Bun starts', async () => {
+		const devIndexPath = join(import.meta.dir, '../../../src/cmd/dev/index.ts');
+		const source = await Bun.file(devIndexPath).text();
+
+		// Verify vitePort is initialized with viteInternalPort
+		const preInitLine = source.indexOf('let vitePort: number = viteInternalPort');
+		expect(preInitLine, 'vitePort should be pre-initialized to viteInternalPort').toBeGreaterThan(
+			0
+		);
+	});
+
+	test('env vars are updated if Vite port changes', async () => {
+		const devIndexPath = join(import.meta.dir, '../../../src/cmd/dev/index.ts');
+		const source = await Bun.file(devIndexPath).text();
+
+		// Verify there's a check for vitePort !== viteInternalPort
+		const portUpdateCheck = source.indexOf('vitePort !== viteInternalPort');
+		expect(
+			portUpdateCheck,
+			'Should check if Vite port differs and update env vars'
+		).toBeGreaterThan(0);
+
+		// Verify AGENTUITY_BASE_URL is updated
+		const baseUrlUpdate = source.indexOf(
+			'process.env.AGENTUITY_BASE_URL = `http://localhost:${' + 'vitePort}`'
+		);
+		expect(baseUrlUpdate, 'AGENTUITY_BASE_URL should be updated on port change').toBeGreaterThan(
+			portUpdateCheck
+		);
+	});
+});

--- a/packages/cli/test/cmd/dev/backend-proxy.test.ts
+++ b/packages/cli/test/cmd/dev/backend-proxy.test.ts
@@ -332,10 +332,10 @@ describe('Backend Proxy ECONNREFUSED Handler', () => {
 					routePaths: ['/api'],
 				});
 
-				// Dynamically import Vite from project node_modules
-				const projectRequire = require('node:module').createRequire(
-					join(testDir, 'package.json')
-				);
+				// Dynamically import Vite from the repo's node_modules,
+				// not from the temp testDir (which has no node_modules).
+				const { createRequire } = await import('node:module');
+				const projectRequire = createRequire(import.meta.url);
 
 				let viteServer: any;
 				try {
@@ -401,34 +401,34 @@ describe('Startup Order Verification', () => {
 		);
 	});
 
-	test('vitePort is pre-initialized before Bun starts', async () => {
+	test('vitePort is pre-resolved before Bun starts', async () => {
 		const devIndexPath = join(import.meta.dir, '../../../src/cmd/dev/index.ts');
 		const source = await Bun.file(devIndexPath).text();
 
-		// Verify vitePort is initialized with viteInternalPort
-		const preInitLine = source.indexOf('let vitePort: number = viteInternalPort');
-		expect(preInitLine, 'vitePort should be pre-initialized to viteInternalPort').toBeGreaterThan(
-			0
-		);
-	});
-
-	test('env vars are updated if Vite port changes', async () => {
-		const devIndexPath = join(import.meta.dir, '../../../src/cmd/dev/index.ts');
-		const source = await Bun.file(devIndexPath).text();
-
-		// Verify there's a check for vitePort !== viteInternalPort
-		const portUpdateCheck = source.indexOf('vitePort !== viteInternalPort');
+		// Verify vitePort is resolved via findAvailablePort before Bun starts
+		const findPortLine = source.indexOf('findAvailablePort(viteInternalPort');
 		expect(
-			portUpdateCheck,
-			'Should check if Vite port differs and update env vars'
+			findPortLine,
+			'vitePort should be resolved via findAvailablePort before Bun starts'
 		).toBeGreaterThan(0);
 
-		// Verify AGENTUITY_BASE_URL is updated
-		const baseUrlUpdate = source.indexOf(
-			'process.env.AGENTUITY_BASE_URL = `http://localhost:${' + 'vitePort}`'
+		// The findAvailablePort call must come before Step 3 (Bun backend)
+		const step3Pos = source.indexOf('Step 3: Start Bun backend');
+		expect(
+			findPortLine,
+			'findAvailablePort must be called before Bun starts (Step 3)'
+		).toBeLessThan(step3Pos);
+	});
+
+	test('env vars use pre-resolved vitePort', async () => {
+		const devIndexPath = join(import.meta.dir, '../../../src/cmd/dev/index.ts');
+		const source = await Bun.file(devIndexPath).text();
+
+		// Verify AGENTUITY_BASE_URL uses the pre-resolved vitePort
+		// We search for a simpler unique pattern to avoid escaping issues
+		const baseUrlLine = source.indexOf(
+			'AGENTUITY_BASE_URL || `http://localhost:${' + 'vitePort}`'
 		);
-		expect(baseUrlUpdate, 'AGENTUITY_BASE_URL should be updated on port change').toBeGreaterThan(
-			portUpdateCheck
-		);
+		expect(baseUrlLine, 'AGENTUITY_BASE_URL should use pre-resolved vitePort').toBeGreaterThan(0);
 	});
 });

--- a/packages/core/src/services/coder/types.ts
+++ b/packages/core/src/services/coder/types.ts
@@ -330,7 +330,10 @@ export const CoderCreateWorkspaceRequestSchema = z
 		repos: z.array(CoderSessionRepositoryRefSchema).optional().describe('Repositories'),
 		savedSkillIds: z.array(z.string()).optional().describe('Saved skill IDs'),
 		skillBucketIds: z.array(z.string()).optional().describe('Skill bucket IDs'),
-		enabledAgents: z.array(z.string()).optional().describe('Effective agent roster to store on the workspace'),
+		enabledAgents: z
+			.array(z.string())
+			.optional()
+			.describe('Effective agent roster to store on the workspace'),
 	})
 	.describe('Request body for creating a workspace');
 export type CoderCreateWorkspaceRequest = z.infer<typeof CoderCreateWorkspaceRequestSchema>;


### PR DESCRIPTION
Reorder startup so Bun backend starts before Vite, preventing the proxy from forwarding requests to a not-yet-listening backend. Add ECONNREFUSED handler to Vite proxy config that returns 503 with retry hint instead of noisy errors — also covers brief disconnects during Bun --hot reloads.

- Bun backend (Step 3) now starts before Vite (Step 4)
- backendProxyOptions() shared helper with configure callback
- Returns HTTP 503 + JSON { error, retry } on ECONNREFUSED
- Handles null/ended responses, ignores non-ECONNREFUSED errors
- vitePort pre-initialized; env vars updated if Vite port differs
- 9 new tests for proxy handler and startup order verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dev proxy now returns a clear 503 JSON response with retry guidance when the backend is unavailable.

* **Chores**
  * Improved dev startup ordering and port resolution for more reliable launches.
  * Simplified and clarified startup logging while preserving a legacy option for backward compatibility.

* **Tests**
  * Added tests for proxy error handling and dev-server startup sequence.

* **Style**
  * Minor schema formatting cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->