### PR TITLE
fix(cli): pass actual front-door proxy port to gravity

### DIFF
--- a/packages/cli/src/cmd/dev/index.ts
+++ b/packages/cli/src/cmd/dev/index.ts
@@ -971,6 +971,15 @@ export const command = createCommand({
 					return;
 				}
 
+				// Gravity must target the user-facing front-door proxy port.
+				// The front-door proxy (ws-proxy) is the only server that correctly
+				// routes public WebSocket upgrades to /api/* through to the Bun backend.
+				// We read the actual bound port from the front-door server to avoid any
+				// mismatch with opts.port (e.g. if the port was overridden or shifted).
+				const frontDoorPort =
+					(frontDoorServer?.address() as import('node:net').AddressInfo | null)?.port ??
+					opts.port;
+
 				try {
 					gravityProcess = Bun.spawn(
 						[
@@ -978,10 +987,7 @@ export const command = createCommand({
 							'--endpoint-id',
 							devmode.id,
 							'--port',
-							// Gravity must target the user-facing front-door proxy, not Vite's
-							// internal port. HTTP can reach Bun through Vite's proxy, but public
-							// WebSocket upgrades to /api/* only reach Bun through ws-proxy.
-							opts.port.toString(),
+							frontDoorPort.toString(),
 							'--url',
 							gravityURL,
 							'--log-level',
@@ -999,8 +1005,16 @@ export const command = createCommand({
 							stdout: 'pipe',
 							stderr: 'pipe',
 							detached: false,
+							// Pass a clean env without PORT to prevent the inherited
+							// PORT (set to bunBackendPort) from leaking into gravity.
+							env: {
+								...process.env,
+								PORT: undefined,
+							},
 						}
 					);
+
+					logger.debug('Gravity tunnel targeting front-door proxy on port %d', frontDoorPort);
 
 					const gravityPid = (gravityProcess as { pid?: number }).pid;
 					if (gravityPid) {


### PR DESCRIPTION
## Problem

Gravity was sometimes connecting to the wrong port during devmode. Two issues:

1. **`opts.port` vs actual bound port** — The gravity spawn used `opts.port` directly, but if the front-door proxy ended up on a different port, gravity would target the wrong place.

2. **`PORT` env var leaking** — Before spawning gravity, the CLI sets `process.env.PORT = bunBackendPort` (which is `opts.port + 1`). Since `Bun.spawn` inherits the parent's environment by default, gravity received `PORT=3501` in its env.

## Fix

- Read the actual bound port from `frontDoorServer.address().port` instead of relying on `opts.port`
- Strip `PORT` from gravity's inherited environment to prevent the backend port from leaking
- Added debug logging to trace which port gravity is targeting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected port configuration for the gravity tunnel to use the actual bound server port instead of a potentially incorrect fallback value.
  * Resolved an environment variable inheritance issue that could prevent the gravity tunnel from targeting the correct server port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->