### PR TITLE
feat(cli): multi-select resource setup in project create with name suggestions

### DIFF
--- a/packages/cli/scripts/test-ghost-prompt.ts
+++ b/packages/cli/scripts/test-ghost-prompt.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env bun
+/**
+ * Manual smoke test for the inline ghost-text placeholder in PromptFlow.text().
+ *
+ * Run: bun packages/cli/scripts/test-ghost-prompt.ts
+ *
+ * What to look for:
+ *   - On the first prompt, you should see `my-bot-storage-abc` painted dim
+ *     after the cursor. The cursor should sit at the start of that text.
+ *   - Pressing Enter immediately should accept the placeholder.
+ *   - Pressing any letter should make the ghost vanish and your typed input
+ *     should appear in normal color.
+ *   - Backspacing back to empty should NOT bring the ghost back.
+ *   - The second prompt has no placeholder — should behave exactly like the
+ *     existing readline-based prompt (regression check).
+ */
+import { createPrompt } from '../src/tui/prompt';
+
+async function main() {
+	const prompt = createPrompt();
+	prompt.intro('Ghost prompt test');
+
+	const v1 = await prompt.text({
+		message: 'Bucket name',
+		hint: 'Optional · lowercase letters, digits, hyphens',
+		placeholder: 'my-bot-storage-abc',
+		validate: (val) => {
+			if (val === '') return true;
+			if (val.length < 3) return 'Too short (min 3)';
+			if (!/^[a-z0-9-]+$/.test(val)) return 'Only lowercase, digits, hyphens';
+			return true;
+		},
+	});
+	console.log('Resolved 1:', JSON.stringify(v1));
+
+	const v2 = await prompt.text({
+		message: 'Description (no placeholder, regression check)',
+		hint: 'Optional · press Enter to skip',
+	});
+	console.log('Resolved 2:', JSON.stringify(v2));
+
+	prompt.outro('done');
+}
+
+main().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/packages/cli/src/cmd/project/random-name.ts
+++ b/packages/cli/src/cmd/project/random-name.ts
@@ -1,0 +1,152 @@
+/**
+ * Generates project-derived suggestions for resource names (DB / S3 bucket).
+ *
+ * The CLI shows these as a dim "press Enter to use ..." default in the create flow.
+ * If the user presses Enter, the suggestion is sent to the server. Otherwise the
+ * server is responsible for assigning a name when none is provided.
+ *
+ * Both suggestions are validated against the same rules the server enforces
+ * (`validateBucketName` / `validateDatabaseName` from `@agentuity/server`) so the
+ * happy path can never produce an invalid suggestion.
+ */
+import { validateBucketName, validateDatabaseName } from '@agentuity/server';
+
+const BUCKET_MAX = 63;
+const BUCKET_MIN = 3;
+const DB_MAX = 63;
+
+/** 3 lowercase alphanumeric chars, e.g. "k7p". */
+function shortSuffix(): string {
+	// toString(36) yields [0-9a-z]; slice 3 chars after the "0." prefix.
+	const s = Math.random().toString(36).slice(2, 5);
+	// Pad in the (extremely unlikely) case the slice is shorter than 3 chars.
+	return s.length === 3 ? s : (s + '000').slice(0, 3);
+}
+
+/**
+ * Sanitize a project name into the bucket-name alphabet:
+ * - lowercase
+ * - spaces / underscores / dots → hyphens
+ * - drop anything else
+ * - collapse and trim hyphens
+ * - strip reserved prefixes (`agentuity*`, `ag-*`, `ago-*`, `xn--`)
+ */
+function sanitizeForBucket(name: string): string {
+	let out = name
+		.toLowerCase()
+		.trim()
+		.replace(/[\s_.]+/g, '-')
+		.replace(/[^a-z0-9-]/g, '')
+		.replace(/-+/g, '-')
+		.replace(/^-+|-+$/g, '');
+
+	// Strip reserved prefixes (rules from validateBucketName).
+	while (
+		out.startsWith('agentuity') ||
+		out.startsWith('ag-') ||
+		out.startsWith('ago-') ||
+		out.startsWith('xn--')
+	) {
+		if (out.startsWith('agentuity')) out = out.slice('agentuity'.length);
+		else if (out.startsWith('ago-')) out = out.slice('ago-'.length);
+		else if (out.startsWith('ag-')) out = out.slice('ag-'.length);
+		else if (out.startsWith('xn--')) out = out.slice('xn--'.length);
+		out = out.replace(/^-+/, '');
+	}
+	return out;
+}
+
+/**
+ * Sanitize a project name into the database-name alphabet:
+ * - lowercase
+ * - non `[a-z0-9_]` → `_`
+ * - collapse and trim underscores
+ * - ensure it starts with a letter or underscore (prepend `p_` otherwise)
+ * - strip reserved `pg_` prefix
+ */
+function sanitizeForDatabase(name: string): string {
+	let out = name
+		.toLowerCase()
+		.trim()
+		.replace(/[^a-z0-9_]+/g, '_')
+		.replace(/_+/g, '_')
+		.replace(/^_+|_+$/g, '');
+
+	if (!/^[a-z_]/.test(out)) {
+		out = out.length > 0 ? `p_${out}` : '';
+	}
+	while (out.startsWith('pg_')) {
+		out = out.slice(3).replace(/^_+/, '');
+		if (!/^[a-z_]/.test(out) && out.length > 0) out = `p_${out}`;
+	}
+	return out;
+}
+
+/**
+ * Truncate so the final string (`<base>-<suffixWithDash>`) fits within `max` chars
+ * while keeping the suffix intact and not ending on a hyphen.
+ */
+function truncateBaseHyphen(base: string, suffixWithDash: string, max: number): string {
+	const room = max - suffixWithDash.length;
+	if (room <= 0) return '';
+	let out = base.slice(0, room);
+	out = out.replace(/-+$/, '');
+	return out;
+}
+
+/** Same as `truncateBaseHyphen` but for underscore-joined names (database). */
+function truncateBaseUnderscore(base: string, suffixWithUnderscore: string, max: number): string {
+	const room = max - suffixWithUnderscore.length;
+	if (room <= 0) return '';
+	let out = base.slice(0, room);
+	out = out.replace(/_+$/, '');
+	return out;
+}
+
+/**
+ * Generate a suggested S3 bucket name derived from the project name.
+ * Format: `<sanitized-project>-storage-<3char>` (≤ 63 chars).
+ *
+ * Falls back to `bucket-<3char><3char>` if the project name produces nothing usable.
+ * Always returns a value that passes `validateBucketName`.
+ */
+export function suggestBucketName(projectName: string): string {
+	const sanitized = sanitizeForBucket(projectName);
+
+	// Try a few times in case sanitization + suffix happens to land on something invalid.
+	for (let attempt = 0; attempt < 5; attempt++) {
+		const suffix = `-storage-${shortSuffix()}`;
+		const base = truncateBaseHyphen(sanitized, suffix, BUCKET_MAX);
+		const candidate = base.length > 0 ? `${base}${suffix}` : `bucket${suffix}`;
+		if (candidate.length >= BUCKET_MIN && validateBucketName(candidate).valid) {
+			return candidate;
+		}
+	}
+
+	// Pure fallback: short, always-valid generic name.
+	const fallback = `bucket-${shortSuffix()}${shortSuffix()}`;
+	return validateBucketName(fallback).valid ? fallback : `bucket-${shortSuffix()}aaa`;
+}
+
+/**
+ * Generate a suggested PostgreSQL database name derived from the project name.
+ * Format: `<sanitized-project>_db_<3char>` (≤ 63 chars).
+ *
+ * Falls back to `db_<3char><3char>` if the project name produces nothing usable.
+ * Always returns a value that passes `validateDatabaseName`.
+ */
+export function suggestDatabaseName(projectName: string): string {
+	const sanitized = sanitizeForDatabase(projectName);
+
+	for (let attempt = 0; attempt < 5; attempt++) {
+		const suffix = `_db_${shortSuffix()}`;
+		const base = truncateBaseUnderscore(sanitized, suffix, DB_MAX);
+		const candidate = base.length > 0 ? `${base}${suffix}` : `db${suffix}`;
+		if (validateDatabaseName(candidate).valid) {
+			return candidate;
+		}
+	}
+
+	const fallback = `db_${shortSuffix()}${shortSuffix()}`;
+	return validateDatabaseName(fallback).valid ? fallback : `db_${shortSuffix()}aaa`;
+}

--- a/packages/cli/src/cmd/project/template-flow.ts
+++ b/packages/cli/src/cmd/project/template-flow.ts
@@ -32,7 +32,12 @@ import { createPrompt, note } from '../../tui';
 import type { AuthData, Config } from '../../types';
 import { getGithubBotIdentity } from '../git/api';
 import { downloadTemplate, initGitRepo, setupProject } from './download';
+import { suggestBucketName, suggestDatabaseName } from './random-name';
 import { fetchTemplates, type TemplateInfo } from './templates';
+
+// Domain validator shared between the multi-select branch and the standalone prompt.
+const DOMAIN_REGEX =
+	/^(?=.{1,253}$)(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[A-Za-z]{2,63}$/;
 
 interface CreateFlowOptions {
 	projectName?: string;
@@ -281,7 +286,7 @@ export async function runCreateFlow(options: CreateFlowOptions): Promise<CreateF
 		};
 	}
 
-	// Add separator bar if we're going to show resource prompts
+	// Resource provisioning gates
 	const canProvision = auth && apiClient && catalystClient && orgId && region;
 	// Only count as resource flags if actually requesting provisioning (not explicit skip)
 	const hasResourceFlags =
@@ -306,13 +311,62 @@ export async function runCreateFlow(options: CreateFlowOptions): Promise<CreateF
 	}
 
 	if (canProvision) {
-		// Fetch resources for selected org and region using Catalyst API (needed for both interactive and CLI flags)
-		let resources: Awaited<ReturnType<typeof listResources>> | undefined;
+		// CLI flags pre-resolve their respective per-resource decision; the multi-select
+		// is only used for resources where the user didn't pass a flag.
+		const dbFlagAction = resolveFlagAction(databaseOption, 'database');
+		const storageFlagAction = resolveFlagAction(storageOption, 'storage');
+		const domainFlagProvided = (domains?.length ?? 0) > 0;
 
+		// Determine which resources should run through the configuration phase.
+		// In interactive mode, ask the user via a single multi-select.
+		// In headless / non-interactive mode, only flagged resources are considered.
+		let wantDb = dbFlagAction !== undefined && dbFlagAction !== 'Skip';
+		let wantStorage = storageFlagAction !== undefined && storageFlagAction !== 'Skip';
+		let wantDomain = domainFlagProvided;
+
+		if (isInteractive) {
+			// Build multi-select options dynamically: only show resources the user hasn't
+			// already decided about via CLI flags. If all three came from flags, skip the prompt.
+			const msOptions: {
+				value: 'database' | 'storage' | 'domain';
+				label: string;
+				hint?: string;
+			}[] = [];
+			if (dbFlagAction === undefined) {
+				msOptions.push({ value: 'database', label: 'SQL Database', hint: 'PostgreSQL' });
+			}
+			if (storageFlagAction === undefined) {
+				msOptions.push({ value: 'storage', label: 'Storage Bucket', hint: 'S3-compatible' });
+			}
+			if (!domainFlagProvided) {
+				msOptions.push({ value: 'domain', label: 'Custom Domain', hint: 'BYO domain' });
+			}
+
+			if (msOptions.length > 0) {
+				const picked = await prompt.multiselect<'database' | 'storage' | 'domain'>({
+					message: 'What would you like to set up? (all optional)',
+					options: msOptions,
+					initial: [],
+				});
+				if (dbFlagAction === undefined) wantDb = picked.includes('database');
+				if (storageFlagAction === undefined) wantStorage = picked.includes('storage');
+				if (!domainFlagProvided) wantDomain = picked.includes('domain');
+			}
+		}
+
+		// Fetch existing resources only if we'll actually need them.
+		// Need them when:
+		//   - user wants db/storage in interactive mode (to offer "use existing")
+		//   - a CLI flag pointed at an existing resource by name
+		let resources: Awaited<ReturnType<typeof listResources>> | undefined;
 		const needResources =
-			isInteractive ||
-			(databaseOption && databaseOption !== 'skip' && databaseOption !== 'new') ||
-			(storageOption && storageOption !== 'skip' && storageOption !== 'new');
+			(isInteractive && (wantDb || wantStorage)) ||
+			(databaseOption !== undefined &&
+				dbFlagAction !== 'Create New' &&
+				dbFlagAction !== 'Skip') ||
+			(storageOption !== undefined &&
+				storageFlagAction !== 'Create New' &&
+				storageFlagAction !== 'Skip');
 
 		if (needResources) {
 			resources = await tui.spinner({
@@ -330,166 +384,66 @@ export async function runCreateFlow(options: CreateFlowOptions): Promise<CreateF
 			logger.debug(
 				`Storage buckets: ${resources.s3.map((b) => b.bucket_name).join(', ') || '(none)'}`
 			);
-		}
 
-		// Determine database action: CLI flag > interactive prompt > skip (headless)
-		let db_action: string;
-		if (databaseOption !== undefined) {
-			// CLI flag provided - normalize to expected values
-			if (databaseOption.toLowerCase() === 'new') {
-				db_action = 'Create New';
-			} else if (databaseOption.toLowerCase() === 'skip') {
-				db_action = 'Skip';
-			} else {
-				// Existing database name - validate it exists
-				const existingDb = resources?.db.find((d) => d.name === databaseOption);
-				if (!existingDb) {
-					logger.fatal(
-						`Database '${databaseOption}' not found. Use 'new' to create a new database or 'skip' to skip.`,
-						ErrorCode.RESOURCE_NOT_FOUND
-					);
-				}
-				db_action = databaseOption;
+			// Validate flag-supplied resource names against the fetched list.
+			if (
+				databaseOption !== undefined &&
+				dbFlagAction !== 'Create New' &&
+				dbFlagAction !== 'Skip' &&
+				!resources.db.find((d) => d.name === dbFlagAction)
+			) {
+				logger.fatal(
+					`Database '${databaseOption}' not found. Use 'new' to create a new database or 'skip' to skip.`,
+					ErrorCode.RESOURCE_NOT_FOUND
+				);
 			}
-		} else if (isInteractive) {
-			db_action = await prompt.select({
-				message: 'Create SQL Database?',
-				options: [
-					{ value: 'Skip', label: 'Skip or Setup later' },
-					{ value: 'Create New', label: 'Create a new database' },
-					...resources!.db.map((db) => ({
-						value: db.name,
-						label: `Use database: ${tui.tuiColors.primary(db.name)}`,
-					})),
-				],
-			});
-		} else {
-			// Headless without flag - skip
-			db_action = 'Skip';
-		}
-
-		// Determine storage action: CLI flag > interactive prompt > skip (headless)
-		let s3_action: string;
-		if (storageOption !== undefined) {
-			// CLI flag provided - normalize to expected values
-			if (storageOption.toLowerCase() === 'new') {
-				s3_action = 'Create New';
-			} else if (storageOption.toLowerCase() === 'skip') {
-				s3_action = 'Skip';
-			} else {
-				// Existing bucket name - validate it exists
-				const existingBucket = resources?.s3.find((b) => b.bucket_name === storageOption);
-				if (!existingBucket) {
-					logger.fatal(
-						`Storage bucket '${storageOption}' not found. Use 'new' to create a new bucket or 'skip' to skip.`,
-						ErrorCode.RESOURCE_NOT_FOUND
-					);
-				}
-				s3_action = storageOption;
-			}
-		} else if (isInteractive) {
-			s3_action = await prompt.select({
-				message: 'Create Storage Bucket?',
-				options: [
-					{ value: 'Skip', label: 'Skip or Setup later' },
-					{ value: 'Create New', label: 'Create a new bucket' },
-					...resources!.s3.map((bucket) => ({
-						value: bucket.bucket_name,
-						label: `Use bucket: ${tui.tuiColors.primary(bucket.bucket_name)}`,
-					})),
-				],
-			});
-		} else {
-			// Headless without flag - skip
-			s3_action = 'Skip';
-		}
-
-		// Custom DNS: only prompt in interactive mode if not already provided
-		if (!domains?.length && isInteractive) {
-			const customDns = await prompt.text({
-				message: 'Setup custom DNS?',
-				hint: 'Enter a domain name or press Enter to skip',
-				validate: (val: string) =>
-					val === ''
-						? true
-						: /^(?=.{1,253}$)(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[A-Za-z]{2,63}$/.test(
-								val
-							),
-			});
-			if (customDns) {
-				_domains = [customDns];
+			if (
+				storageOption !== undefined &&
+				storageFlagAction !== 'Create New' &&
+				storageFlagAction !== 'Skip' &&
+				!resources.s3.find((b) => b.bucket_name === storageFlagAction)
+			) {
+				logger.fatal(
+					`Storage bucket '${storageOption}' not found. Use 'new' to create a new bucket or 'skip' to skip.`,
+					ErrorCode.RESOURCE_NOT_FOUND
+				);
 			}
 		}
 
-		// Process storage action
-		switch (s3_action) {
-			case 'Create New': {
-				let bucketName: string | undefined;
-				let bucketDescription: string | undefined;
+		// === Configure each selected resource: Database → Storage → Domain ===
 
-				// Only prompt for name/description in interactive mode
-				if (isInteractive) {
-					const bucketNameInput = await prompt.text({
-						message: 'Bucket name',
-						hint: 'Optional - lowercase letters, digits, hyphens only',
-						validate: (value: string) => {
-							const trimmed = value.trim();
-							if (trimmed === '') return true;
-							const result = validateBucketName(trimmed);
-							return result.valid ? true : result.error!;
-						},
+		// Database
+		if (wantDb) {
+			let dbAction = dbFlagAction;
+			if (dbAction === undefined && isInteractive) {
+				const existing = resources?.db ?? [];
+				if (existing.length > 0) {
+					dbAction = await prompt.select<string>({
+						message: 'SQL Database',
+						options: [
+							{ value: 'Create New', label: 'Create a new database' },
+							...existing.map((db) => ({
+								value: db.name,
+								label: `Use database: ${tui.tuiColors.primary(db.name)}`,
+							})),
+						],
 					});
-					bucketName = bucketNameInput.trim() || undefined;
-					bucketDescription =
-						(await prompt.text({
-							message: 'Bucket description',
-							hint: 'Optional - press Enter to skip',
-						})) || undefined;
+				} else {
+					// No existing databases — user already opted in via the multi-select, so create new.
+					dbAction = 'Create New';
 				}
+			}
 
-				const created = await tui.spinner({
-					message: 'Provisioning New Bucket',
-					clearOnSuccess: true,
-					callback: async () => {
-						return createResources(catalystClient!, orgId!, region!, [
-							{
-								type: 's3',
-								name: bucketName,
-								description: bucketDescription,
-							},
-						]);
-					},
-				});
-				// Collect env vars from newly created resource
-				if (created[0]?.env) {
-					Object.assign(resourceEnvVars, created[0].env);
-				}
-				break;
-			}
-			case 'Skip': {
-				break;
-			}
-			default: {
-				// User selected an existing bucket - get env vars from the resources list
-				const selectedBucket = resources?.s3.find((b) => b.bucket_name === s3_action);
-				if (selectedBucket?.env) {
-					Object.assign(resourceEnvVars, selectedBucket.env);
-				}
-				break;
-			}
-		}
-
-		// Process database action
-		switch (db_action) {
-			case 'Create New': {
+			if (dbAction === 'Create New') {
 				let dbName: string | undefined;
 				let dbDescription: string | undefined;
 
-				// Only prompt for name/description in interactive mode
 				if (isInteractive) {
+					const suggestion = suggestDatabaseName(projectName);
 					const dbNameInput = await prompt.text({
 						message: 'Database name',
-						hint: 'Optional - lowercase letters, digits, underscores only',
+						hint: 'Optional · lowercase letters, digits, underscores',
+						placeholder: suggestion,
 						validate: (value: string) => {
 							const trimmed = value.trim();
 							if (trimmed === '') return true;
@@ -501,7 +455,7 @@ export async function runCreateFlow(options: CreateFlowOptions): Promise<CreateF
 					dbDescription =
 						(await prompt.text({
 							message: 'Database description',
-							hint: 'Optional - press Enter to skip',
+							hint: 'Optional · press Enter to skip',
 						})) || undefined;
 				}
 
@@ -510,31 +464,93 @@ export async function runCreateFlow(options: CreateFlowOptions): Promise<CreateF
 					clearOnSuccess: true,
 					callback: async () => {
 						return createResources(catalystClient!, orgId!, region!, [
-							{
-								type: 'db',
-								name: dbName,
-								description: dbDescription,
-							},
+							{ type: 'db', name: dbName, description: dbDescription },
 						]);
 					},
 				});
-				// Collect env vars from newly created resource
-				if (created[0]?.env) {
-					Object.assign(resourceEnvVars, created[0].env);
+				if (created[0]?.env) Object.assign(resourceEnvVars, created[0].env);
+			} else if (dbAction && dbAction !== 'Skip') {
+				// Existing database selected — reuse its env vars.
+				const selectedDb = resources?.db.find((d) => d.name === dbAction);
+				if (selectedDb?.env) Object.assign(resourceEnvVars, selectedDb.env);
+			}
+		}
+
+		// Storage
+		if (wantStorage) {
+			let s3Action = storageFlagAction;
+			if (s3Action === undefined && isInteractive) {
+				const existing = resources?.s3 ?? [];
+				if (existing.length > 0) {
+					s3Action = await prompt.select<string>({
+						message: 'Storage Bucket',
+						options: [
+							{ value: 'Create New', label: 'Create a new bucket' },
+							...existing.map((bucket) => ({
+								value: bucket.bucket_name,
+								label: `Use bucket: ${tui.tuiColors.primary(bucket.bucket_name)}`,
+							})),
+						],
+					});
+				} else {
+					s3Action = 'Create New';
 				}
-				break;
 			}
-			case 'Skip': {
-				break;
-			}
-			default: {
-				// User selected an existing database - get env vars from the resources list
-				const selectedDb = resources?.db.find((d) => d.name === db_action);
-				if (selectedDb?.env) {
-					Object.assign(resourceEnvVars, selectedDb.env);
+
+			if (s3Action === 'Create New') {
+				let bucketName: string | undefined;
+				let bucketDescription: string | undefined;
+
+				if (isInteractive) {
+					const suggestion = suggestBucketName(projectName);
+					const bucketNameInput = await prompt.text({
+						message: 'Bucket name',
+						hint: 'Optional · lowercase letters, digits, hyphens',
+						placeholder: suggestion,
+						validate: (value: string) => {
+							const trimmed = value.trim();
+							if (trimmed === '') return true;
+							const result = validateBucketName(trimmed);
+							return result.valid ? true : result.error!;
+						},
+					});
+					bucketName = bucketNameInput.trim() || undefined;
+					bucketDescription =
+						(await prompt.text({
+							message: 'Bucket description',
+							hint: 'Optional · press Enter to skip',
+						})) || undefined;
 				}
-				break;
+
+				const created = await tui.spinner({
+					message: 'Provisioning New Bucket',
+					clearOnSuccess: true,
+					callback: async () => {
+						return createResources(catalystClient!, orgId!, region!, [
+							{ type: 's3', name: bucketName, description: bucketDescription },
+						]);
+					},
+				});
+				if (created[0]?.env) Object.assign(resourceEnvVars, created[0].env);
+			} else if (s3Action && s3Action !== 'Skip') {
+				const selectedBucket = resources?.s3.find((b) => b.bucket_name === s3Action);
+				if (selectedBucket?.env) Object.assign(resourceEnvVars, selectedBucket.env);
 			}
+		}
+
+		// Custom Domain
+		if (wantDomain && !domainFlagProvided && isInteractive) {
+			const customDns = await prompt.text({
+				message: 'Custom domain',
+				hint: 'e.g. agents.example.com',
+				validate: (val: string) =>
+					val === ''
+						? 'Domain is required (or go back and uncheck Custom Domain)'
+						: DOMAIN_REGEX.test(val)
+							? true
+							: 'Invalid domain',
+			});
+			if (customDns) _domains = [customDns];
 		}
 	}
 
@@ -689,6 +705,28 @@ export async function runCreateFlow(options: CreateFlowOptions): Promise<CreateF
 		success: setupResult.success,
 		error: setupResult.success ? undefined : 'Project setup completed with errors',
 	};
+}
+
+/**
+ * Normalize a CLI flag value (`--database` / `--storage`) into the same
+ * action vocabulary the interactive flow uses:
+ *   - 'new'  -> 'Create New'
+ *   - 'skip' -> 'Skip'
+ *   - any other string -> treated as an existing-resource name (returned as-is)
+ *   - undefined -> undefined (no flag passed; multi-select decides)
+ *
+ * The existence check for named resources happens later, after the resource
+ * list is fetched.
+ */
+function resolveFlagAction(
+	flag: string | undefined,
+	_kind: 'database' | 'storage'
+): string | undefined {
+	if (flag === undefined) return undefined;
+	const lower = flag.toLowerCase();
+	if (lower === 'new') return 'Create New';
+	if (lower === 'skip') return 'Skip';
+	return flag;
 }
 
 /**

--- a/packages/cli/src/tui/prompt.ts
+++ b/packages/cli/src/tui/prompt.ts
@@ -14,6 +14,12 @@ export interface TextOptions {
 	message: string;
 	initial?: string;
 	hint?: string;
+	/**
+	 * Pre-generated suggestion shown dim in the hint line.
+	 * Submitting empty input accepts the placeholder.
+	 * Unlike `initial`, this is rendered visibly so the user knows what they'll get.
+	 */
+	placeholder?: string;
 	validate?: (value: string) => boolean | string | Promise<boolean | string>;
 }
 
@@ -94,20 +100,22 @@ export class PromptFlow {
 	 * Text input prompt
 	 */
 	async text(options: TextOptions): Promise<string> {
-		const { message, validate } = options;
-		const initial = options.initial ?? '';
-		const hasDefault = options.initial !== undefined;
+		const { message, validate, placeholder } = options;
+		// `placeholder` acts as a visible default: empty submit resolves to it.
+		// `initial` (legacy, invisible) still works but `placeholder` takes precedence.
+		const fallback = placeholder ?? options.initial ?? '';
+		const hasDefault = placeholder !== undefined || options.initial !== undefined;
 
 		if (!this.isInteractive()) {
 			if (hasDefault) {
-				const validationResult = validate ? await validate(initial) : true;
+				const validationResult = validate ? await validate(fallback) : true;
 				if (validationResult === true) {
-					return initial;
+					return fallback;
 				}
 				// Validation failed - include the error message if it's a string
 				const errorDetail = typeof validationResult === 'string' ? `: ${validationResult}` : '';
 				throw this.nonInteractiveError(
-					`Cannot prompt for "${message}" in non-interactive mode. Validation failed for default value "${initial}"${errorDetail}.`
+					`Cannot prompt for "${message}" in non-interactive mode. Validation failed for default value "${fallback}"${errorDetail}.`
 				);
 			}
 			throw this.nonInteractiveError(`Cannot prompt for "${message}" in non-interactive mode.`);
@@ -123,13 +131,24 @@ export class PromptFlow {
 			let hasError = false;
 			let hadValidationError = false;
 
+			// Count of hint lines we render so we know how many to clear on redraw.
+			let hintLines = 0;
+
 			const showPrompt = () => {
+				hintLines = 0;
 				// Show prompt with active symbol
 				process.stdout.write(`${colors.active(symbols.active)}  ${message}\n`);
 				if (options.hint) {
 					process.stdout.write(
 						`${colors.secondary(symbols.bar)}  ${colors.muted(options.hint)}\n`
 					);
+					hintLines++;
+				}
+				if (placeholder) {
+					process.stdout.write(
+						`${colors.secondary(symbols.bar)}  ${colors.muted(`↵ to use ${placeholder} · or type a custom name`)}\n`
+					);
+					hintLines++;
 				}
 				// Use readline's prompt for the input line
 				rl.prompt();
@@ -139,8 +158,8 @@ export class PromptFlow {
 
 			rl.on('line', async (input) => {
 				const trimmed = input.trim();
-				// After a validation error, require explicit input - don't fall back to initial
-				const value = trimmed.length > 0 ? trimmed : hadValidationError ? '' : initial;
+				// After a validation error, require explicit input - don't fall back to default.
+				const value = trimmed.length > 0 ? trimmed : hadValidationError ? '' : fallback;
 
 				// Validate
 				if (validate) {
@@ -149,8 +168,8 @@ export class PromptFlow {
 						if (result !== true) {
 							const errorMsg = typeof result === 'string' ? result : 'Invalid input';
 
-							// Clear all previous lines (prompt + optional error)
-							const linesToClear = hasError ? 3 : 2;
+							// Clear: input line + message + each hint line + (optional) error line.
+							const linesToClear = (hasError ? 2 : 1) + 1 + hintLines;
 							readline.moveCursor(process.stdout, 0, -linesToClear);
 							readline.clearScreenDown(process.stdout);
 
@@ -158,6 +177,8 @@ export class PromptFlow {
 							process.stdout.write(
 								`${colors.error(symbols.error)}  ${message}\n${colors.secondary(symbols.bar)}  ${colors.error(errorMsg)}\n`
 							);
+							// After error, drop the placeholder hint so user is forced to type.
+							hintLines = 0;
 							// Use readline's prompt for the input line
 							rl.prompt();
 							hasError = true;
@@ -168,8 +189,8 @@ export class PromptFlow {
 						// Handle validation errors
 						const errorMsg = error instanceof Error ? error.message : 'Validation failed';
 
-						// Clear all previous lines
-						const linesToClear = hasError ? 3 : 2;
+						// Clear: input line + message + each hint line + (optional) error line.
+						const linesToClear = (hasError ? 2 : 1) + 1 + hintLines;
 						readline.moveCursor(process.stdout, 0, -linesToClear);
 						readline.clearScreenDown(process.stdout);
 
@@ -188,8 +209,9 @@ export class PromptFlow {
 					}
 				}
 
-				// Clear all lines and show completed state
-				const linesToClear = hasError ? 4 : 3;
+				// Clear all lines and show completed state.
+				// Layout: [error?] [message] [hint?] [placeholder hint?] [input line]
+				const linesToClear = (hasError ? 2 : 1) + 1 + hintLines;
 				readline.moveCursor(process.stdout, 0, -linesToClear);
 				readline.clearScreenDown(process.stdout);
 

--- a/packages/cli/src/tui/prompt.ts
+++ b/packages/cli/src/tui/prompt.ts
@@ -98,6 +98,12 @@ export class PromptFlow {
 
 	/**
 	 * Text input prompt
+	 *
+	 * Two render paths:
+	 *  - With `placeholder`: custom raw-keypress renderer that paints the placeholder
+	 *    inline as dim ghost text at the cursor (autofill style). Vanishes on the first
+	 *    keystroke; Enter on an empty buffer accepts the placeholder.
+	 *  - Without `placeholder`: original readline-based renderer (untouched).
 	 */
 	async text(options: TextOptions): Promise<string> {
 		const { message, validate, placeholder } = options;
@@ -121,6 +127,10 @@ export class PromptFlow {
 			throw this.nonInteractiveError(`Cannot prompt for "${message}" in non-interactive mode.`);
 		}
 
+		if (placeholder) {
+			return this.textWithGhost(options, placeholder);
+		}
+
 		return new Promise((resolve, reject) => {
 			const rl = readline.createInterface({
 				input: process.stdin,
@@ -131,24 +141,13 @@ export class PromptFlow {
 			let hasError = false;
 			let hadValidationError = false;
 
-			// Count of hint lines we render so we know how many to clear on redraw.
-			let hintLines = 0;
-
 			const showPrompt = () => {
-				hintLines = 0;
 				// Show prompt with active symbol
 				process.stdout.write(`${colors.active(symbols.active)}  ${message}\n`);
 				if (options.hint) {
 					process.stdout.write(
 						`${colors.secondary(symbols.bar)}  ${colors.muted(options.hint)}\n`
 					);
-					hintLines++;
-				}
-				if (placeholder) {
-					process.stdout.write(
-						`${colors.secondary(symbols.bar)}  ${colors.muted(`↵ to use ${placeholder} · or type a custom name`)}\n`
-					);
-					hintLines++;
 				}
 				// Use readline's prompt for the input line
 				rl.prompt();
@@ -168,8 +167,8 @@ export class PromptFlow {
 						if (result !== true) {
 							const errorMsg = typeof result === 'string' ? result : 'Invalid input';
 
-							// Clear: input line + message + each hint line + (optional) error line.
-							const linesToClear = (hasError ? 2 : 1) + 1 + hintLines;
+							// Clear all previous lines (prompt + optional error)
+							const linesToClear = hasError ? 3 : 2;
 							readline.moveCursor(process.stdout, 0, -linesToClear);
 							readline.clearScreenDown(process.stdout);
 
@@ -177,8 +176,6 @@ export class PromptFlow {
 							process.stdout.write(
 								`${colors.error(symbols.error)}  ${message}\n${colors.secondary(symbols.bar)}  ${colors.error(errorMsg)}\n`
 							);
-							// After error, drop the placeholder hint so user is forced to type.
-							hintLines = 0;
 							// Use readline's prompt for the input line
 							rl.prompt();
 							hasError = true;
@@ -189,8 +186,8 @@ export class PromptFlow {
 						// Handle validation errors
 						const errorMsg = error instanceof Error ? error.message : 'Validation failed';
 
-						// Clear: input line + message + each hint line + (optional) error line.
-						const linesToClear = (hasError ? 2 : 1) + 1 + hintLines;
+						// Clear all previous lines
+						const linesToClear = hasError ? 3 : 2;
 						readline.moveCursor(process.stdout, 0, -linesToClear);
 						readline.clearScreenDown(process.stdout);
 
@@ -209,9 +206,8 @@ export class PromptFlow {
 					}
 				}
 
-				// Clear all lines and show completed state.
-				// Layout: [error?] [message] [hint?] [placeholder hint?] [input line]
-				const linesToClear = (hasError ? 2 : 1) + 1 + hintLines;
+				// Clear all lines and show completed state
+				const linesToClear = hasError ? 4 : 3;
 				readline.moveCursor(process.stdout, 0, -linesToClear);
 				readline.clearScreenDown(process.stdout);
 
@@ -248,6 +244,194 @@ export class PromptFlow {
 				this.cancel('Operation cancelled');
 				reject(new Error('User cancelled'));
 			});
+		});
+	}
+
+	/**
+	 * Text input with inline ghost-text placeholder (autofill style).
+	 *
+	 * Layout:
+	 *   ◆  <message>
+	 *   │  <hint>           (optional)
+	 *   │  <typed>│<ghost>   ghost is dim, vanishes on first keystroke
+	 *
+	 * Behavior:
+	 *   - Typing any char hides the ghost permanently for this prompt instance.
+	 *   - Backspacing back to empty does NOT bring the ghost back.
+	 *   - Enter on empty buffer → resolves to placeholder.
+	 *   - Enter with typed text → resolves to typed text.
+	 *   - Validation error: shows inline error, ghost stays gone, user must type.
+	 *   - Ctrl+C: cancels.
+	 */
+	private async textWithGhost(options: TextOptions, placeholder: string): Promise<string> {
+		const { message, validate, hint } = options;
+
+		return new Promise((resolve, reject) => {
+			let buffer = '';
+			// Tracks whether the ghost should still be visible. Once any printable key is
+			// pressed it goes false and stays false for the rest of this prompt.
+			let ghostVisible = true;
+			let hasError = false;
+			let errorMsg = '';
+
+			const inputPrefix = `${colors.secondary(symbols.bar)}  `;
+			// Visible-character length of the input-line prefix ("│  " = 3 cells).
+			const PREFIX_VISIBLE = 3;
+
+			/**
+			 * Repaint everything from the message line down. Cursor must be on the
+			 * message line (column 0) when this is called for the first time, or we
+			 * just moved up to it after a clear.
+			 */
+			const paint = () => {
+				const symbol = hasError ? colors.error(symbols.error) : colors.active(symbols.active);
+				process.stdout.write(`${symbol}  ${message}\n`);
+
+				if (hasError) {
+					process.stdout.write(
+						`${colors.secondary(symbols.bar)}  ${colors.error(errorMsg)}\n`
+					);
+				} else if (hint) {
+					process.stdout.write(`${colors.secondary(symbols.bar)}  ${colors.muted(hint)}\n`);
+				}
+
+				// Input line.
+				process.stdout.write(inputPrefix);
+				process.stdout.write(buffer);
+
+				if (ghostVisible && buffer.length === 0) {
+					// Paint the ghost, then move the cursor back to the start of it so the
+					// caret sits where the user would start typing.
+					process.stdout.write(colors.muted(placeholder));
+					readline.moveCursor(process.stdout, -placeholder.length, 0);
+				}
+			};
+
+			/**
+			 * Number of terminal lines currently occupied by our render, so we know
+			 * how many to clear on the next repaint.
+			 * Always: message (1) + hint-or-error (0/1) + input (1).
+			 */
+			const renderedLines = (): number => {
+				let n = 1; // message
+				if (hasError || hint) n += 1;
+				n += 1; // input
+				return n;
+			};
+
+			const repaint = () => {
+				// Move cursor to column 0, then up to the start of our render block, then clear.
+				readline.cursorTo(process.stdout, 0);
+				readline.moveCursor(process.stdout, 0, -(renderedLines() - 1));
+				readline.clearScreenDown(process.stdout);
+				paint();
+			};
+
+			// Resume stdin if it was paused by a prior prompt.
+			if (process.stdin.isTTY && process.stdin.isPaused()) {
+				process.stdin.resume();
+			}
+
+			readline.emitKeypressEvents(process.stdin);
+			if (process.stdin.isTTY) {
+				process.stdin.setRawMode(true);
+			}
+
+			// Initial paint.
+			paint();
+
+			const cleanup = () => {
+				process.stdin.removeListener('keypress', onKeypress);
+				if (process.stdin.isTTY) {
+					process.stdin.setRawMode(false);
+					process.stdin.pause();
+				}
+			};
+
+			const finalize = (value: string) => {
+				// Repaint as completed: replace whole render block with the completed lines.
+				readline.cursorTo(process.stdout, 0);
+				readline.moveCursor(process.stdout, 0, -(renderedLines() - 1));
+				readline.clearScreenDown(process.stdout);
+
+				if (value === '') {
+					process.stdout.write(
+						`${colors.completed(symbols.completed)}  ${message}\n${colors.secondary(symbols.bar)}\n`
+					);
+				} else {
+					process.stdout.write(
+						`${colors.completed(symbols.completed)}  ${message}\n${colors.secondary(symbols.bar)}  ${colors.muted(value)}\n${colors.secondary(symbols.bar)}\n`
+					);
+				}
+
+				this.states.push({ type: 'completed', message, value });
+				cleanup();
+				resolve(value);
+			};
+
+			const onKeypress = async (str: string, key: KeypressEvent) => {
+				if (key.ctrl && key.name === 'c') {
+					cleanup();
+					console.log('\n');
+					this.cancel('Operation cancelled');
+					reject(new Error('User cancelled'));
+					return;
+				}
+
+				if (key.name === 'return') {
+					const trimmed = buffer.trim();
+					// Empty submit accepts the placeholder, but only if no error has occurred
+					// (after an error the user must type explicitly — same rule the readline
+					// path uses).
+					const value = trimmed.length > 0 ? trimmed : hasError ? '' : placeholder;
+
+					if (validate) {
+						try {
+							const result = await validate(value);
+							if (result !== true) {
+								errorMsg = typeof result === 'string' ? result : 'Invalid input';
+								hasError = true;
+								ghostVisible = false;
+								repaint();
+								return;
+							}
+						} catch (err) {
+							errorMsg = err instanceof Error ? err.message : 'Validation failed';
+							hasError = true;
+							ghostVisible = false;
+							repaint();
+							return;
+						}
+					}
+
+					finalize(value);
+					return;
+				}
+
+				if (key.name === 'backspace') {
+					if (buffer.length > 0) {
+						buffer = buffer.slice(0, -1);
+						repaint();
+					}
+					return;
+				}
+
+				// Printable single character (ignore arrow keys, function keys, etc.).
+				if (str && str.length === 1 && !key.ctrl && str >= ' ' && str !== '\x7f') {
+					buffer += str;
+					ghostVisible = false;
+					repaint();
+					return;
+				}
+
+				// Everything else (arrows, tab, etc.) is ignored.
+			};
+
+			// Mark the prefix length as used so the unused-var rule doesn't trip when we
+			// extend this in future. (Keeping it documented for cursor-math sanity.)
+			void PREFIX_VISIBLE;
+
+			process.stdin.on('keypress', onKeypress);
 		});
 	}
 

--- a/packages/cli/test/cmd/project/random-name.test.ts
+++ b/packages/cli/test/cmd/project/random-name.test.ts
@@ -1,0 +1,109 @@
+import { describe, test, expect } from 'bun:test';
+import { validateBucketName, validateDatabaseName } from '@agentuity/server';
+import { suggestBucketName, suggestDatabaseName } from '../../../src/cmd/project/random-name';
+
+describe('suggestBucketName', () => {
+	test('produces a valid name from a simple project name', () => {
+		const name = suggestBucketName('my-bot');
+		expect(validateBucketName(name).valid).toBe(true);
+		expect(name).toMatch(/^my-bot-storage-[a-z0-9]{3}$/);
+	});
+
+	test('lowercases and replaces spaces in project name', () => {
+		const name = suggestBucketName('My Cool Bot');
+		expect(validateBucketName(name).valid).toBe(true);
+		expect(name.startsWith('my-cool-bot-storage-')).toBe(true);
+	});
+
+	test('strips reserved prefix `agentuity`', () => {
+		const name = suggestBucketName('agentuity-helper');
+		expect(validateBucketName(name).valid).toBe(true);
+		expect(name.startsWith('agentuity')).toBe(false);
+	});
+
+	test('strips reserved prefix `ag-`', () => {
+		const name = suggestBucketName('ag-foo');
+		expect(validateBucketName(name).valid).toBe(true);
+		expect(name.startsWith('ag-')).toBe(false);
+	});
+
+	test('falls back to generic name when project name has no usable chars', () => {
+		const name = suggestBucketName('!!!');
+		expect(validateBucketName(name).valid).toBe(true);
+		expect(name.startsWith('bucket')).toBe(true);
+	});
+
+	test('handles empty project name', () => {
+		const name = suggestBucketName('');
+		expect(validateBucketName(name).valid).toBe(true);
+	});
+
+	test('truncates long project names while keeping a valid suffix', () => {
+		const longName = 'a'.repeat(200);
+		const name = suggestBucketName(longName);
+		expect(validateBucketName(name).valid).toBe(true);
+		expect(name.length).toBeLessThanOrEqual(63);
+		expect(name).toMatch(/-storage-[a-z0-9]{3}$/);
+	});
+
+	test('strips trailing hyphens after truncation', () => {
+		// Construct a name that, when truncated, would otherwise end on a hyphen.
+		const tricky = `${'a'.repeat(50)}-${'b'.repeat(50)}`;
+		const name = suggestBucketName(tricky);
+		expect(validateBucketName(name).valid).toBe(true);
+	});
+});
+
+describe('suggestDatabaseName', () => {
+	test('produces a valid name from a simple project name', () => {
+		const name = suggestDatabaseName('mybot');
+		expect(validateDatabaseName(name).valid).toBe(true);
+		expect(name).toMatch(/^mybot_db_[a-z0-9]{3}$/);
+	});
+
+	test('lowercases and replaces hyphens/spaces with underscores', () => {
+		const name = suggestDatabaseName('My-Cool Bot');
+		expect(validateDatabaseName(name).valid).toBe(true);
+		expect(name.startsWith('my_cool_bot_db_')).toBe(true);
+	});
+
+	test('prepends `p_` when project name starts with a digit', () => {
+		const name = suggestDatabaseName('123bot');
+		expect(validateDatabaseName(name).valid).toBe(true);
+		expect(name.startsWith('p_')).toBe(true);
+	});
+
+	test('strips reserved `pg_` prefix', () => {
+		const name = suggestDatabaseName('pg_admin');
+		expect(validateDatabaseName(name).valid).toBe(true);
+		expect(name.startsWith('pg_')).toBe(false);
+	});
+
+	test('falls back to generic name when project name has no usable chars', () => {
+		const name = suggestDatabaseName('!!!');
+		expect(validateDatabaseName(name).valid).toBe(true);
+		expect(name.startsWith('db_')).toBe(true);
+	});
+
+	test('handles empty project name', () => {
+		const name = suggestDatabaseName('');
+		expect(validateDatabaseName(name).valid).toBe(true);
+	});
+
+	test('truncates long project names while keeping a valid suffix', () => {
+		const longName = 'a'.repeat(200);
+		const name = suggestDatabaseName(longName);
+		expect(validateDatabaseName(name).valid).toBe(true);
+		expect(name.length).toBeLessThanOrEqual(63);
+		expect(name).toMatch(/_db_[a-z0-9]{3}$/);
+	});
+
+	test('produces different suffixes across calls', () => {
+		const names = new Set<string>();
+		for (let i = 0; i < 20; i++) {
+			names.add(suggestDatabaseName('mybot'));
+		}
+		// 20 calls × 36^3 (~46k) suffix space — collisions are vanishingly unlikely.
+		expect(names.size).toBeGreaterThan(1);
+	});
+});


### PR DESCRIPTION
## Summary

Restructures the interactive `agentuity project create` resource flow so **database, storage, and custom domain** are presented as a single multi-select with **all options unchecked by default**. Pressing Enter with nothing selected skips the entire block — a one-keystroke happy path for projects that don't need any cloud resources.

For each resource the user opts into, configuration prompts run in order (**Database → Storage → Domain**). When creating a new database or bucket, the name prompt shows a **project-derived suggestion** (e.g. `my-bot_db_4k7`, `my-bot-storage-4k7`) as **inline dim ghost text at the cursor**, autofill style. Pressing Enter on an empty buffer accepts the suggestion; the first keystroke makes the ghost vanish.

## Motivation

Today's flow has three pain points:

1. DB and storage are two separate rigid prompts, each with their own Skip/Create-new/Use-existing select. A multi-select makes it discoverable and skippable in one keystroke.
2. The custom-domain text prompt is asked every time, even for users who clearly want a no-frills project.
3. When "Create new" is picked, the name field's hint says `Optional` but there's no visible default. Users either have to invent a name or trust the hint and submit empty. An inline ghost suggestion makes the optionality obvious and gives a one-keystroke happy path.

## Behavior changes

### Interactive mode
- After project name + template + setup, the user sees: **"What would you like to set up? (all optional)"** with checkboxes for `SQL Database`, `Storage Bucket`, `Custom Domain`.
- Per-resource flow only runs for checked items, in DB → Storage → Domain order.
- For DB/Storage, if the org has existing resources of that type, a select with *Create new + Use existing X* is shown. If none exist, it goes straight to create-new (since the user already opted in via the multi-select).
- Name prompts paint the suggestion as inline dim text at the cursor:
  ```
  ◆  Database name
  │  Optional · lowercase letters, digits, underscores
  │  ▌my-bot_db_4k7
  ```
  - Enter on empty buffer → suggestion is used.
  - Any keystroke → ghost vanishes, typed input replaces it.
  - Backspace back to empty does **not** bring the ghost back (vanish-on-first-keystroke is permanent for that prompt instance).
  - Validation error → ghost is dropped, user must type explicitly.
- Description prompts kept; hints relaxed to `Optional · press Enter to skip`.

### Headless / flag-driven
- `--database`, `--storage`, `--domains` keep their existing semantics.
- They short-circuit per-resource decisions: the multi-select only includes resources the user didn't pre-decide via flags.
- If all three were flagged, the multi-select is skipped entirely.
- Without a TTY, behavior is unchanged: skip everything unless flags are passed.

## Files changed

- **`packages/cli/src/tui/prompt.ts`** — add `placeholder?: string` to `TextOptions`. Two render paths inside `text()`:
  - **With placeholder**: new private `textWithGhost()` method using raw keypress events. Paints `buffer + dim(placeholderSuffix)` and parks the cursor at the start of the ghost. Vanishes on first printable keystroke. Handles backspace, Enter (empty → placeholder, typed → typed), validation errors, and Ctrl+C.
  - **Without placeholder**: original readline-based renderer, untouched. Zero risk to other text prompts in the codebase.
- **`packages/cli/src/cmd/project/random-name.ts`** *(new)* — pure module exporting `suggestBucketName` / `suggestDatabaseName`. Sanitizes to each backend's alphabet (hyphens for buckets, underscores for DBs), strips reserved prefixes (`agentuity*`, `ag-*`, `ago-*`, `xn--`, `pg_`), appends `-storage-<3char>` / `_db_<3char>`, truncates to 63 chars without ending on a separator, validated against `validateBucketName` / `validateDatabaseName`. No new dependencies.
- **`packages/cli/src/cmd/project/template-flow.ts`** — replace the two separate Skip/Create-new selects + standalone domain text prompt with one upfront multi-select, then a per-resource configuration phase in DB → Storage → Domain order. Existing CLI flag handling preserved via a small `resolveFlagAction` helper.
- **`packages/cli/test/cmd/project/random-name.test.ts`** *(new)* — 16 unit tests covering happy path, sanitization, reserved-prefix stripping, empty/garbage input fallback, length truncation, and suffix variability.
- **`packages/cli/scripts/test-ghost-prompt.ts`** *(new)* — manual smoke test for the ghost-text prompt. Run `bun packages/cli/scripts/test-ghost-prompt.ts` to verify rendering interactively.

## How to test locally

```bash
git checkout feat/cli-create-multiselect-resources
bun install

# Quick: just exercise the prompt itself
bun packages/cli/scripts/test-ghost-prompt.ts

# Full flow
bun packages/cli/bin/cli.ts project create
```

Scenarios worth running:

1. **One-keystroke skip**: at the multi-select, just press Enter. Should skip directly to registration.
2. **DB only, accept suggestion**: check `SQL Database`, hit Enter on the name prompt → suggestion is sent.
3. **DB only, type custom**: same, but type a name → typed name is sent.
4. **Validation error**: type `My-Bad-Name` (uppercase invalid for DB) → see error, ghost stays gone, type a valid name to recover.
5. **All three checked**: order should be DB → Storage → Domain.
6. **Flag mode regression**: `--database new --storage skip --confirm` → no multi-select shown, behaves as today.
7. **Non-TTY regression**: pipe stdin → skip all resources without prompting.

## Verification

- `bun test test/cmd/project/` — 50/50 pass (including 16 new ones).
- `bunx tsc --noEmit` on changed files — clean. Two pre-existing errors in `cmd/cloud/sandbox/*` remain, unrelated to this PR (verified by stash).
- `biome check` on changed files — clean.
- `biome format` applied.

## Backwards compatibility

- Server-side name generation still owns the case where `name` is undefined (i.e. when the user types nothing **and** there's no placeholder, e.g. older flows). With this PR, the create flow always supplies a placeholder, so empty submit sends the suggestion; explicit blank after a validation error still sends `undefined` and the server picks.
- All existing CLI flags (`--name`, `--dir`, `--template`, `--database`, `--storage`, `--domains`, `--no-install`, `--no-build`, `--confirm`, `--no-register`) unchanged.
- All existing `text()` consumers without a placeholder still hit the original readline path — no behavior change for them.

## Commits

- `657d8b23` — feat: multi-select resource setup in project create with name suggestions
- `e13e60c2` — refactor: inline ghost-text placeholder in text prompt (autofill style)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI now suggests valid storage bucket and database names during project setup.
  * Unified multi-select flow to configure database, storage, and custom domain together.
  * Interactive text prompts support dim placeholder (ghost) text to guide input.

* **Tests**
  * Added automated tests for name-suggestion behavior and a manual smoke test for the placeholder prompt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->