### PR TITLE
fix: add v2 flag to job logs stream fetch

### DIFF
--- a/packages/cli/src/cmd/cloud/sandbox/job/logs.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/job/logs.ts
@@ -121,6 +121,7 @@ export const logsSubcommand = createSubcommand({
 				tail: opts.tail,
 				json: isJson,
 				label: opts.stderr ? 'stderr' : 'stdout',
+				v2: true,
 			});
 
 			return {


### PR DESCRIPTION
## Summary

- Add `v2: true` flag to the `streamUrlToWritable` call in the job logs command

## Problem

The job logs command was missing the `v2` flag when calling `streamUrlToWritable`. Without this flag, Pulse uses a 500ms timeout probe that can fall back to the legacy path which cannot serve v2 stream data. This caused job log fetching to fail with timeouts or empty responses.

## Test Plan

Verified by running the sandbox-jobs test suite which includes multiple job log fetching tests:
- jobs_16: fetch logs from completed job
- jobs_17: fetch stderr logs from completed job
- jobs_18: fetch logs with grep filter
- jobs_19: fetch logs with tail option
- jobs_20: fetch logs from running job

All 20 tests pass with this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated job log streaming mechanism with improved compatibility for stdout and stderr log handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->