### PR TITLE
feat(cli): add --quiet flag and auto-detect stream optimization

### DIFF
--- a/packages/cli/src/cmd/cloud/sandbox/exec.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/exec.ts
@@ -3,7 +3,7 @@ import { Writable } from 'node:stream';
 import { ErrorCode } from '../../../errors';
 import { createCommand } from '../../../types';
 import * as tui from '../../../tui';
-import { createSandboxClient } from './util';
+import { createSandboxClient, detectNullStream } from './util';
 import { getCommand } from '../../../command-prefix';
 import { sandboxExecute, executionGet, sandboxResolve } from '@agentuity/server';
 import { streamUrlToWritable } from '../../../utils/stream-url';
@@ -63,6 +63,11 @@ export const execSubcommand = createCommand({
 				.default(false)
 				.optional()
 				.describe('Include timestamps in output (default: false)'),
+			quiet: z
+				.boolean()
+				.default(false)
+				.optional()
+				.describe('Suppress output (do not create stdout/stderr streams)'),
 		}),
 		response: SandboxExecResponseSchema,
 	},
@@ -85,6 +90,33 @@ export const execSubcommand = createCommand({
 		const client = createSandboxClient(logger, auth, region);
 		const started = Date.now();
 
+		// Detect if stdout/stderr are redirected to /dev/null
+		const stdoutIsNull = detectNullStream(1);
+		const stderrIsNull = detectNullStream(2);
+
+		// Build stream configuration
+		const streamConfig: {
+			timestamps?: boolean;
+			stdout?: string;
+			stderr?: string;
+		} = {
+			timestamps: opts.timestamps,
+		};
+
+		// --quiet: suppress all output streams
+		if (opts.quiet) {
+			streamConfig.stdout = 'ignore';
+			streamConfig.stderr = 'ignore';
+		} else {
+			// Auto-detect /dev/null redirection
+			if (stdoutIsNull) {
+				streamConfig.stdout = 'ignore';
+			}
+			if (stderrIsNull) {
+				streamConfig.stderr = 'ignore';
+			}
+		}
+
 		const abortController = new AbortController();
 		const handleSignal = () => {
 			abortController.abort();
@@ -100,7 +132,7 @@ export const execSubcommand = createCommand({
 				options: {
 					command: args.command,
 					timeout: opts.timeout,
-					stream: opts.timestamps !== undefined ? { timestamps: opts.timestamps } : undefined,
+					stream: streamConfig,
 				},
 				orgId,
 			});
@@ -135,27 +167,20 @@ export const execSubcommand = createCommand({
 			const stdoutChunks: string[] = [];
 			const stderrChunks: string[] = [];
 
-			let stdoutWritable: NodeJS.WritableStream;
-			let stderrWritable: NodeJS.WritableStream;
-
-			if (options.json) {
-				if (isCombinedOutput) {
-					stdoutWritable = createCaptureStream((chunk) => outputChunks.push(chunk));
-					stderrWritable = createCaptureStream((chunk) => outputChunks.push(chunk));
-				} else {
-					stdoutWritable = createCaptureStream((chunk) => {
-						stdoutChunks.push(chunk);
-						outputChunks.push(chunk);
-					});
-					stderrWritable = createCaptureStream((chunk) => {
-						stderrChunks.push(chunk);
-						outputChunks.push(chunk);
-					});
-				}
-			} else {
-				stdoutWritable = process.stdout;
-				stderrWritable = process.stderr;
-			}
+			const stdoutWritable: NodeJS.WritableStream =
+				options.json || stdoutIsNull
+					? createCaptureStream((chunk) => {
+							stdoutChunks.push(chunk);
+							outputChunks.push(chunk);
+						})
+					: process.stdout;
+			const stderrWritable: NodeJS.WritableStream =
+				options.json || stderrIsNull
+					? createCaptureStream((chunk) => {
+							stderrChunks.push(chunk);
+							outputChunks.push(chunk);
+						})
+					: process.stderr;
 
 			if (isCombinedOutput) {
 				logger.debug('[exec] starting combined stream: %s', stdoutStreamUrl);

--- a/packages/cli/src/cmd/cloud/sandbox/exec.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/exec.ts
@@ -103,12 +103,13 @@ export const execSubcommand = createCommand({
 			timestamps: opts.timestamps,
 		};
 
-		// --quiet: suppress all output streams
+		// --quiet: suppress all output streams (no server streams, no local capture)
 		if (opts.quiet) {
 			streamConfig.stdout = 'ignore';
 			streamConfig.stderr = 'ignore';
-		} else {
-			// Auto-detect /dev/null redirection
+		} else if (!options.json) {
+			// Auto-detect /dev/null redirection (only when not in JSON mode)
+			// In JSON mode we need output for the response, so keep streams even if redirected
 			if (stdoutIsNull) {
 				streamConfig.stdout = 'ignore';
 			}

--- a/packages/cli/src/cmd/cloud/sandbox/run.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/run.ts
@@ -2,12 +2,11 @@ import { z } from 'zod';
 import { Writable } from 'node:stream';
 import { createCommand } from '../../../types';
 import * as tui from '../../../tui';
-import { createSandboxClient, parseFileArgs, cacheSandboxRegion } from './util';
+import { createSandboxClient, parseFileArgs, cacheSandboxRegion, detectNullStream } from './util';
 import { getCommand } from '../../../command-prefix';
 import { sandboxRun } from '@agentuity/server';
 import { validateAptDependencies } from '../../../utils/apt-validator';
 import { ErrorCode } from '../../../errors';
-import { fstatSync, statSync } from 'node:fs';
 
 const SandboxRunResponseSchema = z.object({
 	sandboxId: z.string().describe('Sandbox ID'),
@@ -15,17 +14,6 @@ const SandboxRunResponseSchema = z.object({
 	durationMs: z.number().describe('Duration in milliseconds'),
 	output: z.string().optional().describe('Combined stdout/stderr output'),
 });
-
-function detectNullStream(fd: number): boolean {
-	try {
-		const fdStat = fstatSync(fd);
-		const nullPath = process.platform === 'win32' ? 'NUL' : '/dev/null';
-		const nullStat = statSync(nullPath);
-		return fdStat.dev === nullStat.dev && fdStat.ino === nullStat.ino;
-	} catch {
-		return false;
-	}
-}
 
 export const runSubcommand = createCommand({
 	name: 'run',

--- a/packages/cli/src/cmd/cloud/sandbox/run.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/run.ts
@@ -170,12 +170,13 @@ export const runSubcommand = createCommand({
 			stdin: hasStdin ? undefined : 'ignore',
 		};
 
-		// --quiet: suppress all output streams
+		// --quiet: suppress all output streams (no server streams, no local capture)
 		if (opts.quiet) {
 			streamConfig.stdout = 'ignore';
 			streamConfig.stderr = 'ignore';
-		} else {
-			// Auto-detect /dev/null redirection
+		} else if (!options.json) {
+			// Auto-detect /dev/null redirection (only when not in JSON mode)
+			// In JSON mode we need output for the response, so keep streams even if redirected
 			if (stdoutIsNull) {
 				streamConfig.stdout = 'ignore';
 			}

--- a/packages/cli/src/cmd/cloud/sandbox/run.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/run.ts
@@ -7,6 +7,7 @@ import { getCommand } from '../../../command-prefix';
 import { sandboxRun } from '@agentuity/server';
 import { validateAptDependencies } from '../../../utils/apt-validator';
 import { ErrorCode } from '../../../errors';
+import { fstatSync, statSync } from 'node:fs';
 
 const SandboxRunResponseSchema = z.object({
 	sandboxId: z.string().describe('Sandbox ID'),
@@ -14,6 +15,17 @@ const SandboxRunResponseSchema = z.object({
 	durationMs: z.number().describe('Duration in milliseconds'),
 	output: z.string().optional().describe('Combined stdout/stderr output'),
 });
+
+function detectNullStream(fd: number): boolean {
+	try {
+		const fdStat = fstatSync(fd);
+		const nullPath = process.platform === 'win32' ? 'NUL' : '/dev/null';
+		const nullStat = statSync(nullPath);
+		return fdStat.dev === nullStat.dev && fdStat.ino === nullStat.ino;
+	} catch {
+		return false;
+	}
+}
 
 export const runSubcommand = createCommand({
 	name: 'run',
@@ -59,6 +71,11 @@ export const runSubcommand = createCommand({
 				.default(false)
 				.optional()
 				.describe('Include timestamps in output (default: true)'),
+			quiet: z
+				.boolean()
+				.default(false)
+				.optional()
+				.describe('Suppress output (do not create stdout/stderr streams)'),
 			snapshot: z.string().optional().describe('Snapshot ID or tag to restore from'),
 			dependency: z
 				.array(z.string())
@@ -149,13 +166,45 @@ export const runSubcommand = createCommand({
 		// Determine if we have stdin data (not a TTY means piped input)
 		const hasStdin = !process.stdin.isTTY;
 
-		// For JSON output, we need to capture output instead of streaming to process
-		const stdout = options.json
-			? createCaptureStream((chunk) => outputChunks.push(chunk))
-			: process.stdout;
-		const stderr = options.json
-			? createCaptureStream((chunk) => outputChunks.push(chunk))
-			: process.stderr;
+		// Detect if stdout/stderr are redirected to /dev/null
+		const stdoutIsNull = detectNullStream(1);
+		const stderrIsNull = detectNullStream(2);
+
+		// Detect stream configuration based on TTY status and flags
+		const streamConfig: {
+			timestamps?: boolean;
+			stdin?: string;
+			stdout?: string;
+			stderr?: string;
+		} = {
+			timestamps: opts.timestamps,
+			// Skip stdin stream when no stdin data available
+			stdin: hasStdin ? undefined : 'ignore',
+		};
+
+		// --quiet: suppress all output streams
+		if (opts.quiet) {
+			streamConfig.stdout = 'ignore';
+			streamConfig.stderr = 'ignore';
+		} else {
+			// Auto-detect /dev/null redirection
+			if (stdoutIsNull) {
+				streamConfig.stdout = 'ignore';
+			}
+			if (stderrIsNull) {
+				streamConfig.stderr = 'ignore';
+			}
+		}
+
+		// For JSON output or quiet mode, we need to capture output instead of streaming to process
+		const stdout =
+			options.json || opts.quiet || stdoutIsNull
+				? createCaptureStream((chunk) => outputChunks.push(chunk))
+				: process.stdout;
+		const stderr =
+			options.json || opts.quiet || stderrIsNull
+				? createCaptureStream((chunk) => outputChunks.push(chunk))
+				: process.stderr;
 
 		try {
 			const result = await sandboxRun(client, {
@@ -180,7 +229,7 @@ export const runSubcommand = createCommand({
 					network: opts.network ? { enabled: true } : undefined,
 					timeout: opts.timeout ? { execution: opts.timeout } : undefined,
 					env: Object.keys(envMap).length > 0 ? envMap : undefined,
-					stream: opts.timestamps !== undefined ? { timestamps: opts.timestamps } : undefined,
+					stream: streamConfig,
 					snapshot: opts.snapshot,
 					dependencies: opts.dependency,
 					scopes: opts.scope,

--- a/packages/cli/src/cmd/cloud/sandbox/util.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/util.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { fstatSync, readFileSync, statSync } from 'node:fs';
 import { resolve } from 'node:path';
 import type { FileToWrite, Logger } from '@agentuity/core';
 import { APIClient, getServiceUrls, sandboxGet } from '@agentuity/server';
@@ -7,6 +7,25 @@ import { getGlobalCatalystAPIClient } from '../../../config';
 import { ErrorCode } from '../../../errors';
 import * as tui from '../../../tui';
 import type { AuthData, Config } from '../../../types';
+
+/**
+ * Detect if a file descriptor is redirected to /dev/null (or NUL on Windows).
+ * Used to optimize stream creation - when output goes to /dev/null, we can
+ * skip creating the stream entirely on the server.
+ *
+ * @param fd - File descriptor (1 for stdout, 2 for stderr)
+ * @returns true if the fd points to /dev/null
+ */
+export function detectNullStream(fd: number): boolean {
+	try {
+		const fdStat = fstatSync(fd);
+		const nullPath = process.platform === 'win32' ? 'NUL' : '/dev/null';
+		const nullStat = statSync(nullPath);
+		return fdStat.dev === nullStat.dev && fdStat.ino === nullStat.ino;
+	} catch {
+		return false;
+	}
+}
 
 export function createSandboxClient(logger: Logger, auth: AuthData, region: string): APIClient {
 	return new APIClient(getServiceUrls(region).catalyst, logger, auth.apiKey);

--- a/packages/core/src/services/sandbox/run.ts
+++ b/packages/core/src/services/sandbox/run.ts
@@ -75,11 +75,16 @@ export async function sandboxRun(
 
 	// Handle stdin stream configuration:
 	// - If stdin is "ignore", pass it through to skip stdin handling on server
+	// - If stdin is an explicit stream ID, use it directly
 	// - If stdin readable is provided, create a stream for it
 	const stdinConfig = options.stream?.stdin;
 	if (stdinConfig === 'ignore') {
 		stdinStreamId = 'ignore';
 		logger?.debug('stdin explicitly ignored');
+	} else if (stdinConfig && stdinConfig !== 'ignore') {
+		// User provided an explicit stream ID
+		stdinStreamId = stdinConfig;
+		logger?.debug('using provided stdin stream ID: %s', stdinStreamId);
 	} else if (stdin && region && apiKey) {
 		const streamResult = await createStdinStream(region, apiKey, orgId, logger);
 		stdinStreamId = streamResult.id;

--- a/packages/core/src/services/sandbox/run.ts
+++ b/packages/core/src/services/sandbox/run.ts
@@ -73,8 +73,14 @@ export async function sandboxRun(
 	let stdinStreamId: string | undefined;
 	let stdinStreamUrl: string | undefined;
 
-	// If stdin is provided and has data, create a stream for it
-	if (stdin && region && apiKey) {
+	// Handle stdin stream configuration:
+	// - If stdin is "ignore", pass it through to skip stdin handling on server
+	// - If stdin readable is provided, create a stream for it
+	const stdinConfig = options.stream?.stdin;
+	if (stdinConfig === 'ignore') {
+		stdinStreamId = 'ignore';
+		logger?.debug('stdin explicitly ignored');
+	} else if (stdin && region && apiKey) {
 		const streamResult = await createStdinStream(region, apiKey, orgId, logger);
 		stdinStreamId = streamResult.id;
 		stdinStreamUrl = streamResult.url;


### PR DESCRIPTION
## Summary

- Add `--quiet` flag to `cloud sandbox run` to suppress stdout/stderr streams
- Auto-detect when stdin is not connected (TTY) and pass `stdin: "ignore"` 
- Auto-detect when stdout/stderr are redirected to `/dev/null` and pass `"ignore"`
- Pass stream config to server for resource optimization

When streams are redirected to `/dev/null`, the CLI now signals the server to skip creating those streams entirely, saving resources on the backend.

## Usage Examples

```bash
# No stdin (TTY detected) - stdin stream skipped
agentuity cloud sandbox run -- echo "hello"

# Quiet mode - no output streams created  
agentuity cloud sandbox run --quiet -- ./build.sh

# Stdout to /dev/null - stdout stream skipped automatically
agentuity cloud sandbox run -- ./script > /dev/null

# Both to /dev/null - all output streams skipped
agentuity cloud sandbox run -- ./script > /dev/null 2>&1

# Only stderr ignored
agentuity cloud sandbox run -- ./script 2> /dev/null
```

## How It Works

The CLI detects stream redirection by comparing file descriptor stats with `/dev/null`:

```typescript
function detectNullStream(fd: number): boolean {
  const fdStat = fstatSync(fd);
  const nullStat = statSync('/dev/null');
  return fdStat.dev === nullStat.dev && fdStat.ino === nullStat.ino;
}
```

## Server Behavior

The server (ion/catalyst) already handles these values:
- Both `"ignore"` → no output streams created
- Both empty → creates one combined stream (default)
- One `"ignore"` → creates only the other stream

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --quiet option to suppress sandbox command output.
  * Detects when stdout/stderr are redirected to the null device and avoids emitting noisy output.
  * Unified and more consistent stdin/stdout/stderr behavior: output is captured for JSON or quiet/null-redirected runs, otherwise streamed to the terminal.
  * Improved handling of piped stdin and stream configuration to reliably honor user I/O choices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->