### PR TITLE
fix(runtime): bypass Bun default request timeout in dev mode

### DIFF
--- a/packages/runtime/src/app.ts
+++ b/packages/runtime/src/app.ts
@@ -646,6 +646,24 @@ export async function createApp(config?: AppConfig): Promise<AppResult> {
 
 	const portNumber = parseInt(port, 10);
 
+	// Wrap the fetch handler to set request timeout.
+	// In dev mode, Bun --hot auto-serves from the default export's `fetch` property.
+	// Without this wrapper, Bun uses its default request timeout (10s), which is too
+	// short for long-running agent requests (LLM calls, etc.). In v1, the generated
+	// entry file called server.timeout(req, 0) inside Bun.serve(). In v2, we must do
+	// the same here so dev mode requests don't time out prematurely.
+	const requestTimeout = config?.requestTimeout ?? 0;
+	const wrappedFetch = (req: Request, ...args: any[]) => {
+		const server = args[0];
+		if (server && typeof server === 'object' && 'timeout' in server) {
+			(server as { timeout: (req: Request, seconds: number) => void }).timeout(
+				req,
+				requestTimeout
+			);
+		}
+		return app.fetch(req, ...args);
+	};
+
 	const result: AppResult = {
 		config,
 		router: app as Hono<Env>,
@@ -653,7 +671,7 @@ export async function createApp(config?: AppConfig): Promise<AppResult> {
 		logger: otel.logger,
 		// Bun --hot picks up `fetch` and `port` on the default export to
 		// hot-swap the running server's request handler without restarting.
-		fetch: app.fetch,
+		fetch: wrappedFetch,
 		port: portNumber,
 		hostname: '127.0.0.1',
 		websocket,


### PR DESCRIPTION
In v2, createApp() skips startServer() in dev mode since Bun --hot auto-serves from the default export's fetch/port properties. However, this meant server.timeout(req, 0) was never called, leaving Bun's default 10s request timeout active. Long-running agent requests (LLM calls, etc.) would time out prematurely.

In v1, the generated entry file always called Bun.serve() with an explicit server.timeout(req, 0) in both dev and prod modes.

Fix: wrap the exported fetch handler to call server.timeout(req, 0) so dev mode requests are not subject to Bun's default timeout. The production path is unchanged — startServer() still handles it via the explicit Bun.serve() call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed request timeout settings to properly apply during development mode with hot-reload functionality, ensuring configured timeouts are respected when auto-serving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->