### PR TITLE
fix(docs): correct `v2` auth setup

### DIFF
--- a/apps/docs/src/web/content/AGENTS.md
+++ b/apps/docs/src/web/content/AGENTS.md
@@ -153,6 +153,12 @@ General rules:
 - Use a balance of raw SDK providers and AI SDK providers (`openai()`, `anthropic()`) in examples
 - Prefer `s` from `@agentuity/schema` for schemas. Other StandardSchema libraries (Zod, ArkType, Valibot) are equally valid and should appear across examples to show the SDK is schema-agnostic
 
+### Environment and Migration Examples
+
+- For local-only browser callback values, use `.env.local`. Verify env file precedence before naming an override file.
+- For Drizzle Kit setup, show `drizzle.config.ts` with `defineConfig`, then run `bunx drizzle-kit push` or the normal `generate` / `migrate` flow from that config. Avoid inline `--dialect`, `--schema`, and `--url` commands unless the page is documenting those flags.
+- For deployed origins, say "app URL" and point to `urls.app`. Do not call the dashboard URL or project ID the app URL.
+
 ## Static Assets
 
 Images and other static files live in `src/web/public/`. Vite copies these to the build root, so reference them **without** the `/public/` prefix:

--- a/apps/docs/src/web/content/frontend/authentication.mdx
+++ b/apps/docs/src/web/content/frontend/authentication.mdx
@@ -4,13 +4,13 @@ short_title: Authentication
 description: Add user authentication with Agentuity Auth
 ---
 
-Protect your agents and routes with user authentication. Agentuity provides a first-party auth solution powered by [BetterAuth](https://better-auth.com).
+Protect your agents and routes with user authentication. Agentuity provides a first-party auth solution powered by [Better Auth](https://better-auth.com).
 
 <Callout type="info" title="Platform Auth Overview">
 This page covers React frontend auth setup. For a platform overview covering API keys, bearer tokens, and session auth configuration, see [Authentication Services](/services/authentication).
 </Callout>
 
-## Full-Stack Auth in Seconds
+## Auth in the Frontend, Routes, and Agents
 
 <Tabs items={["Frontend", "API Route", "Agent"]}>
 <Tab value="Frontend">
@@ -43,48 +43,129 @@ handler: async (ctx, input) => {
 - **Email/password authentication** out of the box
 - **Session and API key middleware** for routes
 - **Native `ctx.auth` support** in agents
-- **Organizations, teams, and roles** via BetterAuth plugins
+- **Organizations, teams, and roles** via Better Auth plugins
 - **JWT tokens** for external service integration
 
 ## Quick Start
 
-Use the `agentuity-auth` template, or add auth to any project manually:
+Start with an Agentuity project, then add the auth packages:
 
 ```bash
-# Start from the auth template
-bunx agentuity create my-app --template agentuity-auth
+agentuity create --name my-app
+cd my-app
 
-# Or add auth to an existing project
 bun add @agentuity/auth better-auth drizzle-orm
+bun add -D drizzle-kit
 ```
 
-Then create your auth configuration (see [Server Setup](#server-setup) below), set `DATABASE_URL` and `AGENTUITY_AUTH_SECRET` in your environment, and run the BetterAuth CLI to generate and apply the schema (use `bunx` or `npx`):
+If your project does not already have `DATABASE_URL`, create a Postgres database:
 
 ```bash
-# With Bun
-bunx @better-auth/cli generate
-bunx @better-auth/cli migrate
-
-# Or with npm
-npx @better-auth/cli generate
-npx @better-auth/cli migrate
+agentuity cloud db create --name my_app_auth --region usc
+agentuity cloud db get my_app_auth --show-credentials --json
 ```
 
-## Server Setup
+Database names must be unique and can only use lowercase letters, digits, and underscores. If the create command fails with a name conflict, use a more specific name.
 
-### The Basics
+Generate a secret for `AGENTUITY_AUTH_SECRET`:
 
-Create an auth instance with just a connection string:
+```bash
+openssl rand -hex 32
+```
+
+Add the database URL and auth secret to `.env`:
+
+```env
+DATABASE_URL=postgresql://...
+AGENTUITY_AUTH_SECRET=...
+BETTER_AUTH_URL=http://127.0.0.1:3500
+```
+
+Use the same host in `BETTER_AUTH_URL` that you open in the browser. For local development, use the exact local URL:
+
+```env
+BETTER_AUTH_URL=http://127.0.0.1:3500
+# or
+BETTER_AUTH_URL=http://localhost:3500
+```
+
+If you use the DevMode public tunnel, use the `Public` URL printed by `agentuity dev`:
+
+```env
+BETTER_AUTH_URL=https://<devmode-host>.agentuity-us.live
+```
+
+For a deployed app, use the deployed app URL from `urls.app`:
+
+```bash
+agentuity --json project show <project-id>
+```
+
+```env
+BETTER_AUTH_URL=https://<your-app-host>.agentuity.run
+```
+
+Use the app URL here. The dashboard URL is only for managing the project.
+
+Create `src/auth.ts`:
 
 ```typescript title="src/auth.ts"
 import { createAuth } from '@agentuity/auth';
 
 export const auth = createAuth({
   connectionString: process.env.DATABASE_URL,
+  trustedOrigins: [process.env.BETTER_AUTH_URL],
 });
 ```
 
-That's it! This gives you:
+Create `src/schema.ts` so Drizzle Kit can apply the auth tables:
+
+```typescript title="src/schema.ts"
+export * from '@agentuity/auth/schema';
+```
+
+Mount the auth routes in your API router:
+
+```typescript title="src/api/index.ts"
+import { mountAuthRoutes } from '@agentuity/auth';
+import { auth } from '../auth';
+
+api.on(['GET', 'POST'], '/auth/*', mountAuthRoutes(auth));
+```
+
+If `app.ts` mounts this router at `/api`, auth is available at `/api/auth/*`. If your router variable has a different name, mount the route on that object.
+
+Apply the auth tables:
+
+```bash
+set -a
+source .env
+set +a
+
+bunx drizzle-kit push \
+  --dialect postgresql \
+  --schema ./src/schema.ts \
+  --url "$DATABASE_URL"
+```
+
+Drizzle Kit does not read `.env` for the inline command above, so export it before running `push`.
+
+## Server Setup
+
+### The Basics
+
+Create an auth instance with a database connection string:
+
+```typescript title="src/auth.ts"
+import { createAuth } from '@agentuity/auth';
+
+export const auth = createAuth({
+  connectionString: process.env.DATABASE_URL,
+  trustedOrigins: [process.env.BETTER_AUTH_URL],
+});
+```
+
+This gives you:
 - Email/password authentication
 - Session management
 - All default plugins (see below)
@@ -132,9 +213,9 @@ export const auth = createAuth({
   // Or: database: drizzleAdapter(db, { provider: 'pg', schema: authSchema }),
 
   skipDefaultPlugins: false, // Set true for full control over plugins
+  trustedOrigins: [process.env.BETTER_AUTH_URL],
   apiKey: { enabled: true, defaultPrefix: 'ag_', defaultKeyLength: 64 },
-  trustedOrigins: ['https://your-domain.com'], // Auto-resolved from env by default
-  plugins: [], // Add custom BetterAuth plugins
+  plugins: [], // Add custom Better Auth plugins
 });
 ```
 
@@ -373,6 +454,7 @@ export default createAgent('hello', {
 | `AGENTUITY_AUTH_SECRET` | Secret for signing tokens | Falls back to `BETTER_AUTH_SECRET` |
 | `AGENTUITY_CLOUD_BASE_URL` | Platform-provided base URL for auth callbacks | Checked before `AGENTUITY_BASE_URL` |
 | `AGENTUITY_BASE_URL` | Base URL for auth callbacks | Falls back to `BETTER_AUTH_URL` |
+| `BETTER_AUTH_URL` | Better Auth base URL, useful for local browser auth | Used after Agentuity base URL vars |
 
 **Auto-resolved trusted origins:**
 - `AGENTUITY_CLOUD_DOMAINS` - Platform-set domains (deployment URLs, custom domains)
@@ -384,21 +466,22 @@ export default createAgent('hello', {
 openssl rand -hex 32
 ```
 
-<Callout type="warning" title="Replace Dev Secret Before Deploying">
-If you're using a development secret, generate a new one before deploying to production. Store it securely in your environment variables.
+<Callout type="warning" title="Use the same browser origin">
+For local browser auth, `BETTER_AUTH_URL` must match the URL you open. If you open `http://127.0.0.1:3500`, do not set `BETTER_AUTH_URL` to `http://localhost:3500`.
 </Callout>
 
 ## Database Configuration
 
 ### Connection String (Simplest)
 
-Just provide the connection string and Agentuity handles the rest:
+Provide the connection string and Agentuity configures Better Auth with the default plugins:
 
 ```typescript
 import { createAuth } from '@agentuity/auth';
 
 export const auth = createAuth({
   connectionString: process.env.DATABASE_URL,
+  trustedOrigins: [process.env.BETTER_AUTH_URL],
 });
 ```
 
@@ -448,7 +531,7 @@ if (await c.var.auth.hasOrgRole('admin', 'owner')) {
 ```
 
 <Callout type="info" title="Full Organization API">
-See the [BetterAuth Organization Plugin docs](https://www.better-auth.com/docs/plugins/organization) for the complete API including invitations, member management, and role configuration.
+See the [Better Auth Organization Plugin docs](https://www.better-auth.com/docs/plugins/organization) for the complete API including invitations, member management, and role configuration.
 </Callout>
 
 ### API Keys
@@ -468,7 +551,7 @@ console.log('API Key:', result.key); // Only shown once!
 ```
 
 <Callout type="info" title="Full API Key API">
-See the [BetterAuth API Key Plugin docs](https://www.better-auth.com/docs/plugins/api-key) for listing, revoking, and permission schemas.
+See the [Better Auth API Key Plugin docs](https://www.better-auth.com/docs/plugins/api-key) for listing, revoking, and permission schemas.
 </Callout>
 
 ### JWT & Bearer Tokens
@@ -481,24 +564,33 @@ const token = await c.var.auth.getToken();
 ```
 
 <Callout type="info" title="Full JWT API">
-See the [BetterAuth JWT Plugin docs](https://www.better-auth.com/docs/plugins/jwt) for token customization and verification.
+See the [Better Auth JWT Plugin docs](https://www.better-auth.com/docs/plugins/jwt) for token customization and verification.
 </Callout>
 
-## Schema & Migrations
+## Schema Setup
 
-Use the BetterAuth CLI to generate and apply the auth schema (use `bunx` or `npx`):
+The default Agentuity Auth schema is exported from `@agentuity/auth/schema`. Re-export it from your project, then use your normal Drizzle workflow.
 
-```bash
-# Generate SQL for all auth tables (useful for review or manual migrations)
-bunx @better-auth/cli generate
-# or: npx @better-auth/cli generate
-
-# Apply migrations directly
-bunx @better-auth/cli migrate
-# or: npx @better-auth/cli migrate
+```typescript title="src/schema.ts"
+export * from '@agentuity/auth/schema';
 ```
 
-If you use Drizzle or Prisma, prefer your ORM's own migration tooling and generate the schema with `@better-auth/cli generate`, then incorporate it into your migration files.
+For a quick setup, push the schema directly:
+
+```bash
+set -a
+source .env
+set +a
+
+bunx drizzle-kit push \
+  --dialect postgresql \
+  --schema ./src/schema.ts \
+  --url "$DATABASE_URL"
+```
+
+The Better Auth CLI migration commands are not the default path here. `@agentuity/auth` already ships the Drizzle schema; use Drizzle Kit to apply it.
+
+For a team app, put the same schema file behind a `drizzle.config.ts` and use `drizzle-kit generate` / `drizzle-kit migrate` with your normal migration review process.
 
 ## Next Steps
 

--- a/apps/docs/src/web/content/frontend/authentication.mdx
+++ b/apps/docs/src/web/content/frontend/authentication.mdx
@@ -80,38 +80,21 @@ DATABASE_URL=postgresql://...
 AGENTUITY_AUTH_SECRET=...
 ```
 
-For local development, put the browser origin in `.env.local`. This keeps the local callback URL separate from deployed app configuration:
+Create `.env.local` with the local app URL. This keeps local auth callbacks separate from deployed app configuration:
 
 ```env
+AGENTUITY_BASE_URL=http://127.0.0.1:3500
 BETTER_AUTH_URL=http://127.0.0.1:3500
-# or
-BETTER_AUTH_URL=http://localhost:3500
 ```
+
+Use the `Local` URL printed by `agentuity dev`, then restart the dev server after changing env vars.
 
 If you use the DevMode public tunnel, use the `Public` URL printed by `agentuity dev`:
 
 ```env
+AGENTUITY_BASE_URL=https://<devmode-host>.agentuity-us.live
 BETTER_AUTH_URL=https://<devmode-host>.agentuity-us.live
 ```
-
-For a deployed app, use the deployed app URL from `urls.app`:
-
-```bash
-agentuity --json project show <project-id> | jq -r '.urls.app'
-```
-
-```env
-BETTER_AUTH_URL=https://<your-app-host>.agentuity.run
-```
-
-Set that value on the deployed project:
-
-```bash
-agentuity cloud env set "BETTER_AUTH_URL=https://<your-app-host>.agentuity.run" \
-  --project-id <project-id>
-```
-
-Use the app URL here. The dashboard URL is only for managing the project.
 
 Create `src/auth.ts`:
 
@@ -120,7 +103,6 @@ import { createAuth } from '@agentuity/auth';
 
 export const auth = createAuth({
   connectionString: process.env.DATABASE_URL,
-  trustedOrigins: [process.env.BETTER_AUTH_URL],
 });
 ```
 
@@ -164,6 +146,47 @@ bunx drizzle-kit push
 
 The config reads `DATABASE_URL` from your environment.
 
+Verify the auth routes locally:
+
+```bash
+curl http://127.0.0.1:3500/api/auth/get-session
+```
+
+A signed-out app returns `null`.
+
+For your deployed app, use the stable app URL from `urls.app`:
+
+```bash
+agentuity --json project show <project-id> | jq -r '.urls.app'
+```
+
+Set that value on your deployed project:
+
+```bash
+agentuity cloud env set "BETTER_AUTH_URL=https://<your-app-host>.agentuity.run" \
+  --project-id <project-id>
+```
+
+Use the app URL here. The dashboard URL is only for managing the project.
+
+If your deployed project does not already have the database URL and auth secret, set those too:
+
+```bash
+agentuity cloud env set "DATABASE_URL=postgresql://..." --secret \
+  --project-id <project-id>
+agentuity cloud env set "AGENTUITY_AUTH_SECRET=..." --secret \
+  --project-id <project-id>
+```
+
+Deploy and verify the same route in your deployed app:
+
+```bash
+agentuity deploy --confirm
+curl https://<your-app-host>.agentuity.run/api/auth/get-session
+```
+
+A signed-out app also returns `null`.
+
 ## Server Setup
 
 ### The Basics
@@ -175,7 +198,6 @@ import { createAuth } from '@agentuity/auth';
 
 export const auth = createAuth({
   connectionString: process.env.DATABASE_URL,
-  trustedOrigins: [process.env.BETTER_AUTH_URL],
 });
 ```
 
@@ -227,11 +249,14 @@ export const auth = createAuth({
   // Or: database: drizzleAdapter(db, { provider: 'pg', schema: authSchema }),
 
   skipDefaultPlugins: false, // Set true for full control over plugins
-  trustedOrigins: [process.env.BETTER_AUTH_URL],
   apiKey: { enabled: true, defaultPrefix: 'ag_', defaultKeyLength: 64 },
   plugins: [], // Add custom Better Auth plugins
 });
 ```
+
+<Callout type="tip" title="Set trusted origins only for extra frontends">
+Same-origin Agentuity apps do not need `trustedOrigins` in `createAuth()`. Add `AUTH_TRUSTED_DOMAINS` or pass `trustedOrigins` only when a separate frontend origin calls these auth routes. See Better Auth's [Trusted Origins](https://better-auth.com/docs/reference/security#trusted-origins) docs for the underlying origin checks.
+</Callout>
 
 ## Middleware
 
@@ -404,6 +429,14 @@ await signUp.email({ email, password, name });
 await signOut();
 ```
 
+These are Better Auth's standard client methods. See Better Auth's [Client](https://better-auth.com/docs/concepts/client) docs for `useSession` and error handling, and [Email & Password](https://better-auth.com/docs/authentication/email-password) for the sign-in and sign-up method options.
+
+### Build the UI
+
+Agentuity Auth wires Better Auth into your project, but it does not require a specific sign-in screen. Use the client methods above from your own form, or use a Better Auth-compatible UI package.
+
+If your app already uses shadcn/ui or HeroUI, [Better Auth UI](https://better-auth-ui.com/docs) provides prebuilt auth screens. Point it at the same `authClient` and keep the server setup on this page.
+
 ## Using Auth in Agents
 
 ### The ctx.auth Interface
@@ -480,8 +513,8 @@ export default createAgent('hello', {
 openssl rand -hex 32
 ```
 
-<Callout type="warning" title="Use the same browser origin">
-For local browser auth, `BETTER_AUTH_URL` must match the URL you open. If you open `http://127.0.0.1:3500`, do not set `BETTER_AUTH_URL` to `http://localhost:3500`.
+<Callout type="warning" title="Set Better Auth's base URL">
+For local browser auth, set `AGENTUITY_BASE_URL` and `BETTER_AUTH_URL` to the `Local` URL printed by `agentuity dev`. For your deployed app, set `BETTER_AUTH_URL` to the app URL from `urls.app`.
 </Callout>
 
 ## Database Configuration
@@ -495,7 +528,6 @@ import { createAuth } from '@agentuity/auth';
 
 export const auth = createAuth({
   connectionString: process.env.DATABASE_URL,
-  trustedOrigins: [process.env.BETTER_AUTH_URL],
 });
 ```
 

--- a/apps/docs/src/web/content/frontend/authentication.mdx
+++ b/apps/docs/src/web/content/frontend/authentication.mdx
@@ -78,10 +78,9 @@ Add the database URL and auth secret to `.env`:
 ```env
 DATABASE_URL=postgresql://...
 AGENTUITY_AUTH_SECRET=...
-BETTER_AUTH_URL=http://127.0.0.1:3500
 ```
 
-Use the same host in `BETTER_AUTH_URL` that you open in the browser. For local development, use the exact local URL:
+For local development, put the browser origin in `.env.local`. This keeps the local callback URL separate from deployed app configuration:
 
 ```env
 BETTER_AUTH_URL=http://127.0.0.1:3500
@@ -98,11 +97,18 @@ BETTER_AUTH_URL=https://<devmode-host>.agentuity-us.live
 For a deployed app, use the deployed app URL from `urls.app`:
 
 ```bash
-agentuity --json project show <project-id>
+agentuity --json project show <project-id> | jq -r '.urls.app'
 ```
 
 ```env
 BETTER_AUTH_URL=https://<your-app-host>.agentuity.run
+```
+
+Set that value on the deployed project:
+
+```bash
+agentuity cloud env set "BETTER_AUTH_URL=https://<your-app-host>.agentuity.run" \
+  --project-id <project-id>
 ```
 
 Use the app URL here. The dashboard URL is only for managing the project.
@@ -124,6 +130,21 @@ Create `src/schema.ts` so Drizzle Kit can apply the auth tables:
 export * from '@agentuity/auth/schema';
 ```
 
+Create `drizzle.config.ts`:
+
+```typescript title="drizzle.config.ts"
+import { defineConfig } from 'drizzle-kit';
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) throw new Error('DATABASE_URL is required');
+
+export default defineConfig({
+  dialect: 'postgresql',
+  schema: './src/schema.ts',
+  dbCredentials: { url: databaseUrl },
+});
+```
+
 Mount the auth routes in your API router:
 
 ```typescript title="src/api/index.ts"
@@ -138,17 +159,10 @@ If `app.ts` mounts this router at `/api`, auth is available at `/api/auth/*`. If
 Apply the auth tables:
 
 ```bash
-set -a
-source .env
-set +a
-
-bunx drizzle-kit push \
-  --dialect postgresql \
-  --schema ./src/schema.ts \
-  --url "$DATABASE_URL"
+bunx drizzle-kit push
 ```
 
-Drizzle Kit does not read `.env` for the inline command above, so export it before running `push`.
+The config reads `DATABASE_URL` from your environment.
 
 ## Server Setup
 
@@ -575,22 +589,30 @@ The default Agentuity Auth schema is exported from `@agentuity/auth/schema`. Re-
 export * from '@agentuity/auth/schema';
 ```
 
+Create a Drizzle config:
+
+```typescript title="drizzle.config.ts"
+import { defineConfig } from 'drizzle-kit';
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) throw new Error('DATABASE_URL is required');
+
+export default defineConfig({
+  dialect: 'postgresql',
+  schema: './src/schema.ts',
+  dbCredentials: { url: databaseUrl },
+});
+```
+
 For a quick setup, push the schema directly:
 
 ```bash
-set -a
-source .env
-set +a
-
-bunx drizzle-kit push \
-  --dialect postgresql \
-  --schema ./src/schema.ts \
-  --url "$DATABASE_URL"
+bunx drizzle-kit push
 ```
 
 The Better Auth CLI migration commands are not the default path here. `@agentuity/auth` already ships the Drizzle schema; use Drizzle Kit to apply it.
 
-For a team app, put the same schema file behind a `drizzle.config.ts` and use `drizzle-kit generate` / `drizzle-kit migrate` with your normal migration review process.
+For a team app, use `drizzle-kit generate` / `drizzle-kit migrate` with your normal migration review process.
 
 ## Next Steps
 

--- a/apps/docs/src/web/content/frontend/authentication.mdx
+++ b/apps/docs/src/web/content/frontend/authentication.mdx
@@ -130,10 +130,16 @@ export default defineConfig({
 Mount the auth routes in your API router:
 
 ```typescript title="src/api/index.ts"
+import { Hono } from 'hono';
+import type { Env } from '@agentuity/runtime';
 import { mountAuthRoutes } from '@agentuity/auth';
 import { auth } from '../auth';
 
+const api = new Hono<Env>();
+
 api.on(['GET', 'POST'], '/auth/*', mountAuthRoutes(auth));
+
+export default api;
 ```
 
 If `app.ts` mounts this router at `/api`, auth is available at `/api/auth/*`. If your router variable has a different name, mount the route on that object.

--- a/apps/testing/auth-package-app/README.md
+++ b/apps/testing/auth-package-app/README.md
@@ -206,6 +206,6 @@ Both methods produce the same `c.var.auth` context in routes.
 
 ## Learn More
 
-- [Agentuity Auth Documentation](https://agentuity.dev/Frontend/authentication)
+- [Agentuity Auth Documentation](https://agentuity.dev/frontend/authentication)
 - [BetterAuth Documentation](https://better-auth.com/docs)
 - [Agentuity SDK](https://github.com/agentuity/sdk)

--- a/apps/testing/auth-package-app/README.md
+++ b/apps/testing/auth-package-app/README.md
@@ -118,15 +118,22 @@ Auth tables are stored in your Postgres database. Re-export the Agentuity Auth s
 export * from '@agentuity/auth/schema';
 ```
 
-```bash
-set -a
-source .env
-set +a
+```typescript
+// drizzle.config.ts
+import { defineConfig } from 'drizzle-kit';
 
-bunx drizzle-kit push \
-	--dialect postgresql \
-	--schema ./src/schema.ts \
-	--url "$DATABASE_URL"
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) throw new Error('DATABASE_URL is required');
+
+export default defineConfig({
+	dialect: 'postgresql',
+	schema: './src/schema.ts',
+	dbCredentials: { url: databaseUrl },
+});
+```
+
+```bash
+bunx drizzle-kit push
 ```
 
 ### 2. Environment Variables
@@ -137,8 +144,11 @@ DATABASE_URL="postgresql://..."
 
 # Optional (defaults to dev secret)
 AGENTUITY_AUTH_SECRET="your-32-char-secret"
+```
 
-# Local auth URL
+For local browser auth, put the callback URL in `.env.local`:
+
+```env
 BETTER_AUTH_URL="http://127.0.0.1:3500"
 ```
 

--- a/apps/testing/auth-package-app/README.md
+++ b/apps/testing/auth-package-app/README.md
@@ -4,11 +4,11 @@ A canonical example demonstrating **Agentuity Auth** (BetterAuth) integration wi
 
 ## What This Demonstrates
 
-- ✅ **BetterAuth Integration** - Full auth setup with `@agentuity/auth/agentuity`
+- ✅ **BetterAuth Integration** - Full auth setup with `@agentuity/auth`
 - ✅ **Session & API Key Auth** - Both authentication methods via unified middleware
-- ✅ **Protected Routes** - Using `authMiddleware` and `requireScopes()`
-- ✅ **Protected Agents** - Using `withSession()` wrapper
-- ✅ **React Client** - `AgentuityBetterAuth` provider with `useSession()`
+- ✅ **Protected Routes** - Using `createSessionMiddleware()`
+- ✅ **Protected Agents** - Using propagated auth context
+- ✅ **React Client** - `AuthProvider` with `useSession()`
 - ✅ **Optional Auth** - Routes that work for both authenticated and anonymous users
 
 ## Project Structure
@@ -37,27 +37,28 @@ ag-auth-test-app/
 The single source of truth for authentication:
 
 ```typescript
-import { Pool } from 'pg';
-import { createAuth, createMiddleware } from '@agentuity/auth/agentuity';
-
-const pool = new Pool({ connectionString: process.env.DATABASE_URL! });
+import { createAuth } from '@agentuity/auth';
 
 export const auth = createAuth({
-	database: pool,
-	secret: process.env.BETTER_AUTH_SECRET,
-	basePath: '/api/auth',
-	emailAndPassword: { enabled: true },
+	connectionString: process.env.DATABASE_URL,
+	trustedOrigins: [
+		process.env.BETTER_AUTH_URL,
+		'http://localhost:3500',
+		'http://127.0.0.1:3500',
+	],
 });
-
-export const authMiddleware = createMiddleware(auth);
-export const optionalAuthMiddleware = createMiddleware(auth, { optional: true });
 ```
 
 ### `src/api/index.ts` - Route Protection
 
 ```typescript
-// BetterAuth routes (signup, signin, signout, session, etc.)
-api.on(['GET', 'POST'], '/auth/*', (c) => auth.handler(c.req.raw));
+import { mountAuthRoutes, createSessionMiddleware } from '@agentuity/auth';
+
+const authMiddleware = createSessionMiddleware(auth);
+const optionalAuthMiddleware = createSessionMiddleware(auth, { optional: true });
+
+// Better Auth routes (signup, signin, signout, session, etc.)
+api.on(['GET', 'POST'], '/auth/*', mountAuthRoutes(auth));
 
 // Protected route - requires auth
 api.get('/me', authMiddleware, async (c) => {
@@ -75,8 +76,8 @@ api.get('/greeting', optionalAuthMiddleware, async (c) => {
 	}
 });
 
-// Scope-based protection
-api.get('/admin', authMiddleware, requireScopes(['admin']), async (c) => {
+// Role-based protection
+api.get('/admin', createSessionMiddleware(auth, { hasOrgRole: ['admin'] }), async (c) => {
 	return c.json({ message: 'Admin access granted' });
 });
 ```
@@ -84,9 +85,9 @@ api.get('/admin', authMiddleware, requireScopes(['admin']), async (c) => {
 ### `src/web/auth-client.ts` - React Client
 
 ```typescript
-import { createAuthClient } from 'better-auth/react';
+import { createAuthClient } from '@agentuity/auth/react';
 
-export const authClient = createAuthClient({ baseURL: window.location.origin });
+export const authClient = createAuthClient();
 export const { useSession, signIn, signUp, signOut } = authClient;
 ```
 
@@ -94,13 +95,13 @@ export const { useSession, signIn, signUp, signOut } = authClient;
 
 ```tsx
 import { AgentuityProvider } from '@agentuity/react';
-import { AgentuityBetterAuth } from '@agentuity/auth/agentuity/client';
+import { AuthProvider } from '@agentuity/auth/react';
 import { authClient } from './auth-client';
 
 export function App() {
 	return (
 		<AgentuityProvider>
-			<AgentuityBetterAuth authClient={authClient}>{/* Your app */}</AgentuityBetterAuth>
+			<AuthProvider authClient={authClient}>{/* Your app */}</AuthProvider>
 		</AgentuityProvider>
 	);
 }
@@ -110,14 +111,22 @@ export function App() {
 
 ### 1. Database
 
-Auth tables are stored in your Postgres database. Generate and apply them with the BetterAuth CLI:
+Auth tables are stored in your Postgres database. Re-export the Agentuity Auth schema, then apply it with Drizzle Kit:
+
+```typescript
+// src/schema.ts
+export * from '@agentuity/auth/schema';
+```
 
 ```bash
-# Generate the schema (SQL or your configured ORM)
-npx @better-auth/cli generate
+set -a
+source .env
+set +a
 
-# Apply migrations
-npx @better-auth/cli migrate
+bunx drizzle-kit push \
+	--dialect postgresql \
+	--schema ./src/schema.ts \
+	--url "$DATABASE_URL"
 ```
 
 ### 2. Environment Variables
@@ -128,6 +137,9 @@ DATABASE_URL="postgresql://..."
 
 # Optional (defaults to dev secret)
 AGENTUITY_AUTH_SECRET="your-32-char-secret"
+
+# Local auth URL
+BETTER_AUTH_URL="http://127.0.0.1:3500"
 ```
 
 ### 3. Install Dependencies

--- a/apps/testing/auth-package-app/src/auth.ts
+++ b/apps/testing/auth-package-app/src/auth.ts
@@ -12,7 +12,7 @@ import { lastLoginMethod } from 'better-auth/plugins';
  * Database URL for authentication.
  *
  * Set via DATABASE_URL environment variable.
- * Get yours from: `agentuity cloud database list --region use --json`
+ * Get yours from: `agentuity cloud db get <name> --json`
  */
 const DATABASE_URL = process.env.DATABASE_URL;
 
@@ -38,6 +38,7 @@ export const auth = createAuth({
 	// Simplest setup: just provide the connection string
 	// We create Bun.sql + Drizzle internally with joins enabled
 	connectionString: DATABASE_URL,
+	trustedOrigins: [process.env.BETTER_AUTH_URL, 'http://localhost:3500', 'http://127.0.0.1:3500'],
 	// All options below have sensible defaults and can be omitted:
 	// secret: process.env.AGENTUITY_AUTH_SECRET, // auto-resolved from env
 	// basePath: '/api/auth', // default

--- a/apps/testing/auth-package-app/src/web/App.tsx
+++ b/apps/testing/auth-package-app/src/web/App.tsx
@@ -104,7 +104,7 @@ export function App() {
 						</label>
 						<p className="poem-note">
 							This triggers an agent-to-agent handoff to the Poem Agent, demonstrating auth
-							propagation via withSession.
+							context propagation.
 						</p>
 					</div>
 

--- a/packages/auth/AGENTS.md
+++ b/packages/auth/AGENTS.md
@@ -53,9 +53,15 @@ const auth = createAuth({
 	connectionString: process.env.DATABASE_URL,
 });
 
-api.on(['GET', 'POST'], '/api/auth/*', mountAuthRoutes(auth));
-api.use('/api/*', createSessionMiddleware(auth));
+// In src/api/index.ts, app.ts mounts this router at /api
+// This exposes /api/auth/*
+api.on(['GET', 'POST'], '/auth/*', mountAuthRoutes(auth));
+
+// Protect routes inside this mounted API router
+api.use('/*', createSessionMiddleware(auth));
 ```
+
+Important: Use `/auth/*` inside Agentuity v2 `src/api/index.ts` because `app.ts` already mounts that router at `/api`. Use `/api/auth/*` only when mounting Better Auth on a root Hono app directly.
 
 ### Agent Handler (ctx.auth is native)
 

--- a/packages/auth/AGENTS.md
+++ b/packages/auth/AGENTS.md
@@ -94,6 +94,12 @@ const authClient = createAuthClient();
 2. **database** - Bring your own drizzle adapter or other BetterAuth adapter
 3. **@agentuity/auth/schema** - Export for merging with app schema
 
+## Documentation Patterns
+
+- Put local-only auth callback values in `.env.local`.
+- Show `@agentuity/auth/schema` through `drizzle.config.ts`, then run Drizzle Kit from that config.
+- Avoid inline Drizzle Kit `--dialect`, `--schema`, and `--url` commands unless the docs are about those flags.
+
 ## Default Plugins
 
 - `organization` - Multi-tenancy

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -115,8 +115,11 @@ DATABASE_URL=postgresql://user:pass@host:5432/dbname
 
 # Auth secret (generate with: openssl rand -hex 32)
 AGENTUITY_AUTH_SECRET=your-secret-here
+```
 
-# Local auth URL
+For local browser auth, put the callback URL in `.env.local`:
+
+```env
 BETTER_AUTH_URL=http://127.0.0.1:3500
 ```
 
@@ -127,15 +130,22 @@ BETTER_AUTH_URL=http://127.0.0.1:3500
 export * from '@agentuity/auth/schema';
 ```
 
-```bash
-set -a
-source .env
-set +a
+```typescript
+// drizzle.config.ts
+import { defineConfig } from 'drizzle-kit';
 
-bunx drizzle-kit push \
-	--dialect postgresql \
-	--schema ./src/schema.ts \
-	--url "$DATABASE_URL"
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) throw new Error('DATABASE_URL is required');
+
+export default defineConfig({
+	dialect: 'postgresql',
+	schema: './src/schema.ts',
+	dbCredentials: { url: databaseUrl },
+});
+```
+
+```bash
+bunx drizzle-kit push
 ```
 
 ## Usage
@@ -401,11 +411,21 @@ import type {
 export * from '@agentuity/auth/schema';
 ```
 
+```typescript
+import { defineConfig } from 'drizzle-kit';
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) throw new Error('DATABASE_URL is required');
+
+export default defineConfig({
+	dialect: 'postgresql',
+	schema: './src/schema.ts',
+	dbCredentials: { url: databaseUrl },
+});
+```
+
 ```bash
-bunx drizzle-kit push \
-	--dialect postgresql \
-	--schema ./src/schema.ts \
-	--url "$DATABASE_URL"
+bunx drizzle-kit push
 ```
 
 ## Security Best Practices

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -24,23 +24,20 @@ bun add @agentuity/auth
 
 ```bash
 bun add @agentuity/auth better-auth drizzle-orm
-```
-
-Or start from the template:
-
-```bash
-bunx agentuity create my-app --template agentuity-auth
+bun add -D drizzle-kit
 ```
 
 ### 2. Configure Database
 
 ```bash
-# Create a database and get a connection URL
-agentuity cloud database create --region use
+agentuity cloud db create --name my-app-auth --region usc
+agentuity cloud db get my-app-auth --json
+```
 
-# Generate and run auth migrations with the BetterAuth CLI
-npx @better-auth/cli generate
-npx @better-auth/cli migrate
+Use the database URL in `.env`, then generate an auth secret:
+
+```bash
+openssl rand -hex 32
 ```
 
 ### 3. Server Setup (Hono)
@@ -51,6 +48,11 @@ import { createAuth, createSessionMiddleware, mountAuthRoutes } from '@agentuity
 
 export const auth = createAuth({
 	connectionString: process.env.DATABASE_URL,
+	trustedOrigins: [
+		process.env.BETTER_AUTH_URL,
+		'http://localhost:3500',
+		'http://127.0.0.1:3500',
+	],
 	// Uses AGENTUITY_AUTH_SECRET env var by default
 });
 
@@ -67,12 +69,12 @@ import { mountAuthRoutes } from '@agentuity/auth';
 const api = createRouter();
 
 // Mount auth routes (sign-in, sign-up, sign-out, session, etc.)
-api.on(['GET', 'POST'], '/api/auth/*', mountAuthRoutes(auth));
+api.on(['GET', 'POST'], '/auth/*', mountAuthRoutes(auth));
 
 // Protect API routes
-api.use('/api/*', authMiddleware);
+api.use('/*', authMiddleware);
 
-api.get('/api/me', async (c) => {
+api.get('/me', async (c) => {
 	const user = await c.var.auth.getUser();
 	return c.json({ id: user.id, email: user.email });
 });
@@ -113,6 +115,27 @@ DATABASE_URL=postgresql://user:pass@host:5432/dbname
 
 # Auth secret (generate with: openssl rand -hex 32)
 AGENTUITY_AUTH_SECRET=your-secret-here
+
+# Local auth URL
+BETTER_AUTH_URL=http://127.0.0.1:3500
+```
+
+### 6. Schema Setup
+
+```typescript
+// src/schema.ts
+export * from '@agentuity/auth/schema';
+```
+
+```bash
+set -a
+source .env
+set +a
+
+bunx drizzle-kit push \
+	--dialect postgresql \
+	--schema ./src/schema.ts \
+	--url "$DATABASE_URL"
 ```
 
 ## Usage
@@ -370,37 +393,28 @@ import type {
 } from '@agentuity/auth';
 ```
 
-## CLI Commands
+## Schema Setup
 
-Auth setup uses the BetterAuth CLI directly:
+`@agentuity/auth` exports the Drizzle schema used by the default plugins. Re-export it from your app and apply it with Drizzle Kit:
+
+```typescript
+export * from '@agentuity/auth/schema';
+```
 
 ```bash
-# Generate the auth schema (SQL or Drizzle/Prisma based on your config)
-npx @better-auth/cli generate
-
-# Run database migrations
-npx @better-auth/cli migrate
-
-# Generate a secure secret for AGENTUITY_AUTH_SECRET
-npx @better-auth/cli secret
-# or:  openssl rand -hex 32
+bunx drizzle-kit push \
+	--dialect postgresql \
+	--schema ./src/schema.ts \
+	--url "$DATABASE_URL"
 ```
 
 ## Security Best Practices
 
-1. **Use HTTPS in production** - Always use TLS for deployments
+1. **Use HTTPS in deployed apps** - Always use TLS outside local development
 2. **Keep secrets secret** - Never commit `.env` files or expose `AGENTUITY_AUTH_SECRET`
 3. **Rotate secrets periodically** - Rotate `AGENTUITY_AUTH_SECRET` on a regular schedule
 4. **Control OTEL PII** - Use `otelSpans: { email: false }` to exclude sensitive data from telemetry
 5. **Validate permissions** - Always check `hasPermission()` for API key routes
-
-## Templates
-
-Get started quickly:
-
-```bash
-bunx agentuity create my-app --template agentuity-auth
-```
 
 ## Third-Party Providers
 


### PR DESCRIPTION
- Replace missing auth template flow with manual setup
- Document auth secret and callback URL requirements
- Use shipped auth schema with Drizzle Kit
- Clarify local, DevMode, and deployed app origins
- Refresh auth package examples for current APIs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked authentication docs to an Agentuity-first setup and clarified quick start flow.
  * Added guidance for local vs deployed callback origins and using .env.local, including BETTER_AUTH_URL.
  * Switched schema/migration guidance to Drizzle Kit rather than the previous CLI flow.
  * Clarified route mounting and session protection patterns.
  * Minor UI text refinements in examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->