### PR TITLE
Brand Agentuity CLI commands in coder TUI

### DIFF
--- a/packages/coder-tui/src/agentuity-cli.ts
+++ b/packages/coder-tui/src/agentuity-cli.ts
@@ -1,0 +1,220 @@
+const SHELL_ASSIGNMENT_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|\S+)$/;
+
+export const AGENTUITY_CLI_MARK = '⨺';
+
+type ToolArgsInput = string | Record<string, unknown> | undefined;
+
+export interface ToolDisplayDescriptor {
+	toolName: string;
+	toolArgs?: string;
+	fullLabel: string;
+	branded: boolean;
+}
+
+function stripShellQuotes(value: string): string {
+	if (
+		(value.startsWith('"') && value.endsWith('"')) ||
+		(value.startsWith("'") && value.endsWith("'"))
+	) {
+		return value.slice(1, -1);
+	}
+	return value;
+}
+
+function tokenizeShellLike(command: string): string[] {
+	return (command.match(/"(?:\\.|[^"])*"|'(?:\\.|[^'])*'|&&|\|\||[;|()]|[^\s;|()]+/g) ?? []).map(
+		stripShellQuotes
+	);
+}
+
+function splitShellSegments(command: string): string[] {
+	return command
+		.split(/(?:\r?\n|&&|\|\||;|\|)/)
+		.map((segment) => segment.trim())
+		.filter(Boolean);
+}
+
+function optionConsumesValue(token: string): boolean {
+	return (
+		token === '-c' ||
+		token === '-g' ||
+		token === '-h' ||
+		token === '-p' ||
+		token === '-r' ||
+		token === '-t' ||
+		token === '-u' ||
+		token === '--chdir' ||
+		token === '--config' ||
+		token === '--group' ||
+		token === '--host' ||
+		token === '--package' ||
+		token === '--registry' ||
+		token === '--user'
+	);
+}
+
+function trimShellPrefix(tokens: string[]): string[] {
+	let index = 0;
+
+	while (index < tokens.length) {
+		const token = tokens[index];
+		if (!token || token === '!' || token === '(' || token === ')') {
+			index += 1;
+			continue;
+		}
+
+		if (token === 'env' || token === 'sudo') {
+			index += 1;
+			while (tokens[index]?.startsWith('-')) {
+				const option = tokens[index] ?? '';
+				index += optionConsumesValue(option) ? 2 : 1;
+			}
+			continue;
+		}
+
+		if (SHELL_ASSIGNMENT_PATTERN.test(token)) {
+			index += 1;
+			continue;
+		}
+
+		break;
+	}
+
+	return tokens.slice(index);
+}
+
+function extractAgentuityCliRemainderFromTokens(tokens: string[]): string | null {
+	const trimmed = trimShellPrefix(tokens);
+	if (trimmed.length === 0) return null;
+
+	const first = trimmed[0]?.toLowerCase();
+	if (first === 'agentuity') {
+		return trimmed.slice(1).join(' ').trim();
+	}
+
+	if (first === 'bunx' || first === 'npx') {
+		let index = 1;
+		while (trimmed[index]?.startsWith('-')) {
+			const option = trimmed[index] ?? '';
+			index += optionConsumesValue(option) ? 2 : 1;
+		}
+		if (trimmed[index] === '@agentuity/cli') {
+			return trimmed
+				.slice(index + 1)
+				.join(' ')
+				.trim();
+		}
+	}
+
+	if (first === 'pnpm' && trimmed[1]?.toLowerCase() === 'dlx') {
+		let index = 2;
+		while (trimmed[index]?.startsWith('-')) {
+			const option = trimmed[index] ?? '';
+			index += optionConsumesValue(option) ? 2 : 1;
+		}
+		if (trimmed[index] === '@agentuity/cli') {
+			return trimmed
+				.slice(index + 1)
+				.join(' ')
+				.trim();
+		}
+	}
+
+	return null;
+}
+
+function trimDisplay(value: string, max: number): string {
+	if (value.length <= max) return value;
+	return `${value.slice(0, max - 3)}...`;
+}
+
+function getCommandArg(rawArgs?: ToolArgsInput): string | undefined {
+	if (typeof rawArgs === 'string' && rawArgs.trim()) {
+		return rawArgs.trim();
+	}
+
+	if (!rawArgs || typeof rawArgs !== 'object') {
+		return undefined;
+	}
+
+	const value = rawArgs.command ?? rawArgs.cmd;
+	return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function getGenericToolArgsPreview(rawArgs?: ToolArgsInput): string | undefined {
+	if (typeof rawArgs === 'string' && rawArgs.trim()) {
+		return trimDisplay(rawArgs.trim(), 60);
+	}
+
+	if (!rawArgs || typeof rawArgs !== 'object') {
+		return undefined;
+	}
+
+	if (typeof rawArgs.command === 'string' && rawArgs.command.trim()) {
+		return trimDisplay(rawArgs.command.trim(), 60);
+	}
+	if (typeof rawArgs.filePath === 'string' && rawArgs.filePath.trim()) {
+		return rawArgs.filePath.trim();
+	}
+	if (typeof rawArgs.path === 'string' && rawArgs.path.trim()) {
+		return rawArgs.path.trim();
+	}
+	if (typeof rawArgs.pattern === 'string' && rawArgs.pattern.trim()) {
+		return trimDisplay(rawArgs.pattern.trim(), 40);
+	}
+
+	const first = Object.values(rawArgs)[0];
+	if (typeof first === 'string' && first.trim()) {
+		return trimDisplay(first.trim(), 40);
+	}
+
+	return undefined;
+}
+
+function isCommandToolName(toolName: string): boolean {
+	const normalized = toolName.trim().toLowerCase();
+	return normalized === 'bash' || normalized === 'execute_command' || normalized.includes('shell');
+}
+
+export function getAgentuityCliCommandRemainder(command?: string): string | null {
+	if (!command?.trim()) return null;
+
+	for (const segment of splitShellSegments(command)) {
+		const remainder = extractAgentuityCliRemainderFromTokens(tokenizeShellLike(segment));
+		if (remainder !== null) {
+			return remainder;
+		}
+	}
+
+	return null;
+}
+
+export function formatToolDisplay(
+	toolName: string,
+	rawArgs?: ToolArgsInput
+): ToolDisplayDescriptor {
+	const normalizedToolName = toolName.trim() || 'tool';
+	const command = getCommandArg(rawArgs);
+
+	if (isCommandToolName(normalizedToolName) && command) {
+		const remainder = getAgentuityCliCommandRemainder(command);
+		if (remainder !== null) {
+			const brandedToolName = `${AGENTUITY_CLI_MARK} agentuity`;
+			const toolArgs = remainder ? trimDisplay(remainder, 60) : undefined;
+			return {
+				toolName: brandedToolName,
+				toolArgs,
+				fullLabel: toolArgs ? `${brandedToolName} ${toolArgs}` : brandedToolName,
+				branded: true,
+			};
+		}
+	}
+
+	const toolArgs = getGenericToolArgsPreview(rawArgs);
+	return {
+		toolName: normalizedToolName,
+		toolArgs,
+		fullLabel: toolArgs ? `${normalizedToolName} ${toolArgs}` : normalizedToolName,
+		branded: false,
+	};
+}

--- a/packages/coder-tui/src/agentuity-cli.ts
+++ b/packages/coder-tui/src/agentuity-cli.ts
@@ -123,9 +123,14 @@ function extractAgentuityCliRemainderFromTokens(tokens: string[]): string | null
 	return null;
 }
 
+function normalizeDisplayWhitespace(value: string): string {
+	return value.replace(/\s+/g, ' ').trim();
+}
+
 function trimDisplay(value: string, max: number): string {
-	if (value.length <= max) return value;
-	return `${value.slice(0, max - 3)}...`;
+	const normalized = normalizeDisplayWhitespace(value);
+	if (normalized.length <= max) return normalized;
+	return `${normalized.slice(0, max - 3)}...`;
 }
 
 function getCommandArg(rawArgs?: ToolArgsInput): string | undefined {
@@ -193,7 +198,7 @@ export function formatToolDisplay(
 	toolName: string,
 	rawArgs?: ToolArgsInput
 ): ToolDisplayDescriptor {
-	const normalizedToolName = toolName.trim() || 'tool';
+	const normalizedToolName = normalizeDisplayWhitespace(toolName) || 'tool';
 	const command = getCommandArg(rawArgs);
 
 	if (isCommandToolName(normalizedToolName) && command) {

--- a/packages/coder-tui/src/hub-overlay-state.ts
+++ b/packages/coder-tui/src/hub-overlay-state.ts
@@ -1,3 +1,5 @@
+import { formatToolDisplay } from './agentuity-cli.ts';
+
 export interface StreamBuffer {
 	output: string;
 	thinking: string;
@@ -78,7 +80,8 @@ export function buildProjectionFromEntries(
 		const type = typeof entry.type === 'string' ? entry.type : '';
 		if (type === 'tool_call') {
 			const toolName = typeof entry.toolName === 'string' ? entry.toolName : 'tool';
-			append('output', `[tool_call] ${toolName}\n\n`, entry.taskId);
+			const display = formatToolDisplay(toolName, entry.toolArgs);
+			append('output', `[tool_call] ${display.fullLabel}\n\n`, entry.taskId);
 			continue;
 		}
 

--- a/packages/coder-tui/src/hub-overlay.ts
+++ b/packages/coder-tui/src/hub-overlay.ts
@@ -10,6 +10,7 @@ import {
 	type StreamProjectionSource,
 } from './hub-overlay-state.ts';
 import { applyCoderAuthHeaders } from './auth.ts';
+import { formatToolDisplay } from './agentuity-cli.ts';
 import { truncateToWidth } from './renderers.ts';
 import type {
 	ConversationEntry as HubConversationEntry,
@@ -2128,6 +2129,13 @@ export class HubOverlay implements Component, Focusable {
 						? data.toolName
 						: 'tool';
 			const input = data?.args ?? data?.input;
+			const display = formatToolDisplay(
+				name,
+				typeof input === 'string' || (input && typeof input === 'object')
+					? (input as string | Record<string, unknown>)
+					: undefined
+			);
+			if (display.branded) return `tool_call ${display.fullLabel}`;
 			const summarized = summarizeToolCall(name, input);
 			if (summarized) return summarized;
 			const argsPreview = summarizeArgs(input, 90);
@@ -2171,15 +2179,18 @@ export class HubOverlay implements Component, Focusable {
 				const failed = data?.isError === true || details?.error === true;
 				return `${header}\n${failed ? 'failed' : `done${duration}`}`;
 			}
-			return `tool_result ${name}`;
+			const display = formatToolDisplay(name, input);
+			return `tool_result ${display.toolName}`;
 		}
 
 		if (eventName === 'agent_progress') {
 			const agent = typeof data?.agentName === 'string' ? data.agentName : 'agent';
 			const status = typeof data?.status === 'string' ? data.status : 'progress';
-			const toolName = typeof data?.currentTool === 'string' ? data.currentTool : '';
+			const rawToolName = typeof data?.currentTool === 'string' ? data.currentTool : '';
 			const toolArgsRaw = typeof data?.currentToolArgs === 'string' ? data.currentToolArgs : '';
-			const toolArgs = toolArgsRaw ? truncateToWidth(normalize(toolArgsRaw), 80) : '';
+			const display = formatToolDisplay(rawToolName, toolArgsRaw || undefined);
+			const toolName = display.toolName;
+			const toolArgs = display.toolArgs ? truncateToWidth(normalize(display.toolArgs), 80) : '';
 
 			// Deltas are already represented in rendered stream mode; skip them in event mode
 			// to avoid noisy, low-signal token lines.

--- a/packages/coder-tui/src/index.ts
+++ b/packages/coder-tui/src/index.ts
@@ -1,4 +1,5 @@
-import type {
+import {
+	createBashToolDefinition,
 	AgentToolResult,
 	ExtensionAPI,
 	ExtensionContext,
@@ -22,6 +23,7 @@ import { setNativeRemoteExtensionContext } from './native-remote-ui-context.ts';
 import { handleRemoteUiRequest } from './remote-ui-handler.ts';
 import { buildInboundRpcPromptText, getInboundRpcDeliverAs } from './inbound-rpc.ts';
 import { applyCoderAuthHeaders, getCoderAuthCurlArgs } from './auth.ts';
+import { formatToolDisplay } from './agentuity-cli.ts';
 import type {
 	HubAction,
 	HubResponse,
@@ -410,6 +412,17 @@ export function agentuityCoderHub(pi: ExtensionAPI) {
 
 	// Titlebar: branding + spinner (registers its own event handlers)
 	setupTitlebar(pi);
+
+	// Override Pi's built-in bash call-row rendering so local transcript rows
+	// can brand Agentuity CLI invocations without changing bash execution/result behavior.
+	const localBashRenderers = getToolRenderers('bash');
+	if (localBashRenderers?.renderCall) {
+		const bashToolDefinition = createBashToolDefinition(process.cwd());
+		pi.registerTool({
+			...bashToolDefinition,
+			renderCall: localBashRenderers.renderCall as ToolDefinition['renderCall'],
+		});
+	}
 
 	// ══════════════════════════════════════════════
 	// WebSocket client for runtime communication (tool execution + events)
@@ -1860,25 +1873,19 @@ async function runSubAgent(
 
 					if (evt.type === 'tool_execution_start') {
 						const toolName = evt.toolName || evt.name || evt.tool || 'unknown';
-						let toolArgs = '';
-						if (evt.args && typeof evt.args === 'object') {
-							const args = evt.args as Record<string, unknown>;
-							if (args.command) toolArgs = String(args.command).slice(0, 60);
-							else if (args.filePath || args.path)
-								toolArgs = String(args.filePath || args.path);
-							else if (args.pattern) toolArgs = String(args.pattern).slice(0, 40);
-							else {
-								const first = Object.values(args)[0];
-								if (first) toolArgs = String(first).slice(0, 40);
-							}
-						}
+						const display = formatToolDisplay(
+							toolName,
+							typeof evt.args === 'string' || (evt.args && typeof evt.args === 'object')
+								? (evt.args as string | Record<string, unknown>)
+								: undefined
+						);
 
 						onProgress({
 							agentName: agentConfig.name,
 							status: 'tool_start',
 							toolCallId: typeof evt.toolCallId === 'string' ? evt.toolCallId : undefined,
-							currentTool: toolName,
-							currentToolArgs: toolArgs,
+							currentTool: display.toolName,
+							currentToolArgs: display.toolArgs,
 							elapsed,
 						});
 					} else if (evt.type === 'tool_execution_end') {

--- a/packages/coder-tui/src/index.ts
+++ b/packages/coder-tui/src/index.ts
@@ -24,6 +24,7 @@ import { handleRemoteUiRequest } from './remote-ui-handler.ts';
 import { buildInboundRpcPromptText, getInboundRpcDeliverAs } from './inbound-rpc.ts';
 import { applyCoderAuthHeaders, getCoderAuthCurlArgs } from './auth.ts';
 import { formatToolDisplay } from './agentuity-cli.ts';
+import { adaptInitMessageForLocalTui } from './local-init-filter.ts';
 import type {
 	HubAction,
 	HubResponse,
@@ -285,6 +286,7 @@ export function agentuityCoderHub(pi: ExtensionAPI) {
 	// to an existing sandbox session. The full UI is set up (tools, commands, /hub)
 	// but user input is relayed to the remote sandbox instead of the local Pi agent.
 	const remoteSessionId = process.env[REMOTE_SESSION_ENV] || null;
+	const isRemoteSession = Boolean(remoteSessionId);
 	const isNativeRemote = !!process.env[NATIVE_REMOTE_ENV];
 	if (remoteSessionId) {
 		log(`Remote mode: will connect as controller to session ${remoteSessionId}`);
@@ -300,7 +302,10 @@ export function agentuityCoderHub(pi: ExtensionAPI) {
 	// This is how we discover what tools/agents the server provides.
 	// ══════════════════════════════════════════════
 
-	const initMsg = fetchInitMessageSync(hubUrl, agentRole);
+	const initialInitMsg = fetchInitMessageSync(hubUrl, agentRole);
+	const initMsg = initialInitMsg
+		? adaptInitMessageForLocalTui(initialInitMsg, { isRemoteSession })
+		: null;
 
 	if (!initMsg) {
 		log('Hub not reachable — no tools or agents registered');
@@ -415,8 +420,9 @@ export function agentuityCoderHub(pi: ExtensionAPI) {
 
 	// Override Pi's built-in bash call-row rendering so local transcript rows
 	// can brand Agentuity CLI invocations without changing bash execution/result behavior.
-	const localBashRenderers = getToolRenderers('bash');
-	if (localBashRenderers?.renderCall) {
+	const hasBashTool = serverTools.some((tool) => tool.name === 'bash');
+	const localBashRenderers = hasBashTool ? getToolRenderers('bash') : undefined;
+	if (hasBashTool && localBashRenderers?.renderCall) {
 		const bashToolDefinition = createBashToolDefinition(process.cwd());
 		pi.registerTool({
 			...bashToolDefinition,
@@ -466,9 +472,10 @@ export function agentuityCoderHub(pi: ExtensionAPI) {
 	}
 
 	function applyInitMessage(nextInit: InitMessage): void {
-		cachedInitMessage = nextInit;
-		if (nextInit.sessionId) currentSessionId = nextInit.sessionId;
-		if (nextInit.config) hubConfig = nextInit.config;
+		const effectiveInit = adaptInitMessageForLocalTui(nextInit, { isRemoteSession });
+		cachedInitMessage = effectiveInit;
+		if (effectiveInit.sessionId) currentSessionId = effectiveInit.sessionId;
+		if (effectiveInit.config) hubConfig = effectiveInit.config;
 	}
 
 	client.onInitMessage = (nextInit) => {

--- a/packages/coder-tui/src/local-init-filter.ts
+++ b/packages/coder-tui/src/local-init-filter.ts
@@ -1,0 +1,54 @@
+import type { AgentDefinition, HubToolDefinition, InitMessage } from './protocol.ts';
+
+const LOCAL_TUI_HIDDEN_HUB_TOOL_NAMES = new Set(['sandbox_exec']);
+
+function filterHubToolsForLocalTui(tools?: HubToolDefinition[]): HubToolDefinition[] | undefined {
+	if (!tools) return tools;
+
+	const filtered = tools.filter((tool) => !LOCAL_TUI_HIDDEN_HUB_TOOL_NAMES.has(tool.name));
+	return filtered.length === tools.length ? tools : filtered;
+}
+
+function filterAgentHubToolsForLocalTui(agents?: AgentDefinition[]): AgentDefinition[] | undefined {
+	if (!agents) return agents;
+
+	let changed = false;
+	const filteredAgents = agents.map((agent) => {
+		const filteredHubTools = filterHubToolsForLocalTui(agent.hubTools);
+		if (filteredHubTools === agent.hubTools) {
+			return agent;
+		}
+
+		changed = true;
+		return {
+			...agent,
+			hubTools: filteredHubTools && filteredHubTools.length > 0 ? filteredHubTools : undefined,
+		};
+	});
+
+	return changed ? filteredAgents : agents;
+}
+
+export function adaptInitMessageForLocalTui(
+	init: InitMessage,
+	options: {
+		isRemoteSession: boolean;
+	}
+): InitMessage {
+	if (options.isRemoteSession) {
+		return init;
+	}
+
+	const tools = filterHubToolsForLocalTui(init.tools);
+	const agents = filterAgentHubToolsForLocalTui(init.agents);
+
+	if (tools === init.tools && agents === init.agents) {
+		return init;
+	}
+
+	return {
+		...init,
+		tools,
+		agents,
+	};
+}

--- a/packages/coder-tui/src/remote-session.ts
+++ b/packages/coder-tui/src/remote-session.ts
@@ -23,6 +23,7 @@ import {
 	type RemoteLifecycleState,
 } from './remote-lifecycle.ts';
 import { resolveCoderOrgId } from './auth.ts';
+import { formatToolDisplay } from './agentuity-cli.ts';
 
 const DEBUG = !!process.env['AGENTUITY_DEBUG'];
 
@@ -1001,18 +1002,23 @@ export async function setupRemoteMode(
 				break;
 
 			case 'tool_execution_start': {
-				const tool = (event as { toolName?: string }).toolName ?? 'tool';
-				currentTool = tool;
+				const rawTool = (event as { toolName?: string }).toolName ?? 'tool';
+				const rawArgs = (event as { args?: string | Record<string, unknown> }).args;
+				const display = formatToolDisplay(rawTool, rawArgs);
+				currentTool = display.toolName;
 				if (extensionCtxRef?.hasUI) {
-					setNonLifecycleWorkingMessage(`Running ${tool}...`);
-					extensionCtxRef.ui.setStatus('remote_activity', `Running ${tool}...`);
+					setNonLifecycleWorkingMessage(`Running ${display.fullLabel}...`);
+					extensionCtxRef.ui.setStatus('remote_activity', `Running ${display.fullLabel}...`);
 				}
-				log(`Tool: ${tool}`);
+				log(`Tool: ${display.fullLabel}`);
 				break;
 			}
 
 			case 'tool_execution_end': {
-				const tool = (event as { toolName?: string }).toolName ?? currentTool ?? 'tool';
+				const rawTool = (event as { toolName?: string }).toolName ?? currentTool ?? 'tool';
+				const rawArgs = (event as { args?: string | Record<string, unknown> }).args;
+				const display = rawArgs ? formatToolDisplay(rawTool, rawArgs) : null;
+				const tool = display?.fullLabel ?? currentTool ?? rawTool;
 				currentTool = null;
 				if (extensionCtxRef?.hasUI) {
 					clearWorkingMessage();

--- a/packages/coder-tui/src/renderers.ts
+++ b/packages/coder-tui/src/renderers.ts
@@ -12,6 +12,7 @@ import type {
 	AgentToolResult,
 } from '@mariozechner/pi-coding-agent';
 import { Box, Text, Container, type Component } from '@mariozechner/pi-tui';
+import { formatToolDisplay } from './agentuity-cli.ts';
 
 // ──────────────────────────────────────────────
 // Line-safety helper — must be declared before SimpleText so
@@ -123,6 +124,28 @@ function tryParseJson(text: string): unknown | undefined {
 function truncate(str: string, max: number): string {
 	if (str.length <= max) return str;
 	return str.slice(0, max - 1) + '\u2026';
+}
+
+function isCommandToolName(toolName: string): boolean {
+	const normalized = toolName.trim().toLowerCase();
+	return normalized === 'bash' || normalized === 'execute_command' || normalized.includes('shell');
+}
+
+function getCommandArg(args: Record<string, unknown>): string | undefined {
+	const value = args['command'] ?? args['cmd'];
+	return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function getCommandTimeoutLabel(args: Record<string, unknown>): string | undefined {
+	const timeout = args['timeout'];
+	if (typeof timeout === 'number' && Number.isFinite(timeout) && timeout > 0) {
+		return `${timeout}s`;
+	}
+	if (typeof timeout === 'string' && timeout.trim()) {
+		const value = timeout.trim();
+		return /s$/i.test(value) ? value : `${value}s`;
+	}
+	return undefined;
 }
 
 // ──────────────────────────────────────────────
@@ -709,6 +732,33 @@ function parallelTasksRenderers(): ToolRenderers {
 	};
 }
 
+function commandToolRenderers(toolName: string): ToolRenderers {
+	return {
+		renderCall(args, theme) {
+			const display = formatToolDisplay(toolName, args);
+			const timeout = getCommandTimeoutLabel(args);
+
+			if (display.branded) {
+				let text = theme.fg('toolTitle', theme.bold(display.toolName));
+				if (display.toolArgs) {
+					text += theme.fg('accent', ` ${display.toolArgs}`);
+				}
+				if (timeout) {
+					text += theme.fg('dim', ` (timeout ${timeout})`);
+				}
+				return new SimpleText(text);
+			}
+
+			let text = theme.fg('toolTitle', theme.bold('$ '));
+			text += theme.fg('accent', truncate(getCommandArg(args) ?? display.toolName, 80));
+			if (timeout) {
+				text += theme.fg('dim', ` (timeout ${timeout})`);
+			}
+			return new SimpleText(text);
+		},
+	};
+}
+
 // ──────────────────────────────────────────────
 
 const RENDERERS: Record<string, () => ToolRenderers> = {
@@ -736,5 +786,7 @@ const RENDERERS: Record<string, () => ToolRenderers> = {
  */
 export function getToolRenderers(toolName: string): ToolRenderers | undefined {
 	const factory = RENDERERS[toolName];
-	return factory?.();
+	if (factory) return factory();
+	if (isCommandToolName(toolName)) return commandToolRenderers(toolName);
+	return undefined;
 }

--- a/packages/coder-tui/src/renderers.ts
+++ b/packages/coder-tui/src/renderers.ts
@@ -126,6 +126,10 @@ function truncate(str: string, max: number): string {
 	return str.slice(0, max - 1) + '\u2026';
 }
 
+function toSingleLinePreview(value: string): string {
+	return value.replace(/\s+/g, ' ').trim();
+}
+
 function isCommandToolName(toolName: string): boolean {
 	const normalized = toolName.trim().toLowerCase();
 	return normalized === 'bash' || normalized === 'execute_command' || normalized.includes('shell');
@@ -750,7 +754,11 @@ function commandToolRenderers(toolName: string): ToolRenderers {
 			}
 
 			let text = theme.fg('toolTitle', theme.bold('$ '));
-			text += theme.fg('accent', truncate(getCommandArg(args) ?? display.toolName, 80));
+			const commandPreview = getCommandArg(args);
+			text += theme.fg(
+				'accent',
+				truncate(commandPreview ? toSingleLinePreview(commandPreview) : display.toolName, 80)
+			);
 			if (timeout) {
 				text += theme.fg('dim', ` (timeout ${timeout})`);
 			}

--- a/packages/coder-tui/test/agentuity-cli.test.ts
+++ b/packages/coder-tui/test/agentuity-cli.test.ts
@@ -53,6 +53,19 @@ describe('agentuity CLI display helpers', () => {
 		});
 	});
 
+	it('normalizes multiline command previews into single-line labels', () => {
+		expect(
+			formatToolDisplay('bash', {
+				command: 'bun test\n\tpackages/coder-tui/test/agentuity-cli.test.ts',
+			})
+		).toEqual({
+			toolName: 'bash',
+			toolArgs: 'bun test packages/coder-tui/test/agentuity-cli.test.ts',
+			fullLabel: 'bash bun test packages/coder-tui/test/agentuity-cli.test.ts',
+			branded: false,
+		});
+	});
+
 	it('brands the local TUI command row for Agentuity CLI calls', () => {
 		const renderers = getToolRenderers('bash');
 		const component = renderers?.renderCall?.(
@@ -63,6 +76,21 @@ describe('agentuity CLI display helpers', () => {
 		expect(component?.render(120).join('\n')).toContain(
 			`${AGENTUITY_CLI_MARK} agentuity auth whoami (timeout 45s)`
 		);
+	});
+
+	it('keeps local non-branded command rows single-line', () => {
+		const renderers = getToolRenderers('bash');
+		const component = renderers?.renderCall?.(
+			{
+				command: 'bun test\n\tpackages/coder-tui/test/agentuity-cli.test.ts',
+				timeout: 45,
+			},
+			testTheme as never
+		) as { render: (width: number) => string[] } | undefined;
+
+		expect(component?.render(120)).toEqual([
+			'$ bun test packages/coder-tui/test/agentuity-cli.test.ts (timeout 45s)',
+		]);
 	});
 
 	it('rebuilds projection output with Agentuity-branded tool calls', () => {

--- a/packages/coder-tui/test/agentuity-cli.test.ts
+++ b/packages/coder-tui/test/agentuity-cli.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'bun:test';
+import {
+	AGENTUITY_CLI_MARK,
+	formatToolDisplay,
+	getAgentuityCliCommandRemainder,
+} from '../src/agentuity-cli.ts';
+import { buildProjectionFromEntries } from '../src/hub-overlay-state.ts';
+import { getToolRenderers } from '../src/renderers.ts';
+
+const testTheme = {
+	fg: (_color: string, text: string) => text,
+	bg: (_color: string, text: string) => text,
+	bold: (text: string) => text,
+} as const;
+
+describe('agentuity CLI display helpers', () => {
+	it('detects direct and wrapped agentuity CLI commands', () => {
+		expect(getAgentuityCliCommandRemainder('agentuity cloud task list --org-id org_123')).toBe(
+			'cloud task list --org-id org_123'
+		);
+		expect(
+			getAgentuityCliCommandRemainder(
+				'AGENTUITY_PROFILE=local bunx --bun @agentuity/cli cloud sandbox list'
+			)
+		).toBe('cloud sandbox list');
+		expect(getAgentuityCliCommandRemainder('pnpm dlx @agentuity/cli cloud deployment list')).toBe(
+			'cloud deployment list'
+		);
+		expect(getAgentuityCliCommandRemainder('echo agentuity')).toBeNull();
+	});
+
+	it('brands command-tool displays for Agentuity CLI invocations', () => {
+		expect(
+			formatToolDisplay('bash', {
+				command: 'agentuity cloud task list --org-id org_123',
+			})
+		).toEqual({
+			toolName: `${AGENTUITY_CLI_MARK} agentuity`,
+			toolArgs: 'cloud task list --org-id org_123',
+			fullLabel: `${AGENTUITY_CLI_MARK} agentuity cloud task list --org-id org_123`,
+			branded: true,
+		});
+
+		expect(
+			formatToolDisplay('bash', {
+				command: 'bun test packages/coder-tui/test/agentuity-cli.test.ts',
+			})
+		).toEqual({
+			toolName: 'bash',
+			toolArgs: 'bun test packages/coder-tui/test/agentuity-cli.test.ts',
+			fullLabel: 'bash bun test packages/coder-tui/test/agentuity-cli.test.ts',
+			branded: false,
+		});
+	});
+
+	it('brands the local TUI command row for Agentuity CLI calls', () => {
+		const renderers = getToolRenderers('bash');
+		const component = renderers?.renderCall?.(
+			{ command: 'agentuity auth whoami', timeout: 45 },
+			testTheme as never
+		) as { render: (width: number) => string[] } | undefined;
+
+		expect(component?.render(120).join('\n')).toContain(
+			`${AGENTUITY_CLI_MARK} agentuity auth whoami (timeout 45s)`
+		);
+	});
+
+	it('rebuilds projection output with Agentuity-branded tool calls', () => {
+		expect(
+			buildProjectionFromEntries([
+				{
+					type: 'tool_call',
+					toolName: 'bash',
+					toolArgs: { command: 'agentuity cloud task list' },
+				},
+			])
+		).toEqual({
+			output: `[tool_call] ${AGENTUITY_CLI_MARK} agentuity cloud task list\n\n`,
+			thinking: '',
+			tasks: {},
+		});
+	});
+});

--- a/packages/coder-tui/test/local-init-filter.test.ts
+++ b/packages/coder-tui/test/local-init-filter.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'bun:test';
+import { adaptInitMessageForLocalTui } from '../src/local-init-filter.ts';
+import type { InitMessage } from '../src/protocol.ts';
+
+function makeInitMessage(): InitMessage {
+	return {
+		type: 'init',
+		role: 'lead',
+		tools: [
+			{
+				name: 'sandbox_exec',
+				label: 'Execute in Sandbox',
+				description: 'Run in sandbox',
+				parameters: { type: 'object', properties: {} },
+			},
+			{
+				name: 'web_search',
+				label: 'Web Search',
+				description: 'Search the web',
+				parameters: { type: 'object', properties: {} },
+			},
+		],
+		agents: [
+			{
+				name: 'runner',
+				description: 'Runs commands',
+				systemPrompt: 'runner prompt',
+				hubTools: [
+					{
+						name: 'sandbox_exec',
+						label: 'Execute in Sandbox',
+						description: 'Run in sandbox',
+						parameters: { type: 'object', properties: {} },
+					},
+					{
+						name: 'loop_get_state',
+						label: 'Loop State',
+						description: 'Read loop state',
+						parameters: { type: 'object', properties: {} },
+					},
+				],
+			},
+			{
+				name: 'builder',
+				description: 'Builds code',
+				systemPrompt: 'builder prompt',
+				hubTools: [
+					{
+						name: 'sandbox_exec',
+						label: 'Execute in Sandbox',
+						description: 'Run in sandbox',
+						parameters: { type: 'object', properties: {} },
+					},
+				],
+			},
+		],
+	};
+}
+
+describe('adaptInitMessageForLocalTui', () => {
+	it('hides sandbox_exec for local TUI sessions', () => {
+		const init = makeInitMessage();
+
+		const filtered = adaptInitMessageForLocalTui(init, { isRemoteSession: false });
+
+		expect(filtered.tools?.map((tool) => tool.name)).toEqual(['web_search']);
+		expect(
+			filtered.agents
+				?.find((agent) => agent.name === 'runner')
+				?.hubTools?.map((tool) => tool.name)
+		).toEqual(['loop_get_state']);
+		expect(filtered.agents?.find((agent) => agent.name === 'builder')?.hubTools).toBeUndefined();
+
+		expect(init.tools?.map((tool) => tool.name)).toEqual(['sandbox_exec', 'web_search']);
+		expect(
+			init.agents?.find((agent) => agent.name === 'runner')?.hubTools?.map((tool) => tool.name)
+		).toEqual(['sandbox_exec', 'loop_get_state']);
+	});
+
+	it('preserves sandbox_exec for remote sessions', () => {
+		const init = makeInitMessage();
+
+		const filtered = adaptInitMessageForLocalTui(init, { isRemoteSession: true });
+
+		expect(filtered).toBe(init);
+		expect(filtered.tools?.map((tool) => tool.name)).toEqual(['sandbox_exec', 'web_search']);
+		expect(
+			filtered.agents
+				?.find((agent) => agent.name === 'runner')
+				?.hubTools?.map((tool) => tool.name)
+		).toEqual(['sandbox_exec', 'loop_get_state']);
+	});
+});


### PR DESCRIPTION
## Summary
- add Agentuity CLI command detection and branded display formatting helpers for coder-tui
- brand Hub overlay, remote session, and local transcript command rows for Agentuity CLI invocations
- preserve Pi bash execution/result behavior while overriding the local command call row and add regression coverage

## Companion PR
- coder PR: https://github.com/agentuity/coder/pull/44

## Testing
- bun test test/agentuity-cli.test.ts
- bun run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Branded display for Agentuity CLI invocations with distinctive visual marker
  * Command-line tool rendering with timeout information display
  * Standardized tool label and argument formatting across the UI

* **Refactor**
  * Improved tool call display logic consistency

* **Tests**
  * Added comprehensive test coverage for Agentuity CLI display formatting
  * Added test coverage for local session tool filtering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->