### PR TITLE
Relax stream namespace timestamp fields

### DIFF
--- a/packages/core/src/services/stream/namespaces.ts
+++ b/packages/core/src/services/stream/namespaces.ts
@@ -40,11 +40,11 @@ export const StreamNamespaceEntrySchema = z.object({
 	chunks: z.number().describe('number of chunks'),
 	completed: z.boolean().describe('whether the stream upload is completed'),
 	size_bytes: z.number().describe('size in bytes'),
-	started_at: z.string().nullable().describe('ISO 8601 stream start timestamp'),
+	started_at: z.string().nullable().optional().describe('ISO 8601 stream start timestamp'),
 	ended_at: z.string().nullable().describe('ISO 8601 stream end timestamp'),
 	headers: z.record(z.string(), z.string()).nullable().optional().describe('stream headers'),
 	metadata: z.record(z.string(), z.string()).nullable().optional().describe('stream metadata'),
-	expires_at: z.string().nullable().describe('ISO 8601 expiration timestamp or null'),
+	expires_at: z.string().nullable().optional().describe('ISO 8601 expiration timestamp or null'),
 	url: z.string().describe('public URL to access the stream'),
 });
 


### PR DESCRIPTION
## Summary
- allow started_at and expires_at to be omitted in stream namespace and search responses
- keep the shared SDK compatible with Pulse payloads while the backend fix rolls out

## Verification
- cd sdk/packages/core && bun run build

## Notes
- This is compatible with the Pulse backend returning either explicit null or omitted keys for these nullable timestamps.