### PR TITLE
fix: parse named Coder SSE events

### DIFF
--- a/packages/core/src/services/coder/sse.ts
+++ b/packages/core/src/services/coder/sse.ts
@@ -45,7 +45,7 @@
  * })) {
  *   console.log('Event:', event.event, event.data);
  *
- *   if (event.event === 'broadcast' && event.data.event === 'session_complete') {
+ *   if (event.data.type === 'broadcast' && event.data.event === 'session_complete') {
  *     controller.abort(); // Stop the stream
  *   }
  * }
@@ -166,7 +166,7 @@ export const CoderSSEError = StructuredError('CoderSSEError')<{
  * A single SSE event with its event name and parsed data.
  */
 export interface CoderSSEEvent {
-	/** The SSE event name (e.g., 'snapshot', 'broadcast', 'presence') */
+	/** The SSE event name (e.g., 'snapshot', 'message_update', 'session_join') */
 	event: string;
 	/** The parsed event data */
 	data: ObserverSseMessage;
@@ -234,12 +234,142 @@ async function buildSSEUrl(
 	return queryString ? `${baseUrl}${path}?${queryString}` : `${baseUrl}${path}`;
 }
 
-function getSSEData(event: Event): string | null {
-	const msgEvent = event as unknown as { data?: unknown };
-	if (typeof msgEvent.data === 'string') {
-		return msgEvent.data;
+interface ParsedSSEFrame {
+	event: string;
+	data: string;
+}
+
+const TYPED_TRANSPORT_EVENTS = new Set(['snapshot', 'hydration', 'presence', 'broadcast']);
+
+function isAbortError(err: unknown): boolean {
+	return err instanceof Error && err.name === 'AbortError';
+}
+
+function parseSSEFrame(block: string): ParsedSSEFrame | null {
+	let event = 'message';
+	const dataLines: string[] = [];
+
+	for (const line of block.split('\n')) {
+		if (!line || line.startsWith(':')) continue;
+
+		const separatorIndex = line.indexOf(':');
+		const field = separatorIndex === -1 ? line : line.slice(0, separatorIndex);
+		let value = separatorIndex === -1 ? '' : line.slice(separatorIndex + 1);
+		if (value.startsWith(' ')) {
+			value = value.slice(1);
+		}
+
+		if (field === 'event') {
+			event = value || 'message';
+		} else if (field === 'data') {
+			dataLines.push(value);
+		}
 	}
-	return null;
+
+	if (dataLines.length === 0) {
+		return null;
+	}
+
+	return {
+		event,
+		data: dataLines.join('\n'),
+	};
+}
+
+function consumeSSEBuffer(rawBuffer: string, onFrame: (frame: ParsedSSEFrame) => void): string {
+	const normalized = rawBuffer.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+	let cursor = 0;
+
+	while (true) {
+		const boundary = normalized.indexOf('\n\n', cursor);
+		if (boundary === -1) break;
+
+		const block = normalized.slice(cursor, boundary);
+		cursor = boundary + 2;
+		if (!block.trim()) continue;
+
+		const frame = parseSSEFrame(block);
+		if (frame) {
+			onFrame(frame);
+		}
+	}
+
+	return normalized.slice(cursor);
+}
+
+function decodeCoderSSEEvent(frame: ParsedSSEFrame, sessionId: string): CoderSSEEvent {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(frame.data);
+	} catch (err) {
+		throw new CoderSSEError({
+			message: `Failed to parse SSE ${frame.event} event: ${err instanceof Error ? err.message : String(err)}`,
+			code: 'parse_error',
+			sessionId,
+		});
+	}
+
+	const payload =
+		TYPED_TRANSPORT_EVENTS.has(frame.event) && parsed && typeof parsed === 'object'
+			? { type: frame.event, ...(parsed as Record<string, unknown>) }
+			: parsed;
+	const result = ObserverSseMessageSchema.safeParse(payload);
+
+	if (!result.success) {
+		throw new CoderSSEError({
+			message: `Invalid SSE ${frame.event} event format`,
+			code: 'parse_error',
+			sessionId,
+		});
+	}
+
+	const event = frame.event === 'message' ? result.data.type : frame.event;
+	return { event, data: result.data };
+}
+
+async function readSSEStream(
+	response: Response,
+	signal: AbortSignal,
+	onEvent: (event: CoderSSEEvent) => void,
+	sessionId: string
+): Promise<void> {
+	if (!response.body) {
+		throw new CoderSSEError({
+			message: 'SSE response did not include a readable body',
+			code: 'connection_failed',
+			sessionId,
+		});
+	}
+
+	const reader = response.body.getReader();
+	const decoder = new TextDecoder();
+	let buffer = '';
+
+	try {
+		while (!signal.aborted) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			buffer += decoder.decode(value, { stream: true });
+			buffer = consumeSSEBuffer(buffer, (frame) => {
+				onEvent(decodeCoderSSEEvent(frame, sessionId));
+			});
+		}
+	} finally {
+		try {
+			reader.releaseLock();
+		} catch {
+			// Some runtimes throw if the reader is already released after abort.
+		}
+	}
+}
+
+function buildConnectionError(response: Response, sessionId: string): Error {
+	return new CoderSSEError({
+		message: `SSE connection failed: ${response.status} ${response.statusText || 'HTTP error'}`,
+		code:
+			response.status === 401 || response.status === 403 ? 'auth_failed' : 'connection_failed',
+		sessionId,
+	});
 }
 
 /**
@@ -291,7 +421,7 @@ export class CoderSSEClient {
 		onError?: (error: Error) => void;
 	};
 	#state: CoderSSEState = 'closed';
-	#eventSource: EventSource | null = null;
+	#abortController: AbortController | null = null;
 	#reconnectAttempts = 0;
 	#reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 	#intentionallyClosed = false;
@@ -336,7 +466,7 @@ export class CoderSSEClient {
 	 * Whether the client is currently connected and receiving events.
 	 */
 	get isConnected(): boolean {
-		return this.#state === 'connected' && this.#eventSource?.readyState === 1;
+		return this.#state === 'connected' && this.#abortController !== null;
 	}
 
 	/**
@@ -369,9 +499,9 @@ export class CoderSSEClient {
 			clearTimeout(this.#reconnectTimer);
 			this.#reconnectTimer = null;
 		}
-		if (this.#eventSource) {
-			this.#eventSource.close();
-			this.#eventSource = null;
+		if (this.#abortController) {
+			this.#abortController.abort();
+			this.#abortController = null;
 		}
 		this.#state = 'closed';
 		this.#options.onClose?.();
@@ -381,47 +511,18 @@ export class CoderSSEClient {
 		this.#state = state;
 	}
 
-	#handleEvent(eventName: string, typeOverride?: string): void {
-		this.#eventSource!.addEventListener(eventName, (event: Event) => {
-			const data = getSSEData(event);
-			if (!data) return;
+	#dispatchEvent(event: CoderSSEEvent): void {
+		this.#options.onEvent?.(event);
 
-			try {
-				const parsed = JSON.parse(data);
-				const payload = typeOverride ? { type: typeOverride, ...parsed } : parsed;
-				const result = ObserverSseMessageSchema.safeParse(payload);
-
-				if (result.success) {
-					const semanticEvent = typeOverride || result.data.type;
-					const sseEvent: CoderSSEEvent = { event: semanticEvent, data: result.data };
-					this.#options.onEvent?.(sseEvent);
-
-					if (result.data.type === 'snapshot') {
-						this.#options.onSnapshot?.(result.data);
-					} else if (result.data.type === 'hydration') {
-						this.#options.onHydration?.(result.data);
-					} else if (result.data.type === 'presence') {
-						this.#options.onPresence?.(result.data);
-					} else if (result.data.type === 'broadcast') {
-						this.#options.onBroadcast?.(result.data);
-					}
-				} else {
-					const parseError = new CoderSSEError({
-						message: `Invalid SSE ${eventName} event format`,
-						code: 'parse_error',
-						sessionId: this.#options.sessionId,
-					});
-					this.#options.onError?.(parseError);
-				}
-			} catch (err) {
-				const parseError = new CoderSSEError({
-					message: `Failed to parse SSE ${eventName} event: ${err instanceof Error ? err.message : String(err)}`,
-					code: 'parse_error',
-					sessionId: this.#options.sessionId,
-				});
-				this.#options.onError?.(parseError);
-			}
-		});
+		if (event.data.type === 'snapshot') {
+			this.#options.onSnapshot?.(event.data);
+		} else if (event.data.type === 'hydration') {
+			this.#options.onHydration?.(event.data);
+		} else if (event.data.type === 'presence') {
+			this.#options.onPresence?.(event.data);
+		} else if (event.data.type === 'broadcast') {
+			this.#options.onBroadcast?.(event.data);
+		}
 	}
 
 	async #connectInternal(): Promise<void> {
@@ -444,19 +545,27 @@ export class CoderSSEClient {
 			return;
 		}
 
-		// Workaround for bun-types EventSource constructor typing issue.
-		// The type definitions don't match the runtime signature, so we use
-		// a double type assertion to construct EventSource with a URL parameter.
+		const controller = new AbortController();
+		this.#abortController = controller;
+
+		let response: Response;
 		try {
-			const EventSourceCtor: typeof EventSource = EventSource;
-			this.#eventSource = new (EventSourceCtor as unknown as new (url: string) => EventSource)(
-				url
-			);
+			response = await fetch(url, {
+				headers: {
+					accept: 'text/event-stream',
+				},
+				signal: controller.signal,
+			});
 		} catch (err) {
+			this.#abortController = null;
+			if (this.#intentionallyClosed || isAbortError(err)) {
+				this.#setState('closed');
+				return;
+			}
 			this.#setState('closed');
 			this.#options.onError?.(
 				new CoderSSEError({
-					message: `Failed to create EventSource: ${err instanceof Error ? err.message : String(err)}`,
+					message: `Failed to connect SSE stream: ${err instanceof Error ? err.message : String(err)}`,
 					code: 'connection_failed',
 					sessionId: this.#options.sessionId,
 				})
@@ -465,23 +574,15 @@ export class CoderSSEClient {
 			return;
 		}
 
-		this.#eventSource.onerror = () => {
-			// Notify caller of transient error before reconnecting
-			this.#options.onError?.(new Error('EventSource transient error'));
-
-			if (this.#eventSource) {
-				this.#eventSource.close();
-				this.#eventSource = null;
-			}
-
-			if (this.#intentionallyClosed) {
-				return;
-			}
-
+		if (!response.ok) {
+			this.#abortController = null;
+			this.#setState('closed');
+			this.#options.onError?.(buildConnectionError(response, this.#options.sessionId));
 			this.#scheduleReconnect();
-		};
+			return;
+		}
 
-		this.#eventSource.onopen = () => {
+		try {
 			this.#reconnectAttempts = 0;
 			this.#setState('connected');
 			this.#options.logger.debug(
@@ -489,13 +590,27 @@ export class CoderSSEClient {
 				this.#options.sessionId
 			);
 			this.#options.onOpen?.();
-		};
 
-		this.#handleEvent('snapshot', 'snapshot');
-		this.#handleEvent('hydration', 'hydration');
-		this.#handleEvent('presence', 'presence');
-		this.#handleEvent('broadcast', 'broadcast');
-		this.#handleEvent('message');
+			await readSSEStream(
+				response,
+				controller.signal,
+				(event) => this.#dispatchEvent(event),
+				this.#options.sessionId
+			);
+		} catch (err) {
+			if (this.#intentionallyClosed || isAbortError(err)) {
+				return;
+			}
+			this.#options.onError?.(err instanceof Error ? err : new Error(String(err)));
+		} finally {
+			if (this.#abortController === controller) {
+				this.#abortController = null;
+			}
+		}
+
+		if (!this.#intentionallyClosed) {
+			this.#scheduleReconnect();
+		}
 	}
 
 	#scheduleReconnect(): void {
@@ -600,7 +715,7 @@ export async function* streamCoderSessionSSE(
 		return;
 	}
 
-	let eventSource: EventSource | null = null;
+	let activeController: AbortController | null = null;
 	let reconnectAttempts = 0;
 	const buffer: CoderSSEEvent[] = [];
 	const MAX_BUFFER = 1000;
@@ -616,49 +731,10 @@ export async function* streamCoderSessionSSE(
 	};
 
 	const cleanup = () => {
-		if (eventSource) {
-			eventSource.close();
-			eventSource = null;
+		if (activeController) {
+			activeController.abort();
+			activeController = null;
 		}
-	};
-
-	const handleSSEEvent = (eventName: string, typeOverride?: string) => {
-		eventSource!.addEventListener(eventName, (event: Event) => {
-			const data = getSSEData(event);
-			if (!data) return;
-			try {
-				const parsed = JSON.parse(data);
-				const payload = typeOverride ? { type: typeOverride, ...parsed } : parsed;
-				const result = ObserverSseMessageSchema.safeParse(payload);
-				if (result.success) {
-					if (buffer.length >= MAX_BUFFER) {
-						buffer.shift();
-						logger.debug('SSE buffer full, dropped oldest event');
-					}
-					const semanticEvent = typeOverride || result.data.type;
-					buffer.push({ event: semanticEvent, data: result.data });
-					wake();
-				} else {
-					terminalError = new CoderSSEError({
-						message: `Invalid SSE ${eventName} event format`,
-						code: 'parse_error',
-						sessionId: options.sessionId,
-					});
-					done = true;
-					wake();
-					return;
-				}
-			} catch (err) {
-				terminalError = new CoderSSEError({
-					message: `Failed to parse SSE ${eventName} event: ${err instanceof Error ? err.message : String(err)}`,
-					code: 'parse_error',
-					sessionId: options.sessionId,
-				});
-				done = true;
-				wake();
-				return;
-			}
-		});
 	};
 
 	const connect = async (): Promise<void> => {
@@ -685,76 +761,127 @@ export async function* streamCoderSessionSSE(
 			return;
 		}
 
-		// Workaround for bun-types EventSource constructor typing issue (see above).
+		const controller = new AbortController();
+		activeController = controller;
+		const abortFromCaller = () => controller.abort();
+		signal?.addEventListener('abort', abortFromCaller, { once: true });
+
+		let response: Response;
 		try {
-			const EventSourceCtor: typeof EventSource = EventSource;
-			eventSource = new (EventSourceCtor as unknown as new (url: string) => EventSource)(url);
-		} catch (err) {
-			terminalError = new CoderSSEError({
-				message: `Failed to create EventSource: ${err instanceof Error ? err.message : String(err)}`,
-				code: 'connection_failed',
-				sessionId: options.sessionId,
+			response = await fetch(url, {
+				headers: {
+					accept: 'text/event-stream',
+				},
+				signal: controller.signal,
 			});
+		} catch (err) {
+			signal?.removeEventListener('abort', abortFromCaller);
+			if (activeController === controller) {
+				activeController = null;
+			}
+			if (signal?.aborted || isAbortError(err)) {
+				done = true;
+				wake();
+				return;
+			}
+			terminalError =
+				err instanceof CoderSSEError
+					? err
+					: new CoderSSEError({
+							message: `Failed to connect SSE stream: ${err instanceof Error ? err.message : String(err)}`,
+							code: 'connection_failed',
+							sessionId: options.sessionId,
+						});
 			done = true;
 			wake();
 			return;
 		}
 
 		if (signal?.aborted) {
+			signal?.removeEventListener('abort', abortFromCaller);
 			cleanup();
 			done = true;
 			wake();
 			return;
 		}
 
-		eventSource.onerror = () => {
-			cleanup();
-
-			if (signal?.aborted) {
-				done = true;
-				wake();
-				return;
+		if (!response.ok) {
+			signal?.removeEventListener('abort', abortFromCaller);
+			if (activeController === controller) {
+				activeController = null;
 			}
+			terminalError = buildConnectionError(response, options.sessionId);
+			done = true;
+			wake();
+			return;
+		}
 
-			if (reconnect && reconnectAttempts < maxReconnectAttempts) {
-				const baseDelay = reconnectDelayMs * 2 ** reconnectAttempts;
-				const jitter = 0.5 + Math.random() * 0.5;
-				const delay = Math.min(Math.floor(baseDelay * jitter), maxReconnectDelayMs);
+		reconnectAttempts = 0;
+		logger.debug('SSE connection established for session %s', options.sessionId);
 
-				reconnectAttempts++;
-				logger.debug(
-					'SSE connection lost, reconnecting in %dms (attempt %d)',
-					delay,
-					reconnectAttempts
-				);
-
-				setTimeout(() => {
-					connect();
-				}, delay);
-			} else if (reconnect) {
-				terminalError = new CoderSSEError({
-					message: `Exceeded maximum reconnection attempts (${maxReconnectAttempts})`,
-					code: 'max_reconnects_exceeded',
-					sessionId: options.sessionId,
-				});
+		void readSSEStream(
+			response,
+			controller.signal,
+			(event) => {
+				if (buffer.length >= MAX_BUFFER) {
+					buffer.shift();
+					logger.debug('SSE buffer full, dropped oldest event');
+				}
+				buffer.push(event);
+				wake();
+			},
+			options.sessionId
+		)
+			.catch((err) => {
+				if (signal?.aborted || isAbortError(err)) {
+					done = true;
+					wake();
+					return;
+				}
+				terminalError = err instanceof Error ? err : new Error(String(err));
 				done = true;
 				wake();
-			} else {
-				done = true;
-				wake();
-			}
-		};
+			})
+			.finally(() => {
+				signal?.removeEventListener('abort', abortFromCaller);
+				if (activeController === controller) {
+					activeController = null;
+				}
 
-		eventSource.onopen = () => {
-			reconnectAttempts = 0;
-			logger.debug('SSE connection established for session %s', options.sessionId);
-		};
+				if (done || signal?.aborted) {
+					done = true;
+					wake();
+					return;
+				}
 
-		handleSSEEvent('snapshot', 'snapshot');
-		handleSSEEvent('hydration', 'hydration');
-		handleSSEEvent('presence', 'presence');
-		handleSSEEvent('broadcast', 'broadcast');
-		handleSSEEvent('message');
+				if (reconnect && reconnectAttempts < maxReconnectAttempts) {
+					const baseDelay = reconnectDelayMs * 2 ** reconnectAttempts;
+					const jitter = 0.5 + Math.random() * 0.5;
+					const delay = Math.min(Math.floor(baseDelay * jitter), maxReconnectDelayMs);
+
+					reconnectAttempts++;
+					logger.debug(
+						'SSE connection lost, reconnecting in %dms (attempt %d)',
+						delay,
+						reconnectAttempts
+					);
+
+					setTimeout(() => {
+						connect();
+					}, delay);
+				} else if (reconnect) {
+					terminalError = new CoderSSEError({
+						message: `Exceeded maximum reconnection attempts (${maxReconnectAttempts})`,
+						code: 'max_reconnects_exceeded',
+						sessionId: options.sessionId,
+					});
+					done = true;
+					wake();
+				} else {
+					done = true;
+					wake();
+				}
+			});
 	};
 
 	const onAbort = () => {

--- a/packages/core/src/services/coder/sse.ts
+++ b/packages/core/src/services/coder/sse.ts
@@ -372,6 +372,13 @@ function buildConnectionError(response: Response, sessionId: string): Error {
 	});
 }
 
+function isRetryableStreamError(error: Error): boolean {
+	if (error instanceof CoderSSEError) {
+		return error.code === 'connection_failed';
+	}
+	return true;
+}
+
 /**
  * Class-based SSE client for observing Coder Hub sessions.
  *
@@ -722,6 +729,7 @@ export async function* streamCoderSessionSSE(
 	let resolve: (() => void) | null = null;
 	let done = false;
 	let terminalError: Error | null = null;
+	let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
 	const wake = () => {
 		if (resolve) {
@@ -731,10 +739,70 @@ export async function* streamCoderSessionSSE(
 	};
 
 	const cleanup = () => {
+		if (reconnectTimer !== null) {
+			clearTimeout(reconnectTimer);
+			reconnectTimer = null;
+		}
 		if (activeController) {
 			activeController.abort();
 			activeController = null;
 		}
+	};
+
+	const finish = (error?: Error) => {
+		if (error) {
+			terminalError = error;
+		}
+		done = true;
+		wake();
+	};
+
+	const scheduleReconnect = (error?: Error) => {
+		if (done) {
+			return;
+		}
+
+		if (signal?.aborted || (error && isAbortError(error))) {
+			finish();
+			return;
+		}
+
+		if (error && !isRetryableStreamError(error)) {
+			finish(error);
+			return;
+		}
+
+		if (!reconnect) {
+			finish(error);
+			return;
+		}
+
+		if (reconnectAttempts >= maxReconnectAttempts) {
+			finish(
+				new CoderSSEError({
+					message: `Exceeded maximum reconnection attempts (${maxReconnectAttempts})`,
+					code: 'max_reconnects_exceeded',
+					sessionId: options.sessionId,
+				})
+			);
+			return;
+		}
+
+		const baseDelay = reconnectDelayMs * 2 ** reconnectAttempts;
+		const jitter = 0.5 + Math.random() * 0.5;
+		const delay = Math.min(Math.floor(baseDelay * jitter), maxReconnectDelayMs);
+
+		reconnectAttempts++;
+		logger.debug(
+			'SSE connection lost, reconnecting in %dms (attempt %d)',
+			delay,
+			reconnectAttempts
+		);
+
+		reconnectTimer = setTimeout(() => {
+			reconnectTimer = null;
+			void connect();
+		}, delay);
 	};
 
 	const connect = async (): Promise<void> => {
@@ -749,15 +817,12 @@ export async function* streamCoderSessionSSE(
 				logger,
 			});
 		} catch (err) {
-			terminalError = err as Error;
-			done = true;
-			wake();
+			finish(err instanceof Error ? err : new Error(String(err)));
 			return;
 		}
 
 		if (signal?.aborted) {
-			done = true;
-			wake();
+			finish();
 			return;
 		}
 
@@ -780,11 +845,10 @@ export async function* streamCoderSessionSSE(
 				activeController = null;
 			}
 			if (signal?.aborted || isAbortError(err)) {
-				done = true;
-				wake();
+				finish();
 				return;
 			}
-			terminalError =
+			const error =
 				err instanceof CoderSSEError
 					? err
 					: new CoderSSEError({
@@ -792,16 +856,14 @@ export async function* streamCoderSessionSSE(
 							code: 'connection_failed',
 							sessionId: options.sessionId,
 						});
-			done = true;
-			wake();
+			scheduleReconnect(error);
 			return;
 		}
 
 		if (signal?.aborted) {
 			signal?.removeEventListener('abort', abortFromCaller);
 			cleanup();
-			done = true;
-			wake();
+			finish();
 			return;
 		}
 
@@ -810,14 +872,13 @@ export async function* streamCoderSessionSSE(
 			if (activeController === controller) {
 				activeController = null;
 			}
-			terminalError = buildConnectionError(response, options.sessionId);
-			done = true;
-			wake();
+			scheduleReconnect(buildConnectionError(response, options.sessionId));
 			return;
 		}
 
 		reconnectAttempts = 0;
 		logger.debug('SSE connection established for session %s', options.sessionId);
+		let readFailed = false;
 
 		void readSSEStream(
 			response,
@@ -833,14 +894,8 @@ export async function* streamCoderSessionSSE(
 			options.sessionId
 		)
 			.catch((err) => {
-				if (signal?.aborted || isAbortError(err)) {
-					done = true;
-					wake();
-					return;
-				}
-				terminalError = err instanceof Error ? err : new Error(String(err));
-				done = true;
-				wake();
+				readFailed = true;
+				scheduleReconnect(err instanceof Error ? err : new Error(String(err)));
 			})
 			.finally(() => {
 				signal?.removeEventListener('abort', abortFromCaller);
@@ -849,45 +904,21 @@ export async function* streamCoderSessionSSE(
 				}
 
 				if (done || signal?.aborted) {
-					done = true;
-					wake();
+					finish();
 					return;
 				}
 
-				if (reconnect && reconnectAttempts < maxReconnectAttempts) {
-					const baseDelay = reconnectDelayMs * 2 ** reconnectAttempts;
-					const jitter = 0.5 + Math.random() * 0.5;
-					const delay = Math.min(Math.floor(baseDelay * jitter), maxReconnectDelayMs);
-
-					reconnectAttempts++;
-					logger.debug(
-						'SSE connection lost, reconnecting in %dms (attempt %d)',
-						delay,
-						reconnectAttempts
-					);
-
-					setTimeout(() => {
-						connect();
-					}, delay);
-				} else if (reconnect) {
-					terminalError = new CoderSSEError({
-						message: `Exceeded maximum reconnection attempts (${maxReconnectAttempts})`,
-						code: 'max_reconnects_exceeded',
-						sessionId: options.sessionId,
-					});
-					done = true;
-					wake();
-				} else {
-					done = true;
-					wake();
+				if (readFailed) {
+					return;
 				}
+
+				scheduleReconnect();
 			});
 	};
 
 	const onAbort = () => {
-		done = true;
 		cleanup();
-		wake();
+		finish();
 	};
 
 	signal?.addEventListener('abort', onAbort, { once: true });
@@ -918,6 +949,7 @@ export async function* streamCoderSessionSSE(
 		}
 	} finally {
 		signal?.removeEventListener('abort', onAbort);
+		done = true;
 		cleanup();
 	}
 }

--- a/packages/core/test/coder-sse.test.ts
+++ b/packages/core/test/coder-sse.test.ts
@@ -1,67 +1,94 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { CoderSSEClient, streamCoderSessionSSE } from '../src/services/coder/sse.ts';
 
-const OriginalEventSource = globalThis.EventSource;
+const OriginalFetch = globalThis.fetch;
 
-type MockListener = (event: Event) => void;
+class MockSSEConnection {
+	static instances: MockSSEConnection[] = [];
 
-class MockEventSource {
-	static CONNECTING = 0;
-	static OPEN = 1;
-	static CLOSED = 2;
-	static instances: MockEventSource[] = [];
-
-	readyState = MockEventSource.CONNECTING;
-	onopen: ((event: Event) => void) | null = null;
-	onerror: ((event: Event) => void) | null = null;
 	readonly url: string;
-	readonly listeners = new Map<string, MockListener[]>();
+	readonly init?: RequestInit;
+	readonly response: Response;
+	closed = false;
+	#controller!: ReadableStreamDefaultController<Uint8Array>;
+	#encoder = new TextEncoder();
 
-	constructor(url: string) {
+	constructor(url: string, init?: RequestInit, status = 200, statusText = 'OK') {
 		this.url = url;
-		MockEventSource.instances.push(this);
-	}
+		this.init = init;
 
-	addEventListener(eventName: string, listener: MockListener) {
-		const existing = this.listeners.get(eventName) ?? [];
-		existing.push(listener);
-		this.listeners.set(eventName, existing);
-	}
+		const stream = new ReadableStream<Uint8Array>({
+			start: (controller) => {
+				this.#controller = controller;
+			},
+			cancel: () => {
+				this.closed = true;
+			},
+		});
 
-	close() {
-		this.readyState = MockEventSource.CLOSED;
-	}
-
-	open() {
-		this.readyState = MockEventSource.OPEN;
-		this.onopen?.(new Event('open'));
+		this.response = new Response(stream, {
+			status,
+			statusText,
+			headers: {
+				'content-type': 'text/event-stream',
+			},
+		});
+		MockSSEConnection.instances.push(this);
 	}
 
 	emit(eventName: string, payload: unknown) {
-		const listeners = this.listeners.get(eventName) ?? [];
-		const event = {
-			data: JSON.stringify(payload),
-		} as MessageEvent;
-		for (const listener of listeners) {
-			listener(event);
+		this.#controller.enqueue(
+			this.#encoder.encode(`event: ${eventName}\ndata: ${JSON.stringify(payload)}\n\n`)
+		);
+	}
+
+	close() {
+		this.closed = true;
+		try {
+			this.#controller.close();
+		} catch {
+			// Already closed or aborted.
 		}
 	}
+
+	abort() {
+		this.closed = true;
+		try {
+			this.#controller.error(new DOMException('Aborted', 'AbortError'));
+		} catch {
+			// Already closed or aborted.
+		}
+	}
+}
+
+function installMockFetch(status = 200, statusText = 'OK') {
+	globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+		const connection = new MockSSEConnection(String(input), init, status, statusText);
+		const signal = init?.signal;
+		if (signal?.aborted) {
+			connection.abort();
+			return Promise.reject(new DOMException('Aborted', 'AbortError'));
+		}
+		signal?.addEventListener('abort', () => connection.abort(), { once: true });
+		return Promise.resolve(connection.response);
+	}) as typeof fetch;
 }
 
 async function flushAsyncWork() {
 	await Promise.resolve();
 	await Promise.resolve();
+	await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 describe('Coder SSE observer clients', () => {
 	beforeEach(() => {
-		MockEventSource.instances = [];
-		globalThis.EventSource = MockEventSource as unknown as typeof EventSource;
+		MockSSEConnection.instances = [];
+		installMockFetch();
 	});
 
 	afterEach(() => {
-		globalThis.EventSource = OriginalEventSource;
-		MockEventSource.instances = [];
+		globalThis.fetch = OriginalFetch;
+		MockSSEConnection.instances = [];
 	});
 
 	it('uses default observer subscriptions unless explicit filters are provided', async () => {
@@ -80,21 +107,73 @@ describe('Coder SSE observer clients', () => {
 		client.connect();
 		await flushAsyncWork();
 
-		const eventSource = MockEventSource.instances[0];
-		expect(eventSource).toBeDefined();
-		expect(decodeURIComponent(eventSource!.url)).toContain(
+		const connection = MockSSEConnection.instances[0];
+		expect(connection).toBeDefined();
+		expect(decodeURIComponent(connection!.url)).toContain(
 			'/api/hub/session/codesess_sse_default/events'
 		);
-		expect(decodeURIComponent(eventSource!.url)).toContain('api_key=ag_test');
-		expect(decodeURIComponent(eventSource!.url)).toContain('org_id=org_test');
-		expect(decodeURIComponent(eventSource!.url)).not.toContain('subscribe=');
-
-		eventSource!.open();
+		expect(decodeURIComponent(connection!.url)).toContain('api_key=ag_test');
+		expect(decodeURIComponent(connection!.url)).toContain('org_id=org_test');
+		expect(decodeURIComponent(connection!.url)).not.toContain('subscribe=');
+		expect(connection!.init?.headers).toEqual({ accept: 'text/event-stream' });
 		expect(client.state).toBe('connected');
 		expect(openCount).toBe(1);
+
+		client.close();
 	});
 
-	it('streams broadcast events when explicit raw-event subscriptions are requested', async () => {
+	it('dispatches Hub named broadcast SSE events to class client callbacks', async () => {
+		const seenEvents: Array<{ event: string; data: unknown }> = [];
+		const broadcasts: unknown[] = [];
+		const client = new CoderSSEClient({
+			url: 'https://hub.example',
+			sessionId: 'codesess_sse_client',
+			subscribe: ['*'],
+			reconnect: false,
+			onEvent: (event) => {
+				seenEvents.push(event);
+			},
+			onBroadcast: (event) => {
+				broadcasts.push(event);
+			},
+		});
+
+		client.connect();
+		await flushAsyncWork();
+
+		const connection = MockSSEConnection.instances[0];
+		expect(connection).toBeDefined();
+		connection!.emit('message_update', {
+			type: 'broadcast',
+			event: 'message_update',
+			data: {
+				assistantMessageEvent: {
+					type: 'text_delta',
+					delta: 'hello from named SSE',
+				},
+			},
+			category: 'streaming',
+			sessionId: 'codesess_sse_client',
+			timestamp: Date.now(),
+		});
+		await flushAsyncWork();
+
+		expect(seenEvents).toHaveLength(1);
+		expect(seenEvents[0]).toMatchObject({
+			event: 'message_update',
+			data: {
+				type: 'broadcast',
+				event: 'message_update',
+				category: 'streaming',
+				sessionId: 'codesess_sse_client',
+			},
+		});
+		expect(broadcasts).toHaveLength(1);
+
+		client.close();
+	});
+
+	it('streams Hub named broadcast SSE events when explicit raw-event subscriptions are requested', async () => {
 		const eventsPromise = (async () => {
 			const seen = [];
 			for await (const event of streamCoderSessionSSE({
@@ -111,12 +190,12 @@ describe('Coder SSE observer clients', () => {
 
 		await flushAsyncWork();
 
-		const eventSource = MockEventSource.instances[0];
-		expect(eventSource).toBeDefined();
-		expect(decodeURIComponent(eventSource!.url)).toContain('subscribe=*');
+		const connection = MockSSEConnection.instances[0];
+		expect(connection).toBeDefined();
+		expect(decodeURIComponent(connection!.url)).toContain('subscribe=*');
 
-		eventSource!.open();
-		eventSource!.emit('broadcast', {
+		connection!.emit('message_update', {
+			type: 'broadcast',
 			event: 'message_update',
 			data: {
 				assistantMessageEvent: {
@@ -132,7 +211,7 @@ describe('Coder SSE observer clients', () => {
 		const events = await eventsPromise;
 		expect(events).toHaveLength(1);
 		expect(events[0]).toMatchObject({
-			event: 'broadcast',
+			event: 'message_update',
 			data: {
 				type: 'broadcast',
 				event: 'message_update',
@@ -140,6 +219,6 @@ describe('Coder SSE observer clients', () => {
 				sessionId: 'codesess_sse_stream',
 			},
 		});
-		expect(eventSource!.readyState).toBe(MockEventSource.CLOSED);
+		expect(connection!.closed).toBe(true);
 	});
 });

--- a/packages/core/test/coder-sse.test.ts
+++ b/packages/core/test/coder-sse.test.ts
@@ -59,6 +59,15 @@ class MockSSEConnection {
 			// Already closed or aborted.
 		}
 	}
+
+	fail(error = new Error('SSE stream failed')) {
+		this.closed = true;
+		try {
+			this.#controller.error(error);
+		} catch {
+			// Already closed or aborted.
+		}
+	}
 }
 
 function installMockFetch(status = 200, statusText = 'OK') {
@@ -78,6 +87,32 @@ async function flushAsyncWork() {
 	await Promise.resolve();
 	await Promise.resolve();
 	await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 250) {
+	const start = Date.now();
+	while (!predicate()) {
+		if (Date.now() - start > timeoutMs) {
+			throw new Error('Timed out waiting for condition');
+		}
+		await new Promise((resolve) => setTimeout(resolve, 1));
+	}
+}
+
+function makeMessageUpdate(sessionId: string, delta = 'hello from SSE') {
+	return {
+		type: 'broadcast',
+		event: 'message_update',
+		data: {
+			assistantMessageEvent: {
+				type: 'text_delta',
+				delta,
+			},
+		},
+		category: 'streaming',
+		sessionId,
+		timestamp: Date.now(),
+	};
 }
 
 describe('Coder SSE observer clients', () => {
@@ -143,19 +178,10 @@ describe('Coder SSE observer clients', () => {
 
 		const connection = MockSSEConnection.instances[0];
 		expect(connection).toBeDefined();
-		connection!.emit('message_update', {
-			type: 'broadcast',
-			event: 'message_update',
-			data: {
-				assistantMessageEvent: {
-					type: 'text_delta',
-					delta: 'hello from named SSE',
-				},
-			},
-			category: 'streaming',
-			sessionId: 'codesess_sse_client',
-			timestamp: Date.now(),
-		});
+		connection!.emit(
+			'message_update',
+			makeMessageUpdate('codesess_sse_client', 'hello from named SSE')
+		);
 		await flushAsyncWork();
 
 		expect(seenEvents).toHaveLength(1);
@@ -194,19 +220,7 @@ describe('Coder SSE observer clients', () => {
 		expect(connection).toBeDefined();
 		expect(decodeURIComponent(connection!.url)).toContain('subscribe=*');
 
-		connection!.emit('message_update', {
-			type: 'broadcast',
-			event: 'message_update',
-			data: {
-				assistantMessageEvent: {
-					type: 'text_delta',
-					delta: 'hello from SSE',
-				},
-			},
-			category: 'streaming',
-			sessionId: 'codesess_sse_stream',
-			timestamp: Date.now(),
-		});
+		connection!.emit('message_update', makeMessageUpdate('codesess_sse_stream'));
 
 		const events = await eventsPromise;
 		expect(events).toHaveLength(1);
@@ -220,5 +234,165 @@ describe('Coder SSE observer clients', () => {
 			},
 		});
 		expect(connection!.closed).toBe(true);
+	});
+
+	it('retries async iterator streams after transient fetch failures', async () => {
+		let fetchCalls = 0;
+		globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+			fetchCalls += 1;
+			if (fetchCalls === 1) {
+				return Promise.reject(new TypeError('network unavailable'));
+			}
+			const connection = new MockSSEConnection(String(input), init);
+			return Promise.resolve(connection.response);
+		}) as typeof fetch;
+
+		const eventsPromise = (async () => {
+			const seen = [];
+			for await (const event of streamCoderSessionSSE({
+				url: 'https://hub.example',
+				sessionId: 'codesess_sse_fetch_retry',
+				subscribe: ['*'],
+				reconnectDelayMs: 1,
+				maxReconnectDelayMs: 1,
+				maxReconnectAttempts: 2,
+			})) {
+				seen.push(event);
+				break;
+			}
+			return seen;
+		})();
+
+		await waitFor(() => fetchCalls >= 2 && MockSSEConnection.instances.length === 1);
+		MockSSEConnection.instances[0]!.emit(
+			'message_update',
+			makeMessageUpdate('codesess_sse_fetch_retry')
+		);
+
+		const events = await eventsPromise;
+		expect(fetchCalls).toBe(2);
+		expect(events).toHaveLength(1);
+		expect(events[0]).toMatchObject({
+			event: 'message_update',
+			data: {
+				type: 'broadcast',
+				event: 'message_update',
+				sessionId: 'codesess_sse_fetch_retry',
+			},
+		});
+	});
+
+	it('retries async iterator streams after retryable HTTP responses', async () => {
+		let fetchCalls = 0;
+		globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+			fetchCalls += 1;
+			if (fetchCalls === 1) {
+				return Promise.resolve(new Response('retry later', { status: 503 }));
+			}
+			const connection = new MockSSEConnection(String(input), init);
+			return Promise.resolve(connection.response);
+		}) as typeof fetch;
+
+		const eventsPromise = (async () => {
+			const seen = [];
+			for await (const event of streamCoderSessionSSE({
+				url: 'https://hub.example',
+				sessionId: 'codesess_sse_http_retry',
+				subscribe: ['*'],
+				reconnectDelayMs: 1,
+				maxReconnectDelayMs: 1,
+				maxReconnectAttempts: 2,
+			})) {
+				seen.push(event);
+				break;
+			}
+			return seen;
+		})();
+
+		await waitFor(() => fetchCalls >= 2 && MockSSEConnection.instances.length === 1);
+		MockSSEConnection.instances[0]!.emit(
+			'message_update',
+			makeMessageUpdate('codesess_sse_http_retry')
+		);
+
+		const events = await eventsPromise;
+		expect(fetchCalls).toBe(2);
+		expect(events).toHaveLength(1);
+		expect(events[0]).toMatchObject({
+			event: 'message_update',
+			data: {
+				type: 'broadcast',
+				event: 'message_update',
+				sessionId: 'codesess_sse_http_retry',
+			},
+		});
+	});
+
+	it('retries async iterator streams after reader failures', async () => {
+		const eventsPromise = (async () => {
+			const seen = [];
+			for await (const event of streamCoderSessionSSE({
+				url: 'https://hub.example',
+				sessionId: 'codesess_sse_read_retry',
+				subscribe: ['*'],
+				reconnectDelayMs: 1,
+				maxReconnectDelayMs: 1,
+				maxReconnectAttempts: 2,
+			})) {
+				seen.push(event);
+				break;
+			}
+			return seen;
+		})();
+
+		await waitFor(() => MockSSEConnection.instances.length === 1);
+		MockSSEConnection.instances[0]!.fail(new Error('socket reset'));
+		await waitFor(() => MockSSEConnection.instances.length === 2);
+		MockSSEConnection.instances[1]!.emit(
+			'message_update',
+			makeMessageUpdate('codesess_sse_read_retry')
+		);
+
+		const events = await eventsPromise;
+		expect(events).toHaveLength(1);
+		expect(events[0]).toMatchObject({
+			event: 'message_update',
+			data: {
+				type: 'broadcast',
+				event: 'message_update',
+				sessionId: 'codesess_sse_read_retry',
+			},
+		});
+	});
+
+	it('does not retry async iterator streams after non-retryable auth responses', async () => {
+		let fetchCalls = 0;
+		globalThis.fetch = (() => {
+			fetchCalls += 1;
+			return Promise.resolve(new Response('unauthorized', { status: 401 }));
+		}) as typeof fetch;
+
+		const error = await (async () => {
+			try {
+				for await (const _event of streamCoderSessionSSE({
+					url: 'https://hub.example',
+					sessionId: 'codesess_sse_auth_failure',
+					reconnectDelayMs: 1,
+					maxReconnectDelayMs: 1,
+					maxReconnectAttempts: 2,
+				})) {
+					// The stream should fail before yielding.
+				}
+				return null;
+			} catch (err) {
+				return err;
+			}
+		})();
+
+		expect(fetchCalls).toBe(1);
+		expect(error).toMatchObject({
+			code: 'auth_failed',
+			sessionId: 'codesess_sse_auth_failure',
+		});
 	});
 });


### PR DESCRIPTION
## Summary
- replace the Coder SSE EventSource path with a fetch/ReadableStream SSE parser so arbitrary Hub event names are observed
- preserve the public callbacks; onBroadcast still fires for broadcast payloads delivered as named SSE frames like message_update or session_join
- update tests to model the Hub wire shape with event: message_update instead of synthetic event: broadcast

## Verification
- bun test packages/core/test/coder-sse.test.ts packages/core/test/coder-websocket.test.ts
- bun test packages/coder-tui/test/remote-session.test.ts
- bun run --filter=./packages/core typecheck
- bun run --filter=./packages/core build

## Related
- Follow-up compatibility fix for agentuity/coder#38.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate classification of authentication vs. connection failures and no-retry behavior for auth errors.

* **Improvements**
  * More reliable streaming: manual stream reading, centralized event dispatch, graceful shutdown, and scheduled reconnection after stream termination.

* **Documentation**
  * Updated streaming event examples/types in public docs.

* **Tests**
  * Updated SSE tests to use fetch-backed stream mocks and expanded reconnection/error coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->