### PR TITLE
Support Coder workspace snapshot inputs

### DIFF
--- a/packages/cli/src/cmd/coder/workspace/common.ts
+++ b/packages/cli/src/cmd/coder/workspace/common.ts
@@ -1,0 +1,86 @@
+import {
+	type CoderCreateWorkspaceRequest,
+	type CoderUpdateWorkspaceRequest,
+	type CoderWorkspaceDetail,
+} from '@agentuity/core/coder';
+import * as tui from '../../../tui';
+
+export const EMPTY_WORKSPACE_ERROR =
+	'A workspace needs at least one repo, dependency, setup script, saved skill, skill bucket, or agent';
+
+export function parseCommaList(value?: string): string[] {
+	return value
+		? value
+				.split(',')
+				.map((item) => item.trim())
+				.filter(Boolean)
+		: [];
+}
+
+export async function readSetupScript(input: {
+	setupScript?: string;
+	setupScriptFile?: string;
+}): Promise<string | undefined> {
+	if (input.setupScript && input.setupScriptFile) {
+		throw new Error('Use either --setup-script or --setup-script-file, not both.');
+	}
+	if (input.setupScript) return input.setupScript;
+	if (!input.setupScriptFile) return undefined;
+	return Bun.file(input.setupScriptFile).text();
+}
+
+export function hasWorkspaceSelections(input: CoderCreateWorkspaceRequest): boolean {
+	return (
+		(input.repos?.length ?? 0) > 0 ||
+		(input.dependencies?.length ?? 0) > 0 ||
+		Boolean(input.setupScript?.trim()) ||
+		(input.savedSkillIds?.length ?? 0) > 0 ||
+		(input.skillBucketIds?.length ?? 0) > 0 ||
+		(input.enabledAgents?.length ?? 0) > 0
+	);
+}
+
+export function hasWorkspaceUpdate(input: CoderUpdateWorkspaceRequest): boolean {
+	return Object.keys(input).length > 0;
+}
+
+export function formatWorkspaceValidationMessage(issues: Array<{ message: string }>): string {
+	const messages = [...new Set(issues.map((issue) => issue.message).filter(Boolean))];
+	if (messages.length === 0) {
+		return 'Invalid workspace configuration';
+	}
+	if (messages.includes(EMPTY_WORKSPACE_ERROR)) {
+		return `${EMPTY_WORKSPACE_ERROR}. Use --repo, --dependency, --setup-script, or --enabled-agents.`;
+	}
+	return messages.join('; ');
+}
+
+export function printWorkspaceSummary(workspace: CoderWorkspaceDetail): void {
+	const enabledAgents = Array.isArray(workspace.enabledAgents)
+		? workspace.enabledAgents.filter((name): name is string => typeof name === 'string')
+		: [];
+	const dependencies = Array.isArray(workspace.dependencies) ? workspace.dependencies : [];
+
+	tui.output(`  Name:        ${tui.bold(workspace.name)}`);
+	if (workspace.description) {
+		tui.output(`  Description: ${workspace.description}`);
+	}
+	tui.output(`  Scope:       ${workspace.scope}`);
+	tui.output(`  Repos:       ${workspace.repoCount}`);
+	tui.output(`  Selections:  ${workspace.selectionCount}`);
+	if (dependencies.length > 0) {
+		tui.output(`  Dependencies:${dependencies.length === 1 ? ` ${dependencies[0]}` : ''}`);
+		for (const dependency of dependencies.length === 1 ? [] : dependencies) {
+			tui.output(`    - ${dependency}`);
+		}
+	}
+	if (workspace.setupScript) {
+		tui.output('  Setup:       configured');
+	}
+	if (workspace.snapshot?.status) {
+		tui.output(`  Snapshot:    ${workspace.snapshot.status}`);
+	}
+	if (enabledAgents.length > 0) {
+		tui.output(`  Agents:      ${enabledAgents.join(', ')}`);
+	}
+}

--- a/packages/cli/src/cmd/coder/workspace/common.ts
+++ b/packages/cli/src/cmd/coder/workspace/common.ts
@@ -10,6 +10,7 @@ export const EMPTY_WORKSPACE_ERROR =
 	'A workspace needs at least one repo, dependency, setup script, saved skill, skill bucket, or agent';
 export const SetupScriptValidationError = StructuredError('SetupScriptValidationError')<{
 	message: string;
+	path?: string;
 }>();
 
 export function parseCommaList(value?: string): string[] {
@@ -32,7 +33,17 @@ export async function readSetupScript(input: {
 	}
 	if (input.setupScript !== undefined) return input.setupScript;
 	if (!input.setupScriptFile) return undefined;
-	return Bun.file(input.setupScriptFile).text();
+	try {
+		return await Bun.file(input.setupScriptFile).text();
+	} catch (error) {
+		throw new SetupScriptValidationError({
+			message: `Failed to read setup script file "${input.setupScriptFile}": ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+			path: input.setupScriptFile,
+			cause: error,
+		});
+	}
 }
 
 export function hasWorkspaceSelections(input: CoderCreateWorkspaceRequest): boolean {

--- a/packages/cli/src/cmd/coder/workspace/common.ts
+++ b/packages/cli/src/cmd/coder/workspace/common.ts
@@ -3,10 +3,14 @@ import {
 	type CoderUpdateWorkspaceRequest,
 	type CoderWorkspaceDetail,
 } from '@agentuity/core/coder';
+import { StructuredError } from '@agentuity/core';
 import * as tui from '../../../tui';
 
 export const EMPTY_WORKSPACE_ERROR =
 	'A workspace needs at least one repo, dependency, setup script, saved skill, skill bucket, or agent';
+export const SetupScriptValidationError = StructuredError('SetupScriptValidationError')<{
+	message: string;
+}>();
 
 export function parseCommaList(value?: string): string[] {
 	return value
@@ -21,10 +25,12 @@ export async function readSetupScript(input: {
 	setupScript?: string;
 	setupScriptFile?: string;
 }): Promise<string | undefined> {
-	if (input.setupScript && input.setupScriptFile) {
-		throw new Error('Use either --setup-script or --setup-script-file, not both.');
+	if (input.setupScript !== undefined && input.setupScriptFile) {
+		throw new SetupScriptValidationError({
+			message: 'Use either --setup-script or --setup-script-file, not both.',
+		});
 	}
-	if (input.setupScript) return input.setupScript;
+	if (input.setupScript !== undefined) return input.setupScript;
 	if (!input.setupScriptFile) return undefined;
 	return Bun.file(input.setupScriptFile).text();
 }

--- a/packages/cli/src/cmd/coder/workspace/create.ts
+++ b/packages/cli/src/cmd/coder/workspace/create.ts
@@ -110,7 +110,7 @@ export const createWorkspaceSubcommand = createSubcommand({
 				setupScript: opts?.setupScript,
 				setupScriptFile: opts?.setupScriptFile,
 			});
-			if (setupScript) body.setupScript = setupScript;
+			if (setupScript !== undefined) body.setupScript = setupScript;
 		} catch (err) {
 			const msg = err instanceof Error ? err.message : String(err);
 			tui.fatal(`Failed to read setup script: ${msg}`, ErrorCode.VALIDATION_FAILED);

--- a/packages/cli/src/cmd/coder/workspace/get.ts
+++ b/packages/cli/src/cmd/coder/workspace/get.ts
@@ -5,6 +5,7 @@ import { createSubcommand } from '../../../types';
 import * as tui from '../../../tui';
 import { getCommand } from '../../../command-prefix';
 import { ErrorCode } from '../../../errors';
+import { printWorkspaceSummary } from './common';
 
 function formatRelativeTime(isoDate: string): string {
 	const parsed = new Date(isoDate).getTime();
@@ -63,11 +64,7 @@ export const getWorkspaceSubcommand = createSubcommand({
 			tui.header(`Workspace: ${workspace.name}`);
 			tui.newline();
 			tui.output(`  ID:          ${workspace.id}`);
-			tui.output(`  Name:        ${tui.bold(workspace.name)}`);
-			if (workspace.description) {
-				tui.output(`  Description: ${workspace.description}`);
-			}
-			tui.output(`  Scope:       ${workspace.scope}`);
+			printWorkspaceSummary(workspace);
 			tui.output(`  Owner:       ${workspace.ownerUserId}`);
 			tui.output(`  Created:     ${formatRelativeTime(workspace.createdAt)}`);
 			tui.output(`  Updated:     ${formatRelativeTime(workspace.updatedAt)}`);

--- a/packages/cli/src/cmd/coder/workspace/index.ts
+++ b/packages/cli/src/cmd/coder/workspace/index.ts
@@ -2,6 +2,9 @@ import { createCommand } from '../../../types';
 import { listSubcommand } from './list';
 import { createWorkspaceSubcommand } from './create';
 import { getWorkspaceSubcommand } from './get';
+import { refreshWorkspaceSnapshotSubcommand } from './refresh';
+import { updateWorkspaceSubcommand } from './update';
+import { validateWorkspaceDependenciesSubcommand } from './validate-dependencies';
 import { deleteWorkspaceSubcommand } from './delete';
 import { getCommand } from '../../../command-prefix';
 
@@ -30,11 +33,18 @@ export const workspaceCommand = createCommand({
 			command: getCommand('coder workspace delete ws_abc123'),
 			description: 'Delete a workspace',
 		},
+		{
+			command: getCommand('coder workspace validate-dependencies git,nodejs'),
+			description: 'Validate workspace dependencies',
+		},
 	],
 	subcommands: [
 		listSubcommand,
 		createWorkspaceSubcommand,
 		getWorkspaceSubcommand,
+		updateWorkspaceSubcommand,
+		refreshWorkspaceSnapshotSubcommand,
+		validateWorkspaceDependenciesSubcommand,
 		deleteWorkspaceSubcommand,
 	],
 });

--- a/packages/cli/src/cmd/coder/workspace/list.ts
+++ b/packages/cli/src/cmd/coder/workspace/list.ts
@@ -83,6 +83,8 @@ export const listSubcommand = createSubcommand({
 				Name: w.name,
 				Scope: w.scope,
 				Repos: String(w.repoCount),
+				Deps: String(w.dependencies?.length ?? 0),
+				Snapshot: w.snapshot?.status ?? '',
 				Selections: String(w.selectionCount),
 				Created: formatRelativeTime(w.createdAt),
 			})),
@@ -91,6 +93,8 @@ export const listSubcommand = createSubcommand({
 				{ name: 'Name', alignment: 'left' },
 				{ name: 'Scope', alignment: 'center' },
 				{ name: 'Repos', alignment: 'right' },
+				{ name: 'Deps', alignment: 'right' },
+				{ name: 'Snapshot', alignment: 'left' },
 				{ name: 'Selections', alignment: 'right' },
 				{ name: 'Created', alignment: 'right' },
 			]

--- a/packages/cli/src/cmd/coder/workspace/refresh.ts
+++ b/packages/cli/src/cmd/coder/workspace/refresh.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+import { APIError, ValidationOutputError } from '@agentuity/core';
+import { CoderClient } from '@agentuity/core/coder';
+import { createSubcommand } from '../../../types';
+import * as tui from '../../../tui';
+import { getCommand } from '../../../command-prefix';
+import { ErrorCode } from '../../../errors';
+import { printWorkspaceSummary } from './common';
+
+export const refreshWorkspaceSnapshotSubcommand = createSubcommand({
+	name: 'refresh',
+	aliases: ['snapshot-refresh', 'rebuild'],
+	description: 'Refresh a Coder workspace snapshot',
+	tags: ['mutating', 'requires-auth'],
+	requires: { auth: true, org: true },
+	examples: [
+		{
+			command: getCommand('coder workspace refresh ws_abc123'),
+			description: 'Queue a workspace snapshot refresh',
+		},
+	],
+	schema: {
+		args: z.object({
+			workspaceId: z.string().describe('Workspace ID to refresh'),
+		}),
+		options: z.object({
+			url: z.string().optional().describe('Coder API URL override'),
+		}),
+	},
+	async handler(ctx) {
+		const { args, opts, options } = ctx;
+		const client = new CoderClient({
+			apiKey: ctx.auth.apiKey,
+			url: opts?.url,
+			orgId: ctx.orgId,
+		});
+
+		try {
+			const workspace = await client.refreshWorkspaceSnapshot(args.workspaceId);
+			if (options.json) {
+				return workspace;
+			}
+
+			tui.success(`Workspace ${workspace.id} snapshot refresh queued.`);
+			tui.newline();
+			printWorkspaceSummary(workspace);
+			return workspace;
+		} catch (err) {
+			if (err instanceof ValidationOutputError) {
+				ctx.logger.trace('Validation response URL: %s', err.url ?? 'unknown');
+				ctx.logger.trace('Validation issues: %s', JSON.stringify(err.issues, null, 2));
+			}
+			if (err instanceof APIError && err.status >= 400 && err.status < 500) {
+				tui.fatal(
+					`Failed to refresh workspace snapshot: ${err.message}`,
+					ErrorCode.VALIDATION_FAILED
+				);
+			}
+			const msg = err instanceof Error ? err.message : String(err);
+			tui.fatal(`Failed to refresh workspace snapshot: ${msg}`, ErrorCode.NETWORK_ERROR);
+		}
+	},
+});

--- a/packages/cli/src/cmd/coder/workspace/update.ts
+++ b/packages/cli/src/cmd/coder/workspace/update.ts
@@ -2,8 +2,8 @@ import { z } from 'zod';
 import { APIError, ValidationInputError, ValidationOutputError } from '@agentuity/core';
 import {
 	CoderClient,
-	CoderCreateWorkspaceRequestSchema,
-	type CoderCreateWorkspaceRequest,
+	CoderUpdateWorkspaceRequestSchema,
+	type CoderUpdateWorkspaceRequest,
 } from '@agentuity/core/coder';
 import { createSubcommand } from '../../../types';
 import * as tui from '../../../tui';
@@ -11,53 +11,39 @@ import { getCommand } from '../../../command-prefix';
 import { ErrorCode } from '../../../errors';
 import { resolveGitHubRepo } from '../resolve-repo';
 import {
-	EMPTY_WORKSPACE_ERROR,
 	formatWorkspaceValidationMessage,
-	hasWorkspaceSelections,
+	hasWorkspaceUpdate,
 	parseCommaList,
 	printWorkspaceSummary,
 	readSetupScript,
 } from './common';
 
-export const createWorkspaceSubcommand = createSubcommand({
-	name: 'create',
-	aliases: ['new', 'add'],
-	description: 'Create a new Coder workspace with at least one repo or agent',
+export const updateWorkspaceSubcommand = createSubcommand({
+	name: 'update',
+	aliases: ['edit', 'patch'],
+	description: 'Update a Coder workspace',
 	tags: ['mutating', 'requires-auth'],
 	requires: { auth: true, org: true },
 	examples: [
 		{
-			command: getCommand(
-				'coder workspace create "My Workspace" --repo https://github.com/org/repo --repo-branch main'
-			),
-			description: 'Create a workspace with a repository',
+			command: getCommand('coder workspace update ws_abc123 --dependency git,nodejs'),
+			description: 'Update workspace dependencies',
 		},
 		{
-			command: getCommand(
-				'coder workspace create "My Workspace" --dependency git --setup-script-file ./setup.sh --scope org'
-			),
-			description: 'Create an org-scoped workspace with dependencies and a setup script',
-		},
-		{
-			command: getCommand('coder workspace create "My Workspace" --enabled-agents code-review'),
-			description: 'Create a workspace with an agent roster',
-		},
-		{
-			command: getCommand(
-				'coder workspace create "My Workspace" --enabled-agents code-review --json'
-			),
-			description: 'Create a workspace and return JSON output',
+			command: getCommand('coder workspace update ws_abc123 --setup-script-file ./setup.sh'),
+			description: 'Update the workspace setup script',
 		},
 	],
 	schema: {
 		args: z.object({
-			name: z.string().describe('Workspace name'),
+			workspaceId: z.string().describe('Workspace ID to update'),
 		}),
 		options: z.object({
 			url: z.string().optional().describe('Coder API URL override'),
+			name: z.string().optional().describe('Workspace name'),
 			description: z.string().optional().describe('Workspace description'),
 			scope: z.string().optional().describe('Workspace scope: user or org'),
-			repo: z.string().optional().describe('Repository URL to add'),
+			repo: z.string().optional().describe('Repository URL to set'),
 			repoBranch: z.string().optional().describe('Branch for the repository'),
 			dependency: z
 				.string()
@@ -85,8 +71,8 @@ export const createWorkspaceSubcommand = createSubcommand({
 			orgId: ctx.orgId,
 		});
 
-		const body: CoderCreateWorkspaceRequest = {
-			name: args.name,
+		const body: CoderUpdateWorkspaceRequest = {
+			...(opts?.name && { name: opts.name }),
 			...(opts?.description && { description: opts.description }),
 			...(opts?.scope && { scope: opts.scope as 'user' | 'org' }),
 		};
@@ -110,7 +96,7 @@ export const createWorkspaceSubcommand = createSubcommand({
 				setupScript: opts?.setupScript,
 				setupScriptFile: opts?.setupScriptFile,
 			});
-			if (setupScript) body.setupScript = setupScript;
+			if (setupScript !== undefined) body.setupScript = setupScript;
 		} catch (err) {
 			const msg = err instanceof Error ? err.message : String(err);
 			tui.fatal(`Failed to read setup script: ${msg}`, ErrorCode.VALIDATION_FAILED);
@@ -119,51 +105,50 @@ export const createWorkspaceSubcommand = createSubcommand({
 		if (opts?.enabledAgents) {
 			body.enabledAgents = parseCommaList(opts.enabledAgents);
 		}
-		if (!hasWorkspaceSelections(body)) {
+		if (!hasWorkspaceUpdate(body)) {
 			tui.fatal(
-				`Failed to create workspace: ${EMPTY_WORKSPACE_ERROR}. Use --repo, --dependency, --setup-script, or --enabled-agents.`,
+				'Failed to update workspace: At least one field must be provided.',
 				ErrorCode.VALIDATION_FAILED
 			);
 		}
 
-		const validationResult = CoderCreateWorkspaceRequestSchema.safeParse(body);
+		const validationResult = CoderUpdateWorkspaceRequestSchema.safeParse(body);
 		if (!validationResult.success) {
 			ctx.logger.trace(
 				'Validation issues: %s',
 				JSON.stringify(validationResult.error.issues, null, 2)
 			);
 			tui.fatal(
-				`Failed to create workspace: ${formatWorkspaceValidationMessage(validationResult.error.issues)}`,
+				`Failed to update workspace: ${formatWorkspaceValidationMessage(validationResult.error.issues)}`,
 				ErrorCode.VALIDATION_FAILED
 			);
 		}
 
 		try {
-			const created = await client.createWorkspace(validationResult.data);
+			const updated = await client.updateWorkspace(args.workspaceId, validationResult.data);
 
 			if (options.json) {
-				return created;
+				return updated;
 			}
 
-			tui.success(`Workspace ${created.id} created.`);
+			tui.success(`Workspace ${updated.id} updated.`);
 			tui.newline();
-			printWorkspaceSummary(created);
-
-			return created;
+			printWorkspaceSummary(updated);
+			return updated;
 		} catch (err) {
 			if (err instanceof ValidationInputError || err instanceof ValidationOutputError) {
 				ctx.logger.trace('Validation response URL: %s', err.url ?? 'unknown');
 				ctx.logger.trace('Validation issues: %s', JSON.stringify(err.issues, null, 2));
 				tui.fatal(
-					`Failed to create workspace: ${formatWorkspaceValidationMessage(err.issues)}`,
+					`Failed to update workspace: ${formatWorkspaceValidationMessage(err.issues)}`,
 					ErrorCode.VALIDATION_FAILED
 				);
 			}
 			if (err instanceof APIError && err.status >= 400 && err.status < 500) {
-				tui.fatal(`Failed to create workspace: ${err.message}`, ErrorCode.VALIDATION_FAILED);
+				tui.fatal(`Failed to update workspace: ${err.message}`, ErrorCode.VALIDATION_FAILED);
 			}
 			const msg = err instanceof Error ? err.message : String(err);
-			tui.fatal(`Failed to create workspace: ${msg}`, ErrorCode.NETWORK_ERROR);
+			tui.fatal(`Failed to update workspace: ${msg}`, ErrorCode.NETWORK_ERROR);
 		}
 	},
 });

--- a/packages/cli/src/cmd/coder/workspace/validate-dependencies.ts
+++ b/packages/cli/src/cmd/coder/workspace/validate-dependencies.ts
@@ -1,0 +1,75 @@
+import { z } from 'zod';
+import { APIError, ValidationOutputError } from '@agentuity/core';
+import { CoderClient } from '@agentuity/core/coder';
+import { createSubcommand } from '../../../types';
+import * as tui from '../../../tui';
+import { getCommand } from '../../../command-prefix';
+import { ErrorCode } from '../../../errors';
+import { parseCommaList } from './common';
+
+export const validateWorkspaceDependenciesSubcommand = createSubcommand({
+	name: 'validate-dependencies',
+	aliases: ['validate-deps'],
+	description: 'Validate APT dependencies for Coder workspace snapshots',
+	tags: ['read-only', 'requires-auth'],
+	idempotent: true,
+	requires: { auth: true, org: true },
+	examples: [
+		{
+			command: getCommand('coder workspace validate-dependencies git,nodejs'),
+			description: 'Validate dependency package names',
+		},
+	],
+	schema: {
+		args: z.object({
+			dependencies: z.string().describe('Comma-separated APT dependencies to validate'),
+		}),
+		options: z.object({
+			url: z.string().optional().describe('Coder API URL override'),
+		}),
+	},
+	async handler(ctx) {
+		const { args, opts, options } = ctx;
+		const dependencies = parseCommaList(args.dependencies);
+		if (dependencies.length === 0) {
+			tui.fatal('At least one dependency is required.', ErrorCode.VALIDATION_FAILED);
+		}
+
+		const client = new CoderClient({
+			apiKey: ctx.auth.apiKey,
+			url: opts?.url,
+			orgId: ctx.orgId,
+		});
+
+		try {
+			const result = await client.validateWorkspaceDependencies(dependencies);
+			if (options.json) {
+				return result;
+			}
+
+			if (result.valid.length > 0) {
+				tui.success(`Valid dependencies: ${result.valid.join(', ')}`);
+			}
+			if (result.invalid.length > 0) {
+				tui.error(`Invalid dependencies: ${result.invalid.length}`);
+				for (const invalid of result.invalid) {
+					tui.output(`  - ${invalid.package}: ${invalid.error}`);
+				}
+			}
+			return result;
+		} catch (err) {
+			if (err instanceof ValidationOutputError) {
+				ctx.logger.trace('Validation response URL: %s', err.url ?? 'unknown');
+				ctx.logger.trace('Validation issues: %s', JSON.stringify(err.issues, null, 2));
+			}
+			if (err instanceof APIError && err.status >= 400 && err.status < 500) {
+				tui.fatal(
+					`Failed to validate dependencies: ${err.message}`,
+					ErrorCode.VALIDATION_FAILED
+				);
+			}
+			const msg = err instanceof Error ? err.message : String(err);
+			tui.fatal(`Failed to validate dependencies: ${msg}`, ErrorCode.NETWORK_ERROR);
+		}
+	},
+});

--- a/packages/cli/test/cmd/coder/workspace.test.ts
+++ b/packages/cli/test/cmd/coder/workspace.test.ts
@@ -1,20 +1,28 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { workspaceCommand } from '../../../src/cmd/coder/workspace';
 import { createWorkspaceSubcommand } from '../../../src/cmd/coder/workspace/create';
+import { refreshWorkspaceSnapshotSubcommand } from '../../../src/cmd/coder/workspace/refresh';
+import { updateWorkspaceSubcommand } from '../../../src/cmd/coder/workspace/update';
+import { validateWorkspaceDependenciesSubcommand } from '../../../src/cmd/coder/workspace/validate-dependencies';
 import { ErrorCode, getExitCode } from '../../../src/errors';
 
 const ORIGINAL_EXIT = process.exit;
 const ORIGINAL_STDERR_WRITE = process.stderr.write;
 const ORIGINAL_FETCH = globalThis.fetch;
 
-function makeContext(opts: Record<string, unknown> = {}) {
+function makeContext(
+	input: { args?: Record<string, unknown>; opts?: Record<string, unknown>; json?: boolean } = {}
+) {
 	return {
-		args: { name: 'My Workspace' },
+		args: { name: 'My Workspace', ...input.args },
 		opts: {
 			url: 'https://coder.example',
-			...opts,
+			...input.opts,
 		},
-		options: { json: false },
+		options: { json: input.json ?? false },
 		auth: { apiKey: 'ag_test' },
 		orgId: 'org_test',
 		config: null,
@@ -48,6 +56,34 @@ function interceptFatal() {
 	};
 }
 
+function makeWorkspace(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 'ws_test',
+		name: 'My Workspace',
+		description: 'Workspace description',
+		scope: 'org',
+		ownerUserId: 'user_test',
+		repos: [],
+		repoCount: 0,
+		dependencies: [],
+		setupScript: '',
+		savedSkillIds: [],
+		skillBucketIds: [],
+		enabledAgents: [],
+		selectionCount: 0,
+		createdAt: '2026-04-08T00:00:00.000Z',
+		updatedAt: '2026-04-08T00:00:00.000Z',
+		...overrides,
+	};
+}
+
+function jsonResponse(body: unknown, status = 200) {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { 'content-type': 'application/json' },
+	});
+}
+
 describe('coder workspace commands', () => {
 	beforeEach(() => {
 		globalThis.fetch = ORIGINAL_FETCH;
@@ -68,13 +104,18 @@ describe('coder workspace commands', () => {
 
 		expect(rootCreateExamples).toHaveLength(1);
 		for (const example of [...rootCreateExamples, ...createExamples]) {
-			expect(
-				example.command.includes('--repo') || example.command.includes('--enabled-agents')
-			).toBe(true);
+			const hasValidSelection =
+				example.command.includes('--repo') ||
+				example.command.includes('--dependency') ||
+				example.command.includes('--setup-script') ||
+				example.command.includes('--setup-script-file') ||
+				example.command.includes('--enabled-agents');
+			expect(hasValidSelection).toBe(true);
 		}
 		expect(createExamples.some((example) => example.command.includes('--enabled-agents'))).toBe(
 			true
 		);
+		expect(createExamples.some((example) => example.command.includes('--dependency'))).toBe(true);
 	});
 
 	test('create handler fails locally before fetch when no selections are provided', async () => {
@@ -89,8 +130,243 @@ describe('coder workspace commands', () => {
 
 		expect(requestedUrls).toEqual([]);
 		expect(fatal.stderr).toContain(
-			'Failed to create workspace: A workspace needs at least one repo, saved skill, skill bucket, or agent. Use --repo or --enabled-agents.'
+			'Failed to create workspace: A workspace needs at least one repo, dependency, setup script, saved skill, skill bucket, or agent. Use --repo, --dependency, --setup-script, or --enabled-agents.'
 		);
 		expect(fatal.exitCode).toBe(getExitCode(ErrorCode.VALIDATION_FAILED));
+	});
+
+	test('create handler sends dependencies from --dependency', async () => {
+		let requestBody: unknown;
+		globalThis.fetch = (async (url: string, init?: RequestInit) => {
+			expect(String(url)).toBe('https://coder.example/api/hub/workspaces');
+			expect(init?.method).toBe('POST');
+			requestBody = JSON.parse(String(init?.body));
+			return jsonResponse({
+				workspace: makeWorkspace({
+					dependencies: ['git', 'nodejs'],
+					selectionCount: 2,
+				}),
+			});
+		}) as typeof globalThis.fetch;
+
+		const result = await createWorkspaceSubcommand.handler(
+			makeContext({ opts: { dependency: 'git,nodejs' }, json: true })
+		);
+
+		expect(requestBody).toMatchObject({
+			name: 'My Workspace',
+			dependencies: ['git', 'nodejs'],
+		});
+		expect(result).toMatchObject({
+			dependencies: ['git', 'nodejs'],
+		});
+	});
+
+	test('create handler sends inline setup script', async () => {
+		let requestBody: unknown;
+		globalThis.fetch = (async (url: string, init?: RequestInit) => {
+			expect(String(url)).toBe('https://coder.example/api/hub/workspaces');
+			expect(init?.method).toBe('POST');
+			requestBody = JSON.parse(String(init?.body));
+			return jsonResponse({
+				workspace: makeWorkspace({
+					setupScript: 'echo ready',
+					selectionCount: 1,
+				}),
+			});
+		}) as typeof globalThis.fetch;
+
+		const result = await createWorkspaceSubcommand.handler(
+			makeContext({ opts: { setupScript: 'echo ready' }, json: true })
+		);
+
+		expect(requestBody).toMatchObject({
+			name: 'My Workspace',
+			setupScript: 'echo ready',
+		});
+		expect(result).toMatchObject({
+			setupScript: 'echo ready',
+		});
+	});
+
+	test('create handler reads setup script from file', async () => {
+		const dir = mkdtempSync(join(tmpdir(), 'agentuity-workspace-test-'));
+		const setupScriptFile = join(dir, 'setup.sh');
+		writeFileSync(setupScriptFile, 'echo from-file\n');
+		let requestBody: unknown;
+		try {
+			globalThis.fetch = (async (url: string, init?: RequestInit) => {
+				expect(String(url)).toBe('https://coder.example/api/hub/workspaces');
+				expect(init?.method).toBe('POST');
+				requestBody = JSON.parse(String(init?.body));
+				return jsonResponse({
+					workspace: makeWorkspace({
+						setupScript: 'echo from-file\n',
+						selectionCount: 1,
+					}),
+				});
+			}) as typeof globalThis.fetch;
+
+			const result = await createWorkspaceSubcommand.handler(
+				makeContext({ opts: { setupScriptFile }, json: true })
+			);
+
+			expect(requestBody).toMatchObject({
+				name: 'My Workspace',
+				setupScript: 'echo from-file\n',
+			});
+			expect(result).toMatchObject({
+				setupScript: 'echo from-file\n',
+			});
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	test('create handler fails locally when both setup script options are provided', async () => {
+		const requestedUrls: string[] = [];
+		globalThis.fetch = (async (url: string) => {
+			requestedUrls.push(String(url));
+			throw new Error('unexpected fetch');
+		}) as typeof globalThis.fetch;
+		const fatal = interceptFatal();
+
+		await expect(
+			createWorkspaceSubcommand.handler(
+				makeContext({
+					opts: {
+						setupScript: 'echo inline',
+						setupScriptFile: './setup.sh',
+					},
+				})
+			)
+		).rejects.toThrow('__EXIT__');
+
+		expect(requestedUrls).toEqual([]);
+		expect(fatal.stderr).toContain(
+			'Failed to read setup script: Use either --setup-script or --setup-script-file, not both.'
+		);
+		expect(fatal.exitCode).toBe(getExitCode(ErrorCode.VALIDATION_FAILED));
+	});
+
+	test('update handler fails locally before fetch when no fields are provided', async () => {
+		const requestedUrls: string[] = [];
+		globalThis.fetch = (async (url: string) => {
+			requestedUrls.push(String(url));
+			throw new Error('unexpected fetch');
+		}) as typeof globalThis.fetch;
+		const fatal = interceptFatal();
+
+		await expect(
+			updateWorkspaceSubcommand.handler(makeContext({ args: { workspaceId: 'ws_test' } }))
+		).rejects.toThrow('__EXIT__');
+
+		expect(requestedUrls).toEqual([]);
+		expect(fatal.stderr).toContain(
+			'Failed to update workspace: At least one field must be provided.'
+		);
+		expect(fatal.exitCode).toBe(getExitCode(ErrorCode.VALIDATION_FAILED));
+	});
+
+	test('update handler patches dependencies and setup script', async () => {
+		let requestBody: unknown;
+		globalThis.fetch = (async (url: string, init?: RequestInit) => {
+			expect(String(url)).toBe('https://coder.example/api/hub/workspaces/ws_test');
+			expect(init?.method).toBe('PATCH');
+			requestBody = JSON.parse(String(init?.body));
+			return jsonResponse({
+				workspace: makeWorkspace({
+					id: 'ws_test',
+					dependencies: ['git'],
+					setupScript: 'echo updated',
+					snapshot: { status: 'building' },
+					selectionCount: 2,
+				}),
+			});
+		}) as typeof globalThis.fetch;
+
+		const result = await updateWorkspaceSubcommand.handler(
+			makeContext({
+				args: { workspaceId: 'ws_test' },
+				opts: { dependency: 'git', setupScript: 'echo updated' },
+				json: true,
+			})
+		);
+
+		expect(requestBody).toEqual({
+			dependencies: ['git'],
+			setupScript: 'echo updated',
+		});
+		expect(result).toMatchObject({
+			id: 'ws_test',
+			dependencies: ['git'],
+			setupScript: 'echo updated',
+			snapshot: { status: 'building' },
+		});
+	});
+
+	test('refresh handler posts to workspace snapshot refresh endpoint', async () => {
+		globalThis.fetch = (async (url: string, init?: RequestInit) => {
+			expect(String(url)).toBe(
+				'https://coder.example/api/hub/workspaces/ws_test/snapshot/refresh'
+			);
+			expect(init?.method).toBe('POST');
+			return jsonResponse({
+				workspace: makeWorkspace({
+					id: 'ws_test',
+					snapshot: { status: 'building', buildId: 'wsbuild_test' },
+				}),
+			});
+		}) as typeof globalThis.fetch;
+
+		const result = await refreshWorkspaceSnapshotSubcommand.handler(
+			makeContext({ args: { workspaceId: 'ws_test' }, json: true })
+		);
+
+		expect(result).toMatchObject({
+			id: 'ws_test',
+			snapshot: { status: 'building', buildId: 'wsbuild_test' },
+		});
+	});
+
+	test('validate-dependencies handler parses dependencies and returns validation result', async () => {
+		let requestBody: unknown;
+		globalThis.fetch = (async (url: string, init?: RequestInit) => {
+			expect(String(url)).toBe('https://coder.example/api/hub/workspaces/dependencies/validate');
+			expect(init?.method).toBe('POST');
+			requestBody = JSON.parse(String(init?.body));
+			return jsonResponse({
+				success: true,
+				data: {
+					valid: ['git'],
+					invalid: [
+						{
+							package: 'nope',
+							error: 'Package "nope" does not exist',
+							searchUrl: 'https://packages.debian.org/search?keywords=nope',
+						},
+					],
+				},
+			});
+		}) as typeof globalThis.fetch;
+
+		const result = await validateWorkspaceDependenciesSubcommand.handler(
+			makeContext({
+				args: { dependencies: 'git,nope' },
+				json: true,
+			})
+		);
+
+		expect(requestBody).toEqual({ dependencies: ['git', 'nope'] });
+		expect(result).toEqual({
+			valid: ['git'],
+			invalid: [
+				{
+					package: 'nope',
+					error: 'Package "nope" does not exist',
+					searchUrl: 'https://packages.debian.org/search?keywords=nope',
+				},
+			],
+		});
 	});
 });

--- a/packages/cli/test/cmd/coder/workspace.test.ts
+++ b/packages/cli/test/cmd/coder/workspace.test.ts
@@ -189,6 +189,36 @@ describe('coder workspace commands', () => {
 		});
 	});
 
+	test('create handler preserves explicit empty inline setup script values', async () => {
+		let requestBody: unknown;
+		globalThis.fetch = (async (url: string, init?: RequestInit) => {
+			expect(String(url)).toBe('https://coder.example/api/hub/workspaces');
+			expect(init?.method).toBe('POST');
+			requestBody = JSON.parse(String(init?.body));
+			return jsonResponse({
+				workspace: makeWorkspace({
+					dependencies: ['git'],
+					setupScript: '',
+					selectionCount: 1,
+				}),
+			});
+		}) as typeof globalThis.fetch;
+
+		const result = await createWorkspaceSubcommand.handler(
+			makeContext({ opts: { dependency: 'git', setupScript: '' }, json: true })
+		);
+
+		expect(requestBody).toMatchObject({
+			name: 'My Workspace',
+			dependencies: ['git'],
+			setupScript: '',
+		});
+		expect(result).toMatchObject({
+			dependencies: ['git'],
+			setupScript: '',
+		});
+	});
+
 	test('create handler reads setup script from file', async () => {
 		const dir = mkdtempSync(join(tmpdir(), 'agentuity-workspace-test-'));
 		const setupScriptFile = join(dir, 'setup.sh');

--- a/packages/cli/test/cmd/coder/workspace.test.ts
+++ b/packages/cli/test/cmd/coder/workspace.test.ts
@@ -279,6 +279,31 @@ describe('coder workspace commands', () => {
 		expect(fatal.exitCode).toBe(getExitCode(ErrorCode.VALIDATION_FAILED));
 	});
 
+	test('create handler reports setup script file read failures as validation errors', async () => {
+		const requestedUrls: string[] = [];
+		globalThis.fetch = (async (url: string) => {
+			requestedUrls.push(String(url));
+			throw new Error('unexpected fetch');
+		}) as typeof globalThis.fetch;
+		const fatal = interceptFatal();
+
+		await expect(
+			createWorkspaceSubcommand.handler(
+				makeContext({
+					opts: {
+						setupScriptFile: join(tmpdir(), `missing-setup-${crypto.randomUUID()}.sh`),
+					},
+				})
+			)
+		).rejects.toThrow('__EXIT__');
+
+		expect(requestedUrls).toEqual([]);
+		expect(fatal.stderr).toContain(
+			'Failed to read setup script: Failed to read setup script file'
+		);
+		expect(fatal.exitCode).toBe(getExitCode(ErrorCode.VALIDATION_FAILED));
+	});
+
 	test('update handler fails locally before fetch when no fields are provided', async () => {
 		const requestedUrls: string[] = [];
 		globalThis.fetch = (async (url: string) => {

--- a/packages/coder/README.md
+++ b/packages/coder/README.md
@@ -35,6 +35,25 @@ const workspaceSession = await client.createSession({
 });
 console.log(`Created workspace session: ${workspaceSession.sessionId}`);
 
+// Manage workspace snapshot inputs
+const validation = await client.validateWorkspaceDependencies(['git', 'nodejs']);
+if (validation.invalid.length > 0) {
+  throw new Error(validation.invalid.map((pkg) => pkg.error).join(', '));
+}
+
+const workspace = await client.createWorkspace({
+  name: 'Node workspace',
+  scope: 'org',
+  dependencies: ['git', 'nodejs'],
+  setupScript: 'corepack enable',
+});
+
+await client.updateWorkspace(workspace.id, {
+  setupScript: 'corepack enable && bun install',
+});
+
+await client.refreshWorkspaceSnapshot(workspace.id);
+
 // Get session details
 const details = await client.getSession(session.sessionId);
 console.log(`Task: ${details.task}`);

--- a/packages/coder/README.md
+++ b/packages/coder/README.md
@@ -28,6 +28,13 @@ const session = await client.createSession({
 });
 console.log(`Created session: ${session.sessionId}`);
 
+// Create a session from a saved workspace
+const workspaceSession = await client.createSession({
+  task: 'Test workspace startup',
+  workspaceId: 'ws_...',
+});
+console.log(`Created workspace session: ${workspaceSession.sessionId}`);
+
 // Get session details
 const details = await client.getSession(session.sessionId);
 console.log(`Task: ${details.task}`);

--- a/packages/core/src/services/coder/client.ts
+++ b/packages/core/src/services/coder/client.ts
@@ -44,6 +44,9 @@ import {
 	coderDeleteWorkspace,
 	coderGetWorkspace,
 	coderListWorkspaces,
+	coderRefreshWorkspaceSnapshot,
+	coderUpdateWorkspace,
+	coderValidateWorkspaceDependencies,
 } from './workspaces.ts';
 import { coderListGitHubAccounts, coderListGitHubRepos } from './github.ts';
 import { coderGetLoopState, type CoderGetLoopStateParams } from './loop-state.ts';
@@ -78,6 +81,8 @@ import type {
 	CoderCreateSkillBucketRequest,
 	CoderUpdateCustomAgentRequest,
 	CoderCreateWorkspaceRequest,
+	CoderUpdateWorkspaceRequest,
+	CoderWorkspaceDependencyValidationResponse,
 	CoderWorkspaceDetail,
 	CoderWorkspaceListResponse,
 	CoderSaveSkillRequest,
@@ -326,6 +331,35 @@ export class CoderClient {
 	async createWorkspace(body: CoderCreateWorkspaceRequest): Promise<CoderWorkspaceDetail> {
 		const client = await this.#getClient();
 		return coderCreateWorkspace(client, { body });
+	}
+
+	/**
+	 * Updates an existing workspace.
+	 */
+	async updateWorkspace(
+		workspaceId: string,
+		body: CoderUpdateWorkspaceRequest
+	): Promise<CoderWorkspaceDetail> {
+		const client = await this.#getClient();
+		return coderUpdateWorkspace(client, { workspaceId, body });
+	}
+
+	/**
+	 * Queues a snapshot refresh for an existing workspace.
+	 */
+	async refreshWorkspaceSnapshot(workspaceId: string): Promise<CoderWorkspaceDetail> {
+		const client = await this.#getClient();
+		return coderRefreshWorkspaceSnapshot(client, { workspaceId });
+	}
+
+	/**
+	 * Validates APT package dependencies for workspace snapshot preparation.
+	 */
+	async validateWorkspaceDependencies(
+		dependencies: string[]
+	): Promise<CoderWorkspaceDependencyValidationResponse> {
+		const client = await this.#getClient();
+		return coderValidateWorkspaceDependencies(client, { dependencies });
 	}
 
 	/**

--- a/packages/core/src/services/coder/types.ts
+++ b/packages/core/src/services/coder/types.ts
@@ -113,6 +113,33 @@ export const CoderWorkspaceDetailSchema = z
 		ownerUserId: z.string().describe('Owner user ID'),
 		repos: z.array(CoderSessionRepositoryRefSchema).describe('Repositories in workspace'),
 		repoCount: z.number().describe('Number of repositories'),
+		dependencies: z
+			.array(z.string())
+			.optional()
+			.default([])
+			.describe('APT package dependencies installed into workspace snapshots'),
+		setupScript: z
+			.string()
+			.optional()
+			.default('')
+			.describe('Shell script run while preparing workspace snapshots'),
+		snapshot: z
+			.object({
+				status: z.string().describe('Workspace snapshot build status'),
+				snapshotId: z.string().optional().describe('Created sandbox snapshot ID'),
+				snapshotRef: z.string().optional().describe('Snapshot reference used for sessions'),
+				baseSnapshotRef: z.string().optional().describe('Base session snapshot reference'),
+				baseDriverVersion: z.string().optional().describe('Base driver version stamp'),
+				configHash: z.string().optional().describe('Workspace snapshot input hash'),
+				buildId: z.string().optional().describe('Workspace snapshot build identifier'),
+				requestedAt: z.string().optional().describe('Snapshot build request timestamp'),
+				updatedAt: z.string().optional().describe('Snapshot build update timestamp'),
+				createdAt: z.string().optional().describe('Snapshot creation timestamp'),
+				error: z.string().optional().describe('Snapshot build error message'),
+			})
+			.passthrough()
+			.optional()
+			.describe('Workspace snapshot metadata'),
 		savedSkillIds: z.array(z.string()).describe('Saved skill IDs in workspace'),
 		skillBucketIds: z.array(z.string()).describe('Skill bucket IDs in workspace'),
 		enabledAgents: z
@@ -324,12 +351,16 @@ export type CoderWorkspaceListResponse = z.infer<typeof CoderWorkspaceListRespon
 
 function hasWorkspaceSelections(input: {
 	repos?: unknown[];
+	dependencies?: unknown[];
+	setupScript?: string;
 	savedSkillIds?: unknown[];
 	skillBucketIds?: unknown[];
 	enabledAgents?: unknown[];
 }): boolean {
 	return (
 		(input.repos?.length ?? 0) > 0 ||
+		(input.dependencies?.length ?? 0) > 0 ||
+		Boolean(input.setupScript?.trim()) ||
 		(input.savedSkillIds?.length ?? 0) > 0 ||
 		(input.skillBucketIds?.length ?? 0) > 0 ||
 		(input.enabledAgents?.length ?? 0) > 0
@@ -342,6 +373,14 @@ export const CoderCreateWorkspaceRequestSchema = z
 		description: z.string().optional().describe('Workspace description'),
 		scope: z.enum(['user', 'org']).optional().describe('Workspace scope'),
 		repos: z.array(CoderSessionRepositoryRefSchema).optional().describe('Repositories'),
+		dependencies: z
+			.array(z.string())
+			.optional()
+			.describe('APT package dependencies installed into workspace snapshots'),
+		setupScript: z
+			.string()
+			.optional()
+			.describe('Shell script run while preparing workspace snapshots'),
 		savedSkillIds: z.array(z.string()).optional().describe('Saved skill IDs'),
 		skillBucketIds: z.array(z.string()).optional().describe('Skill bucket IDs'),
 		enabledAgents: z
@@ -350,10 +389,64 @@ export const CoderCreateWorkspaceRequestSchema = z
 			.describe('Effective agent roster to store on the workspace'),
 	})
 	.refine(hasWorkspaceSelections, {
-		message: 'A workspace needs at least one repo, saved skill, skill bucket, or agent',
+		message:
+			'A workspace needs at least one repo, dependency, setup script, saved skill, skill bucket, or agent',
 	})
 	.describe('Request body for creating a workspace');
 export type CoderCreateWorkspaceRequest = z.infer<typeof CoderCreateWorkspaceRequestSchema>;
+
+export const CoderUpdateWorkspaceRequestSchema = z
+	.object({
+		name: z.string().optional().describe('Workspace name'),
+		description: z.string().optional().describe('Workspace description'),
+		scope: z.enum(['user', 'org']).optional().describe('Workspace scope'),
+		repos: z.array(CoderSessionRepositoryRefSchema).optional().describe('Repositories'),
+		dependencies: z
+			.array(z.string())
+			.optional()
+			.describe('APT package dependencies installed into workspace snapshots'),
+		setupScript: z
+			.string()
+			.optional()
+			.describe('Shell script run while preparing workspace snapshots'),
+		savedSkillIds: z.array(z.string()).optional().describe('Saved skill IDs'),
+		skillBucketIds: z.array(z.string()).optional().describe('Skill bucket IDs'),
+		enabledAgents: z
+			.array(z.string())
+			.optional()
+			.describe('Effective agent roster to store on the workspace'),
+	})
+	.refine((input) => Object.keys(input).length > 0, {
+		message: 'At least one workspace field must be provided',
+	})
+	.describe('Request body for updating a workspace');
+export type CoderUpdateWorkspaceRequest = z.infer<typeof CoderUpdateWorkspaceRequestSchema>;
+
+export const CoderWorkspaceDependencyValidationResponseSchema = z
+	.object({
+		valid: z.array(z.string()).describe('Valid dependency package specs'),
+		invalid: z
+			.array(
+				z
+					.object({
+						package: z.string().describe('Invalid dependency package spec'),
+						error: z.string().describe('Validation error'),
+						requestedVersion: z.string().optional().describe('Requested package version'),
+						availableVersions: z
+							.array(z.string())
+							.optional()
+							.describe('Available package versions returned by validation'),
+						searchUrl: z.string().describe('Package search URL'),
+					})
+					.passthrough()
+			)
+			.describe('Invalid dependency package specs'),
+	})
+	.passthrough()
+	.describe('Workspace dependency validation result');
+export type CoderWorkspaceDependencyValidationResponse = z.infer<
+	typeof CoderWorkspaceDependencyValidationResponseSchema
+>;
 
 export const CoderCreateCustomAgentRequestSchema = z
 	.object({

--- a/packages/core/src/services/coder/workspaces.ts
+++ b/packages/core/src/services/coder/workspaces.ts
@@ -2,9 +2,13 @@ import { z } from 'zod/v4';
 import { type APIClient } from '../api.ts';
 import {
 	CoderCreateWorkspaceRequestSchema,
+	CoderUpdateWorkspaceRequestSchema,
+	CoderWorkspaceDependencyValidationResponseSchema,
 	CoderWorkspaceDetailSchema,
 	CoderWorkspaceListResponseSchema,
 	type CoderCreateWorkspaceRequest,
+	type CoderUpdateWorkspaceRequest,
+	type CoderWorkspaceDependencyValidationResponse,
 	type CoderWorkspaceDetail,
 	type CoderWorkspaceListResponse,
 } from './types.ts';
@@ -24,6 +28,34 @@ const WorkspaceCreateResponseSchema = z
 	})
 	.passthrough()
 	.describe('Wrapped workspace create response from coder hub');
+
+const WorkspaceUpdateResponseSchema = z
+	.object({
+		workspace: CoderWorkspaceDetailSchema.describe(
+			'Updated workspace payload returned by coder hub'
+		),
+	})
+	.passthrough()
+	.describe('Wrapped workspace update response from coder hub');
+
+const WorkspaceSnapshotRefreshResponseSchema = z
+	.object({
+		workspace: CoderWorkspaceDetailSchema.describe(
+			'Workspace payload returned after refreshing its snapshot'
+		),
+	})
+	.passthrough()
+	.describe('Wrapped workspace snapshot refresh response from coder hub');
+
+const WorkspaceDependencyValidationWrappedResponseSchema = z
+	.object({
+		success: z.boolean().describe('Validation request success indicator'),
+		data: CoderWorkspaceDependencyValidationResponseSchema.describe(
+			'Dependency validation result'
+		),
+	})
+	.passthrough()
+	.describe('Wrapped workspace dependency validation response from coder hub');
 
 const OkResponseSchema = z
 	.object({
@@ -66,6 +98,48 @@ export async function coderCreateWorkspace(
 	);
 
 	return resp.workspace;
+}
+
+export async function coderUpdateWorkspace(
+	client: APIClient,
+	params: { workspaceId: string; body: CoderUpdateWorkspaceRequest }
+): Promise<CoderWorkspaceDetail> {
+	const path = `/hub/workspaces/${encodeURIComponent(params.workspaceId)}`;
+	const resp = await client.patch<
+		z.infer<typeof WorkspaceUpdateResponseSchema>,
+		CoderUpdateWorkspaceRequest
+	>(path, params.body, WorkspaceUpdateResponseSchema, CoderUpdateWorkspaceRequestSchema);
+
+	return resp.workspace;
+}
+
+export async function coderRefreshWorkspaceSnapshot(
+	client: APIClient,
+	params: { workspaceId: string }
+): Promise<CoderWorkspaceDetail> {
+	const path = `/hub/workspaces/${encodeURIComponent(params.workspaceId)}/snapshot/refresh`;
+	const resp = await client.post<z.infer<typeof WorkspaceSnapshotRefreshResponseSchema>>(
+		path,
+		undefined,
+		WorkspaceSnapshotRefreshResponseSchema
+	);
+
+	return resp.workspace;
+}
+
+export async function coderValidateWorkspaceDependencies(
+	client: APIClient,
+	params: { dependencies: string[] }
+): Promise<CoderWorkspaceDependencyValidationResponse> {
+	const resp = await client.post<
+		z.infer<typeof WorkspaceDependencyValidationWrappedResponseSchema>
+	>(
+		'/hub/workspaces/dependencies/validate',
+		{ dependencies: params.dependencies },
+		WorkspaceDependencyValidationWrappedResponseSchema
+	);
+
+	return resp.data;
 }
 
 export async function coderDeleteWorkspace(

--- a/packages/core/test/coder-client.test.ts
+++ b/packages/core/test/coder-client.test.ts
@@ -5,6 +5,7 @@ import { APIError, ValidationInputError } from '../src/services/api.ts';
 import {
 	CoderCreateAgentBuilderSessionRequestSchema,
 	CoderCreateWorkspaceRequestSchema,
+	CoderUpdateWorkspaceRequestSchema,
 } from '../src/services/coder/types.ts';
 
 const ORIGINAL_FETCH = globalThis.fetch;
@@ -403,10 +404,15 @@ describe('CoderClient enabled agent roster contract', () => {
 			name: 'My Workspace',
 			enabledAgents: ['code-review'],
 		};
+		const updateWorkspaceBody: Parameters<CoderClient['updateWorkspace']>[1] = {
+			dependencies: ['git'],
+			setupScript: 'echo ready',
+		};
 
 		expect(createSessionBody.enabledAgents).toEqual(['code-review']);
 		expect(updateSessionBody.enabledAgents).toEqual(['code-review']);
 		expect(createWorkspaceBody.enabledAgents).toEqual(['code-review']);
+		expect(updateWorkspaceBody.dependencies).toEqual(['git']);
 	});
 
 	test('workspace create schema rejects a name-only request', () => {
@@ -420,7 +426,37 @@ describe('CoderClient enabled agent roster contract', () => {
 				expect.arrayContaining([
 					expect.objectContaining({
 						message:
-							'A workspace needs at least one repo, saved skill, skill bucket, or agent',
+							'A workspace needs at least one repo, dependency, setup script, saved skill, skill bucket, or agent',
+					}),
+				])
+			);
+		}
+	});
+
+	test('workspace create schema accepts dependencies and setup scripts as selections', () => {
+		expect(
+			CoderCreateWorkspaceRequestSchema.safeParse({
+				name: 'Dependency Workspace',
+				dependencies: ['git'],
+			}).success
+		).toBe(true);
+		expect(
+			CoderCreateWorkspaceRequestSchema.safeParse({
+				name: 'Setup Workspace',
+				setupScript: 'echo ready',
+			}).success
+		).toBe(true);
+	});
+
+	test('workspace update schema rejects an empty body', () => {
+		const result = CoderUpdateWorkspaceRequestSchema.safeParse({});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						message: 'At least one workspace field must be provided',
 					}),
 				])
 			);
@@ -451,7 +487,8 @@ describe('CoderClient enabled agent roster contract', () => {
 		expect(error).toMatchObject({
 			issues: expect.arrayContaining([
 				expect.objectContaining({
-					message: 'A workspace needs at least one repo, saved skill, skill bucket, or agent',
+					message:
+						'A workspace needs at least one repo, dependency, setup script, saved skill, skill bucket, or agent',
 				}),
 			]),
 		});
@@ -594,6 +631,170 @@ describe('CoderClient enabled agent roster contract', () => {
 		).resolves.toMatchObject({
 			id: 'hworkspace_enabled_create',
 			enabledAgents: ['code-review', 'qa-team'],
+		});
+	});
+
+	test('createWorkspace sends dependencies and setupScript in the request body', async () => {
+		mockFetch(async (url, init) => {
+			expect(url).toBe('https://coder.example/api/hub/workspaces');
+			expect(init?.method).toBe('POST');
+			expect(JSON.parse(String(init?.body))).toMatchObject({
+				name: 'Workspace deps',
+				dependencies: ['git', 'nodejs'],
+				setupScript: 'echo ready',
+			});
+			return new Response(
+				JSON.stringify({
+					workspace: makeWorkspace({
+						id: 'hworkspace_deps_create',
+						dependencies: ['git', 'nodejs'],
+						setupScript: 'echo ready',
+						selectionCount: 2,
+						snapshot: { status: 'building', buildId: 'wsbuild_test' },
+					}),
+				}),
+				{
+					status: 201,
+					headers: { 'content-type': 'application/json' },
+				}
+			);
+		});
+
+		const client = new CoderClient({
+			apiKey: 'ag_test',
+			url: 'https://coder.example',
+			orgId: 'org_test',
+		});
+
+		await expect(
+			client.createWorkspace({
+				name: 'Workspace deps',
+				dependencies: ['git', 'nodejs'],
+				setupScript: 'echo ready',
+			})
+		).resolves.toMatchObject({
+			id: 'hworkspace_deps_create',
+			dependencies: ['git', 'nodejs'],
+			setupScript: 'echo ready',
+			snapshot: { status: 'building' },
+		});
+	});
+
+	test('updateWorkspace patches dependencies and setupScript', async () => {
+		mockFetch(async (url, init) => {
+			expect(url).toBe('https://coder.example/api/hub/workspaces/hworkspace_update');
+			expect(init?.method).toBe('PATCH');
+			expect(JSON.parse(String(init?.body))).toMatchObject({
+				dependencies: ['git'],
+				setupScript: 'echo updated',
+			});
+			return new Response(
+				JSON.stringify({
+					workspace: makeWorkspace({
+						id: 'hworkspace_update',
+						dependencies: ['git'],
+						setupScript: 'echo updated',
+						snapshot: { status: 'building' },
+					}),
+				}),
+				{
+					status: 200,
+					headers: { 'content-type': 'application/json' },
+				}
+			);
+		});
+
+		const client = new CoderClient({
+			apiKey: 'ag_test',
+			url: 'https://coder.example',
+			orgId: 'org_test',
+		});
+
+		await expect(
+			client.updateWorkspace('hworkspace_update', {
+				dependencies: ['git'],
+				setupScript: 'echo updated',
+			})
+		).resolves.toMatchObject({
+			id: 'hworkspace_update',
+			dependencies: ['git'],
+			setupScript: 'echo updated',
+		});
+	});
+
+	test('refreshWorkspaceSnapshot posts to the refresh endpoint', async () => {
+		mockFetch(async (url, init) => {
+			expect(url).toBe(
+				'https://coder.example/api/hub/workspaces/hworkspace_refresh/snapshot/refresh'
+			);
+			expect(init?.method).toBe('POST');
+			return new Response(
+				JSON.stringify({
+					workspace: makeWorkspace({
+						id: 'hworkspace_refresh',
+						snapshot: { status: 'building', buildId: 'wsbuild_refresh' },
+					}),
+				}),
+				{
+					status: 200,
+					headers: { 'content-type': 'application/json' },
+				}
+			);
+		});
+
+		const client = new CoderClient({
+			apiKey: 'ag_test',
+			url: 'https://coder.example',
+			orgId: 'org_test',
+		});
+
+		await expect(client.refreshWorkspaceSnapshot('hworkspace_refresh')).resolves.toMatchObject({
+			id: 'hworkspace_refresh',
+			snapshot: { status: 'building' },
+		});
+	});
+
+	test('validateWorkspaceDependencies returns valid and invalid dependency results', async () => {
+		mockFetch(async (url, init) => {
+			expect(url).toBe('https://coder.example/api/hub/workspaces/dependencies/validate');
+			expect(init?.method).toBe('POST');
+			expect(JSON.parse(String(init?.body))).toEqual({ dependencies: ['git', 'nope'] });
+			return new Response(
+				JSON.stringify({
+					success: true,
+					data: {
+						valid: ['git'],
+						invalid: [
+							{
+								package: 'nope',
+								error: 'Package "nope" does not exist',
+								searchUrl: 'https://packages.debian.org/search?keywords=nope',
+							},
+						],
+					},
+				}),
+				{
+					status: 200,
+					headers: { 'content-type': 'application/json' },
+				}
+			);
+		});
+
+		const client = new CoderClient({
+			apiKey: 'ag_test',
+			url: 'https://coder.example',
+			orgId: 'org_test',
+		});
+
+		await expect(client.validateWorkspaceDependencies(['git', 'nope'])).resolves.toEqual({
+			valid: ['git'],
+			invalid: [
+				{
+					package: 'nope',
+					error: 'Package "nope" does not exist',
+					searchUrl: 'https://packages.debian.org/search?keywords=nope',
+				},
+			],
 		});
 	});
 

--- a/packages/core/test/coder-client.test.ts
+++ b/packages/core/test/coder-client.test.ts
@@ -492,6 +492,43 @@ describe('CoderClient enabled agent roster contract', () => {
 		});
 	});
 
+	test('createSession sends workspaceId in the request body', async () => {
+		mockFetch(async (url, init) => {
+			expect(url).toBe('https://coder.example/api/hub/session');
+			expect(init?.method).toBe('POST');
+			expect(JSON.parse(String(init?.body))).toMatchObject({
+				task: 'Start from workspace',
+				workspaceId: 'hworkspace_test123',
+			});
+			return new Response(
+				JSON.stringify({
+					sessionId: 'codesess_workspace_create',
+					status: 'creating',
+				}),
+				{
+					status: 201,
+					headers: { 'content-type': 'application/json' },
+				}
+			);
+		});
+
+		const client = new CoderClient({
+			apiKey: 'ag_test',
+			url: 'https://coder.example',
+			orgId: 'org_test',
+		});
+
+		await expect(
+			client.createSession({
+				task: 'Start from workspace',
+				workspaceId: 'hworkspace_test123',
+			})
+		).resolves.toMatchObject({
+			sessionId: 'codesess_workspace_create',
+			status: 'creating',
+		});
+	});
+
 	test('updateSession sends enabledAgents in the request body', async () => {
 		mockFetch(async (url, init) => {
 			expect(url).toBe('https://coder.example/api/hub/session/codesess_enabled_update');


### PR DESCRIPTION
## Summary

- adds SDK support for Coder workspace dependency/setup-script snapshot inputs
- exposes workspace update, snapshot refresh, and dependency validation APIs
- extends Coder workspace CLI create/get/list plus adds update, refresh, and validate-dependencies subcommands
- documents workspace-backed sessions and workspace snapshot input management

## Test

- `bun test packages/core/test/coder-client.test.ts`
- `bun run --filter='./packages/core' typecheck`
- `bun run --filter='./packages/cli' typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: added workspace subcommands — update, refresh (snapshot rebuild), validate-dependencies; create/update accept dependencies and setup-script, and parse comma lists.

* **User Experience**
  * Unified workspace summary for get/create; list shows Deps and Snapshot columns; commands return clearer validation errors and concise summaries.

* **Documentation**
  * Quick Start updated with workspace session, snapshot, dependency validation, and setup-script examples.

* **Tests**
  * Expanded coverage for workspace payloads, setup-script handling, updates, refresh, and dependency validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->