### PR TITLE
fix(cli): prevent orphaned dev mode processes on shutdown / respawn

### DIFF
--- a/packages/cli/src/cmd/build/vite/bun-dev-server.ts
+++ b/packages/cli/src/cmd/build/vite/bun-dev-server.ts
@@ -17,6 +17,18 @@ import type { Logger } from '../../../types';
 import { getAgentEnv } from '../../../agent-detection';
 import { createServer as createNetServer } from 'node:net';
 
+/**
+ * Minimal handle for the spawned Bun subprocess. Mirrors the shape used
+ * elsewhere (procManager, killBunSubprocess) so callers can register
+ * the process with their tracking layer without depending on Bun-specific
+ * Subprocess types.
+ */
+export interface BunSubprocessHandle {
+	kill: (signal?: number | NodeJS.Signals) => void;
+	exitCode: number | null;
+	pid?: number;
+}
+
 export interface BunDevServerOptions {
 	rootDir: string;
 	port?: number;
@@ -25,6 +37,15 @@ export interface BunDevServerOptions {
 	inspect?: boolean;
 	inspectWait?: boolean;
 	inspectBrk?: boolean;
+	/**
+	 * Optional callback fired the moment `Bun.spawn` returns, BEFORE the
+	 * readiness wait. Lets callers register the subprocess with a process
+	 * manager / shutdown handler immediately, eliminating the multi-second
+	 * window during which a SIGINT could orphan the child.
+	 *
+	 * If this throws, the subprocess is killed and the error is rethrown.
+	 */
+	onSpawn?: (proc: BunSubprocessHandle) => void;
 }
 
 export interface BunDevServerResult {
@@ -420,6 +441,35 @@ export async function startBunDevServer(options: BunDevServerOptions): Promise<B
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	(globalThis as any).__AGENTUITY_BUN_SUBPROCESS__ = bunProcess;
+
+	// Notify caller IMMEDIATELY so the subprocess can be registered with the
+	// process manager before the readiness wait below. Without this, a SIGINT
+	// during the up-to-5s readiness wait would leave the subprocess unmanaged
+	// (only the synchronous exit-handler safety net would catch it).
+	if (options.onSpawn) {
+		try {
+			options.onSpawn(bunProcess as BunSubprocessHandle);
+		} catch (err) {
+			logger.debug('onSpawn callback threw, killing subprocess: %s', err);
+			const pid = bunProcess.pid;
+			try {
+				if (typeof pid === 'number' && pid > 1 && process.platform !== 'win32') {
+					try {
+						process.kill(-pid, 'SIGKILL');
+					} catch {
+						bunProcess.kill('SIGKILL');
+					}
+				} else {
+					bunProcess.kill('SIGKILL');
+				}
+			} catch {
+				// Best effort
+			}
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			(globalThis as any).__AGENTUITY_BUN_SUBPROCESS__ = undefined;
+			throw err;
+		}
+	}
 
 	// Wait for server to start listening
 	const maxRetries = 50;

--- a/packages/cli/src/cmd/build/vite/ws-proxy.ts
+++ b/packages/cli/src/cmd/build/vite/ws-proxy.ts
@@ -33,7 +33,7 @@
  * ```
  */
 
-import { createServer, connect, type Server } from 'node:net';
+import { createServer, connect, type Server, type Socket } from 'node:net';
 import type { Logger } from '../../../types';
 
 export interface WsProxyOptions {
@@ -49,17 +49,43 @@ export interface WsProxyOptions {
 }
 
 /**
+ * Front-door TCP proxy server.
+ *
+ * Extends `net.Server` with a `closeAll()` method that destroys all live
+ * client + upstream sockets and waits for the listening socket to close.
+ * The native `Server.close()` only stops accepting new connections — long-
+ * lived piped sockets (Vite HMR WebSocket, backend WS) keep the listener
+ * bound until they close on their own. During dev-mode shutdown we want
+ * the user-facing port released immediately, so cleanup paths should
+ * prefer `closeAll()` over `close()`.
+ */
+export interface WsProxyServer extends Server {
+	closeAll(): Promise<void>;
+}
+
+/**
  * Start a front-door TCP proxy that routes WebSocket upgrades to the Bun
  * backend and everything else to Vite. Returns the `net.Server` instance.
  */
-export function startWsProxy(options: WsProxyOptions): Promise<Server> {
+export function startWsProxy(options: WsProxyOptions): Promise<WsProxyServer> {
 	const { port, vitePort, backendPort, routePaths, logger } = options;
 
 	// Prefixes whose WebSocket upgrades go to Bun instead of Vite
 	const wsPathPrefixes = ['/_agentuity', ...routePaths];
 
+	// Track every live socket pair so shutdown can drop them. Without this,
+	// `server.close()` waits for active connections to terminate by themselves
+	// (e.g. browser HMR WebSockets), which can keep the user-facing port bound
+	// for many seconds after dev mode exits.
+	const liveSockets = new Set<Socket>();
+	const trackSocket = (sock: Socket) => {
+		liveSockets.add(sock);
+		sock.once('close', () => liveSockets.delete(sock));
+	};
+
 	return new Promise((resolve, reject) => {
 		const server = createServer((socket) => {
+			trackSocket(socket);
 			let handled = false;
 
 			// Peek at the first chunk to decide where to route
@@ -87,6 +113,7 @@ export function startWsProxy(options: WsProxyOptions): Promise<Server> {
 				}
 
 				const target = connect(targetPort, '127.0.0.1');
+				trackSocket(target);
 
 				target.on('connect', () => {
 					target.write(firstChunk);
@@ -109,7 +136,29 @@ export function startWsProxy(options: WsProxyOptions): Promise<Server> {
 			socket.on('error', () => {
 				if (!handled) socket.destroy();
 			});
-		});
+		}) as WsProxyServer;
+
+		// Async close that destroys live sockets first, then waits for the
+		// listener to close. Idempotent: safe to call after the server has
+		// already been closed by other means.
+		server.closeAll = () => {
+			return new Promise<void>((resolveClose) => {
+				for (const sock of liveSockets) {
+					try {
+						if (!sock.destroyed) sock.destroy();
+					} catch {
+						// Best effort
+					}
+				}
+				liveSockets.clear();
+
+				if (!server.listening) {
+					resolveClose();
+					return;
+				}
+				server.close(() => resolveClose());
+			});
+		};
 
 		server.on('error', reject);
 

--- a/packages/cli/src/cmd/dev/index.ts
+++ b/packages/cli/src/cmd/dev/index.ts
@@ -576,7 +576,7 @@ export const command = createCommand({
 			// Declared early so signal handlers can reference them before
 			// servers are started.
 			let viteServer: ServerLike | null = null;
-			let frontDoorServer: import('node:net').Server | null = null;
+			let frontDoorServer: import('../build/vite/ws-proxy').WsProxyServer | null = null;
 			let gravityProcess: ProcessLike | null = null;
 			let gravityHeartbeatInterval: ReturnType<typeof setInterval> | null = null;
 			let stdinListenerRegistered = false;
@@ -891,21 +891,20 @@ export const command = createCommand({
 					inspect: opts.inspect,
 					inspectWait: opts.inspectWait,
 					inspectBrk: opts.inspectBrk,
+					// Register the subprocess BEFORE the readiness wait so a SIGINT
+					// during startup can clean it up via procManager. Without this,
+					// the only safety net is the synchronous process.on('exit')
+					// handler, which is fragile and runs too late on some signals.
+					onSpawn: (proc) => {
+						procManager.registerProcess({
+							id: 'bun-backend',
+							process: proc,
+							description: 'Bun backend server (--hot)',
+							port: bunBackendPort,
+							critical: true,
+						});
+					},
 				});
-
-				// Register Bun subprocess with process manager
-				// The subprocess is stored in globalThis.__AGENTUITY_BUN_SUBPROCESS__
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				const bunSubprocess = (globalThis as any).__AGENTUITY_BUN_SUBPROCESS__ as ProcessLike;
-				if (bunSubprocess) {
-					procManager.registerProcess({
-						id: 'bun-backend',
-						process: bunSubprocess,
-						description: 'Bun backend server (--hot)',
-						port: bunBackendPort,
-						critical: true,
-					});
-				}
 			} catch (error) {
 				tui.error(`Failed to start Bun backend server: ${error}`);
 				await cleanup(true, 1, true);
@@ -939,12 +938,38 @@ export const command = createCommand({
 					);
 				}
 
-				// Register Vite server with process manager
+				// Register Vite server with process manager.
+				// We wrap close() to first force-drop keep-alive HTTP/HMR sockets via
+				// httpServer.closeAllConnections() (Node 18.2+). Without this, idle
+				// keep-alive connections keep the listener bound until they time out,
+				// which leaves the Vite port reserved for several seconds after the
+				// CLI exits. We also extend the close timeout (Vite's chokidar +
+				// HMR teardown can exceed 1s under load).
+				const viteForCleanup = viteServer;
 				procManager.registerServer({
 					id: 'vite',
-					server: viteServer,
+					server: {
+						close: async () => {
+							try {
+								const http = (
+									viteForCleanup as unknown as {
+										httpServer?: {
+											closeAllConnections?: () => void;
+											closeIdleConnections?: () => void;
+										};
+									}
+								).httpServer;
+								http?.closeIdleConnections?.();
+								http?.closeAllConnections?.();
+							} catch {
+								// Best effort — these methods are runtime-dependent.
+							}
+							await viteForCleanup.close();
+						},
+					},
 					description: 'Vite dev server (frontend assets)',
 					port: vitePort,
+					closeTimeoutMs: 3000,
 				});
 
 				// Update dev lock with actual Vite port
@@ -976,13 +1001,15 @@ export const command = createCommand({
 					logger,
 				});
 
-				// Register front-door proxy with process manager
+				// Register front-door proxy with process manager. Use closeAll()
+				// (returns a Promise) so cleanup actually waits for the listener
+				// to release the user-facing port instead of fire-and-forgetting.
+				// closeAll() also destroys live piped sockets (HMR WS, backend WS)
+				// so the listener doesn't sit waiting for clients to disconnect.
 				procManager.registerServer({
 					id: 'front-door-proxy',
 					server: {
-						close: () => {
-							frontDoorServer?.close();
-						},
+						close: () => frontDoorServer?.closeAll() ?? Promise.resolve(),
 					},
 					description: 'Front-door TCP proxy (WS routing)',
 					port: opts.port,

--- a/packages/cli/src/cmd/dev/process-manager.ts
+++ b/packages/cli/src/cmd/dev/process-manager.ts
@@ -47,6 +47,12 @@ export interface ManagedServer {
 	description: string;
 	/** The port this server uses */
 	port?: number;
+	/**
+	 * Maximum time (ms) to wait for this server's close() to resolve before
+	 * moving on. Defaults to 1000ms. Servers like Vite that own filesystem
+	 * watchers and HMR sockets may need more time.
+	 */
+	closeTimeoutMs?: number;
 }
 
 /**
@@ -208,14 +214,28 @@ export class ProcessManager {
 			const server = serverSnapshot[i];
 			if (!server) continue;
 
+			const closeTimeout = server.closeTimeoutMs ?? 1000;
 			try {
-				this.logger.debug('Closing server %s', server.id);
+				this.logger.debug('Closing server %s (timeout=%dms)', server.id, closeTimeout);
 				const closePromise = server.server.close();
 				if (closePromise instanceof Promise) {
+					let timedOut = false;
 					await Promise.race([
 						closePromise,
-						new Promise<void>((resolve) => setTimeout(resolve, 1000)),
+						new Promise<void>((resolve) =>
+							setTimeout(() => {
+								timedOut = true;
+								resolve();
+							}, closeTimeout)
+						),
 					]);
+					if (timedOut) {
+						this.logger.debug(
+							'Server %s did not close within %dms, continuing cleanup',
+							server.id,
+							closeTimeout
+						);
+					}
 				}
 			} catch (err) {
 				this.logger.debug('Error closing server %s: %s', server.id, err);

--- a/packages/cli/test/cmd/dev/bun-dev-server-onspawn.test.ts
+++ b/packages/cli/test/cmd/dev/bun-dev-server-onspawn.test.ts
@@ -115,35 +115,40 @@ describe('startBunDevServer onSpawn callback', () => {
 		const events: string[] = [];
 		let captured: { pid?: number; kill: (s?: NodeJS.Signals) => void } | null = null;
 
-		await startBunDevServer({
-			rootDir: projectDir,
-			port,
-			logger: mockLogger,
-			vitePort: port + 1,
-			onSpawn: (proc) => {
-				events.push('onSpawn');
-				captured = proc;
-				expect(typeof proc.kill).toBe('function');
-				// pid should be a real OS pid (>1) so the procManager can target
-				// the process group via process.kill(-pid, ...).
-				expect(typeof proc.pid).toBe('number');
-				expect(proc.pid!).toBeGreaterThan(1);
-				// At spawn time the child is alive \u2014 exitCode is null.
-				expect(proc.exitCode).toBeNull();
-			},
-		});
-		events.push('resolved');
+		try {
+			await startBunDevServer({
+				rootDir: projectDir,
+				port,
+				logger: mockLogger,
+				vitePort: port + 1,
+				onSpawn: (proc) => {
+					events.push('onSpawn');
+					captured = proc;
+					expect(typeof proc.kill).toBe('function');
+					// pid should be a real OS pid (>1) so the procManager can target
+					// the process group via process.kill(-pid, ...).
+					expect(typeof proc.pid).toBe('number');
+					expect(proc.pid!).toBeGreaterThan(1);
+					// At spawn time the child is alive \u2014 exitCode is null.
+					expect(proc.exitCode).toBeNull();
+				},
+			});
+			events.push('resolved');
 
-		// onSpawn must have fired BEFORE startBunDevServer resolved. This is
-		// the core orphan-prevention guarantee: registration with procManager
-		// happens before the readiness wait completes.
-		expect(events).toEqual(['onSpawn', 'resolved']);
-		expect(captured).not.toBeNull();
-
-		// Cleanup: kill the running subprocess.
-		killHandle(captured!);
-		// Give the OS a moment to release the port.
-		await new Promise((r) => setTimeout(r, 200));
+			// onSpawn must have fired BEFORE startBunDevServer resolved. This is
+			// the core orphan-prevention guarantee: registration with procManager
+			// happens before the readiness wait completes.
+			expect(events).toEqual(['onSpawn', 'resolved']);
+			expect(captured).not.toBeNull();
+		} finally {
+			// Always tear down, even if an assertion above failed. Without this
+			// a failed expect() would leave the Bun child alive and could poison
+			// later tests via reused PIDs / bound ports.
+			if (captured) {
+				killHandle(captured);
+				await new Promise((r) => setTimeout(r, 200));
+			}
+		}
 	}, 30000);
 
 	test('kills subprocess and rethrows when onSpawn throws', async () => {
@@ -200,11 +205,13 @@ describe('startBunDevServer onSpawn callback', () => {
 		expect(free).toBe(true);
 	}, 30000);
 
-	test('onSpawn fires even before HTTP readiness probe succeeds', async () => {
-		// This is a stricter version of the first test. We record the time
-		// from spawn-call to onSpawn invocation, and from spawn-call to
-		// resolution. onSpawn should fire well before resolution \u2014 there's
-		// always a multi-100ms gap as Bun boots and starts listening.
+	test('onSpawn fires strictly before HTTP readiness probe succeeds', async () => {
+		// Stricter version of the first test. We record the time of onSpawn
+		// invocation vs. function resolution. onSpawn must fire STRICTLY
+		// before resolution \u2014 the readiness probe always takes time as
+		// Bun boots and starts listening, so there's always a measurable gap.
+		// A non-strict (<=) check would pass even if onSpawn fired
+		// concurrently with resolution, missing real ordering regressions.
 		const { startBunDevServer } = await import(bunDevServerPath);
 		const port = await findAvailablePort(17500);
 
@@ -212,30 +219,32 @@ describe('startBunDevServer onSpawn callback', () => {
 		let onSpawnAt = 0;
 		let captured: { pid?: number; kill: (s?: NodeJS.Signals) => void } | null = null;
 
-		await startBunDevServer({
-			rootDir: projectDir,
-			port,
-			logger: mockLogger,
-			vitePort: port + 1,
-			onSpawn: (proc) => {
-				onSpawnAt = Date.now();
-				captured = proc;
-			},
-		});
-		const resolvedAt = Date.now();
+		try {
+			await startBunDevServer({
+				rootDir: projectDir,
+				port,
+				logger: mockLogger,
+				vitePort: port + 1,
+				onSpawn: (proc) => {
+					onSpawnAt = Date.now();
+					captured = proc;
+				},
+			});
+			const resolvedAt = Date.now();
 
-		const onSpawnDelay = onSpawnAt - startedAt;
-		const totalDelay = resolvedAt - startedAt;
-
-		// onSpawn must have fired strictly before resolution.
-		expect(onSpawnAt).toBeGreaterThan(0);
-		expect(onSpawnAt).toBeLessThanOrEqual(resolvedAt);
-		// And meaningfully earlier \u2014 at least the readiness probe takes
-		// some time. We use a soft lower bound (>=0ms) but require that
-		// total is >= onSpawn time, which is the real guarantee.
-		expect(totalDelay).toBeGreaterThanOrEqual(onSpawnDelay);
-
-		killHandle(captured!);
-		await new Promise((r) => setTimeout(r, 200));
+			// onSpawn fired at all, with a real timestamp.
+			expect(onSpawnAt).toBeGreaterThan(0);
+			// Sanity: onSpawn happened at or after we started.
+			expect(onSpawnAt).toBeGreaterThanOrEqual(startedAt);
+			// Strict ordering: onSpawn must fire BEFORE resolution. This is
+			// the actual guarantee \u2014 the readiness probe takes time, so
+			// the timestamps are always distinguishable when the contract holds.
+			expect(onSpawnAt).toBeLessThan(resolvedAt);
+		} finally {
+			if (captured) {
+				killHandle(captured);
+				await new Promise((r) => setTimeout(r, 200));
+			}
+		}
 	}, 30000);
 });

--- a/packages/cli/test/cmd/dev/bun-dev-server-onspawn.test.ts
+++ b/packages/cli/test/cmd/dev/bun-dev-server-onspawn.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Tests for the onSpawn callback added to startBunDevServer().
+ *
+ * The callback is the central piece of the orphan-prevention fix for the Bun
+ * backend: it lets dev/index.ts register the spawned subprocess with the
+ * process manager IMMEDIATELY after spawn, before the readiness wait.
+ * Without it, a SIGINT during the up-to-5s readiness loop would leave the
+ * subprocess unmanaged.
+ *
+ * These tests spawn a real (but tiny) Bun app, so they're slower than the
+ * pure-mock process-manager tests. We keep them in their own file so the
+ * fast tests remain fast.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import { createServer } from 'node:net';
+
+const bunDevServerPath = join(import.meta.dir, '../../../src/cmd/build/vite/bun-dev-server.ts');
+
+const mockLogger = {
+	trace: () => {},
+	debug: () => {},
+	info: () => {},
+	warn: () => {},
+	error: () => {},
+	fatal: () => {},
+	child: () => mockLogger,
+};
+
+async function findAvailablePort(start: number): Promise<number> {
+	for (let port = start; port < start + 200; port++) {
+		const free = await new Promise<boolean>((resolve) => {
+			const s = createServer();
+			s.once('error', () => resolve(false));
+			s.listen(port, '127.0.0.1', () => {
+				s.close(() => resolve(true));
+			});
+		});
+		if (free) return port;
+	}
+	throw new Error('No available port');
+}
+
+/**
+ * Build a minimal project Bun --hot can run successfully:
+ *   export default { fetch, port }
+ * Returns the project root.
+ */
+function createMinimalProject(): string {
+	const root = join(tmpdir(), `bun-onspawn-${Date.now()}-${randomUUID()}`);
+	mkdirSync(root, { recursive: true });
+	mkdirSync(join(root, 'src'), { recursive: true });
+	writeFileSync(
+		join(root, 'package.json'),
+		JSON.stringify({ name: 't', version: '0.0.0', type: 'module' })
+	);
+	writeFileSync(
+		join(root, 'app.ts'),
+		`export default {
+  port: Number(process.env.PORT ?? 0),
+  fetch() { return new Response('ok'); },
+};\n`
+	);
+	return root;
+}
+
+/**
+ * Best-effort cleanup of a running subprocess registered via onSpawn.
+ * Uses process-group SIGKILL on Unix to match production behavior.
+ */
+function killHandle(handle: { pid?: number; kill: (s?: NodeJS.Signals) => void }) {
+	const pid = handle.pid;
+	try {
+		if (typeof pid === 'number' && pid > 1 && process.platform !== 'win32') {
+			try {
+				process.kill(-pid, 'SIGKILL');
+				return;
+			} catch {
+				// fall through
+			}
+		}
+		handle.kill('SIGKILL');
+	} catch {
+		// best effort
+	}
+}
+
+describe('startBunDevServer onSpawn callback', () => {
+	let projectDir: string;
+
+	beforeEach(() => {
+		projectDir = createMinimalProject();
+	});
+
+	afterEach(() => {
+		try {
+			rmSync(projectDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+		// Clear any global subprocess handle the production code may have set,
+		// so tests stay isolated.
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(globalThis as any).__AGENTUITY_BUN_SUBPROCESS__ = undefined;
+	});
+
+	test('invokes onSpawn before startBunDevServer resolves, with a usable handle', async () => {
+		const { startBunDevServer } = await import(bunDevServerPath);
+		const port = await findAvailablePort(17100);
+
+		const events: string[] = [];
+		let captured: { pid?: number; kill: (s?: NodeJS.Signals) => void } | null = null;
+
+		await startBunDevServer({
+			rootDir: projectDir,
+			port,
+			logger: mockLogger,
+			vitePort: port + 1,
+			onSpawn: (proc) => {
+				events.push('onSpawn');
+				captured = proc;
+				expect(typeof proc.kill).toBe('function');
+				// pid should be a real OS pid (>1) so the procManager can target
+				// the process group via process.kill(-pid, ...).
+				expect(typeof proc.pid).toBe('number');
+				expect(proc.pid!).toBeGreaterThan(1);
+				// At spawn time the child is alive \u2014 exitCode is null.
+				expect(proc.exitCode).toBeNull();
+			},
+		});
+		events.push('resolved');
+
+		// onSpawn must have fired BEFORE startBunDevServer resolved. This is
+		// the core orphan-prevention guarantee: registration with procManager
+		// happens before the readiness wait completes.
+		expect(events).toEqual(['onSpawn', 'resolved']);
+		expect(captured).not.toBeNull();
+
+		// Cleanup: kill the running subprocess.
+		killHandle(captured!);
+		// Give the OS a moment to release the port.
+		await new Promise((r) => setTimeout(r, 200));
+	}, 30000);
+
+	test('kills subprocess and rethrows when onSpawn throws', async () => {
+		const { startBunDevServer } = await import(bunDevServerPath);
+		const port = await findAvailablePort(17300);
+
+		let capturedPid: number | undefined;
+		const sentinel = new Error('intentional onSpawn failure');
+
+		await expect(
+			startBunDevServer({
+				rootDir: projectDir,
+				port,
+				logger: mockLogger,
+				vitePort: port + 1,
+				onSpawn: (proc) => {
+					capturedPid = proc.pid;
+					throw sentinel;
+				},
+			})
+		).rejects.toBe(sentinel);
+
+		// The global handle must have been cleared so downstream cleanup
+		// doesn't try to re-kill an already-dead process.
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		expect((globalThis as any).__AGENTUITY_BUN_SUBPROCESS__).toBeUndefined();
+
+		// And the subprocess must be gone \u2014 verify the OS no longer sees it.
+		// Allow a brief grace window for SIGKILL to take effect.
+		await new Promise((r) => setTimeout(r, 200));
+
+		if (capturedPid && capturedPid > 1) {
+			let stillAlive = false;
+			try {
+				process.kill(capturedPid, 0);
+				stillAlive = true;
+			} catch (err) {
+				const code = (err as NodeJS.ErrnoException).code;
+				// ESRCH = no such process \u2014 exactly what we want.
+				stillAlive = code !== 'ESRCH';
+			}
+			expect(stillAlive).toBe(false);
+		}
+
+		// Port should be free again now that the subprocess is dead.
+		await new Promise((r) => setTimeout(r, 100));
+		const free = await new Promise<boolean>((resolve) => {
+			const s = createServer();
+			s.once('error', () => resolve(false));
+			s.listen(port, '127.0.0.1', () => {
+				s.close(() => resolve(true));
+			});
+		});
+		expect(free).toBe(true);
+	}, 30000);
+
+	test('onSpawn fires even before HTTP readiness probe succeeds', async () => {
+		// This is a stricter version of the first test. We record the time
+		// from spawn-call to onSpawn invocation, and from spawn-call to
+		// resolution. onSpawn should fire well before resolution \u2014 there's
+		// always a multi-100ms gap as Bun boots and starts listening.
+		const { startBunDevServer } = await import(bunDevServerPath);
+		const port = await findAvailablePort(17500);
+
+		const startedAt = Date.now();
+		let onSpawnAt = 0;
+		let captured: { pid?: number; kill: (s?: NodeJS.Signals) => void } | null = null;
+
+		await startBunDevServer({
+			rootDir: projectDir,
+			port,
+			logger: mockLogger,
+			vitePort: port + 1,
+			onSpawn: (proc) => {
+				onSpawnAt = Date.now();
+				captured = proc;
+			},
+		});
+		const resolvedAt = Date.now();
+
+		const onSpawnDelay = onSpawnAt - startedAt;
+		const totalDelay = resolvedAt - startedAt;
+
+		// onSpawn must have fired strictly before resolution.
+		expect(onSpawnAt).toBeGreaterThan(0);
+		expect(onSpawnAt).toBeLessThanOrEqual(resolvedAt);
+		// And meaningfully earlier \u2014 at least the readiness probe takes
+		// some time. We use a soft lower bound (>=0ms) but require that
+		// total is >= onSpawn time, which is the real guarantee.
+		expect(totalDelay).toBeGreaterThanOrEqual(onSpawnDelay);
+
+		killHandle(captured!);
+		await new Promise((r) => setTimeout(r, 200));
+	}, 30000);
+});

--- a/packages/cli/test/cmd/dev/dev-respawn.test.ts
+++ b/packages/cli/test/cmd/dev/dev-respawn.test.ts
@@ -20,7 +20,7 @@
  * EADDRINUSE.
  */
 
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, afterEach } from 'bun:test';
 import { join } from 'node:path';
 import { createServer, connect } from 'node:net';
 
@@ -56,7 +56,19 @@ interface OrchHandle {
 	vitePort: number;
 	bunPort: number;
 	stop: (signal?: NodeJS.Signals) => Promise<number | null>;
+	/** Set true by stop() so afterEach can skip already-cleaned-up handles. */
+	stopped: boolean;
 }
+
+/**
+ * Tracks every orchestrator started by the current test. Cleared after each
+
+ * test by the afterEach hook in the describe block, which force-stops any
+ * handle still alive (i.e. a test threw before reaching its happy-path
+ * stop()). Without this, a failed assertion would leak the detached process
+ * group and bind ports for subsequent tests.
+ */
+const startedHandles: OrchHandle[] = [];
 
 /**
  * Spawn the orchestrator and resolve once it prints "READY".
@@ -128,30 +140,48 @@ async function startOrchestrator(opts: {
 				// already dead
 			}
 		}
-		// Wait for exit. Force-kill after 5s.
-		const exitCode = await Promise.race([
-			proc.exited,
-			new Promise<number | null>((resolve) =>
-				setTimeout(() => {
-					try {
-						process.kill(-pid, 'SIGKILL');
-					} catch {
-						// already dead
-					}
-					resolve(null);
-				}, 5000)
-			),
-		]);
-		return typeof exitCode === 'number' ? exitCode : null;
+		// Wait for exit. Force-kill after 5s. We hold a reference to the
+		// fallback timer so we can clearTimeout() it when proc.exited wins;
+		// otherwise Promise.race leaves a live timer that will later try to
+		// SIGKILL a (now reused) PID and may also keep the test runner alive.
+		let killTimer: ReturnType<typeof setTimeout> | null = null;
+		try {
+			const exitCode = await Promise.race([
+				proc.exited,
+				new Promise<number | null>((resolve) => {
+					killTimer = setTimeout(() => {
+						try {
+							process.kill(-pid, 'SIGKILL');
+						} catch {
+							try {
+								proc.kill('SIGKILL');
+							} catch {
+								// already dead
+							}
+						}
+						resolve(null);
+					}, 5000);
+				}),
+			]);
+			return typeof exitCode === 'number' ? exitCode : null;
+		} finally {
+			if (killTimer) clearTimeout(killTimer);
+		}
 	};
 
-	return {
+	const handle: OrchHandle = {
 		pid,
 		proxyPort: opts.proxyPort,
 		vitePort: opts.vitePort,
 		bunPort: opts.bunPort,
-		stop,
+		stopped: false,
+		stop: async (signal?: NodeJS.Signals) => {
+			handle.stopped = true;
+			return stop(signal);
+		},
 	};
+	startedHandles.push(handle);
+	return handle;
 }
 
 async function expectPortServingHttp(port: number): Promise<string> {
@@ -162,6 +192,22 @@ async function expectPortServingHttp(port: number): Promise<string> {
 }
 
 describe('dev mode spawn / kill / respawn', () => {
+	afterEach(async () => {
+		// Force-tear-down any orchestrator still alive (a test failed before
+		// reaching its happy-path stop()). We use SIGKILL because we no
+		// longer care about graceful shutdown at this point \u2014 we just
+		// need the process group dead so the next test isn't poisoned.
+		const leaked = startedHandles.filter((h) => !h.stopped);
+		startedHandles.length = 0;
+		for (const h of leaked) {
+			try {
+				await h.stop('SIGKILL');
+			} catch {
+				// best effort
+			}
+		}
+	});
+
 	test('SIGTERM releases all three ports so a fresh instance can bind them', async () => {
 		// Pick three ports we can reuse.
 		const proxyPort = await findAvailablePort(18000);

--- a/packages/cli/test/cmd/dev/dev-respawn.test.ts
+++ b/packages/cli/test/cmd/dev/dev-respawn.test.ts
@@ -1,0 +1,302 @@
+/**
+ * End-to-end orphan-prevention test for the dev-mode startup/shutdown cycle.
+ *
+ * Verifies the central guarantee the user asked about: spawning dev mode,
+ * killing it, and spawning another instance on the same ports must succeed
+ * without conflicts. Concretely:
+ *
+ *   1. Spawn an orchestrator subprocess that boots all three pieces of the
+ *      dev-mode plumbing (front-door proxy, Vite stub, Bun stub) registered
+ *      with the real ProcessManager.
+ *   2. Wait for "READY".
+ *   3. SIGTERM the subprocess.
+ *   4. Verify all three ports are free again (the orphan-prevention fix).
+ *   5. Spawn a SECOND orchestrator on the SAME ports \u2014 must succeed.
+ *   6. Verify it works, then clean up.
+ *
+ * If the front-door proxy's old `close()` (which doesn't destroy live
+ * sockets) had been used, an open WebSocket would have kept the proxy
+ * port bound past the SIGTERM grace window, and step 5 would fail with
+ * EADDRINUSE.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { join } from 'node:path';
+import { createServer, connect } from 'node:net';
+
+const orchestratorPath = join(import.meta.dir, 'fixtures/dev-orchestrator.ts');
+
+async function findAvailablePort(start: number): Promise<number> {
+	for (let port = start; port < start + 500; port++) {
+		const free = await new Promise<boolean>((resolve) => {
+			const s = createServer();
+			s.once('error', () => resolve(false));
+			s.listen(port, '127.0.0.1', () => {
+				s.close(() => resolve(true));
+			});
+		});
+		if (free) return port;
+	}
+	throw new Error('No available port');
+}
+
+async function isPortFree(port: number): Promise<boolean> {
+	return new Promise((resolve) => {
+		const s = createServer();
+		s.once('error', () => resolve(false));
+		s.listen(port, '127.0.0.1', () => {
+			s.close(() => resolve(true));
+		});
+	});
+}
+
+interface OrchHandle {
+	pid: number;
+	proxyPort: number;
+	vitePort: number;
+	bunPort: number;
+	stop: (signal?: NodeJS.Signals) => Promise<number | null>;
+}
+
+/**
+ * Spawn the orchestrator and resolve once it prints "READY".
+ *
+ * Spawned with detached:true so it becomes a process-group leader. That
+ * mirrors how dev/index.ts runs in production (Bun subprocess is a PG
+ * leader so process.kill(-pid, ...) reaches the whole tree) and also
+ * isolates SIGTERM to the orchestrator's group, not the test runner's.
+ */
+async function startOrchestrator(opts: {
+	proxyPort: number;
+	vitePort: number;
+	bunPort: number;
+}): Promise<OrchHandle> {
+	const proc = Bun.spawn(['bun', 'run', orchestratorPath], {
+		stdout: 'pipe',
+		stderr: 'pipe',
+		env: {
+			...process.env,
+			ORCH_PROXY_PORT: String(opts.proxyPort),
+			ORCH_VITE_PORT: String(opts.vitePort),
+			ORCH_BUN_PORT: String(opts.bunPort),
+		},
+		detached: true,
+	});
+
+	const pid = proc.pid;
+	if (!pid) throw new Error('orchestrator spawn returned no pid');
+
+	// Stream stdout looking for READY. Time out after 10s.
+	const ready = new Promise<void>((resolve, reject) => {
+		const timer = setTimeout(() => reject(new Error('orchestrator never reported READY')), 10000);
+		(async () => {
+			try {
+				if (!proc.stdout) {
+					clearTimeout(timer);
+					reject(new Error('orchestrator has no stdout'));
+					return;
+				}
+				const decoder = new TextDecoder();
+				let buf = '';
+				for await (const chunk of proc.stdout as ReadableStream<Uint8Array>) {
+					buf += decoder.decode(chunk);
+					if (buf.includes('READY')) {
+						clearTimeout(timer);
+						resolve();
+						return;
+					}
+				}
+				clearTimeout(timer);
+				reject(new Error('orchestrator stdout closed before READY'));
+			} catch (err) {
+				clearTimeout(timer);
+				reject(err);
+			}
+		})();
+	});
+
+	await ready;
+
+	const stop = async (signal: NodeJS.Signals = 'SIGTERM'): Promise<number | null> => {
+		// Kill the orchestrator's process group so any children are also caught.
+		try {
+			process.kill(-pid, signal);
+		} catch {
+			try {
+				proc.kill(signal);
+			} catch {
+				// already dead
+			}
+		}
+		// Wait for exit. Force-kill after 5s.
+		const exitCode = await Promise.race([
+			proc.exited,
+			new Promise<number | null>((resolve) =>
+				setTimeout(() => {
+					try {
+						process.kill(-pid, 'SIGKILL');
+					} catch {
+						// already dead
+					}
+					resolve(null);
+				}, 5000)
+			),
+		]);
+		return typeof exitCode === 'number' ? exitCode : null;
+	};
+
+	return {
+		pid,
+		proxyPort: opts.proxyPort,
+		vitePort: opts.vitePort,
+		bunPort: opts.bunPort,
+		stop,
+	};
+}
+
+async function expectPortServingHttp(port: number): Promise<string> {
+	const res = await fetch(`http://127.0.0.1:${port}/`, {
+		signal: AbortSignal.timeout(2000),
+	});
+	return await res.text();
+}
+
+describe('dev mode spawn / kill / respawn', () => {
+	test('SIGTERM releases all three ports so a fresh instance can bind them', async () => {
+		// Pick three ports we can reuse.
+		const proxyPort = await findAvailablePort(18000);
+		const vitePort = await findAvailablePort(proxyPort + 1);
+		const bunPort = await findAvailablePort(vitePort + 1);
+
+		// --- Round 1 ---
+		const first = await startOrchestrator({ proxyPort, vitePort, bunPort });
+
+		// All three ports are bound now.
+		expect(await isPortFree(proxyPort)).toBe(false);
+		expect(await isPortFree(vitePort)).toBe(false);
+		expect(await isPortFree(bunPort)).toBe(false);
+
+		// And the front-door proxy actually proxies through to Vite.
+		const body1 = await expectPortServingHttp(proxyPort);
+		expect(body1).toContain('ok-vite');
+
+		// SIGTERM and wait for exit.
+		const code = await first.stop('SIGTERM');
+		expect(code).toBe(0);
+
+		// All three ports must be free now. This is the central orphan-
+		// prevention assertion: the front-door proxy must have released
+		// its listener, even though the proxy holds piped sockets.
+		// Allow a brief OS tick for TIME_WAIT / TCP teardown.
+		await new Promise((r) => setTimeout(r, 200));
+		expect(await isPortFree(proxyPort)).toBe(true);
+		expect(await isPortFree(vitePort)).toBe(true);
+		expect(await isPortFree(bunPort)).toBe(true);
+
+		// --- Round 2: same ports, must succeed ---
+		const second = await startOrchestrator({ proxyPort, vitePort, bunPort });
+
+		expect(await isPortFree(proxyPort)).toBe(false);
+		expect(await isPortFree(vitePort)).toBe(false);
+		expect(await isPortFree(bunPort)).toBe(false);
+
+		const body2 = await expectPortServingHttp(proxyPort);
+		expect(body2).toContain('ok-vite');
+
+		// Cleanup.
+		await second.stop('SIGTERM');
+		await new Promise((r) => setTimeout(r, 200));
+		expect(await isPortFree(proxyPort)).toBe(true);
+		expect(await isPortFree(vitePort)).toBe(true);
+		expect(await isPortFree(bunPort)).toBe(true);
+	}, 30000);
+
+	test('SIGTERM with a long-lived WebSocket through the proxy still releases ports', async () => {
+		// Reproduces the actual orphan condition. Open a WebSocket-style
+		// piped connection through the front-door proxy and keep it alive,
+		// then kill the orchestrator. Without the closeAll() fix the proxy
+		// listener would refuse to close while the WS is open and the
+		// proxy port would remain bound past SIGTERM \u2014 the second
+		// startOrchestrator() call would fail with EADDRINUSE.
+		const proxyPort = await findAvailablePort(18500);
+		const vitePort = await findAvailablePort(proxyPort + 1);
+		const bunPort = await findAvailablePort(vitePort + 1);
+
+		const first = await startOrchestrator({ proxyPort, vitePort, bunPort });
+
+		// Open a long-lived "WebSocket" upgrade through the proxy. The
+		// orchestrator's Bun stub is a plain HTTP server that won't speak
+		// WS, but the proxy still pipes the bytes through and that's all
+		// we need to exercise the keep-the-port-bound code path.
+		const wsKey = Buffer.from('test-key-1234567890ab').toString('base64');
+		const upgradeReq = [
+			'GET /api/stream HTTP/1.1',
+			`Host: 127.0.0.1:${proxyPort}`,
+			'Upgrade: websocket',
+			'Connection: Upgrade',
+			`Sec-WebSocket-Key: ${wsKey}`,
+			'Sec-WebSocket-Version: 13',
+			'\r\n',
+		].join('\r\n');
+
+		const wsClient = await new Promise<ReturnType<typeof connect>>((resolve, reject) => {
+			const c = connect(proxyPort, '127.0.0.1');
+			c.once('error', reject);
+			c.once('connect', () => {
+				c.write(upgradeReq);
+				// Wait briefly so the proxy actually pipes through.
+				setTimeout(() => resolve(c), 100);
+			});
+		});
+
+		// Kill the orchestrator while the WS is still connected.
+		const code = await first.stop('SIGTERM');
+		expect(code).toBe(0);
+
+		// The piped client should be torn down by closeAll().
+		await new Promise((r) => setTimeout(r, 200));
+
+		// Ports MUST be free even though we held a WS open.
+		expect(await isPortFree(proxyPort)).toBe(true);
+		expect(await isPortFree(vitePort)).toBe(true);
+		expect(await isPortFree(bunPort)).toBe(true);
+
+		// And we can bind a fresh instance on the same ports.
+		const second = await startOrchestrator({ proxyPort, vitePort, bunPort });
+		const body = await expectPortServingHttp(proxyPort);
+		expect(body).toContain('ok-vite');
+
+		await second.stop('SIGTERM');
+		await new Promise((r) => setTimeout(r, 200));
+		expect(await isPortFree(proxyPort)).toBe(true);
+
+		// Make sure we don't leak the client socket.
+		try {
+			wsClient.destroy();
+		} catch {
+			// already dead
+		}
+	}, 45000);
+
+	test('SIGKILL of orchestrator also leaves ports free (worst-case OS reaping)', async () => {
+		// Belt-and-suspenders: even on SIGKILL (no graceful shutdown), the
+		// kernel reaps the listening sockets. This is what happens when
+		// dev mode crashes hard. We verify the next instance can still bind.
+		const proxyPort = await findAvailablePort(19000);
+		const vitePort = await findAvailablePort(proxyPort + 1);
+		const bunPort = await findAvailablePort(vitePort + 1);
+
+		const first = await startOrchestrator({ proxyPort, vitePort, bunPort });
+		await first.stop('SIGKILL');
+
+		// SIGKILL relies on the OS to release sockets \u2014 give it a moment.
+		await new Promise((r) => setTimeout(r, 500));
+		expect(await isPortFree(proxyPort)).toBe(true);
+		expect(await isPortFree(vitePort)).toBe(true);
+		expect(await isPortFree(bunPort)).toBe(true);
+
+		// Respawn must succeed.
+		const second = await startOrchestrator({ proxyPort, vitePort, bunPort });
+		await second.stop('SIGTERM');
+	}, 30000);
+});

--- a/packages/cli/test/cmd/dev/fixtures/dev-orchestrator.ts
+++ b/packages/cli/test/cmd/dev/fixtures/dev-orchestrator.ts
@@ -1,0 +1,119 @@
+/**
+ * Test fixture that simulates the dev mode startup/shutdown flow.
+ *
+ * Spawned as a subprocess by `dev-respawn.test.ts`. Boots:
+ *   - A real front-door TCP proxy (the production ws-proxy.ts module).
+ *   - A stand-in HTTP server on the "Bun" port.
+ *   - A stand-in HTTP server on the "Vite" port.
+ *
+ * All three are registered with a real ProcessManager, mirroring what
+ * dev/index.ts does in production. On SIGTERM we run procManager.cleanup()
+ * and exit.
+ *
+ * Reads ports from env: ORCH_PROXY_PORT, ORCH_VITE_PORT, ORCH_BUN_PORT.
+ * Writes "READY <proxyPort>" to stdout once everything is listening.
+ */
+
+import { createServer as createHttpServer } from 'node:http';
+import { startWsProxy } from '../../../../src/cmd/build/vite/ws-proxy';
+import { ProcessManager, initProcessManager } from '../../../../src/cmd/dev/process-manager';
+
+const proxyPort = Number(process.env.ORCH_PROXY_PORT ?? 0);
+const vitePort = Number(process.env.ORCH_VITE_PORT ?? 0);
+const bunPort = Number(process.env.ORCH_BUN_PORT ?? 0);
+
+if (!proxyPort || !vitePort || !bunPort) {
+	console.error(
+		'orchestrator: missing required env (ORCH_PROXY_PORT, ORCH_VITE_PORT, ORCH_BUN_PORT)'
+	);
+	process.exit(2);
+}
+
+const logger = {
+	trace: () => {},
+	debug: () => {},
+	info: () => {},
+	warn: () => {},
+	error: (msg: string, ...args: unknown[]) => console.error('[orch]', msg, ...args),
+	fatal: () => {},
+	child: () => logger,
+};
+
+// Use the real ProcessManager so we exercise the production cleanup path.
+const procManager: ProcessManager = initProcessManager(logger);
+
+async function main() {
+	// 1) Stand-in "Bun" backend.
+	const bunServer = createHttpServer((_req, res) => {
+		res.statusCode = 200;
+		res.end('ok-bun');
+	});
+	await new Promise<void>((resolve, reject) => {
+		bunServer.once('error', reject);
+		bunServer.listen(bunPort, '127.0.0.1', () => resolve());
+	});
+	procManager.registerServer({
+		id: 'bun-stub',
+		server: bunServer,
+		description: 'Bun backend stub',
+		port: bunPort,
+	});
+
+	// 2) Stand-in "Vite" server.
+	const viteServer = createHttpServer((_req, res) => {
+		res.statusCode = 200;
+		res.end('ok-vite');
+	});
+	await new Promise<void>((resolve, reject) => {
+		viteServer.once('error', reject);
+		viteServer.listen(vitePort, '127.0.0.1', () => resolve());
+	});
+	procManager.registerServer({
+		id: 'vite-stub',
+		server: viteServer,
+		description: 'Vite stub',
+		port: vitePort,
+	});
+
+	// 3) Real front-door proxy. Critical: register with closeAll() so
+	// shutdown actually destroys piped sockets and releases the user port.
+	const frontDoor = await startWsProxy({
+		port: proxyPort,
+		vitePort,
+		backendPort: bunPort,
+		routePaths: ['/api'],
+		logger,
+	});
+	procManager.registerServer({
+		id: 'front-door-proxy',
+		server: { close: () => frontDoor.closeAll() },
+		description: 'Front-door TCP proxy',
+		port: proxyPort,
+	});
+
+	// Signal readiness.
+	console.log(`READY ${proxyPort}`);
+
+	let cleaning = false;
+	const shutdown = async (reason: string) => {
+		if (cleaning) return;
+		cleaning = true;
+		try {
+			await procManager.cleanup(reason, 3000);
+		} catch (err) {
+			console.error('[orch] cleanup error:', err);
+		}
+		// Give the OS a final tick to release listening sockets.
+		await new Promise((r) => setTimeout(r, 50));
+		process.exit(0);
+	};
+
+	process.on('SIGTERM', () => void shutdown('SIGTERM'));
+	process.on('SIGINT', () => void shutdown('SIGINT'));
+	process.on('SIGHUP', () => void shutdown('SIGHUP'));
+}
+
+main().catch((err) => {
+	console.error('[orch] startup failed:', err);
+	process.exit(1);
+});

--- a/packages/cli/test/cmd/dev/process-manager.test.ts
+++ b/packages/cli/test/cmd/dev/process-manager.test.ts
@@ -197,6 +197,89 @@ describe('ProcessManager', () => {
 			expect(serverClosed).toBe(true);
 		});
 
+		test('default server close timeout (~1s) gives up on slow servers', async () => {
+			// A server whose close() never resolves should not block cleanup
+			// past the default 1s budget.
+			let resolved = false;
+
+			manager.registerServer({
+				id: 'slow-server',
+				server: {
+					close: () =>
+						new Promise<void>((resolve) => {
+							setTimeout(() => {
+								resolved = true;
+								resolve();
+							}, 5000);
+						}),
+				},
+				description: 'Slow server',
+			});
+
+			const start = Date.now();
+			await manager.cleanup('test', 200);
+			const elapsed = Date.now() - start;
+
+			// cleanup should bail out via the default 1000ms server-close cap,
+			// not wait for the 5s close().
+			expect(elapsed).toBeLessThan(1500);
+			expect(resolved).toBe(false);
+		});
+
+		test('respects per-server closeTimeoutMs override', async () => {
+			// A server with a longer override should be waited on past the
+			// 1s default. We use 1500ms close() with a 2500ms override and
+			// verify close() actually completed.
+			let resolved = false;
+
+			manager.registerServer({
+				id: 'patient-server',
+				server: {
+					close: () =>
+						new Promise<void>((resolve) => {
+							setTimeout(() => {
+								resolved = true;
+								resolve();
+							}, 1500);
+						}),
+				},
+				description: 'Patient server',
+				closeTimeoutMs: 2500,
+			});
+
+			await manager.cleanup('test', 200);
+
+			expect(resolved).toBe(true);
+		});
+
+		test('per-server closeTimeoutMs caps a hung close()', async () => {
+			// Override BELOW default to verify we use the override, not 1000ms.
+			let resolved = false;
+
+			manager.registerServer({
+				id: 'tight-budget',
+				server: {
+					close: () =>
+						new Promise<void>((resolve) => {
+							setTimeout(() => {
+								resolved = true;
+								resolve();
+							}, 5000);
+						}),
+				},
+				description: 'Tight budget server',
+				closeTimeoutMs: 100,
+			});
+
+			const start = Date.now();
+			await manager.cleanup('test', 200);
+			const elapsed = Date.now() - start;
+
+			// We should bail out around the 100ms override, well before 1000ms default.
+			expect(elapsed).toBeLessThan(500);
+			expect(resolved).toBe(false);
+		});
+
 		test('handles already-exited processes gracefully', async () => {
 			let killCalled = false;
 

--- a/packages/cli/test/cmd/dev/ws-proxy.test.ts
+++ b/packages/cli/test/cmd/dev/ws-proxy.test.ts
@@ -687,4 +687,302 @@ describe('WS Proxy', () => {
 			await new Promise<void>((resolve) => backendServer.close(() => resolve()));
 		});
 	});
+
+	describe('closeAll() shutdown semantics', () => {
+		// These tests verify the orphan-prevention fix: server.close() alone
+		// only stops accepting new connections, but leaves piped sockets (HMR
+		// WebSocket, backend WS) holding the listening port bound. closeAll()
+		// must destroy live sockets first so the user-facing port is released
+		// immediately on dev-mode shutdown.
+
+		test('exposes a closeAll() method that resolves with no connections', async () => {
+			const { startWsProxy } = await import(wsProxyPath);
+
+			const proxyPort = await findAvailablePort(15500);
+			const vitePort = await findAvailablePort(proxyPort + 1);
+			const backendPort = await findAvailablePort(vitePort + 1);
+
+			const viteServer = await createEchoServer(vitePort, 'VITE');
+			const backendServer = await createEchoServer(backendPort, 'BUN');
+
+			const proxy = await startWsProxy({
+				port: proxyPort,
+				vitePort,
+				backendPort,
+				routePaths: ['/api'],
+				logger: mockLogger,
+			});
+
+			expect(typeof proxy.closeAll).toBe('function');
+			await proxy.closeAll();
+			expect(proxy.listening).toBe(false);
+
+			await new Promise<void>((resolve) => viteServer.close(() => resolve()));
+			await new Promise<void>((resolve) => backendServer.close(() => resolve()));
+		});
+
+		test('closeAll() releases the listening port (rebindable immediately)', async () => {
+			const { startWsProxy } = await import(wsProxyPath);
+
+			const proxyPort = await findAvailablePort(15600);
+			const vitePort = await findAvailablePort(proxyPort + 1);
+			const backendPort = await findAvailablePort(vitePort + 1);
+
+			const viteServer = await createEchoServer(vitePort, 'VITE');
+			const backendServer = await createEchoServer(backendPort, 'BUN');
+
+			const proxy = await startWsProxy({
+				port: proxyPort,
+				vitePort,
+				backendPort,
+				routePaths: ['/api'],
+				logger: mockLogger,
+			});
+
+			await proxy.closeAll();
+
+			// We must be able to bind the same port immediately.
+			await new Promise<void>((resolve, reject) => {
+				const rebind = createServer();
+				rebind.once('error', reject);
+				rebind.listen(proxyPort, '127.0.0.1', () => {
+					rebind.close(() => resolve());
+				});
+			});
+
+			await new Promise<void>((resolve) => viteServer.close(() => resolve()));
+			await new Promise<void>((resolve) => backendServer.close(() => resolve()));
+		});
+
+		test('plain close() does NOT finish while a piped WebSocket is open', async () => {
+			// Establishes the orphan condition closeAll() must fix: native
+			// `Server.close(cb)` only stops accepting new connections — the
+			// callback does not fire until every active socket has closed.
+			// With long-lived HMR / backend WebSockets piped through the proxy
+			// this means dev-mode shutdown would hang indefinitely waiting for
+			// the listener to release the port.
+			const { startWsProxy } = await import(wsProxyPath);
+
+			const proxyPort = await findAvailablePort(15700);
+			const vitePort = await findAvailablePort(proxyPort + 1);
+			const backendPort = await findAvailablePort(vitePort + 1);
+
+			// Backend that never closes the socket — simulates a long-lived WS.
+			const stickyBackend = await new Promise<Server>((resolve, reject) => {
+				const s = createServer((sock) => {
+					sock.on('data', () => {
+						/* keep alive, never respond, never close */
+					});
+					sock.on('error', () => {});
+				});
+				s.on('error', reject);
+				s.listen(backendPort, '127.0.0.1', () => resolve(s));
+			});
+
+			const viteServer = await createEchoServer(vitePort, 'VITE');
+
+			const proxy = await startWsProxy({
+				port: proxyPort,
+				vitePort,
+				backendPort,
+				routePaths: ['/api'],
+				logger: mockLogger,
+			});
+
+			// Open a WebSocket upgrade to the backend and keep the client alive.
+			const client = await new Promise<ReturnType<typeof connect>>((resolve, reject) => {
+				const c = connect(proxyPort, '127.0.0.1');
+				c.once('error', reject);
+				c.once('connect', () => {
+					c.write(createWebSocketUpgradeRequest('/api/stream', '127.0.0.1', proxyPort));
+					setTimeout(() => resolve(c), 100);
+				});
+			});
+
+			// Trigger native close() and watch for the callback. It must NOT
+			// fire while the WebSocket is still piped — that's the orphan
+			// condition the closeAll() fix addresses.
+			let closeCallbackFired = false;
+			proxy.close(() => {
+				closeCallbackFired = true;
+			});
+			await new Promise<void>((resolve) => setTimeout(resolve, 200));
+			expect(closeCallbackFired).toBe(false);
+
+			// Dropping the client lets close() finally complete — confirms it
+			// really was waiting on the WebSocket and not on something else.
+			client.destroy();
+			await new Promise<void>((resolve) => setTimeout(resolve, 200));
+			expect(closeCallbackFired).toBe(true);
+
+			await new Promise<void>((resolve) => viteServer.close(() => resolve()));
+			await new Promise<void>((resolve) => stickyBackend.close(() => resolve()));
+		});
+
+		test('closeAll() releases the port even with a long-lived WebSocket open', async () => {
+			// The fix: closeAll() destroys live piped sockets first, so the
+			// listening port is released immediately, regardless of any open
+			// HMR/backend WebSockets. This is the central orphan-prevention
+			// guarantee for the front-door proxy on dev-mode shutdown.
+			const { startWsProxy } = await import(wsProxyPath);
+
+			const proxyPort = await findAvailablePort(15800);
+			const vitePort = await findAvailablePort(proxyPort + 1);
+			const backendPort = await findAvailablePort(vitePort + 1);
+
+			const stickyBackend = await new Promise<Server>((resolve, reject) => {
+				const s = createServer((sock) => {
+					sock.on('data', () => {});
+					sock.on('error', () => {});
+				});
+				s.on('error', reject);
+				s.listen(backendPort, '127.0.0.1', () => resolve(s));
+			});
+
+			const viteServer = await createEchoServer(vitePort, 'VITE');
+
+			const proxy = await startWsProxy({
+				port: proxyPort,
+				vitePort,
+				backendPort,
+				routePaths: ['/api'],
+				logger: mockLogger,
+			});
+
+			// Open a WS upgrade and keep the client alive; the proxy will
+			// pipe it to the sticky backend that never closes.
+			const client = await new Promise<ReturnType<typeof connect>>((resolve, reject) => {
+				const c = connect(proxyPort, '127.0.0.1');
+				c.once('error', reject);
+				c.once('connect', () => {
+					c.write(createWebSocketUpgradeRequest('/api/stream', '127.0.0.1', proxyPort));
+					setTimeout(() => resolve(c), 100);
+				});
+			});
+
+			// closeAll() must complete promptly even with the WS open.
+			const start = Date.now();
+			await proxy.closeAll();
+			const elapsed = Date.now() - start;
+
+			// Generous bound — we only need to confirm it didn't hang on the
+			// open client connection. With socket.destroy() this should be ~ms.
+			expect(elapsed).toBeLessThan(500);
+			expect(proxy.listening).toBe(false);
+
+			// And the port must be immediately rebindable — the actual orphan
+			// symptom we're preventing.
+			await new Promise<void>((resolve, reject) => {
+				const rebind = createServer();
+				rebind.once('error', reject);
+				rebind.listen(proxyPort, '127.0.0.1', () => {
+					rebind.close(() => resolve());
+				});
+			});
+
+			// The piped client socket should have been destroyed by closeAll().
+			// Wait briefly for the close event to propagate to the client side.
+			await new Promise<void>((resolve) => {
+				if (client.destroyed) return resolve();
+				client.once('close', () => resolve());
+				setTimeout(resolve, 200);
+			});
+			expect(client.destroyed).toBe(true);
+
+			await new Promise<void>((resolve) => viteServer.close(() => resolve()));
+			await new Promise<void>((resolve) => stickyBackend.close(() => resolve()));
+		});
+
+		test('closeAll() lets you immediately bind a fresh proxy on the same port (the orphan-prevention guarantee)', async () => {
+			// In-process equivalent of the spawn / kill / respawn cycle from
+			// dev-respawn.test.ts, but exercising only the proxy. This is the
+			// scenario where the closeAll() fix matters most: the parent
+			// process stays alive across cleanup, so we don't get the
+			// kernel-on-process-exit safety net. Without closeAll(), an open
+			// piped WebSocket would keep the listener bound and the second
+			// startWsProxy() on the same port would fail with EADDRINUSE.
+			const { startWsProxy } = await import(wsProxyPath);
+
+			const proxyPort = await findAvailablePort(15850);
+			const vitePort = await findAvailablePort(proxyPort + 1);
+			const backendPort = await findAvailablePort(vitePort + 1);
+
+			const stickyBackend = await new Promise<Server>((resolve, reject) => {
+				const s = createServer((sock) => {
+					sock.on('data', () => {});
+					sock.on('error', () => {});
+				});
+				s.on('error', reject);
+				s.listen(backendPort, '127.0.0.1', () => resolve(s));
+			});
+
+			const viteServer = await createEchoServer(vitePort, 'VITE');
+
+			const proxy1 = await startWsProxy({
+				port: proxyPort,
+				vitePort,
+				backendPort,
+				routePaths: ['/api'],
+				logger: mockLogger,
+			});
+
+			// Open the long-lived WS that would otherwise leak the listener.
+			const client = await new Promise<ReturnType<typeof connect>>((resolve, reject) => {
+				const c = connect(proxyPort, '127.0.0.1');
+				c.once('error', reject);
+				c.once('connect', () => {
+					c.write(createWebSocketUpgradeRequest('/api/stream', '127.0.0.1', proxyPort));
+					setTimeout(() => resolve(c), 100);
+				});
+			});
+
+			await proxy1.closeAll();
+
+			// Immediate respawn on the same port — must succeed.
+			const proxy2 = await startWsProxy({
+				port: proxyPort,
+				vitePort,
+				backendPort,
+				routePaths: ['/api'],
+				logger: mockLogger,
+			});
+			expect(proxy2.listening).toBe(true);
+
+			await proxy2.closeAll();
+			try {
+				client.destroy();
+			} catch {
+				// already dead
+			}
+			await new Promise<void>((resolve) => viteServer.close(() => resolve()));
+			await new Promise<void>((resolve) => stickyBackend.close(() => resolve()));
+		});
+
+		test('closeAll() is idempotent', async () => {
+			const { startWsProxy } = await import(wsProxyPath);
+
+			const proxyPort = await findAvailablePort(15900);
+			const vitePort = await findAvailablePort(proxyPort + 1);
+			const backendPort = await findAvailablePort(vitePort + 1);
+
+			const viteServer = await createEchoServer(vitePort, 'VITE');
+			const backendServer = await createEchoServer(backendPort, 'BUN');
+
+			const proxy = await startWsProxy({
+				port: proxyPort,
+				vitePort,
+				backendPort,
+				routePaths: ['/api'],
+				logger: mockLogger,
+			});
+
+			await proxy.closeAll();
+			// Second call must not throw.
+			await proxy.closeAll();
+			expect(proxy.listening).toBe(false);
+
+			await new Promise<void>((resolve) => viteServer.close(() => resolve()));
+			await new Promise<void>((resolve) => backendServer.close(() => resolve()));
+		});
+	});
 });


### PR DESCRIPTION
The dev mode process manager had three gaps that could leak listening sockets and orphan subprocesses across spawn/kill/respawn cycles:

1. Front-door TCP proxy was registered with a fire-and-forget close() that returned no Promise and never destroyed live piped sockets (HMR WebSocket, backend WS). procManager.cleanup() couldn't actually await the listener release, and long-lived WebSockets kept the user-facing port bound past shutdown.

2. Bun --hot subprocess was registered with procManager only AFTER the up-to-5s readiness wait completed. A SIGINT during that window left the subprocess unmanaged \u2014 only the synchronous process.on('exit') safety net would catch it.

3. Vite's close() was given a hard 1s budget shared with all other servers, with no way to extend it. Vite's chokidar + HMR teardown can exceed 1s under load, leaving the listener bound briefly.

Fixes:

- ws-proxy: WsProxyServer now exposes closeAll(): Promise<void> that destroys tracked client+upstream sockets, then awaits the native close. dev/index.ts registers the proxy with this method so cleanup is bounded and deterministic.

- bun-dev-server: startBunDevServer accepts onSpawn?: (proc) => void, invoked the moment Bun.spawn returns (before readiness probe). dev/index.ts uses it to register the subprocess with procManager atomically with spawn. If onSpawn throws, the subprocess is killed and the error rethrown.

- process-manager: ManagedServer gains closeTimeoutMs?: number for per-server overrides (default 1000ms). Vite is registered with 3000ms and a wrapper that calls httpServer.closeIdleConnections() + closeAllConnections() before close() to actively drop keep-alive HTTP/HMR sockets.

Tests added (15 new, 99 total in dev/):

- ws-proxy.test.ts: closeAll() exists & resolves, releases port with no connections, plain close() does NOT finish while a piped WS is open (proves the bug), closeAll() releases port even with open WS, closeAll() lets you immediately bind a fresh proxy on the same port, closeAll() is idempotent.

- process-manager.test.ts: default 1s server-close cap, per-server closeTimeoutMs extends the wait, per-server override caps a hung close().

- bun-dev-server-onspawn.test.ts (new): onSpawn fires before startBunDevServer resolves with a usable handle (real pid, kill function), throwing in onSpawn kills the subprocess and clears the global handle and frees the port.

- dev-respawn.test.ts + fixtures/dev-orchestrator.ts (new): spawn the dev plumbing as a subprocess via a real ProcessManager + real ws-proxy + HTTP stand-ins for Bun/Vite, then SIGTERM and verify all 3 ports are released and a second instance can bind them. Repeated with a long-lived WebSocket open through the proxy (the orphan-causing condition) and with SIGKILL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a spawn callback to register subprocess management immediately when the dev backend starts.
  * Proxy server now exposes an enhanced shutdown that force-closes piped connections to free ports immediately.

* **Bug Fixes**
  * Improved dev shutdown to reliably release listening ports and avoid "address in use" on restart.
  * Added per-server shutdown timeout to prevent indefinite hangs.

* **Tests**
  * Added extensive end-to-end and unit tests covering spawn behavior, shutdown/respawn, proxy teardown, and port-release semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->