### PR TITLE
fix: migrate SDK Pi integration for v0.68.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -625,12 +625,12 @@
       "name": "@agentuity/coder-tui",
       "version": "2.0.9",
       "dependencies": {
-        "@mariozechner/pi-coding-agent": "^0.67.68",
-        "@mariozechner/pi-tui": "^0.67.68",
+        "@mariozechner/pi-coding-agent": "^0.68.1",
+        "@mariozechner/pi-tui": "^0.68.1",
         "@sinclair/typebox": "^0.34.48",
       },
       "devDependencies": {
-        "@mariozechner/pi-ai": "^0.67.68",
+        "@mariozechner/pi-ai": "^0.68.1",
         "@types/bun": "^1.3.9",
         "bun-types": "^1.3.9",
         "typescript": "^5.9.0",
@@ -1552,13 +1552,13 @@
 
     "@mariozechner/jiti": ["@mariozechner/jiti@2.6.5", "", { "dependencies": { "std-env": "^3.10.0", "yoctocolors": "^2.1.2" }, "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw=="],
 
-    "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.67.68", "", { "dependencies": { "@mariozechner/pi-ai": "^0.67.68" } }, "sha512-anwFuzeUL7Qjbyih4DWY7w1zrOTrBxaz1L6+duLUuuzpHOun0EiP4KWIGTXPT5oJA7ZaeRNTyXJ7PlWfGQG33g=="],
+    "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.68.1", "", { "dependencies": { "@mariozechner/pi-ai": "^0.68.1" } }, "sha512-7q0vHSc6IIlNNdfP5+4ktv/9Bidfo6dCFRRJVz96K9qjN+5rYJ+4V28quvcw/Vf0pfDgRMBRR0Yhjx51lb60tg=="],
 
-    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.67.68", "", { "dependencies": { "@anthropic-ai/sdk": "^0.90.0", "@aws-sdk/client-bedrock-runtime": "^3.1030.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "^2.2.0", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-DWWQmcb3IV3mbGXmzYBScfKA6kA52n/stY029eiBikrIxVT7DGLG6n7KSvTA2R4qBSgi1iFL3nGHtwxmtIn6Lg=="],
+    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.68.1", "", { "dependencies": { "@anthropic-ai/sdk": "^0.90.0", "@aws-sdk/client-bedrock-runtime": "^3.1030.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "^2.2.0", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-z52kMOZK1/fxzKu7nTwdfOCHhOE/G5GwGsxzR98X6LX7yAz384iqwG4DoXn7nI05ETH7jXLET6wUrYIHMo91Qw=="],
 
-    "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.67.68", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.67.68", "@mariozechner/pi-ai": "^0.67.68", "@mariozechner/pi-tui": "^0.67.68", "@silvia-odwyer/photon-node": "^0.3.4", "ajv": "^8.17.1", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "strip-ansi": "^7.1.0", "undici": "^7.19.1", "uuid": "^11.1.0", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-Bai2yUBpgjftqGvg3GNV9pxcMAatqJwQYsqM+7j39+tm+IpoW7hbMBnzXZQvykAwXIrTXpZFF5yp5ajeDI5Atg=="],
+    "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.68.1", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.68.1", "@mariozechner/pi-ai": "^0.68.1", "@mariozechner/pi-tui": "^0.68.1", "@silvia-odwyer/photon-node": "^0.3.4", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "strip-ansi": "^7.1.0", "undici": "^7.19.1", "uuid": "^11.1.0", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-EqNZrce9b1cjsxDJlIjPHhT44tUtGax5EvzYO9oPTnSBybWwjGddW9WmdhL0Gz1ulSekgNTa2zrlo4uoD7ecDg=="],
 
-    "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.67.68", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" }, "optionalDependencies": { "koffi": "^2.9.0" } }, "sha512-RhcMaGz88lNOm5+9yx+YCIfXZALLbMxB2cwsoHzyOzs+OZAItw8tz6xJZPAnX0RHY+ENQEGMMDY9TF6pxxnkbA=="],
+    "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.68.1", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" }, "optionalDependencies": { "koffi": "^2.9.0" } }, "sha512-j+XI22ehKo4c1gEAzohoSBcgA4X5+vVinTn8a9Osb7h9N8B/rvF23GArJpiMsmE001U47rsLw0mrPop5Kmta+w=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 

--- a/packages/coder-tui/package.json
+++ b/packages/coder-tui/package.json
@@ -25,12 +25,12 @@
 		"prepublishOnly": "bun run clean && bun run build"
 	},
 	"dependencies": {
-		"@mariozechner/pi-coding-agent": "^0.67.68",
-		"@mariozechner/pi-tui": "^0.67.68",
+		"@mariozechner/pi-coding-agent": "^0.68.1",
+		"@mariozechner/pi-tui": "^0.68.1",
 		"@sinclair/typebox": "^0.34.48"
 	},
 	"devDependencies": {
-		"@mariozechner/pi-ai": "^0.67.68",
+		"@mariozechner/pi-ai": "^0.68.1",
 		"@types/bun": "^1.3.9",
 		"bun-types": "^1.3.9",
 		"typescript": "^5.9.0"

--- a/packages/coder-tui/src/index.ts
+++ b/packages/coder-tui/src/index.ts
@@ -1756,12 +1756,7 @@ async function runSubAgent(
 	const { piSdk, piAi } = await loadPiSdk();
 	// Runtime-resolved dynamic imports — exact types unavailable statically
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const {
-		createAgentSession,
-		DefaultResourceLoader,
-		getAgentDir,
-		SessionManager,
-	} = piSdk as any;
+	const { createAgentSession, DefaultResourceLoader, getAgentDir, SessionManager } = piSdk as any;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const { getModel } = piAi as any;
 
@@ -1825,9 +1820,9 @@ async function runSubAgent(
 			| 'off'
 			| 'minimal'
 			| 'low'
-		| 'medium'
-		| 'high'
-		| 'xhigh',
+			| 'medium'
+			| 'high'
+			| 'xhigh',
 		tools,
 		resourceLoader: subLoader,
 		// Pi now tracks cwd per session, so bind in-memory sub-agents to the actual repo cwd.

--- a/packages/coder-tui/src/index.ts
+++ b/packages/coder-tui/src/index.ts
@@ -22,6 +22,7 @@ import { setNativeRemoteExtensionContext } from './native-remote-ui-context.ts';
 import { handleRemoteUiRequest } from './remote-ui-handler.ts';
 import { buildInboundRpcPromptText, getInboundRpcDeliverAs } from './inbound-rpc.ts';
 import { applyCoderAuthHeaders, getCoderAuthCurlArgs } from './auth.ts';
+import { selectSubAgentToolNames } from './subagent-tool-selection.ts';
 import type {
 	HubAction,
 	HubResponse,
@@ -1758,9 +1759,8 @@ async function runSubAgent(
 	const {
 		createAgentSession,
 		DefaultResourceLoader,
+		getAgentDir,
 		SessionManager,
-		createCodingTools,
-		createReadOnlyTools,
 	} = piSdk as any;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const { getModel } = piAi as any;
@@ -1783,13 +1783,16 @@ async function runSubAgent(
 	// Sub-agents get Hub tools (memory, context7, etc.) via extensionFactories
 	// so they work in both driver and TUI mode.
 	const hubTools = agentConfig.hubTools ?? [];
+	const cwd = process.cwd();
+	const agentDir = getAgentDir();
 
 	// Resource loader — no extensions (prevents recursive task tool registration),
 	// no skills, agent's system prompt injected directly.
 	// Hub tools are injected via extensionFactories so sub-agents can use
 	// memory_recall, context7_search, etc.
 	const subLoader = new DefaultResourceLoader({
-		cwd: process.cwd(),
+		cwd,
+		agentDir,
 		noExtensions: true,
 		extensionFactories:
 			hubTools.length > 0
@@ -1808,9 +1811,12 @@ async function runSubAgent(
 	});
 	await subLoader.reload();
 
-	// Select tools based on readOnly flag
-	const cwd = process.cwd();
-	const tools = agentConfig.readOnly ? createReadOnlyTools(cwd) : createCodingTools(cwd);
+	// Pi v0.68.x uses a name allowlist for both built-in and extension/custom tools.
+	const builtInToolNames = selectSubAgentToolNames(agentConfig);
+	const hubToolNames = hubTools
+		.map((tool) => (typeof tool.name === 'string' ? tool.name.trim() : ''))
+		.filter((name): name is string => name.length > 0);
+	const tools = Array.from(new Set([...builtInToolNames, ...hubToolNames]));
 
 	const { session } = await createAgentSession({
 		// subModel is already untyped (from dynamic import) — createAgentSession is also dynamically imported
@@ -1819,12 +1825,13 @@ async function runSubAgent(
 			| 'off'
 			| 'minimal'
 			| 'low'
-			| 'medium'
-			| 'high'
-			| 'xhigh',
+		| 'medium'
+		| 'high'
+		| 'xhigh',
 		tools,
 		resourceLoader: subLoader,
-		sessionManager: SessionManager.inMemory('/tmp'),
+		// Pi now tracks cwd per session, so bind in-memory sub-agents to the actual repo cwd.
+		sessionManager: SessionManager.inMemory(cwd),
 	});
 	await session.bindExtensions({});
 

--- a/packages/coder-tui/src/protocol.ts
+++ b/packages/coder-tui/src/protocol.ts
@@ -75,6 +75,7 @@ export type HubAction =
 export interface AgentDefinition {
 	name: string;
 	displayName?: string;
+	source?: 'builtin' | 'custom';
 	description: string;
 	systemPrompt: string;
 	model?: string;
@@ -84,6 +85,7 @@ export interface AgentDefinition {
 	readOnly?: boolean;
 	hubTools?: HubToolDefinition[];
 	capabilities?: string[];
+	strictToolSelection?: boolean;
 	status?: 'available' | 'busy' | 'offline';
 }
 

--- a/packages/coder-tui/src/subagent-tool-selection.ts
+++ b/packages/coder-tui/src/subagent-tool-selection.ts
@@ -7,20 +7,20 @@ function normalizeToolName(name: string): string {
 	return name.trim().toLowerCase();
 }
 
-export function selectSubAgentToolNames(
-	agentConfig: AgentDefinition,
-): string[] {
+export function selectSubAgentToolNames(agentConfig: AgentDefinition): string[] {
 	const declared = new Set(
 		(agentConfig.tools ?? [])
 			.filter((name): name is string => typeof name === 'string' && name.trim().length > 0)
-			.map(normalizeToolName),
+			.map(normalizeToolName)
 	);
 	const needsBash = declared.has('bash');
 	const baseToolNames =
 		agentConfig.readOnly && !needsBash ? READ_ONLY_TOOL_NAMES : CODING_TOOL_NAMES;
+	const allowLegacyFallback =
+		agentConfig.strictToolSelection !== true && agentConfig.source === 'builtin';
 
 	if (declared.size === 0) {
-		return agentConfig.strictToolSelection ? [] : [...baseToolNames];
+		return allowLegacyFallback ? [...baseToolNames] : [];
 	}
 
 	const filtered = baseToolNames.filter((toolName) => declared.has(toolName));
@@ -29,5 +29,5 @@ export function selectSubAgentToolNames(
 		return filtered;
 	}
 
-	return agentConfig.strictToolSelection ? [] : [...baseToolNames];
+	return allowLegacyFallback ? [...baseToolNames] : [];
 }

--- a/packages/coder-tui/src/subagent-tool-selection.ts
+++ b/packages/coder-tui/src/subagent-tool-selection.ts
@@ -1,0 +1,33 @@
+import type { AgentDefinition } from './protocol.ts';
+
+const READ_ONLY_TOOL_NAMES = ['read', 'grep', 'find', 'ls'] as const;
+const CODING_TOOL_NAMES = ['read', 'bash', 'edit', 'write'] as const;
+
+function normalizeToolName(name: string): string {
+	return name.trim().toLowerCase();
+}
+
+export function selectSubAgentToolNames(
+	agentConfig: AgentDefinition,
+): string[] {
+	const declared = new Set(
+		(agentConfig.tools ?? [])
+			.filter((name): name is string => typeof name === 'string' && name.trim().length > 0)
+			.map(normalizeToolName),
+	);
+	const needsBash = declared.has('bash');
+	const baseToolNames =
+		agentConfig.readOnly && !needsBash ? READ_ONLY_TOOL_NAMES : CODING_TOOL_NAMES;
+
+	if (declared.size === 0) {
+		return agentConfig.strictToolSelection ? [] : [...baseToolNames];
+	}
+
+	const filtered = baseToolNames.filter((toolName) => declared.has(toolName));
+
+	if (filtered.length > 0) {
+		return filtered;
+	}
+
+	return agentConfig.strictToolSelection ? [] : [...baseToolNames];
+}

--- a/packages/coder-tui/test/subagent-tool-selection.test.ts
+++ b/packages/coder-tui/test/subagent-tool-selection.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'bun:test';
+import type { AgentDefinition } from '../src/protocol.ts';
+import { selectSubAgentToolNames } from '../src/subagent-tool-selection.ts';
+
+function createAgent(overrides?: Partial<AgentDefinition>): AgentDefinition {
+	return {
+		name: 'runner',
+		description: 'test',
+		systemPrompt: 'test',
+		tools: ['read', 'grep', 'find', 'ls'],
+		readOnly: true,
+		...overrides,
+	};
+}
+
+describe('selectSubAgentToolNames', () => {
+	it('uses the read-only baseline for read-only agents without bash', () => {
+		expect(selectSubAgentToolNames(createAgent())).toEqual(['read', 'grep', 'find', 'ls']);
+	});
+
+	it('switches to the coding baseline when a read-only agent declares bash', () => {
+		expect(
+			selectSubAgentToolNames(createAgent({ tools: ['read', 'bash', 'ls'], readOnly: true })),
+		).toEqual(['read', 'bash']);
+	});
+
+	it('keeps the legacy fallback for non-strict agents when declarations do not match', () => {
+		expect(
+			selectSubAgentToolNames(createAgent({ tools: ['totally_unknown_tool'] })),
+		).toEqual(['read', 'grep', 'find', 'ls']);
+	});
+
+	it('does not widen tool access for strict custom agents when names do not match', () => {
+		expect(
+			selectSubAgentToolNames(
+				createAgent({
+					name: 'code-review',
+					source: 'custom',
+					tools: ['totally_unknown_tool'],
+					strictToolSelection: true,
+				}),
+			),
+		).toEqual([]);
+	});
+
+	it('returns the coding baseline for non-read-only agents without declared Pi tools', () => {
+		expect(
+			selectSubAgentToolNames(
+				createAgent({
+					readOnly: false,
+					tools: undefined,
+				}),
+			),
+		).toEqual(['read', 'bash', 'edit', 'write']);
+	});
+});

--- a/packages/coder-tui/test/subagent-tool-selection.test.ts
+++ b/packages/coder-tui/test/subagent-tool-selection.test.ts
@@ -5,6 +5,7 @@ import { selectSubAgentToolNames } from '../src/subagent-tool-selection.ts';
 function createAgent(overrides?: Partial<AgentDefinition>): AgentDefinition {
 	return {
 		name: 'runner',
+		source: 'builtin',
 		description: 'test',
 		systemPrompt: 'test',
 		tools: ['read', 'grep', 'find', 'ls'],
@@ -20,14 +21,29 @@ describe('selectSubAgentToolNames', () => {
 
 	it('switches to the coding baseline when a read-only agent declares bash', () => {
 		expect(
-			selectSubAgentToolNames(createAgent({ tools: ['read', 'bash', 'ls'], readOnly: true })),
+			selectSubAgentToolNames(createAgent({ tools: ['read', 'bash', 'ls'], readOnly: true }))
 		).toEqual(['read', 'bash']);
 	});
 
 	it('keeps the legacy fallback for non-strict agents when declarations do not match', () => {
+		expect(selectSubAgentToolNames(createAgent({ tools: ['totally_unknown_tool'] }))).toEqual([
+			'read',
+			'grep',
+			'find',
+			'ls',
+		]);
+	});
+
+	it('keeps custom agents deny-by-default when declarations do not match', () => {
 		expect(
-			selectSubAgentToolNames(createAgent({ tools: ['totally_unknown_tool'] })),
-		).toEqual(['read', 'grep', 'find', 'ls']);
+			selectSubAgentToolNames(
+				createAgent({
+					name: 'qa-review',
+					source: 'custom',
+					tools: ['totally_unknown_tool'],
+				})
+			)
+		).toEqual([]);
 	});
 
 	it('does not widen tool access for strict custom agents when names do not match', () => {
@@ -38,8 +54,8 @@ describe('selectSubAgentToolNames', () => {
 					source: 'custom',
 					tools: ['totally_unknown_tool'],
 					strictToolSelection: true,
-				}),
-			),
+				})
+			)
 		).toEqual([]);
 	});
 
@@ -49,8 +65,8 @@ describe('selectSubAgentToolNames', () => {
 				createAgent({
 					readOnly: false,
 					tools: undefined,
-				}),
-			),
+				})
+			)
 		).toEqual(['read', 'bash', 'edit', 'write']);
 	});
 });

--- a/packages/core/src/services/coder/protocol.ts
+++ b/packages/core/src/services/coder/protocol.ts
@@ -73,7 +73,9 @@ export const AgentDefinitionSchema = z
 		source: z
 			.enum(['builtin', 'custom'])
 			.optional()
-			.describe('Whether this agent is part of the built-in roster or a custom user-defined agent.'),
+			.describe(
+				'Whether this agent is part of the built-in roster or a custom user-defined agent.'
+			),
 		description: z.string().describe('Summary of the agent role and capabilities.'),
 		systemPrompt: z
 			.string()
@@ -106,7 +108,9 @@ export const AgentDefinitionSchema = z
 		strictToolSelection: z
 			.boolean()
 			.optional()
-			.describe('When true, unknown or unmatched tool names should not widen the effective Pi tool allowlist.'),
+			.describe(
+				'When true, unknown or unmatched tool names should not widen the effective Pi tool allowlist.'
+			),
 		status: z
 			.enum(['available', 'busy', 'offline'])
 			.optional()

--- a/packages/core/src/services/coder/protocol.ts
+++ b/packages/core/src/services/coder/protocol.ts
@@ -70,6 +70,10 @@ export const AgentDefinitionSchema = z
 			.string()
 			.optional()
 			.describe('Human-friendly name shown in UIs; defaults to name if omitted.'),
+		source: z
+			.enum(['builtin', 'custom'])
+			.optional()
+			.describe('Whether this agent is part of the built-in roster or a custom user-defined agent.'),
 		description: z.string().describe('Summary of the agent role and capabilities.'),
 		systemPrompt: z
 			.string()
@@ -99,6 +103,10 @@ export const AgentDefinitionSchema = z
 			.array(z.string())
 			.optional()
 			.describe('Capability tags advertising what this agent can do (e.g. "code", "review").'),
+		strictToolSelection: z
+			.boolean()
+			.optional()
+			.describe('When true, unknown or unmatched tool names should not widen the effective Pi tool allowlist.'),
 		status: z
 			.enum(['available', 'busy', 'offline'])
 			.optional()


### PR DESCRIPTION
## Summary

This migrates the SDK-side Pi integration to `v0.68.1`.

Pi `0.68.x` changed sub-agent/session tool configuration from built-in `Tool[]` instances to tool-name allowlists and made direct resource-loader construction require explicit `agentDir`. This PR updates `coder-tui` for that runtime change and keeps the programmatic coder schemas aligned in `@agentuity/core/coder`.

## What Changed

- bump `@agentuity/coder-tui` Pi dependencies to `^0.68.1`
- refresh `bun.lock`
- migrate local sub-agent tool selection to built-in tool-name allowlists
- pass explicit `agentDir` to direct `DefaultResourceLoader(...)` construction in `coder-tui`
- bind in-memory sub-agent sessions to the actual repo cwd
- add shared sub-agent tool-selection coverage for the new allowlist behavior
- align `@agentuity/core/coder` `AgentDefinitionSchema` with Hub metadata by including `source` and `strictToolSelection`
- leave CLI telemetry behavior unchanged (`PI_TELEMETRY=0` still applies to interactive startup)

## Validation

- `bun run --filter='./packages/coder-tui' typecheck`
- `bun run --filter='./packages/coder-tui' build`
- `bun test packages/coder-tui/test`
- `bun run --filter='./packages/cli' typecheck`
- `bun run --filter='./packages/cli' build`
- `bun run --filter='./packages/core' typecheck`
- `bun run --filter='./packages/core' build`
- `bun run --filter='./packages/coder' typecheck`
- `bun run --filter='./packages/coder' build`
- live smoke
  - local `agentuity coder start` booted Pi `v0.68.1`
  - remote `agentuity coder start --remote` successfully hydrated the live sandbox session

## Notes

- `packages/coder` itself remains Pi-free.
- The runtime-sensitive migration work stays in `coder-tui`; the core/package-level change here is schema alignment for programmatic consumers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated agent framework dependencies to v0.68.1.
  * Sub-agent sessions and resource loading now use the repository working directory.

* **New Features**
  * Support for designating agents as built-in or custom.
  * Optional strict tool-selection mode to constrain available tools.
  * Improved tool-selection behavior for read-only vs coding agents.

* **Tests**
  * Added tests covering agent tool-selection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->