### PR TITLE
Add SDK support for agent builder sessions

### DIFF
--- a/packages/coder-tui/src/protocol.ts
+++ b/packages/coder-tui/src/protocol.ts
@@ -363,61 +363,6 @@ export interface SessionListDiagnostics {
 	}>;
 }
 
-export type AgentBuilderSessionMode = 'new' | 'edit' | 'from_session';
-
-export interface AgentBuilderSourceSessionRef {
-	sessionId: string;
-	label?: string;
-}
-
-export interface AgentBuilderTargetAgentRef {
-	agentId?: string;
-	slug: string;
-	displayName?: string;
-}
-
-export interface AgentBuilderDurableState {
-	draftAgentId?: string;
-	draftAgentSlug?: string;
-	lastPublishedVersion?: number;
-}
-
-export interface AgentBuilderActionState {
-	kind: 'create_draft' | 'update_draft' | 'publish';
-	status: 'completed' | 'failed';
-	occurredAt: string;
-	message?: string;
-	agentId?: string;
-	agentSlug?: string;
-	publishedVersion?: number;
-}
-
-export interface AgentBuilderProposalState {
-	slug?: string;
-	displayName?: string;
-	description?: string;
-	instructions?: string;
-	model?: string;
-	thinkingLevel?: string;
-	headlessCompatible?: boolean;
-	tools?: string[];
-	serviceTools?: string[];
-	savedSkills?: SessionSkillRef[];
-	companionAgents?: string[];
-}
-
-export interface AgentBuilderSessionSummary {
-	mode: AgentBuilderSessionMode;
-	sourceSession?: AgentBuilderSourceSessionRef;
-	targetAgent?: AgentBuilderTargetAgentRef;
-	durable?: AgentBuilderDurableState;
-	lastAction?: AgentBuilderActionState;
-}
-
-export interface AgentBuilderSessionState extends AgentBuilderSessionSummary {
-	proposal?: AgentBuilderProposalState;
-}
-
 export interface SessionListItem {
 	sessionId: string;
 	label: string;
@@ -583,7 +528,6 @@ export interface SessionSnapshotMetadataExtensions {
 	};
 	observed?: SessionObservedProjection;
 	product?: SessionProductProjection;
-	builder?: AgentBuilderSessionState;
 	tags: string[];
 	skills: SessionSkillRef[];
 	enabledAgents: string[];

--- a/packages/coder-tui/src/protocol.ts
+++ b/packages/coder-tui/src/protocol.ts
@@ -363,6 +363,61 @@ export interface SessionListDiagnostics {
 	}>;
 }
 
+export type AgentBuilderSessionMode = 'new' | 'edit' | 'from_session';
+
+export interface AgentBuilderSourceSessionRef {
+	sessionId: string;
+	label?: string;
+}
+
+export interface AgentBuilderTargetAgentRef {
+	agentId?: string;
+	slug: string;
+	displayName?: string;
+}
+
+export interface AgentBuilderDurableState {
+	draftAgentId?: string;
+	draftAgentSlug?: string;
+	lastPublishedVersion?: number;
+}
+
+export interface AgentBuilderActionState {
+	kind: 'create_draft' | 'update_draft' | 'publish';
+	status: 'completed' | 'failed';
+	occurredAt: string;
+	message?: string;
+	agentId?: string;
+	agentSlug?: string;
+	publishedVersion?: number;
+}
+
+export interface AgentBuilderProposalState {
+	slug?: string;
+	displayName?: string;
+	description?: string;
+	instructions?: string;
+	model?: string;
+	thinkingLevel?: string;
+	headlessCompatible?: boolean;
+	tools?: string[];
+	serviceTools?: string[];
+	savedSkills?: SessionSkillRef[];
+	companionAgents?: string[];
+}
+
+export interface AgentBuilderSessionSummary {
+	mode: AgentBuilderSessionMode;
+	sourceSession?: AgentBuilderSourceSessionRef;
+	targetAgent?: AgentBuilderTargetAgentRef;
+	durable?: AgentBuilderDurableState;
+	lastAction?: AgentBuilderActionState;
+}
+
+export interface AgentBuilderSessionState extends AgentBuilderSessionSummary {
+	proposal?: AgentBuilderProposalState;
+}
+
 export interface SessionListItem {
 	sessionId: string;
 	label: string;
@@ -528,6 +583,7 @@ export interface SessionSnapshotMetadataExtensions {
 	};
 	observed?: SessionObservedProjection;
 	product?: SessionProductProjection;
+	builder?: AgentBuilderSessionState;
 	tags: string[];
 	skills: SessionSkillRef[];
 	enabledAgents: string[];

--- a/packages/core/src/services/coder/api-reference.ts
+++ b/packages/core/src/services/coder/api-reference.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod/v4';
 import {
+	CoderCreateAgentBuilderSessionRequestSchema,
 	CoderCreateCustomAgentRequestSchema,
 	CoderCreateSessionRequestSchema,
 	CoderCustomAgentListResponseSchema,
@@ -144,6 +145,36 @@ const service: Service = {
 			],
 			examplePath: '/hub/session',
 			exampleBody: { task: 'Implement feature X', workflowMode: 'standard' },
+		},
+		{
+			id: 'create-agent-builder-session',
+			title: 'Create Agent Builder Session',
+			sectionTitle: 'Sessions',
+			method: 'POST',
+			path: '/hub/session/builder',
+			description:
+				'Creates a dedicated Lead + agent-builder session for designing, editing, or publishing a custom agent.',
+			pathParams: [],
+			queryParams: CoderCreateSessionParamsSchema.shape.orgId
+				? [{ name: 'orgId', type: 'string', description: 'Organization ID', required: false }]
+				: [],
+			requestBody: {
+				description: 'Agent-builder launch payload.',
+				fields: { schema: CoderCreateAgentBuilderSessionRequestSchema },
+			},
+			responseDescription: 'Returns the created builder session.',
+			responseFields: { schema: CoderCreateSessionResponseWireSchema, stripRequired: true },
+			statuses: [
+				{ code: 201, description: 'Builder session created' },
+				{ code: 404, description: 'Source session or target agent not found' },
+			],
+			examplePath: '/hub/session/builder',
+			exampleBody: {
+				mode: 'from_session',
+				sourceSessionId: 'codesess_123',
+				label: 'Build from release triage',
+				prompt: 'Turn the repeated release-triage workflow into a reusable QA agent',
+			},
 		},
 		{
 			id: 'list-sessions',

--- a/packages/core/src/services/coder/client.ts
+++ b/packages/core/src/services/coder/client.ts
@@ -7,6 +7,7 @@ import { createMinimalLogger } from '../logger.ts';
 import { discoverUrl } from './discover.ts';
 import {
 	coderArchiveSession,
+	coderCreateAgentBuilderSession,
 	type CoderCreateSessionResponse,
 	type CoderLifecycleResponse,
 	coderCreateSession,
@@ -61,6 +62,7 @@ import type {
 	CoderCustomAgent,
 	CoderCustomAgentListResponse,
 	CoderCustomAgentVersionListResponse,
+	CoderCreateAgentBuilderSessionRequest,
 	CoderCreateCustomAgentRequest,
 	CoderListUsersResponse,
 	CoderSavedSkill,
@@ -187,6 +189,16 @@ export class CoderClient {
 	): Promise<CoderCreateSessionResponse> {
 		const client = await this.#getClient();
 		return coderCreateSession(client, { body, orgId: this.#orgId });
+	}
+
+	/**
+	 * Creates a dedicated agent-builder session.
+	 */
+	async createAgentBuilderSession(
+		body: CoderCreateAgentBuilderSessionRequest
+	): Promise<CoderCreateSessionResponse> {
+		const client = await this.#getClient();
+		return coderCreateAgentBuilderSession(client, { body, orgId: this.#orgId });
 	}
 
 	/**

--- a/packages/core/src/services/coder/index.ts
+++ b/packages/core/src/services/coder/index.ts
@@ -3,6 +3,7 @@ export * from './types.ts';
 export { discoverUrl, DiscoverCoderUrlDataSchema } from './discover.ts';
 
 export type {
+	CoderCreateAgentBuilderSessionParams,
 	CoderCreateSessionParams,
 	CoderCreateSessionResponse,
 	CoderGetSessionParams,
@@ -15,6 +16,7 @@ export type {
 } from './sessions.ts';
 export {
 	coderArchiveSession,
+	coderCreateAgentBuilderSession,
 	coderCreateSession,
 	coderDeleteSession,
 	coderGetSession,
@@ -22,6 +24,7 @@ export {
 	coderListSessions,
 	coderResumeSession,
 	coderUpdateSession,
+	CoderCreateAgentBuilderSessionParamsSchema,
 	CoderCreateSessionParamsSchema,
 	CoderGetSessionParamsSchema,
 	CoderListConnectableSessionsParamsSchema,

--- a/packages/core/src/services/coder/sessions.ts
+++ b/packages/core/src/services/coder/sessions.ts
@@ -1,12 +1,14 @@
 import { z } from 'zod/v4';
 import { type APIClient } from '../api.ts';
 import {
+	CoderCreateAgentBuilderSessionRequestSchema,
 	CoderCreateSessionRequestSchema,
 	CoderListSessionsParamsSchema,
 	CoderSessionListResponseSchema,
 	CoderSessionListItemSchema,
 	CoderSessionSchema,
 	CoderUpdateSessionRequestSchema,
+	type CoderCreateAgentBuilderSessionRequest,
 	type CoderCreateSessionRequest,
 	type CoderListSessionsParams,
 	type CoderSession,
@@ -45,6 +47,18 @@ export const CoderCreateSessionParamsSchema = z
 	})
 	.describe('Parameters for creating a coder session');
 export type CoderCreateSessionParams = z.infer<typeof CoderCreateSessionParamsSchema>;
+
+export const CoderCreateAgentBuilderSessionParamsSchema = z
+	.object({
+		body: CoderCreateAgentBuilderSessionRequestSchema.describe(
+			'Create-agent-builder-session request body'
+		),
+		orgId: z.string().optional().describe('Optional org id for CLI auth context'),
+	})
+	.describe('Parameters for creating an agent-builder session');
+export type CoderCreateAgentBuilderSessionParams = z.infer<
+	typeof CoderCreateAgentBuilderSessionParamsSchema
+>;
 
 export const CoderGetSessionParamsSchema = CoderSessionIdParamsSchema.describe(
 	'Parameters for retrieving a coder session'
@@ -139,6 +153,18 @@ export async function coderCreateSession(
 		params.body,
 		CoderCreateSessionResponseSchema,
 		CoderCreateSessionRequestSchema
+	);
+}
+
+export async function coderCreateAgentBuilderSession(
+	client: APIClient,
+	params: CoderCreateAgentBuilderSessionParams
+): Promise<CoderCreateSessionResponse> {
+	return client.post<CoderCreateSessionResponse, CoderCreateAgentBuilderSessionRequest>(
+		'/hub/session/builder',
+		params.body,
+		CoderCreateSessionResponseSchema,
+		CoderCreateAgentBuilderSessionRequestSchema
 	);
 }
 

--- a/packages/core/src/services/coder/types.ts
+++ b/packages/core/src/services/coder/types.ts
@@ -520,6 +520,33 @@ export const CoderCreateSessionRequestSchema = z
 	.describe('Request body for creating a coder session');
 export type CoderCreateSessionRequest = z.infer<typeof CoderCreateSessionRequestSchema>;
 
+export const CoderCreateAgentBuilderSessionRequestSchema = z
+	.object({
+		label: z.string().optional().describe('Builder session label override'),
+		prompt: z.string().optional().describe('Optional user focus for the builder session kickoff'),
+		mode: z
+			.enum(['new', 'edit', 'from_session'])
+			.optional()
+			.describe('Builder launch mode override'),
+		visibility: CoderSessionVisibilitySchema.optional().describe('Builder session visibility'),
+		sourceSessionId: z
+			.string()
+			.optional()
+			.describe('Source session identifier for build-from-session launches'),
+		targetAgentId: z
+			.string()
+			.optional()
+			.describe('Target custom-agent identifier for edit launches'),
+		targetAgentSlug: z
+			.string()
+			.optional()
+			.describe('Target custom-agent slug for edit launches'),
+	})
+	.describe('Request body for creating an agent-builder session');
+export type CoderCreateAgentBuilderSessionRequest = z.infer<
+	typeof CoderCreateAgentBuilderSessionRequestSchema
+>;
+
 export const CoderUpdateSessionRequestSchema = z
 	.object({
 		label: z.string().optional().describe('Updated session label'),
@@ -573,6 +600,130 @@ export const CoderSessionWorkspaceSchema = z
 	})
 	.describe('Workspace associated with a coder session');
 export type CoderSessionWorkspace = z.infer<typeof CoderSessionWorkspaceSchema>;
+
+export const CoderAgentBuilderSessionModeSchema = z
+	.enum(['new', 'edit', 'from_session'])
+	.describe('Agent-builder launch mode for a builder session');
+export type CoderAgentBuilderSessionMode = z.infer<typeof CoderAgentBuilderSessionModeSchema>;
+
+export const CoderAgentBuilderActionKindSchema = z
+	.enum(['create_draft', 'update_draft', 'publish'])
+	.describe('Durable builder action emitted by an agent-builder session');
+export type CoderAgentBuilderActionKind = z.infer<typeof CoderAgentBuilderActionKindSchema>;
+
+export const CoderAgentBuilderSourceSessionSchema = z
+	.object({
+		sessionId: z.string().describe('Source session identifier linked to the builder session'),
+		label: z.string().optional().describe('Source session label when available'),
+	})
+	.describe('Source session reference used by agent-builder flows');
+export type CoderAgentBuilderSourceSession = z.infer<typeof CoderAgentBuilderSourceSessionSchema>;
+
+export const CoderAgentBuilderTargetAgentSchema = z
+	.object({
+		agentId: z.string().optional().describe('Target custom-agent identifier when editing'),
+		slug: z.string().describe('Target custom-agent slug'),
+		displayName: z.string().optional().describe('Target custom-agent display name'),
+	})
+	.describe('Target custom-agent reference for agent-builder edit flows');
+export type CoderAgentBuilderTargetAgent = z.infer<typeof CoderAgentBuilderTargetAgentSchema>;
+
+export const CoderAgentBuilderProposalSchema = z
+	.object({
+		slug: z.string().optional().describe('Proposed custom-agent slug'),
+		displayName: z.string().optional().describe('Proposed custom-agent name'),
+		description: z.string().optional().describe('Proposed custom-agent description'),
+		instructions: z.string().optional().describe('Proposed custom-agent system prompt'),
+		model: z.string().optional().describe('Proposed model override'),
+		thinkingLevel: CoderCustomAgentThinkingLevelSchema.optional().describe(
+			'Proposed thinking level override'
+		),
+		headlessCompatible: z
+			.boolean()
+			.optional()
+			.describe('Whether the proposed agent is safe for non-interactive callers'),
+		tools: z
+			.array(CoderCustomAgentToolResponseSchema)
+			.default([])
+			.describe('Proposed workspace tools for the agent'),
+		serviceTools: z
+			.array(CoderCustomAgentServiceToolResponseSchema)
+			.default([])
+			.describe('Proposed service tools for the agent'),
+		savedSkills: z
+			.array(CoderSkillRefSchema)
+			.default([])
+			.describe('Proposed frozen skill refs to attach'),
+		companionAgents: z
+			.array(z.string())
+			.default([])
+			.describe('Proposed companion agents to auto-include'),
+	})
+	.passthrough()
+	.describe('Session-scoped agent-builder proposal state');
+export type CoderAgentBuilderProposal = z.infer<typeof CoderAgentBuilderProposalSchema>;
+
+export const CoderAgentBuilderDurableStateSchema = z
+	.object({
+		draftAgentId: z.string().optional().describe('Linked draft custom-agent identifier'),
+		draftAgentSlug: z.string().optional().describe('Linked draft custom-agent slug'),
+		lastPublishedVersion: z
+			.number()
+			.int()
+			.optional()
+			.describe('Latest published version created through the builder flow'),
+	})
+	.describe('Durable agent-library state associated with a builder session');
+export type CoderAgentBuilderDurableState = z.infer<typeof CoderAgentBuilderDurableStateSchema>;
+
+export const CoderAgentBuilderActionStateSchema = z
+	.object({
+		kind: CoderAgentBuilderActionKindSchema.describe('Last durable builder action'),
+		status: z
+			.enum(['completed', 'failed'])
+			.describe('Result of the last durable builder action'),
+		occurredAt: z.string().describe('Timestamp of the last durable builder action'),
+		message: z.string().optional().describe('Human-readable builder action result summary'),
+		agentId: z.string().optional().describe('Affected custom-agent identifier'),
+		agentSlug: z.string().optional().describe('Affected custom-agent slug'),
+		publishedVersion: z
+			.number()
+			.int()
+			.optional()
+			.describe('Published version number when publish succeeded'),
+	})
+	.describe('Latest durable action emitted by a builder session');
+export type CoderAgentBuilderActionState = z.infer<typeof CoderAgentBuilderActionStateSchema>;
+
+export const CoderAgentBuilderSessionSummarySchema = z
+	.object({
+		mode: CoderAgentBuilderSessionModeSchema.describe('Builder session mode'),
+		sourceSession: CoderAgentBuilderSourceSessionSchema.optional().describe(
+			'Linked source session when the builder was launched from an existing session'
+		),
+		targetAgent: CoderAgentBuilderTargetAgentSchema.optional().describe(
+			'Target agent baseline when the builder is editing an existing custom agent'
+		),
+		durable: CoderAgentBuilderDurableStateSchema.optional().describe(
+			'Linked durable draft/publish state'
+		),
+		lastAction: CoderAgentBuilderActionStateSchema.optional().describe(
+			'Most recent durable builder action'
+		),
+	})
+	.describe('Projected builder-session summary returned in session listings');
+export type CoderAgentBuilderSessionSummary = z.infer<
+	typeof CoderAgentBuilderSessionSummarySchema
+>;
+
+export const CoderAgentBuilderSessionStateSchema = CoderAgentBuilderSessionSummarySchema.extend({
+	proposal: CoderAgentBuilderProposalSchema.optional().describe(
+		'Full builder proposal state projected in session detail responses'
+	),
+})
+	.passthrough()
+	.describe('Full builder-session state returned in session details');
+export type CoderAgentBuilderSessionState = z.infer<typeof CoderAgentBuilderSessionStateSchema>;
 
 export const CoderSessionListItemSchema = z
 	.object({
@@ -650,6 +801,9 @@ export const CoderSessionSchema = CoderSessionListItemSchema.extend({
 		.string()
 		.optional()
 		.describe('Last update timestamp for session metadata (ISO-8601)'),
+	builder: CoderAgentBuilderSessionStateSchema.optional().describe(
+		'Full builder-session state when this session is an agent-builder flow'
+	),
 	// These fields are present in list items but may be absent in detail responses
 	lastActivityAt: z.string().optional().describe('Timestamp of most recent activity (ISO-8601)'),
 	taskCount: z.number().optional().describe('Number of tasks associated with the session'),

--- a/packages/core/src/services/coder/types.ts
+++ b/packages/core/src/services/coder/types.ts
@@ -520,6 +520,18 @@ export const CoderCreateSessionRequestSchema = z
 	.describe('Request body for creating a coder session');
 export type CoderCreateSessionRequest = z.infer<typeof CoderCreateSessionRequestSchema>;
 
+function inferCoderAgentBuilderSessionMode(input: {
+	mode?: 'new' | 'edit' | 'from_session';
+	sourceSessionId?: string;
+	targetAgentId?: string;
+	targetAgentSlug?: string;
+}): 'new' | 'edit' | 'from_session' {
+	if (input.mode) return input.mode;
+	if (input.sourceSessionId) return 'from_session';
+	if (input.targetAgentId || input.targetAgentSlug) return 'edit';
+	return 'new';
+}
+
 export const CoderCreateAgentBuilderSessionRequestSchema = z
 	.object({
 		label: z.string().optional().describe('Builder session label override'),
@@ -537,10 +549,24 @@ export const CoderCreateAgentBuilderSessionRequestSchema = z
 			.string()
 			.optional()
 			.describe('Target custom-agent identifier for edit launches'),
-		targetAgentSlug: z
-			.string()
-			.optional()
-			.describe('Target custom-agent slug for edit launches'),
+		targetAgentSlug: z.string().optional().describe('Target custom-agent slug for edit launches'),
+	})
+	.superRefine((value, ctx) => {
+		const mode = inferCoderAgentBuilderSessionMode(value);
+		if (mode === 'from_session' && !value.sourceSessionId?.trim()) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ['sourceSessionId'],
+				message: 'sourceSessionId is required for from-session builder launches.',
+			});
+		}
+		if (mode === 'edit' && !value.targetAgentId?.trim() && !value.targetAgentSlug?.trim()) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ['targetAgentId'],
+				message: 'targetAgentId or targetAgentSlug is required for edit launches.',
+			});
+		}
 	})
 	.describe('Request body for creating an agent-builder session');
 export type CoderCreateAgentBuilderSessionRequest = z.infer<
@@ -679,9 +705,7 @@ export type CoderAgentBuilderDurableState = z.infer<typeof CoderAgentBuilderDura
 export const CoderAgentBuilderActionStateSchema = z
 	.object({
 		kind: CoderAgentBuilderActionKindSchema.describe('Last durable builder action'),
-		status: z
-			.enum(['completed', 'failed'])
-			.describe('Result of the last durable builder action'),
+		status: z.enum(['completed', 'failed']).describe('Result of the last durable builder action'),
 		occurredAt: z.string().describe('Timestamp of the last durable builder action'),
 		message: z.string().optional().describe('Human-readable builder action result summary'),
 		agentId: z.string().optional().describe('Affected custom-agent identifier'),
@@ -712,9 +736,7 @@ export const CoderAgentBuilderSessionSummarySchema = z
 		),
 	})
 	.describe('Projected builder-session summary returned in session listings');
-export type CoderAgentBuilderSessionSummary = z.infer<
-	typeof CoderAgentBuilderSessionSummarySchema
->;
+export type CoderAgentBuilderSessionSummary = z.infer<typeof CoderAgentBuilderSessionSummarySchema>;
 
 export const CoderAgentBuilderSessionStateSchema = CoderAgentBuilderSessionSummarySchema.extend({
 	proposal: CoderAgentBuilderProposalSchema.optional().describe(
@@ -770,6 +792,9 @@ export const CoderSessionListItemSchema = z
 			.optional()
 			.default([])
 			.describe('Enabled agent roster attached to the session'),
+		builder: CoderAgentBuilderSessionSummarySchema.optional().describe(
+			'Projected builder-session summary when this session is an agent-builder flow'
+		),
 		defaultAgent: z.string().optional().describe('Default agent assigned to session operations'),
 		bucket: CoderSessionBucketSchema.describe('Derived bucket for session listing'),
 		runtimeAvailable: z.boolean().describe('Whether runtime is currently reachable'),

--- a/packages/core/test/coder-client.test.ts
+++ b/packages/core/test/coder-client.test.ts
@@ -2,7 +2,10 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mockFetch } from '@agentuity/test-utils';
 import { CoderClient } from '../src/services/coder/client.ts';
 import { APIError, ValidationInputError } from '../src/services/api.ts';
-import { CoderCreateWorkspaceRequestSchema } from '../src/services/coder/types.ts';
+import {
+	CoderCreateAgentBuilderSessionRequestSchema,
+	CoderCreateWorkspaceRequestSchema,
+} from '../src/services/coder/types.ts';
 
 const ORIGINAL_FETCH = globalThis.fetch;
 
@@ -858,6 +861,65 @@ describe('CoderClient agent-builder helpers', () => {
 		});
 	});
 
+	test('createAgentBuilderSession rejects invalid mode-specific payloads before sending', async () => {
+		let fetchCalled = false;
+		mockFetch(async () => {
+			fetchCalled = true;
+			throw new Error('fetch should not be called for invalid builder payloads');
+		});
+
+		const client = new CoderClient({
+			apiKey: 'ag_test',
+			url: 'https://coder.example',
+			orgId: 'org_test',
+		});
+
+		const missingSource = CoderCreateAgentBuilderSessionRequestSchema.safeParse({
+			mode: 'from_session',
+		});
+		expect(missingSource.success).toBe(false);
+		if (missingSource.success) throw new Error('Expected missingSource to fail validation');
+		expect(missingSource.error.issues).toContainEqual(
+			expect.objectContaining({
+				path: ['sourceSessionId'],
+				message: 'sourceSessionId is required for from-session builder launches.',
+			})
+		);
+
+		const missingTarget = CoderCreateAgentBuilderSessionRequestSchema.safeParse({
+			mode: 'edit',
+		});
+		expect(missingTarget.success).toBe(false);
+		if (missingTarget.success) throw new Error('Expected missingTarget to fail validation');
+		expect(missingTarget.error.issues).toContainEqual(
+			expect.objectContaining({
+				path: ['targetAgentId'],
+				message: 'targetAgentId or targetAgentSlug is required for edit launches.',
+			})
+		);
+
+		expect(
+			CoderCreateAgentBuilderSessionRequestSchema.safeParse({
+				mode: 'new',
+				targetAgentId: 'agt_123',
+			}).success
+		).toBe(true);
+
+		await expect(
+			client.createAgentBuilderSession({
+				mode: 'from_session',
+			})
+		).rejects.toThrow('There was an error validating the API input data.');
+
+		await expect(
+			client.createAgentBuilderSession({
+				mode: 'edit',
+			})
+		).rejects.toThrow('There was an error validating the API input data.');
+
+		expect(fetchCalled).toBe(false);
+	});
+
 	test('session payloads preserve builder detail projections from the backend', async () => {
 		let getCount = 0;
 
@@ -950,6 +1012,13 @@ describe('CoderClient agent-builder helpers', () => {
 
 		const sessions = await client.listSessions();
 		expect(sessions.sessions[0]?.sessionKind).toBe('agent_builder');
+		expect(sessions.sessions[0]?.builder).toEqual({
+			mode: 'from_session',
+			sourceSession: {
+				sessionId: 'codesess_source_1',
+				label: 'Recurring triage',
+			},
+		});
 		expect(getCount).toBe(1);
 	});
 });

--- a/packages/core/test/coder-client.test.ts
+++ b/packages/core/test/coder-client.test.ts
@@ -811,3 +811,145 @@ describe('CoderClient custom agent helpers', () => {
 		});
 	});
 });
+
+describe('CoderClient agent-builder helpers', () => {
+	beforeEach(() => {
+		globalThis.fetch = ORIGINAL_FETCH;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = ORIGINAL_FETCH;
+	});
+
+	test('createAgentBuilderSession posts to the builder-session endpoint', async () => {
+		mockFetch(async (url, init) => {
+			expect(url).toBe('https://coder.example/api/hub/session/builder');
+			expect(init?.method).toBe('POST');
+			expect(init?.body).toContain('"mode":"from_session"');
+			expect(init?.body).toContain('"sourceSessionId":"codesess_source_1"');
+			return new Response(
+				JSON.stringify({
+					sessionId: 'codesess_builder_1',
+					status: 'creating',
+					visibility: 'private',
+				}),
+				{
+					status: 201,
+					headers: { 'content-type': 'application/json' },
+				}
+			);
+		});
+
+		const client = new CoderClient({
+			apiKey: 'ag_test',
+			url: 'https://coder.example',
+			orgId: 'org_test',
+		});
+
+		await expect(
+			client.createAgentBuilderSession({
+				mode: 'from_session',
+				sourceSessionId: 'codesess_source_1',
+				label: 'Build from release triage',
+			})
+		).resolves.toMatchObject({
+			sessionId: 'codesess_builder_1',
+			status: 'creating',
+		});
+	});
+
+	test('session payloads preserve builder detail projections from the backend', async () => {
+		let getCount = 0;
+
+		mockFetch(async (url, init) => {
+			if (url === 'https://coder.example/api/hub/session/codesess_builder_1') {
+				getCount += 1;
+				return new Response(
+					JSON.stringify(
+						makeSession({
+							sessionId: 'codesess_builder_1',
+							sessionKind: 'agent_builder',
+							builder: {
+								mode: 'edit',
+								targetAgent: {
+									agentId: 'agt_123',
+									slug: 'qa-team',
+									displayName: 'QA Team',
+								},
+								proposal: {
+									displayName: 'QA Team',
+									tools: ['read', 'grep'],
+									serviceTools: ['session_dashboard'],
+									savedSkills: [],
+									companionAgents: ['reviewer'],
+								},
+							},
+						})
+					),
+					{
+						status: 200,
+						headers: { 'content-type': 'application/json' },
+					}
+				);
+			}
+
+			if (url === 'https://coder.example/api/hub/sessions') {
+				return new Response(
+					JSON.stringify({
+						sessions: {
+							websocket: [
+								makeSession({
+									sessionId: 'codesess_builder_1',
+									sessionKind: 'agent_builder',
+									builder: {
+										mode: 'from_session',
+										sourceSession: {
+											sessionId: 'codesess_source_1',
+											label: 'Recurring triage',
+										},
+									},
+								}),
+							],
+							sandbox: [],
+						},
+						total: 1,
+					}),
+					{
+						status: 200,
+						headers: { 'content-type': 'application/json' },
+					}
+				);
+			}
+
+			throw new Error(`Unexpected request: ${init?.method ?? 'GET'} ${url}`);
+		});
+
+		const client = new CoderClient({
+			apiKey: 'ag_test',
+			url: 'https://coder.example',
+			orgId: 'org_test',
+		});
+
+		const detail = await client.getSession('codesess_builder_1');
+		expect(detail.builder).toEqual(
+			expect.objectContaining({
+				mode: 'edit',
+				targetAgent: {
+					agentId: 'agt_123',
+					slug: 'qa-team',
+					displayName: 'QA Team',
+				},
+				proposal: expect.objectContaining({
+					displayName: 'QA Team',
+					tools: ['read', 'grep'],
+					serviceTools: ['session_dashboard'],
+					companionAgents: ['reviewer'],
+				}),
+			})
+		);
+
+		const sessions = await client.listSessions();
+		expect(sessions.sessions[0]?.sessionKind).toBe('agent_builder');
+		expect(getCount).toBe(1);
+	});
+});


### PR DESCRIPTION
## Summary
- add the core SDK surface for `POST /hub/session/builder`
- add agent-builder request/detail/list schemas, including preserving `builder` on session list items
- align SDK validation with the current Hub request semantics for builder launches
- add client tests for create flow, validation, detail projections, and list projections

## Why
This replaces the stale work in #1371 with a fresh branch from current `main`.

## Related
- Complements agentuity/coder#36
- Supersedes #1371

## Validation
- `bun test packages/core/test/coder-client.test.ts`
- `bun run --filter='@agentuity/core' typecheck`
- `bun run --filter='@agentuity/coder-tui' typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added agent builder session creation functionality via new API endpoint and client method.
  * Sessions can be created from existing sessions or based on target agents with optional organization parameter support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->