### PR TITLE
feat: add auth project template

### DIFF
--- a/scripts/test-templates.ts
+++ b/scripts/test-templates.ts
@@ -580,11 +580,14 @@ async function startServer(
 	return { proc, success: false, error: 'Server failed to start within 30 seconds' };
 }
 
-async function testEndpoints(port: number): Promise<{ health: boolean; errors: string[] }> {
+async function testEndpoints(
+	port: number,
+	templateId: string
+): Promise<{ health: boolean; errors: string[] }> {
 	const errors: string[] = [];
 	let health = false;
 
-	// Test health endpoint only - sufficient to verify template builds and starts correctly
+	// Test health endpoint first, this verifies every template builds and starts
 	try {
 		const response = await fetch(`http://127.0.0.1:${port}/_health`);
 		health = response.ok;
@@ -593,6 +596,33 @@ async function testEndpoints(port: number): Promise<{ health: boolean; errors: s
 		}
 	} catch (e) {
 		errors.push(`Health endpoint failed: ${e}`);
+	}
+
+	if (templateId === 'auth') {
+		const origin = `http://127.0.0.1:${port}`;
+
+		try {
+			const response = await fetch(`${origin}/api/auth/get-session`, {
+				headers: { Origin: origin },
+			});
+			const body = await response.text();
+			if (!response.ok) {
+				errors.push(`Auth session endpoint returned ${response.status}`);
+			} else if (body.trim() !== 'null') {
+				errors.push(`Auth session endpoint returned unexpected body: ${body}`);
+			}
+		} catch (e) {
+			errors.push(`Auth session endpoint failed: ${e}`);
+		}
+
+		try {
+			const response = await fetch(`${origin}/api/me`);
+			if (response.status !== 401) {
+				errors.push(`Protected auth endpoint returned ${response.status}, expected 401`);
+			}
+		} catch (e) {
+			errors.push(`Protected auth endpoint failed: ${e}`);
+		}
 	}
 
 	return { health, errors };
@@ -739,11 +769,13 @@ async function testTemplate(
 			envVars.CLERK_SECRET_KEY = 'sk_test_dummy';
 			envVars.AGENTUITY_PUBLIC_CLERK_PUBLISHABLE_KEY = 'pk_test_dummy';
 		} else if (template.id === 'auth') {
-			// Auth template needs Postgres + auth secret to actually serve protected routes.
-			// db.ts is lazy, so the server boots without these — but setting them anyway
-			// lets future test extensions exercise the auth flow.
+			// Auth template needs Postgres + auth secret to actually serve protected routes
+			// db.ts is lazy, so the server boots without these, but setting them anyway
+			// lets future test extensions exercise the auth flow
 			envVars.DATABASE_URL = 'postgres://user:pass@localhost:5432/testdb';
-			envVars.AGENTUITY_AUTH_SECRET = 'test-secret-for-auth-template';
+			envVars.AGENTUITY_AUTH_SECRET =
+				'8f88a98d2c9f7f0da2b0a52f0d71a84767f5d7207fdfdecbf39d5b8b8c2a7d6b';
+			envVars.BETTER_AUTH_URL = `http://127.0.0.1:${basePort}`;
 		}
 
 		// Step 4: Typecheck
@@ -784,23 +816,24 @@ async function testTemplate(
 		}
 		logSuccess('Server started');
 
-		// Step 6: Test health endpoint
-		logStep('Testing health endpoint...');
+		// Step 6: Test endpoints
+		logStep('Testing endpoints...');
 		stepStart = Date.now();
-		const endpointResults = await testEndpoints(basePort);
+		const endpointResults = await testEndpoints(basePort, template.id);
+		const endpointsPassed = endpointResults.health && endpointResults.errors.length === 0;
 
 		result.steps.push({
-			name: 'Test health endpoint',
-			passed: endpointResults.health,
+			name: 'Test endpoints',
+			passed: endpointsPassed,
 			error: endpointResults.errors.length > 0 ? endpointResults.errors.join('; ') : undefined,
 			duration: Date.now() - stepStart,
 		});
 
-		if (!endpointResults.health) {
+		if (!endpointsPassed) {
 			result.passed = false;
-			logError(`Health endpoint test failed: ${endpointResults.errors.join('; ')}`);
+			logError(`Endpoint test failed: ${endpointResults.errors.join('; ')}`);
 		} else {
-			logSuccess('Health endpoint test passed');
+			logSuccess('Endpoint tests passed');
 		}
 
 		// Step 7: Check outdated dependencies (report-only)

--- a/scripts/test-templates.ts
+++ b/scripts/test-templates.ts
@@ -769,12 +769,11 @@ async function testTemplate(
 			envVars.CLERK_SECRET_KEY = 'sk_test_dummy';
 			envVars.AGENTUITY_PUBLIC_CLERK_PUBLISHABLE_KEY = 'pk_test_dummy';
 		} else if (template.id === 'auth') {
-			// Auth template needs Postgres + auth secret to actually serve protected routes
+			// Auth template needs Postgres + auth secret to serve protected routes
 			// db.ts is lazy, so the server boots without these, but setting them anyway
 			// lets future test extensions exercise the auth flow
 			envVars.DATABASE_URL = 'postgres://user:pass@localhost:5432/testdb';
-			envVars.AGENTUITY_AUTH_SECRET =
-				'8f88a98d2c9f7f0da2b0a52f0d71a84767f5d7207fdfdecbf39d5b8b8c2a7d6b';
+			envVars.AGENTUITY_AUTH_SECRET = 'test-secret-for-auth-template-tests';
 			envVars.BETTER_AUTH_URL = `http://127.0.0.1:${basePort}`;
 		}
 

--- a/scripts/test-templates.ts
+++ b/scripts/test-templates.ts
@@ -738,8 +738,10 @@ async function testTemplate(
 		} else if (template.id === 'clerk') {
 			envVars.CLERK_SECRET_KEY = 'sk_test_dummy';
 			envVars.AGENTUITY_PUBLIC_CLERK_PUBLISHABLE_KEY = 'pk_test_dummy';
-		} else if (template.id === 'agentuity-auth') {
-			// Auth template requires DATABASE_URL to be set (throws at import time otherwise)
+		} else if (template.id === 'auth') {
+			// Auth template needs Postgres + auth secret to actually serve protected routes.
+			// db.ts is lazy, so the server boots without these — but setting them anyway
+			// lets future test extensions exercise the auth flow.
 			envVars.DATABASE_URL = 'postgres://user:pass@localhost:5432/testdb';
 			envVars.AGENTUITY_AUTH_SECRET = 'test-secret-for-auth-template';
 		}

--- a/templates/auth/AGENTS.md
+++ b/templates/auth/AGENTS.md
@@ -77,7 +77,7 @@ The `src/web/` folder contains your React frontend, which is automatically bundl
 - `index.html` - Main HTML file with `<script type="module" src="./frontend.tsx">`
 - `frontend.tsx` - Entry point that wires `AgentuityProvider` and `AuthProvider`
 - `auth-client.ts` - `createAuthClient()` from `@agentuity/auth/react`
-- `App.tsx` - Main React component. Uses `<SignedIn>` and `<SignedOut>` from `@daveyplate/better-auth-ui`
+- `App.tsx` - Main React component. Renders `<AuthView>` (Better Auth UI's sign-in form) when signed out, and a profile + protected-route demo when signed in
 - `App.css` - Tailwind theme tokens for Agentuity cyan and Better Auth UI
 
 **Key Points:**
@@ -85,7 +85,7 @@ The `src/web/` folder contains your React frontend, which is automatically bundl
 - `<AuthUIProvider>` from `@daveyplate/better-auth-ui` accepts the `authClient`. Wrap any auth UI in it.
 - `<AuthView pathname={...}>` renders the right form (sign-in / sign-up / forgot-password / etc.) based on the current pathname.
 - `useAuthenticate()` returns `{ user, isPending }` for the signed-in user.
-- `<SignedIn>` / `<SignedOut>` gate children based on session state.
+- An `<AuthSwitch>` wrapper (App.tsx) keeps the previous auth state visible during `isPending` refetches, so the layout doesn't collapse on sign-in or sign-out.
 
 ## Environment variables
 

--- a/templates/auth/AGENTS.md
+++ b/templates/auth/AGENTS.md
@@ -1,0 +1,106 @@
+# Agent Guidelines for {{PROJECT_NAME}}
+
+## Commands
+
+- **Build**: `bun run build` (compiles your application)
+- **Dev**: `bun run dev` (starts development server at `http://127.0.0.1:3500`)
+- **Typecheck**: `bun run typecheck` (runs TypeScript type checking)
+- **Deploy**: `bun run deploy` (deploys your app to the Agentuity cloud)
+- **DB push**: `bunx drizzle-kit push` (apply schema changes to your Postgres)
+- **DB studio**: `bunx drizzle-kit studio` (browse rows in your Postgres)
+
+## Agent-Friendly CLI
+
+The Agentuity CLI is designed to be agent-friendly with programmatic interfaces, structured output, and comprehensive introspection.
+
+Read the [AGENTS.md](./node_modules/@agentuity/cli/AGENTS.md) file in the Agentuity CLI for more information on how to work with this project.
+
+## Instructions
+
+- This project uses Bun instead of NodeJS and TypeScript for all source code
+- Auth is wired via [Better Auth](https://better-auth.com) through `@agentuity/auth`
+
+## Auth architecture
+
+One Drizzle client serves both Better Auth's tables and your own (the "Bring Your Own Drizzle" pattern).
+
+**Files:**
+
+- `src/db.ts`. Builds a single Drizzle client lazily via `createPostgresDrizzle({ connectionString, schema })`.
+- `src/auth.ts`. Wraps that client with `drizzleAdapter` and passes it to `createAuth`.
+- `src/schema.ts`. Re-exports `@agentuity/auth/schema` so drizzle-kit sees Better Auth's tables. Add your own tables here.
+- `src/api/index.ts`. Registers `/auth/*` (mountAuthRoutes) and `/me` (createSessionMiddleware). The router is mounted under `/api` in `app.ts`, so the served URLs are `/api/auth/*` and `/api/me`.
+- `src/agent/index.ts`. Inherited from the base template and intentionally empty. Add agents only if this app needs them.
+
+## Adding your own tables
+
+Declare them in `src/schema.ts` next to the auth schema re-export. Reference `user.id` for per-user rows. Run `bunx drizzle-kit push` after schema changes.
+
+```typescript
+import { pgTable, text, timestamp } from '@agentuity/drizzle';
+import { user } from '@agentuity/auth/schema';
+
+export const note = pgTable('note', {
+	id: text('id').primaryKey(),
+	userId: text('user_id')
+		.notNull()
+		.references(() => user.id, { onDelete: 'cascade' }),
+	body: text('body').notNull(),
+	createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+});
+```
+
+## Adding protected routes
+
+Apply `createSessionMiddleware(auth)` to any route that should require a signed-in user. The middleware sets `c.var.auth.getUser()` and `c.var.auth.authMethod`.
+
+```typescript
+import { createSessionMiddleware } from '@agentuity/auth';
+import { auth } from '../auth';
+
+api.get('/profile', createSessionMiddleware(auth), async (c) => {
+	const user = await c.var.auth.getUser();
+	return c.json({ email: user.email });
+});
+```
+
+This serves at `GET /api/profile`. The `/api` prefix comes from `app.ts`, where the router is mounted.
+
+For optional auth (route works signed in or out), pass `{ optional: true }`.
+
+## Web Frontend (src/web/)
+
+The `src/web/` folder contains your React frontend, which is automatically bundled by the Agentuity build system.
+
+**File structure:**
+
+- `index.html` — Main HTML file with `<script type="module" src="./frontend.tsx">`
+- `frontend.tsx` — Entry point. Wires `AgentuityProvider` + `AuthProvider` from `@agentuity/auth/react`.
+- `auth-client.ts` — `createAuthClient()` from `@agentuity/auth/react`.
+- `App.tsx` — Renders the auth UI. Uses `<SignedIn>` / `<SignedOut>` from `@daveyplate/better-auth-ui` to gate content.
+- `App.css` — Tailwind theme tokens (Agentuity cyan + Better Auth UI shadcn variables).
+
+**Key Points:**
+
+- `<AuthUIProvider>` from `@daveyplate/better-auth-ui` accepts the `authClient`. Wrap any auth UI in it.
+- `<AuthView pathname={...}>` renders the right form (sign-in / sign-up / forgot-password / etc.) based on the current pathname.
+- `useAuthenticate()` returns `{ user, isPending }` for the signed-in user.
+- `<SignedIn>` / `<SignedOut>` gate children based on session state.
+
+## Environment variables
+
+| Variable | Required | Where set | Notes |
+|---|---|---|---|
+| `DATABASE_URL` | yes | `.env` (local), `agentuity cloud env set --secret` | Postgres connection string. Used by both Better Auth and your Drizzle client. |
+| `AGENTUITY_AUTH_SECRET` | yes | `.env`, `agentuity cloud env set --secret` | Generate via `openssl rand -hex 32`. Used to sign session cookies. |
+| `BETTER_AUTH_URL` | yes | `.env.local` (local), `agentuity cloud env set` | The deployed app's origin. Better Auth rejects mismatched origins. |
+| `AGENTUITY_BASE_URL` | local dev | `.env.local` | The local URL `agentuity dev` prints. |
+
+## Learn More
+
+- [Agentuity Documentation](https://agentuity.dev)
+- [Better Auth Documentation](https://better-auth.com/docs)
+- [Better Auth UI Documentation](https://better-auth-ui.com)
+- [Drizzle ORM Documentation](https://orm.drizzle.team)
+- [Bun Documentation](https://bun.sh/docs)
+- [Hono Documentation](https://hono.dev/)

--- a/templates/auth/AGENTS.md
+++ b/templates/auth/AGENTS.md
@@ -24,13 +24,13 @@ Read the [AGENTS.md](./node_modules/@agentuity/cli/AGENTS.md) file in the Agentu
 
 One Drizzle client serves both Better Auth's tables and your own (the "Bring Your Own Drizzle" pattern).
 
-**Files:**
+**File Structure:**
 
-- `src/db.ts`. Builds a single Drizzle client lazily via `createPostgresDrizzle({ connectionString, schema })`.
-- `src/auth.ts`. Wraps that client with `drizzleAdapter` and passes it to `createAuth`.
-- `src/schema.ts`. Re-exports `@agentuity/auth/schema` so drizzle-kit sees Better Auth's tables. Add your own tables here.
-- `src/api/index.ts`. Registers `/auth/*` (mountAuthRoutes) and `/me` (createSessionMiddleware). The router is mounted under `/api` in `app.ts`, so the served URLs are `/api/auth/*` and `/api/me`.
-- `src/agent/index.ts`. Inherited from the base template and intentionally empty. Add agents only if this app needs them.
+- `src/db.ts` - Builds one Drizzle client lazily via `createPostgresDrizzle({ connectionString, schema })`
+- `src/auth.ts` - Wraps that client with `drizzleAdapter` and passes it to `createAuth`
+- `src/schema.ts` - Re-exports `@agentuity/auth/schema` so drizzle-kit sees Better Auth's tables. Add your own tables here
+- `src/api/index.ts` - Registers `/auth/*` with `mountAuthRoutes` and `/me` with `createSessionMiddleware`. The router is mounted under `/api` in `app.ts`, so the served URLs are `/api/auth/*` and `/api/me`
+- `src/agent/index.ts` - Inherited from the base template and intentionally empty. Add agents only if this app needs them
 
 ## Adding your own tables
 
@@ -72,13 +72,13 @@ For optional auth (route works signed in or out), pass `{ optional: true }`.
 
 The `src/web/` folder contains your React frontend, which is automatically bundled by the Agentuity build system.
 
-**File structure:**
+**File Structure:**
 
-- `index.html` — Main HTML file with `<script type="module" src="./frontend.tsx">`
-- `frontend.tsx` — Entry point. Wires `AgentuityProvider` + `AuthProvider` from `@agentuity/auth/react`.
-- `auth-client.ts` — `createAuthClient()` from `@agentuity/auth/react`.
-- `App.tsx` — Renders the auth UI. Uses `<SignedIn>` / `<SignedOut>` from `@daveyplate/better-auth-ui` to gate content.
-- `App.css` — Tailwind theme tokens (Agentuity cyan + Better Auth UI shadcn variables).
+- `index.html` - Main HTML file with `<script type="module" src="./frontend.tsx">`
+- `frontend.tsx` - Entry point that wires `AgentuityProvider` and `AuthProvider`
+- `auth-client.ts` - `createAuthClient()` from `@agentuity/auth/react`
+- `App.tsx` - Main React component. Uses `<SignedIn>` and `<SignedOut>` from `@daveyplate/better-auth-ui`
+- `App.css` - Tailwind theme tokens for Agentuity cyan and Better Auth UI
 
 **Key Points:**
 

--- a/templates/auth/README.md
+++ b/templates/auth/README.md
@@ -4,16 +4,16 @@ An Agentuity project with [Better Auth](https://better-auth.com) wired up: auth 
 
 ## What you get
 
-- ✅ **Better Auth** — email + password auth via `@agentuity/auth`
-- ✅ **Postgres + Drizzle** — one shared client. Add your own tables in `src/schema.ts`
-- ✅ **`/api/auth/*`** — sign-up, sign-in, sign-out, sessions
-- ✅ **`/api/me`** — protected route that returns the signed-in user
-- ✅ **Better Auth UI** — drop-in sign-in and sign-up screens themed to Agentuity cyan
-- ✅ **React frontend** — `<SignedIn>` / `<SignedOut>` gating, sign-out, session detail card
+- ✅ **Better Auth** - email + password auth via `@agentuity/auth`
+- ✅ **Postgres + Drizzle** - one shared client. Add your own tables in `src/schema.ts`
+- ✅ **`/api/auth/*`** - sign-up, sign-in, sign-out, sessions
+- ✅ **`/api/me`** - protected route that returns the signed-in user
+- ✅ **Better Auth UI** - drop-in sign-in and sign-up screens themed to Agentuity cyan
+- ✅ **React frontend** - `<SignedIn>` / `<SignedOut>` gating, sign-out, session detail card
 
 ## Project structure
 
-```
+```text
 {{PROJECT_NAME}}/
 ├── src/
 │   ├── auth.ts              # createAuth() with drizzleAdapter

--- a/templates/auth/README.md
+++ b/templates/auth/README.md
@@ -9,7 +9,7 @@ An Agentuity project with [Better Auth](https://better-auth.com) wired up: auth 
 - ✅ **`/api/auth/*`** - sign-up, sign-in, sign-out, sessions
 - ✅ **`/api/me`** - protected route that returns the signed-in user
 - ✅ **Better Auth UI** - drop-in sign-in and sign-up screens themed to Agentuity cyan
-- ✅ **React frontend** - `<SignedIn>` / `<SignedOut>` gating, sign-out, session detail card
+- ✅ **React frontend** - signed-in / signed-out panels, sign-out, session detail card
 
 ## Project structure
 
@@ -110,7 +110,7 @@ Returns `{ id, name, email, authMethod, memberSince }`.
 - **Edit auth options**: `src/auth.ts`. `createAuth({ database, ... })` accepts the full Better Auth config.
 - **Add your tables**: `src/schema.ts`. Declare them next to the auth schema re-export and reference `user.id` for per-user rows. Run `bunx drizzle-kit push` after schema changes. See AGENTS.md for an example.
 - **Add API routes**: `src/api/index.ts`. Apply `createSessionMiddleware(auth)` to any route that should require a signed-in user.
-- **Edit the UI**: `src/web/App.tsx`. `<AuthView>`, `<SignedIn>`, and `<SignedOut>` come from [`@daveyplate/better-auth-ui`](https://better-auth-ui.com).
+- **Edit the UI**: `src/web/App.tsx`. The sign-in form (`<AuthView>`) is from [`@daveyplate/better-auth-ui`](https://better-auth-ui.com); the rest is React and Tailwind.
 
 ## Deploy
 

--- a/templates/auth/README.md
+++ b/templates/auth/README.md
@@ -1,0 +1,146 @@
+# {{PROJECT_NAME}}
+
+An Agentuity project with [Better Auth](https://better-auth.com) wired up: auth routes, Postgres-backed sessions, and a protected API route. The Drizzle schema is set up so you can add your own tables alongside Better Auth's.
+
+## What you get
+
+- ✅ **Better Auth** — email + password auth via `@agentuity/auth`
+- ✅ **Postgres + Drizzle** — one shared client. Add your own tables in `src/schema.ts`
+- ✅ **`/api/auth/*`** — sign-up, sign-in, sign-out, sessions
+- ✅ **`/api/me`** — protected route that returns the signed-in user
+- ✅ **Better Auth UI** — drop-in sign-in and sign-up screens themed to Agentuity cyan
+- ✅ **React frontend** — `<SignedIn>` / `<SignedOut>` gating, sign-out, session detail card
+
+## Project structure
+
+```
+{{PROJECT_NAME}}/
+├── src/
+│   ├── auth.ts              # createAuth() with drizzleAdapter
+│   ├── db.ts                # Shared Drizzle client (Better Auth + your tables)
+│   ├── schema.ts            # Re-exports auth schema; add your tables here
+│   ├── agent/
+│   │   └── index.ts         # Empty agent registry inherited from the base template
+│   ├── api/
+│   │   └── index.ts         # /api/auth/* routes + protected /api/me
+│   └── web/
+│       ├── App.tsx          # Auth UI + signed-in panel + session demo
+│       ├── App.css          # Tailwind theme tokens (cyan + Better Auth UI)
+│       ├── auth-client.ts   # createAuthClient() for the browser
+│       ├── frontend.tsx     # AgentuityProvider + AuthProvider wiring
+│       └── index.html
+├── agentuity.config.ts
+├── drizzle.config.ts
+├── package.json
+└── tsconfig.json
+```
+
+## Setup
+
+Install dependencies:
+
+```bash
+bun install
+```
+
+Generate an auth secret:
+
+```bash
+openssl rand -hex 32
+```
+
+Create `.env` with your Postgres connection and the secret:
+
+```bash
+DATABASE_URL=postgresql://user:pass@host:5432/dbname
+AGENTUITY_AUTH_SECRET=<value-from-openssl>
+```
+
+Create `.env.local` with the local Better Auth origin (the URL `agentuity dev` prints):
+
+```bash
+AGENTUITY_BASE_URL=http://127.0.0.1:3500
+BETTER_AUTH_URL=http://127.0.0.1:3500
+```
+
+Apply the database schema (creates Better Auth's tables):
+
+```bash
+bunx drizzle-kit push
+```
+
+Start the dev server:
+
+```bash
+bun run dev
+```
+
+Open `http://127.0.0.1:3500` and sign up. After signing in, click **Check session** to call `GET /api/me`.
+
+## Verify
+
+Signed-out session check:
+
+```bash
+curl http://127.0.0.1:3500/api/auth/get-session
+```
+
+Returns `null`.
+
+Sign up via curl. Better Auth requires a valid `Origin` header on mutating endpoints, so pass one:
+
+```bash
+curl -c cookies.txt -b cookies.txt \
+  -X POST http://127.0.0.1:3500/api/auth/sign-up/email \
+  -H 'Content-Type: application/json' \
+  -H 'Origin: http://127.0.0.1:3500' \
+  --data '{"email":"you@example.com","password":"password1234","name":"You"}'
+```
+
+Call the protected route:
+
+```bash
+curl -b cookies.txt http://127.0.0.1:3500/api/me
+```
+
+Returns `{ id, name, email, authMethod, memberSince }`.
+
+## Customize
+
+- **Edit auth options**: `src/auth.ts`. `createAuth({ database, ... })` accepts the full Better Auth config.
+- **Add your tables**: `src/schema.ts`. Declare them next to the auth schema re-export and reference `user.id` for per-user rows. Run `bunx drizzle-kit push` after schema changes. See AGENTS.md for an example.
+- **Add API routes**: `src/api/index.ts`. Apply `createSessionMiddleware(auth)` to any route that should require a signed-in user.
+- **Edit the UI**: `src/web/App.tsx`. `<AuthView>`, `<SignedIn>`, and `<SignedOut>` come from [`@daveyplate/better-auth-ui`](https://better-auth-ui.com).
+
+## Deploy
+
+Set the deployed Better Auth origin and your secrets in your Agentuity project:
+
+```bash
+agentuity cloud env set "BETTER_AUTH_URL=https://<your-app-host>.agentuity.run" \
+  --project-id <project-id>
+
+agentuity cloud env set "DATABASE_URL=postgresql://..." --secret \
+  --project-id <project-id>
+
+agentuity cloud env set "AGENTUITY_AUTH_SECRET=..." --secret \
+  --project-id <project-id>
+```
+
+Deploy:
+
+```bash
+bun run deploy -- --confirm
+```
+
+## Learn more
+
+- [Agentuity Auth Documentation](https://agentuity.dev/frontend/authentication)
+- [Better Auth Documentation](https://better-auth.com/docs)
+- [Better Auth UI Documentation](https://better-auth-ui.com)
+- [Drizzle ORM Documentation](https://orm.drizzle.team)
+
+## Requirements
+
+- [Bun](https://bun.sh/) v1.0 or higher
+- A Postgres database (e.g., `agentuity cloud database create --region use`, Neon, Supabase, RDS)

--- a/templates/auth/agentuity.config.ts
+++ b/templates/auth/agentuity.config.ts
@@ -1,0 +1,32 @@
+/**
+ * Agentuity Configuration
+ *
+ */
+
+import type { AgentuityConfig } from '@agentuity/cli';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+
+export default {
+	/**
+	 * Workbench (development only)
+	 *
+	 * Visual UI for testing agents during development. Not included in production builds.
+	 * Omit this section to disable. Access at http://localhost:3500/workbench
+	 */
+	workbench: {
+		route: '/workbench',
+		headers: {},
+	},
+
+	/**
+	 * Vite Plugins
+	 *
+	 * Plugins for the client build (src/web/).
+	 * The React plugin is included by default — replace it with your
+	 * framework of choice (e.g., @sveltejs/vite-plugin-svelte).
+	 *
+	 * @see https://vitejs.dev/plugins/
+	 */
+	plugins: [react(), tailwindcss()],
+} satisfies AgentuityConfig;

--- a/templates/auth/agentuity.config.ts
+++ b/templates/auth/agentuity.config.ts
@@ -11,7 +11,7 @@ export default {
 	/**
 	 * Workbench (development only)
 	 *
-	 * Visual UI for testing agents during development. Not included in production builds.
+	 * Visual UI for testing agents during development. Not included in production builds
 	 * Omit this section to disable. Access at http://localhost:3500/workbench
 	 */
 	workbench: {
@@ -22,9 +22,9 @@ export default {
 	/**
 	 * Vite Plugins
 	 *
-	 * Plugins for the client build (src/web/).
-	 * The React plugin is included by default — replace it with your
-	 * framework of choice (e.g., @sveltejs/vite-plugin-svelte).
+	 * Plugins for the client build (src/web/)
+	 * The React plugin is included by default
+	 * Replace it with your framework of choice (e.g., @sveltejs/vite-plugin-svelte)
 	 *
 	 * @see https://vitejs.dev/plugins/
 	 */

--- a/templates/auth/drizzle.config.ts
+++ b/templates/auth/drizzle.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'drizzle-kit';
+
+const databaseUrl = process.env.DATABASE_URL;
+
+if (!databaseUrl) {
+	throw new Error('DATABASE_URL is required');
+}
+
+export default defineConfig({
+	dialect: 'postgresql',
+	schema: './src/schema.ts',
+	dbCredentials: { url: databaseUrl },
+});

--- a/templates/auth/package.overlay.json
+++ b/templates/auth/package.overlay.json
@@ -10,6 +10,7 @@
 		"clsx": "^2.1.1",
 		"input-otp": "^1.4.2",
 		"lucide-react": "^1.14.0",
+		"motion": "^12.38.0",
 		"react-hook-form": "^7.74.0",
 		"sonner": "^2.0.7",
 		"tailwind-merge": "^3.5.0",

--- a/templates/auth/package.overlay.json
+++ b/templates/auth/package.overlay.json
@@ -1,0 +1,24 @@
+{
+	"dependencies": {
+		"@agentuity/auth": "^2.0.0",
+		"@agentuity/core": "^2.0.0",
+		"@agentuity/drizzle": "^2.0.0",
+		"@daveyplate/better-auth-ui": "^3.4.0",
+		"@hookform/resolvers": "^5.2.2",
+		"@tanstack/react-query": "^5.100.6",
+		"class-variance-authority": "^0.7.1",
+		"clsx": "^2.1.1",
+		"input-otp": "^1.4.2",
+		"lucide-react": "^1.14.0",
+		"react-hook-form": "^7.74.0",
+		"sonner": "^2.0.7",
+		"tailwind-merge": "^3.5.0",
+		"vaul": "^1.1.2",
+		"zod": "^4.3.6"
+	},
+	"devDependencies": {
+		"@tailwindcss/vite": "^4.1.18",
+		"drizzle-kit": "^0.31.10",
+		"tailwindcss": "^4.1.18"
+	}
+}

--- a/templates/auth/src/api/index.ts
+++ b/templates/auth/src/api/index.ts
@@ -5,7 +5,7 @@ import { auth } from '../auth';
 
 // Chained method calls so the route types propagate into `typeof api`,
 // which the Hono `hc<ApiRouter>` client uses for typed calls like
-// `client.me.$get()`.
+// `client.me.$get()`
 const api = new Hono<Env>()
 	.on(['GET', 'POST'], '/auth/*', mountAuthRoutes(auth))
 	.get('/health', (c) => c.json({ status: 'ok', timestamp: new Date().toISOString() }))

--- a/templates/auth/src/api/index.ts
+++ b/templates/auth/src/api/index.ts
@@ -1,0 +1,33 @@
+import { createSessionMiddleware, mountAuthRoutes } from '@agentuity/auth';
+import type { Env } from '@agentuity/runtime';
+import { Hono } from 'hono';
+import { auth } from '../auth';
+
+// Chained method calls so the route types propagate into `typeof api`,
+// which the Hono `hc<ApiRouter>` client uses for typed calls like
+// `client.me.$get()`.
+const api = new Hono<Env>()
+	.on(['GET', 'POST'], '/auth/*', mountAuthRoutes(auth))
+	.get('/health', (c) => c.json({ status: 'ok', timestamp: new Date().toISOString() }))
+	.get('/me', createSessionMiddleware(auth), async (c) => {
+		const user = await c.var.auth.getUser();
+
+		const memberSince =
+			user.createdAt instanceof Date
+				? user.createdAt.toISOString()
+				: typeof user.createdAt === 'string'
+					? user.createdAt
+					: null;
+
+		return c.json({
+			id: user.id,
+			name: user.name ?? null,
+			email: user.email,
+			authMethod: c.var.auth.authMethod,
+			memberSince,
+		});
+	});
+
+export type ApiRouter = typeof api;
+
+export default api;

--- a/templates/auth/src/auth.ts
+++ b/templates/auth/src/auth.ts
@@ -1,0 +1,13 @@
+import { createAuth } from '@agentuity/auth';
+import * as authSchema from '@agentuity/auth/schema';
+import { drizzleAdapter } from '@agentuity/drizzle';
+import { db } from './db';
+
+export const auth = createAuth({
+	database: drizzleAdapter(db, {
+		provider: 'pg',
+		schema: authSchema,
+	}),
+});
+
+export type Auth = typeof auth;

--- a/templates/auth/src/db.ts
+++ b/templates/auth/src/db.ts
@@ -1,0 +1,31 @@
+import { createPostgresDrizzle, type PostgresDrizzlePg } from '@agentuity/drizzle';
+import * as schema from './schema';
+
+type Schema = typeof schema;
+type Db = PostgresDrizzlePg<Schema>['db'];
+
+/**
+ * Build the Drizzle client lazily so the server can boot without DATABASE_URL.
+ * The error surfaces only when a route actually tries to query the database.
+ */
+function buildDb(): Db {
+	const databaseUrl = process.env.DATABASE_URL;
+	if (!databaseUrl) {
+		throw new Error('DATABASE_URL is required');
+	}
+	return createPostgresDrizzle({ connectionString: databaseUrl, schema }).db;
+}
+
+let _db: Db | null = null;
+
+/**
+ * Single Drizzle client shared by Better Auth's adapter and your app's queries.
+ * The schema spans both halves: Better Auth's tables (re-exported from
+ * `@agentuity/auth/schema` in `./schema`) plus your own tables.
+ */
+export const db = new Proxy({} as Db, {
+	get(_target, prop, receiver) {
+		_db ??= buildDb();
+		return Reflect.get(_db, prop, receiver);
+	},
+});

--- a/templates/auth/src/db.ts
+++ b/templates/auth/src/db.ts
@@ -5,8 +5,8 @@ type Schema = typeof schema;
 type Db = PostgresDrizzlePg<Schema>['db'];
 
 /**
- * Build the Drizzle client lazily so the server can boot without DATABASE_URL.
- * The error surfaces only when a route actually tries to query the database.
+ * Build the Drizzle client lazily so the server can boot without DATABASE_URL
+ * The error surfaces only when a route actually tries to query the database
  */
 function buildDb(): Db {
 	const databaseUrl = process.env.DATABASE_URL;
@@ -19,13 +19,14 @@ function buildDb(): Db {
 let _db: Db | null = null;
 
 /**
- * Single Drizzle client shared by Better Auth's adapter and your app's queries.
+ * Single Drizzle client shared by Better Auth's adapter and your app's queries
  * The schema spans both halves: Better Auth's tables (re-exported from
- * `@agentuity/auth/schema` in `./schema`) plus your own tables.
+ * `@agentuity/auth/schema` in `./schema`) plus your own tables
  */
 export const db = new Proxy({} as Db, {
-	get(_target, prop, receiver) {
+	get(_target, prop) {
 		_db ??= buildDb();
-		return Reflect.get(_db, prop, receiver);
+		const value = Reflect.get(_db, prop, _db);
+		return typeof value === 'function' ? value.bind(_db) : value;
 	},
 });

--- a/templates/auth/src/schema.ts
+++ b/templates/auth/src/schema.ts
@@ -1,8 +1,8 @@
 /**
- * Re-export Better Auth's tables so drizzle-kit picks them up.
+ * Re-export Better Auth's tables so drizzle-kit picks them up
  *
  * To add your own tables, declare them below. They share the same Postgres
  * database and Drizzle client as Better Auth's tables. Reference `user.id`
- * for per-user rows. See AGENTS.md for an example.
+ * for per-user rows. See AGENTS.md for an example
  */
 export * from '@agentuity/auth/schema';

--- a/templates/auth/src/schema.ts
+++ b/templates/auth/src/schema.ts
@@ -1,0 +1,8 @@
+/**
+ * Re-export Better Auth's tables so drizzle-kit picks them up.
+ *
+ * To add your own tables, declare them below. They share the same Postgres
+ * database and Drizzle client as Better Auth's tables. Reference `user.id`
+ * for per-user rows. See AGENTS.md for an example.
+ */
+export * from '@agentuity/auth/schema';

--- a/templates/auth/src/web/App.css
+++ b/templates/auth/src/web/App.css
@@ -1,0 +1,96 @@
+@import "tailwindcss";
+@import "@daveyplate/better-auth-ui/css";
+
+@source "../../node_modules/@daveyplate/better-auth-ui/dist";
+
+@theme {
+	/* Cyan (Agentuity Brand) */
+	--color-cyan-50: oklch(0.9812 0.027 196.72);
+	--color-cyan-100: oklch(0.965 0.0516 196.33);
+	--color-cyan-200: oklch(0.938 0.0956 195.64);
+	--color-cyan-300: oklch(0.9193 0.1285 195.15);
+	--color-cyan-400: oklch(0.9089 0.1478 194.87);
+	--color-cyan-500: oklch(0.9054 0.15455 194.769);
+	--color-cyan-600: oklch(0.7653 0.1306 194.77);
+	--color-cyan-700: oklch(0.6183 0.10555 194.769);
+	--color-cyan-800: oklch(0.462 0.078864 194.769);
+	--color-cyan-900: oklch(0.2907 0.0496 194.77);
+	--color-cyan-950: oklch(0.1932 0.033 194.77);
+
+	/* Gray (Zinc) */
+	--color-gray-50: oklch(0.985 0 0);
+	--color-gray-100: oklch(0.967 0.001 286.375);
+	--color-gray-200: oklch(0.92 0.004 286.32);
+	--color-gray-300: oklch(0.871 0.006 286.286);
+	--color-gray-400: oklch(0.705 0.015 286.067);
+	--color-gray-500: oklch(0.552 0.016 285.938);
+	--color-gray-600: oklch(0.442 0.017 285.786);
+	--color-gray-700: oklch(0.37 0.013 285.805);
+	--color-gray-800: oklch(0.274 0.006 286.033);
+	--color-gray-900: oklch(0.21 0.006 285.885);
+	--color-gray-950: oklch(0.141 0.005 285.823);
+
+	/* Green */
+	--color-green-500: oklch(0.723 0.219 149.579);
+	--color-green-950: oklch(0.196 0.044 163.128);
+
+	/* Better Auth UI tokens */
+	--color-background: var(--color-gray-950);
+	--color-foreground: var(--color-gray-50);
+	--color-card: var(--color-gray-950);
+	--color-card-foreground: var(--color-gray-50);
+	--color-popover: var(--color-gray-950);
+	--color-popover-foreground: var(--color-gray-50);
+	--color-primary: var(--color-cyan-500);
+	--color-primary-foreground: var(--color-gray-950);
+	--color-secondary: var(--color-gray-900);
+	--color-secondary-foreground: var(--color-gray-50);
+	--color-muted: var(--color-gray-900);
+	--color-muted-foreground: var(--color-gray-400);
+	--color-accent: var(--color-gray-900);
+	--color-accent-foreground: var(--color-gray-50);
+	--color-destructive: oklch(0.58 0.18 25);
+	--color-destructive-foreground: var(--color-gray-50);
+	--color-border: var(--color-gray-800);
+	--color-input: var(--color-gray-900);
+	--color-ring: var(--color-cyan-500);
+	--radius-lg: 0.5rem;
+	--radius-md: 0.375rem;
+	--radius-sm: 0.25rem;
+
+	/* Animations */
+	--animate-ellipsis: ellipsis 1.5s steps(4, end) infinite;
+
+	@keyframes ellipsis {
+		0% {
+			content: ".";
+		}
+		25% {
+			content: "..";
+		}
+		50% {
+			content: "...";
+		}
+		75% {
+			content: "";
+		}
+	}
+}
+
+body {
+	background-color: #09090b;
+}
+
+[data-loading="true"]::after {
+	content: ".";
+	display: inline-block;
+	text-align: left;
+	width: 1rem;
+	animation: ellipsis 1.5s steps(4, end) infinite;
+}
+
+@media (max-width: 700px) {
+	.min-h-screen > div {
+		padding: 2rem 1rem;
+	}
+}

--- a/templates/auth/src/web/App.tsx
+++ b/templates/auth/src/web/App.tsx
@@ -217,9 +217,9 @@ function AuthSwitch({ signedOut, signedIn }: AuthSwitchProps) {
 	const { user, isPending } = useAuthenticate();
 	const [isSignedIn, setIsSignedIn] = useState(!!user);
 
-	useEffect(() => {
-		if (!isPending) setIsSignedIn(!!user);
-	}, [user, isPending]);
+	if (!isPending && isSignedIn !== !!user) {
+		setIsSignedIn(!!user);
+	}
 
 	return (
 		<AnimatePresence initial={false} mode="wait">

--- a/templates/auth/src/web/App.tsx
+++ b/templates/auth/src/web/App.tsx
@@ -9,7 +9,7 @@ import {
 	useAuthenticate,
 } from '@daveyplate/better-auth-ui';
 import { hc } from 'hono/client';
-import { Toaster } from 'sonner';
+import { Toaster, toast } from 'sonner';
 import type { ApiRouter } from '../api/index';
 import { authClient } from './auth-client';
 import './App.css';
@@ -71,7 +71,7 @@ interface ProtectedRouteResult {
 }
 
 function formatDate(value: string | null | undefined): string {
-	if (!value) return '—';
+	if (!value) return 'Not set';
 	try {
 		return new Date(value).toLocaleDateString(undefined, { dateStyle: 'medium' });
 	} catch {
@@ -226,6 +226,8 @@ export function App() {
 			setRouteResult(null);
 			setRouteError(null);
 			replace('/');
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : 'Sign out failed');
 		} finally {
 			setIsSigningOut(false);
 		}

--- a/templates/auth/src/web/App.tsx
+++ b/templates/auth/src/web/App.tsx
@@ -1,14 +1,13 @@
 import type { ReactNode } from 'react';
-import { Fragment, useCallback, useEffect, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 import {
 	AuthUIProvider,
 	AuthView,
-	SignedIn,
-	SignedOut,
 	UserView,
 	useAuthenticate,
 } from '@daveyplate/better-auth-ui';
 import { hc } from 'hono/client';
+import { AnimatePresence, motion } from 'motion/react';
 import { Toaster, toast } from 'sonner';
 import type { ApiRouter } from '../api/index';
 import { authClient } from './auth-client';
@@ -174,7 +173,67 @@ function AgentuityLogo() {
 
 function getPathFromHref(href: string): string {
 	const url = new URL(href, window.location.origin);
-	return `${url.pathname}${url.search}`;
+	return url.pathname;
+}
+
+interface AuthLinkProps {
+	readonly href: string;
+	readonly className?: string;
+	readonly children: ReactNode;
+}
+
+function makeAuthLink(navigate: (href: string) => void) {
+	return function AuthLink({ href, className, children }: AuthLinkProps) {
+		const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+			if (
+				event.defaultPrevented ||
+				event.button !== 0 ||
+				event.metaKey ||
+				event.ctrlKey ||
+				event.shiftKey ||
+				event.altKey
+			) {
+				return;
+			}
+			event.preventDefault();
+			navigate(href);
+		};
+		return (
+			<a className={className} href={href} onClick={handleClick}>
+				{children}
+			</a>
+		);
+	};
+}
+
+interface AuthSwitchProps {
+	readonly signedOut: ReactNode;
+	readonly signedIn: ReactNode;
+}
+
+// Hold the previous auth state during pending transitions so the layout
+// doesn't collapse between Better Auth's session refetches
+function AuthSwitch({ signedOut, signedIn }: AuthSwitchProps) {
+	const { user, isPending } = useAuthenticate();
+	const [isSignedIn, setIsSignedIn] = useState(!!user);
+
+	useEffect(() => {
+		if (!isPending) setIsSignedIn(!!user);
+	}, [user, isPending]);
+
+	return (
+		<AnimatePresence initial={false} mode="wait">
+			<motion.div
+				key={isSignedIn ? 'in' : 'out'}
+				initial={{ opacity: 0 }}
+				animate={{ opacity: 1 }}
+				exit={{ opacity: 0 }}
+				transition={{ duration: 0.18, ease: 'easeOut' }}
+			>
+				{isSignedIn ? signedIn : signedOut}
+			</motion.div>
+		</AnimatePresence>
+	);
 }
 
 export function App() {
@@ -191,15 +250,13 @@ export function App() {
 	}, []);
 
 	const navigate = useCallback((href: string) => {
-		const nextPath = getPathFromHref(href);
-		window.history.pushState(null, '', nextPath);
-		setPathname(nextPath);
+		window.history.pushState(null, '', href);
+		setPathname(getPathFromHref(href));
 	}, []);
 
 	const replace = useCallback((href: string) => {
-		const nextPath = getPathFromHref(href);
-		window.history.replaceState(null, '', nextPath);
-		setPathname(nextPath);
+		window.history.replaceState(null, '', href);
+		setPathname(getPathFromHref(href));
 	}, []);
 
 	const checkProtectedRoute = useCallback(async () => {
@@ -234,12 +291,14 @@ export function App() {
 	}, [replace]);
 
 	const authPathname = pathname.startsWith('/auth/') ? pathname : '/auth/sign-in';
+	const AuthLink = useMemo(() => makeAuthLink(navigate), [navigate]);
 
 	return (
 		<AuthUIProvider
 			authClient={authClient}
 			basePath="/auth"
 			credentials={{ forgotPassword: false }}
+			Link={AuthLink}
 			navigate={navigate}
 			redirectTo="/"
 			replace={replace}
@@ -258,24 +317,37 @@ export function App() {
 						</p>
 					</div>
 
-					<SignedOut>
-						<div className="flex justify-center">
-							<AuthView
-								className="w-full max-w-sm [&_button]:cursor-pointer [&_button:disabled]:cursor-not-allowed"
-								classNames={{
-									footerLink:
-										'transition-colors hover:text-cyan-300 focus-visible:text-cyan-300',
-								}}
-								pathname={authPathname}
-								redirectTo="/"
-							/>
-						</div>
-					</SignedOut>
+					<AuthSwitch
+						signedOut={
+							<div className="flex justify-center">
+								<div className="relative w-full max-w-sm">
+									<AnimatePresence initial={false} mode="popLayout">
+										<motion.div
+											key={authPathname}
+											initial={{ opacity: 0, y: 4 }}
+											animate={{ opacity: 1, y: 0 }}
+											exit={{ opacity: 0, y: -4 }}
+											transition={{ duration: 0.18, ease: 'easeOut' }}
+										>
+											<AuthView
+												className="[&_button]:cursor-pointer [&_button:disabled]:cursor-not-allowed"
+												classNames={{
+													footerLink:
+														'transition-colors hover:text-cyan-300 focus-visible:text-cyan-300',
+												}}
+												pathname={authPathname}
+												redirectTo="/"
+											/>
+										</motion.div>
+									</AnimatePresence>
+								</div>
+							</div>
+						}
+						signedIn={
+							<div className="flex flex-col gap-8">
+								<SignedInPanel isSigningOut={isSigningOut} onSignOut={handleSignOut} />
 
-					<SignedIn>
-						<SignedInPanel isSigningOut={isSigningOut} onSignOut={handleSignOut} />
-
-						<div className="bg-black border border-gray-900 rounded-lg p-8 shadow-2xl flex flex-col gap-6">
+								<div className="bg-black border border-gray-900 rounded-lg p-8 shadow-2xl flex flex-col gap-6">
 							<div>
 								<h2 className="text-white text-xl font-normal leading-none m-0 mb-3">
 									Protected API
@@ -354,7 +426,9 @@ export function App() {
 								</div>
 							)}
 						</div>
-					</SignedIn>
+								</div>
+							}
+						/>
 
 					<div className="bg-black border border-gray-900 rounded-lg p-8">
 						<h2 className="text-white text-xl font-normal leading-none m-0 mb-6">

--- a/templates/auth/src/web/App.tsx
+++ b/templates/auth/src/web/App.tsx
@@ -1,0 +1,399 @@
+import type { ReactNode } from 'react';
+import { Fragment, useCallback, useEffect, useState } from 'react';
+import {
+	AuthUIProvider,
+	AuthView,
+	SignedIn,
+	SignedOut,
+	UserView,
+	useAuthenticate,
+} from '@daveyplate/better-auth-ui';
+import { hc } from 'hono/client';
+import { Toaster } from 'sonner';
+import type { ApiRouter } from '../api/index';
+import { authClient } from './auth-client';
+import './App.css';
+
+const client = hc<ApiRouter>('/api');
+
+const NEXT_STEPS: ReadonlyArray<{
+	readonly key: string;
+	readonly title: string;
+	readonly text: ReactNode;
+}> = [
+	{
+		key: 'customize-auth-routes',
+		title: 'Customize auth routes',
+		text: (
+			<>
+				Edit <code className="text-white">src/api/index.ts</code> to change how your app
+				handles auth requests.
+			</>
+		),
+	},
+	{
+		key: 'change-auth-options',
+		title: 'Change auth options',
+		text: (
+			<>
+				Edit <code className="text-white">src/auth.ts</code> to configure Better Auth.
+			</>
+		),
+	},
+	{
+		key: 'update-frontend',
+		title: 'Update the frontend',
+		text: (
+			<>
+				Modify <code className="text-white">src/web/App.tsx</code> to build your auth UI.
+			</>
+		),
+	},
+	{
+		key: 'deploy-with-auth',
+		title: 'Deploy with auth',
+		text: (
+			<>
+				Set <code className="text-white">DATABASE_URL</code>,{' '}
+				<code className="text-white">AGENTUITY_AUTH_SECRET</code>, and{' '}
+				<code className="text-white">BETTER_AUTH_URL</code> before deploying.
+			</>
+		),
+	},
+];
+
+interface ProtectedRouteResult {
+	readonly authMethod: string;
+	readonly email: string;
+	readonly id: string;
+	readonly memberSince: string | null;
+	readonly name: string | null;
+}
+
+function formatDate(value: string | null | undefined): string {
+	if (!value) return '—';
+	try {
+		return new Date(value).toLocaleDateString(undefined, { dateStyle: 'medium' });
+	} catch {
+		return value;
+	}
+}
+
+interface SessionFieldPopup {
+	readonly title: ReactNode;
+	readonly description: ReactNode;
+}
+
+interface SessionField {
+	readonly key: string;
+	readonly label: string;
+	readonly value: string;
+	readonly popup: SessionFieldPopup;
+}
+
+function SessionFieldValue({ value, popup }: { value: string; popup: SessionFieldPopup }) {
+	return (
+		<span className="group relative inline-block">
+			<span className="border-b border-dashed border-gray-700 cursor-help transition-colors duration-200 group-hover:border-b-cyan-400">
+				{value}
+			</span>
+			<div className="hidden group-hover:flex absolute z-10 bg-gray-900 border border-gray-800 rounded-lg p-4 leading-normal shadow-2xl text-left w-64 flex-col gap-2 left-0 top-full mt-2 md:left-full md:ml-3 md:top-0 md:mt-0">
+				<div className="text-xs font-mono text-cyan-400">{popup.title}</div>
+				<p className="text-gray-400 text-xs leading-relaxed">{popup.description}</p>
+			</div>
+		</span>
+	);
+}
+
+function SessionDetailGrid({ fields }: { fields: ReadonlyArray<SessionField> }) {
+	return (
+		<dl className="grid grid-cols-[max-content_max-content] gap-x-6 gap-y-2 text-sm">
+			{fields.map((field) => (
+				<Fragment key={field.key}>
+					<dt className="text-gray-500">{field.label}</dt>
+					<dd className="text-gray-200 font-medium">
+						<SessionFieldValue value={field.value} popup={field.popup} />
+					</dd>
+				</Fragment>
+			))}
+		</dl>
+	);
+}
+
+interface SignedInPanelProps {
+	readonly isSigningOut: boolean;
+	readonly onSignOut: () => void;
+}
+
+function SignedInPanel({ isSigningOut, onSignOut }: SignedInPanelProps) {
+	const { user, isPending } = useAuthenticate();
+
+	return (
+		<div className="bg-black border border-gray-900 rounded-lg p-6 shadow-2xl flex flex-wrap items-center justify-between gap-4">
+			<UserView user={user} isPending={isPending} />
+
+			<button
+				className="border border-gray-800 rounded-md text-gray-300 px-4 py-2 text-sm transition-colors cursor-pointer hover:bg-gray-900 hover:text-white hover:border-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500/40 disabled:opacity-50 disabled:cursor-not-allowed"
+				data-loading={isSigningOut}
+				disabled={isSigningOut}
+				onClick={onSignOut}
+				type="button"
+			>
+				{isSigningOut ? 'Signing out' : 'Sign out'}
+			</button>
+		</div>
+	);
+}
+
+function AgentuityLogo() {
+	return (
+		<svg
+			aria-hidden="true"
+			className="h-auto mb-4 w-12"
+			fill="none"
+			height="191"
+			viewBox="0 0 220 191"
+			width="220"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path
+				clipRule="evenodd"
+				d="M220 191H0L31.427 136.5H0L8 122.5H180.5L220 191ZM47.5879 136.5L24.2339 177H195.766L172.412 136.5H47.5879Z"
+				fill="var(--color-cyan-500)"
+				fillRule="evenodd"
+			/>
+			<path
+				clipRule="evenodd"
+				d="M110 0L157.448 82.5H189L197 96.5H54.5L110 0ZM78.7021 82.5L110 28.0811L141.298 82.5H78.7021Z"
+				fill="var(--color-cyan-500)"
+				fillRule="evenodd"
+			/>
+		</svg>
+	);
+}
+
+function getPathFromHref(href: string): string {
+	const url = new URL(href, window.location.origin);
+	return `${url.pathname}${url.search}`;
+}
+
+export function App() {
+	const [pathname, setPathname] = useState(() => window.location.pathname);
+	const [routeResult, setRouteResult] = useState<ProtectedRouteResult | null>(null);
+	const [routeError, setRouteError] = useState<string | null>(null);
+	const [isCheckingRoute, setIsCheckingRoute] = useState(false);
+	const [isSigningOut, setIsSigningOut] = useState(false);
+
+	useEffect(() => {
+		const handlePopState = () => setPathname(window.location.pathname);
+		window.addEventListener('popstate', handlePopState);
+		return () => window.removeEventListener('popstate', handlePopState);
+	}, []);
+
+	const navigate = useCallback((href: string) => {
+		const nextPath = getPathFromHref(href);
+		window.history.pushState(null, '', nextPath);
+		setPathname(nextPath);
+	}, []);
+
+	const replace = useCallback((href: string) => {
+		const nextPath = getPathFromHref(href);
+		window.history.replaceState(null, '', nextPath);
+		setPathname(nextPath);
+	}, []);
+
+	const checkProtectedRoute = useCallback(async () => {
+		setIsCheckingRoute(true);
+		setRouteError(null);
+		try {
+			const res = await client.me.$get();
+			if (!res.ok) {
+				throw new Error(`GET /api/me returned ${res.status}`);
+			}
+			setRouteResult(await res.json());
+		} catch (err) {
+			setRouteResult(null);
+			setRouteError(err instanceof Error ? err.message : 'Could not call /api/me');
+		} finally {
+			setIsCheckingRoute(false);
+		}
+	}, []);
+
+	const handleSignOut = useCallback(async () => {
+		setIsSigningOut(true);
+		try {
+			await authClient.signOut();
+			setRouteResult(null);
+			setRouteError(null);
+			replace('/');
+		} finally {
+			setIsSigningOut(false);
+		}
+	}, [replace]);
+
+	const authPathname = pathname.startsWith('/auth/') ? pathname : '/auth/sign-in';
+
+	return (
+		<AuthUIProvider
+			authClient={authClient}
+			basePath="/auth"
+			credentials={{ forgotPassword: false }}
+			navigate={navigate}
+			redirectTo="/"
+			replace={replace}
+		>
+			<div className="text-white flex font-sans justify-center min-h-screen">
+				<div className="flex flex-col gap-8 max-w-3xl p-16 w-full">
+					{/* Hero */}
+					<div className="items-center flex flex-col gap-2 justify-center mb-2 relative text-center">
+						<AgentuityLogo />
+
+						<h1 className="text-5xl font-thin">Agentuity Auth</h1>
+
+						<p className="text-gray-400 text-lg">
+							Auth routes, Postgres sessions, and a protected API, with{' '}
+							<span className="italic font-serif">Better Auth</span>
+						</p>
+					</div>
+
+					<SignedOut>
+						<div className="flex justify-center">
+							<AuthView
+								className="w-full max-w-sm [&_button]:cursor-pointer [&_button:disabled]:cursor-not-allowed"
+								classNames={{
+									footerLink:
+										'transition-colors hover:text-cyan-300 focus-visible:text-cyan-300',
+								}}
+								pathname={authPathname}
+								redirectTo="/"
+							/>
+						</div>
+					</SignedOut>
+
+					<SignedIn>
+						<SignedInPanel isSigningOut={isSigningOut} onSignOut={handleSignOut} />
+
+						<div className="bg-black border border-gray-900 rounded-lg p-8 shadow-2xl flex flex-col gap-6">
+							<div>
+								<h2 className="text-white text-xl font-normal leading-none m-0 mb-3">
+									Protected API
+								</h2>
+								<p className="text-gray-400 text-sm m-0">
+									<code className="text-white">GET /api/me</code> reads the signed-in
+									user from your Better Auth session.
+								</p>
+							</div>
+
+							<div className="relative self-start group">
+								<div className="absolute inset-0 bg-linear-to-r from-cyan-700 via-blue-500 to-purple-600 rounded-lg blur-xl opacity-75 group-hover:blur-2xl group-hover:opacity-100 transition-all duration-700" />
+								<div className="absolute inset-0 bg-cyan-500/50 rounded-lg blur-3xl opacity-50" />
+								<button
+									className="relative font-semibold text-white px-4 py-2 bg-gray-950 rounded-lg shadow-2xl cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+									data-loading={isCheckingRoute}
+									disabled={isCheckingRoute}
+									onClick={checkProtectedRoute}
+									type="button"
+								>
+									{isCheckingRoute ? 'Checking' : 'Check session'}
+								</button>
+							</div>
+
+							{isCheckingRoute ? (
+								<div
+									className="text-sm bg-gray-950 border border-gray-800 rounded-md text-gray-600 py-3 px-4"
+									data-loading
+								/>
+							) : routeError ? (
+								<div className="text-sm bg-gray-950 border border-red-900/60 rounded-md text-red-300 py-3 px-4">
+									{routeError}
+								</div>
+							) : !routeResult ? (
+								<div className="text-sm bg-gray-950 border border-gray-800 rounded-md text-gray-600 py-3 px-4">
+									Click Check session to call <code>/api/me</code>
+								</div>
+							) : (
+								<div className="flex flex-col gap-4">
+									<div className="text-sm bg-gray-950 border border-gray-800 rounded-md text-cyan-500 py-3 px-4">
+										{routeResult.email} authenticated with {routeResult.authMethod}
+									</div>
+
+									<SessionDetailGrid
+										fields={[
+											{
+												key: 'user',
+												label: 'User',
+												value: `${routeResult.id.slice(0, 12)}...`,
+												popup: {
+													title: 'user.id',
+													description: (
+														<>
+															Stable primary key from the{' '}
+															<strong className="text-gray-200">user</strong>{' '}
+															table. Better Auth assigns it on sign-up. Use it
+															as a foreign key when you add per-user tables in{' '}
+															<strong className="text-gray-200">src/schema.ts</strong>.
+														</>
+													),
+												},
+											},
+											{
+												key: 'memberSince',
+												label: 'Member since',
+												value: formatDate(routeResult.memberSince),
+												popup: {
+													title: 'user.createdAt',
+													description: (
+														<>Better Auth sets this when the account is created.</>
+													),
+												},
+											},
+										]}
+									/>
+								</div>
+							)}
+						</div>
+					</SignedIn>
+
+					<div className="bg-black border border-gray-900 rounded-lg p-8">
+						<h2 className="text-white text-xl font-normal leading-none m-0 mb-6">
+							Next Steps
+						</h2>
+
+						<div className="flex flex-col gap-6">
+							{NEXT_STEPS.map((step) => (
+								<div key={step.key} className="items-start flex gap-3">
+									<div className="items-center bg-green-950 border border-green-500 rounded flex size-4 shrink-0 justify-center">
+										<svg
+											aria-hidden="true"
+											className="size-2.5"
+											fill="none"
+											height="24"
+											stroke="var(--color-green-500)"
+											strokeLinecap="round"
+											strokeLinejoin="round"
+											strokeWidth="2"
+											viewBox="0 0 24 24"
+											width="24"
+											xmlns="http://www.w3.org/2000/svg"
+										>
+											<path d="M20 6 9 17l-5-5"></path>
+										</svg>
+									</div>
+
+									<div>
+										<h3 className="text-white text-sm font-normal -mt-0.5 mb-0.5">
+											{step.title}
+										</h3>
+
+										<p className="text-gray-400 text-xs">{step.text}</p>
+									</div>
+								</div>
+							))}
+						</div>
+					</div>
+				</div>
+			</div>
+			<Toaster richColors />
+		</AuthUIProvider>
+	);
+}

--- a/templates/auth/src/web/auth-client.ts
+++ b/templates/auth/src/web/auth-client.ts
@@ -1,0 +1,5 @@
+import { createAuthClient } from '@agentuity/auth/react';
+
+export const authClient = createAuthClient();
+
+export const { getSession, signIn, signOut, signUp, useSession } = authClient;

--- a/templates/auth/src/web/frontend.tsx
+++ b/templates/auth/src/web/frontend.tsx
@@ -1,8 +1,8 @@
 /**
  * This file is the entry point for the React app, it sets up the root
- * element and renders the App component to the DOM.
+ * element and renders the App component to the DOM
  *
- * It is included in `src/web/index.html`.
+ * It is included in `src/web/index.html`
  */
 
 import { StrictMode } from 'react';
@@ -29,18 +29,18 @@ function init() {
 	);
 
 	if (import.meta.hot) {
-		// With hot module reloading, `import.meta.hot.data` is persisted.
+		// With hot module reloading, `import.meta.hot.data` is persisted
 		const root = (import.meta.hot.data.root ??= createRoot(elem));
 		root.render(app);
 	} else {
-		// The hot module reloading API is not available in production.
+		// The hot module reloading API is not available in production
 		createRoot(elem).render(app);
 	}
 }
 
 // Wait for DOM to be ready before initializing
 if (document.readyState === 'loading') {
-	document.addEventListener('DOMContentLoaded', init);
+	document.addEventListener('DOMContentLoaded', init, { once: true });
 } else {
 	// DOM is already ready
 	init();

--- a/templates/auth/src/web/frontend.tsx
+++ b/templates/auth/src/web/frontend.tsx
@@ -1,0 +1,47 @@
+/**
+ * This file is the entry point for the React app, it sets up the root
+ * element and renders the App component to the DOM.
+ *
+ * It is included in `src/web/index.html`.
+ */
+
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { AgentuityProvider } from '@agentuity/react';
+import { AuthProvider } from '@agentuity/auth/react';
+import { App } from './App';
+import { authClient } from './auth-client';
+
+function init() {
+	const elem = document.getElementById('root');
+	if (!elem) {
+		throw new Error('Root element not found');
+	}
+
+	const app = (
+		<StrictMode>
+			<AgentuityProvider>
+				<AuthProvider authClient={authClient}>
+					<App />
+				</AuthProvider>
+			</AgentuityProvider>
+		</StrictMode>
+	);
+
+	if (import.meta.hot) {
+		// With hot module reloading, `import.meta.hot.data` is persisted.
+		const root = (import.meta.hot.data.root ??= createRoot(elem));
+		root.render(app);
+	} else {
+		// The hot module reloading API is not available in production.
+		createRoot(elem).render(app);
+	}
+}
+
+// Wait for DOM to be ready before initializing
+if (document.readyState === 'loading') {
+	document.addEventListener('DOMContentLoaded', init);
+} else {
+	// DOM is already ready
+	init();
+}

--- a/templates/auth/src/web/index.html
+++ b/templates/auth/src/web/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<title>Agentuity Auth Template</title>
+		<script type="module" src="./frontend.tsx"></script>
+	</head>
+	<body class="bg-gray-950">
+		<div id="root"></div>
+	</body>
+</html>

--- a/templates/auth/src/web/index.html
+++ b/templates/auth/src/web/index.html
@@ -5,6 +5,12 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 		<title>Agentuity Auth Template</title>
+		<style>
+			html,
+			body {
+				background-color: #09090b;
+			}
+		</style>
 		<script type="module" src="./frontend.tsx"></script>
 	</head>
 	<body class="bg-gray-950">

--- a/templates/auth/vite.config.ts
+++ b/templates/auth/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
 	plugins: [react(), tailwindcss()],
 	root: '.',
 	// Files in src/web/public/ are served at the URL root (/favicon.ico,
-	// /robots.txt, ...). See AGENTS.md “Static Assets” for the full convention.
+	// /robots.txt, ...). See AGENTS.md for the full convention
 	publicDir: 'src/web/public',
 	build: {
 		rollupOptions: {

--- a/templates/auth/vite.config.ts
+++ b/templates/auth/vite.config.ts
@@ -1,0 +1,17 @@
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+import { defineConfig } from 'vite';
+import { join } from 'node:path';
+
+export default defineConfig({
+	plugins: [react(), tailwindcss()],
+	root: '.',
+	// Files in src/web/public/ are served at the URL root (/favicon.ico,
+	// /robots.txt, ...). See AGENTS.md “Static Assets” for the full convention.
+	publicDir: 'src/web/public',
+	build: {
+		rollupOptions: {
+			input: join(import.meta.dirname, 'src/web/index.html'),
+		},
+	},
+});

--- a/templates/templates.json
+++ b/templates/templates.json
@@ -5,6 +5,12 @@
 			"name": "Default Template",
 			"description": "Showcases core Agentuity features using OpenAI SDK",
 			"directory": "default"
+		},
+		{
+			"id": "auth",
+			"name": "Auth Template",
+			"description": "Sets up Better Auth, Drizzle, and a protected API route",
+			"directory": "auth"
 		}
 	]
 }

--- a/templates/templates.json
+++ b/templates/templates.json
@@ -9,7 +9,7 @@
 		{
 			"id": "auth",
 			"name": "Auth Template",
-			"description": "Sets up Better Auth, Drizzle, and a protected API route",
+			"description": "Sets up Better Auth, Drizzle, a sign-in UI, and a protected API route",
 			"directory": "auth"
 		}
 	]


### PR DESCRIPTION
## Summary

- Add an `auth` project template with Better Auth, Drizzle, a sign-in UI, and protected route examples.
- Register the template in `templates/templates.json` so it is included in the template set published with SDK releases.
- Cover the auth template in template integration tests.

## Verification

- `bunx biome check scripts/test-templates.ts`
- `bun scripts/test-templates.ts --template auth --skip-outdated`
