### PR TITLE
Fix sandbox snapshot org ID handling

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1385,6 +1385,7 @@ async function registerSubcommand(
 		) {
 			options.projectId = (baseCtx.options as unknown as Record<string, unknown>).projectId;
 		}
+		const ctxOptions = { ...baseCtx.options, ...options } as GlobalOptions;
 
 		if (subcommand.banner) {
 			showBanner();
@@ -1568,6 +1569,7 @@ async function registerSubcommand(
 					);
 					const ctx: Record<string, unknown> = {
 						...baseCtx,
+						options: ctxOptions,
 						config: {
 							...(baseCtx.config ?? {}),
 							auth: {
@@ -1697,6 +1699,7 @@ async function registerSubcommand(
 			} else {
 				const ctx: Record<string, unknown> = {
 					...baseCtx,
+					options: ctxOptions,
 					config: baseCtx.config
 						? {
 								...baseCtx.config,
@@ -1864,6 +1867,7 @@ async function registerSubcommand(
 					);
 					const ctx: Record<string, unknown> = {
 						...baseCtx,
+						options: ctxOptions,
 						config: auth
 							? {
 									...(baseCtx.config ?? {}),
@@ -1996,6 +2000,7 @@ async function registerSubcommand(
 			} else {
 				const ctx: Record<string, unknown> = {
 					...baseCtx,
+					options: ctxOptions,
 					config: auth
 						? {
 								...(baseCtx.config ?? {}),
@@ -2134,6 +2139,7 @@ async function registerSubcommand(
 					);
 					const ctx: Record<string, unknown> = {
 						...baseCtx,
+						options: ctxOptions,
 					};
 					if (project || projectDir) {
 						if (project) {
@@ -2185,6 +2191,7 @@ async function registerSubcommand(
 			} else {
 				const ctx: Record<string, unknown> = {
 					...baseCtx,
+					options: ctxOptions,
 				};
 				if (project || projectDir) {
 					if (project) {

--- a/packages/core/src/services/sandbox/api-reference.ts
+++ b/packages/core/src/services/sandbox/api-reference.ts
@@ -613,7 +613,7 @@ const service: Service = {
 			],
 			requestBody: {
 				description: 'Snapshot creation payload.',
-				fields: { schema: SnapshotCreateOptionsSchema },
+				fields: { schema: SnapshotCreateOptionsSchema.omit({ orgId: true }) },
 			},
 			responseDescription: 'Returns the created snapshot.',
 			statuses: [

--- a/packages/core/src/services/sandbox/types.ts
+++ b/packages/core/src/services/sandbox/types.ts
@@ -843,6 +843,8 @@ export const SnapshotCreateOptionsSchema = z.object({
 	tag: z.string().optional().describe('Tag for the snapshot (defaults to "latest")'),
 	/** Make the snapshot publicly accessible */
 	public: z.boolean().optional().describe('Make the snapshot publicly accessible'),
+	/** Organization ID to use for CLI-authenticated requests */
+	orgId: z.string().optional().describe('Organization ID for CLI-authenticated requests'),
 });
 export type SnapshotCreateOptions = z.infer<typeof SnapshotCreateOptionsSchema>;
 

--- a/packages/runtime/src/services/sandbox/http.ts
+++ b/packages/runtime/src/services/sandbox/http.ts
@@ -147,7 +147,7 @@ function createStreamReaderFromUrl(streamUrl: string | undefined): StreamReader 
 /**
  * Creates the method implementations shared by all Sandbox instances.
  */
-function createSandboxMethods(client: APIClient, sandboxId: string) {
+function createSandboxMethods(client: APIClient, sandboxId: string, orgId?: string) {
 	return {
 		async execute(options: ExecuteOptions): Promise<Execution> {
 			return withSpan(
@@ -160,6 +160,7 @@ function createSandboxMethods(client: APIClient, sandboxId: string) {
 					const initial = await sandboxExecute(client, {
 						sandboxId,
 						options,
+						orgId,
 						signal: options.signal,
 					});
 					// Wait for execution to reach a terminal state via long-polling.
@@ -174,6 +175,7 @@ function createSandboxMethods(client: APIClient, sandboxId: string) {
 						}
 						final = await executionGet(client, {
 							executionId: initial.executionId,
+							orgId,
 							wait: '60s',
 							signal: options.signal,
 						});
@@ -197,7 +199,7 @@ function createSandboxMethods(client: APIClient, sandboxId: string) {
 					'sandbox.id': sandboxId,
 					'sandbox.files.count': files.length,
 				},
-				() => sandboxWriteFiles(client, { sandboxId, files })
+				() => sandboxWriteFiles(client, { sandboxId, files, orgId })
 			);
 		},
 
@@ -208,7 +210,7 @@ function createSandboxMethods(client: APIClient, sandboxId: string) {
 					'sandbox.id': sandboxId,
 					'sandbox.file.path': path,
 				},
-				() => sandboxReadFile(client, { sandboxId, path })
+				() => sandboxReadFile(client, { sandboxId, path, orgId })
 			);
 		},
 
@@ -220,7 +222,7 @@ function createSandboxMethods(client: APIClient, sandboxId: string) {
 					'sandbox.dir.path': path ?? '',
 				},
 				async () => {
-					const result = await sandboxListFiles(client, { sandboxId, path });
+					const result = await sandboxListFiles(client, { sandboxId, path, orgId });
 					return result.files;
 				}
 			);
@@ -233,7 +235,7 @@ function createSandboxMethods(client: APIClient, sandboxId: string) {
 					'sandbox.id': sandboxId,
 					'sandbox.dir.path': path,
 				},
-				() => sandboxMkDir(client, { sandboxId, path, recursive })
+				() => sandboxMkDir(client, { sandboxId, path, recursive, orgId })
 			);
 		},
 
@@ -244,7 +246,7 @@ function createSandboxMethods(client: APIClient, sandboxId: string) {
 					'sandbox.id': sandboxId,
 					'sandbox.file.path': path,
 				},
-				() => sandboxRmFile(client, { sandboxId, path })
+				() => sandboxRmFile(client, { sandboxId, path, orgId })
 			);
 		},
 
@@ -255,32 +257,32 @@ function createSandboxMethods(client: APIClient, sandboxId: string) {
 					'sandbox.id': sandboxId,
 					'sandbox.dir.path': path,
 				},
-				() => sandboxRmDir(client, { sandboxId, path, recursive })
+				() => sandboxRmDir(client, { sandboxId, path, recursive, orgId })
 			);
 		},
 
 		async setEnv(env: Record<string, string | null>): Promise<Record<string, string>> {
 			return withSpan('agentuity.sandbox.setEnv', { 'sandbox.id': sandboxId }, async () => {
-				const result = await sandboxSetEnv(client, { sandboxId, env });
+				const result = await sandboxSetEnv(client, { sandboxId, env, orgId });
 				return result.env;
 			});
 		},
 
 		async pause(): Promise<SandboxPauseResult> {
 			return withSpan('agentuity.sandbox.pause', { 'sandbox.id': sandboxId }, () =>
-				sandboxPause(client, { sandboxId })
+				sandboxPause(client, { sandboxId, orgId })
 			);
 		},
 
 		async resume(): Promise<void> {
 			await withSpan('agentuity.sandbox.resume', { 'sandbox.id': sandboxId }, () =>
-				sandboxResume(client, { sandboxId })
+				sandboxResume(client, { sandboxId, orgId })
 			);
 		},
 
 		async destroy(): Promise<void> {
 			await withSpan('agentuity.sandbox.destroy', { 'sandbox.id': sandboxId }, () =>
-				sandboxDestroy(client, { sandboxId })
+				sandboxDestroy(client, { sandboxId, orgId })
 			);
 		},
 
@@ -288,7 +290,7 @@ function createSandboxMethods(client: APIClient, sandboxId: string) {
 			return withSpan(
 				'agentuity.sandbox.createJob',
 				{ 'sandbox.id': sandboxId, 'sandbox.command': options.command?.join(' ') ?? '' },
-				() => jobCreate(client, { sandboxId, options })
+				() => jobCreate(client, { sandboxId, options, orgId })
 			);
 		},
 
@@ -296,13 +298,13 @@ function createSandboxMethods(client: APIClient, sandboxId: string) {
 			return withSpan(
 				'agentuity.sandbox.getJob',
 				{ 'sandbox.id': sandboxId, 'job.id': jobId },
-				() => jobGet(client, { sandboxId, jobId })
+				() => jobGet(client, { sandboxId, jobId, orgId })
 			);
 		},
 
 		async listJobs(limit?: number): Promise<JobListResponse> {
 			return withSpan('agentuity.sandbox.listJobs', { 'sandbox.id': sandboxId }, () =>
-				jobList(client, { sandboxId, limit })
+				jobList(client, { sandboxId, limit, orgId })
 			);
 		},
 
@@ -310,7 +312,7 @@ function createSandboxMethods(client: APIClient, sandboxId: string) {
 			return withSpan(
 				'agentuity.sandbox.stopJob',
 				{ 'sandbox.id': sandboxId, 'job.id': jobId },
-				() => jobStop(client, { sandboxId, jobId, force })
+				() => jobStop(client, { sandboxId, jobId, force, orgId })
 			);
 		},
 	};
@@ -323,7 +325,8 @@ function createSandboxInstance(
 	streamBaseUrl: string,
 	stdoutStreamId?: string,
 	stderrStreamId?: string,
-	auditStreamId?: string
+	auditStreamId?: string,
+	orgId?: string
 ): Sandbox {
 	const interleaved = !!(stdoutStreamId && stderrStreamId && stdoutStreamId === stderrStreamId);
 	return {
@@ -333,11 +336,15 @@ function createSandboxInstance(
 		stderr: createStreamReader(stderrStreamId, streamBaseUrl),
 		interleaved,
 		auditStreamId,
-		...createSandboxMethods(client, sandboxId),
+		...createSandboxMethods(client, sandboxId, orgId),
 	};
 }
 
-function createSandboxInstanceFromInfo(client: APIClient, info: SandboxInfo): Sandbox {
+function createSandboxInstanceFromInfo(
+	client: APIClient,
+	info: SandboxInfo,
+	orgId?: string
+): Sandbox {
 	const stdoutReader = createStreamReaderFromUrl(info.stdoutStreamUrl);
 	const stderrReader = createStreamReaderFromUrl(info.stderrStreamUrl);
 	const interleaved = !!(
@@ -355,7 +362,7 @@ function createSandboxInstanceFromInfo(client: APIClient, info: SandboxInfo): Sa
 		stderr: stderrReader,
 		interleaved,
 		auditStreamId: info.auditStreamId,
-		...createSandboxMethods(client, info.sandboxId),
+		...createSandboxMethods(client, info.sandboxId, orgId),
 	};
 }
 
@@ -364,9 +371,11 @@ function createSandboxInstanceFromInfo(client: APIClient, info: SandboxInfo): Sa
  */
 class HTTPSnapshotService implements SnapshotService {
 	private client: APIClient;
+	private orgId?: string;
 
-	constructor(client: APIClient) {
+	constructor(client: APIClient, orgId?: string) {
 		this.client = client;
+		this.orgId = orgId;
 	}
 
 	async create(sandboxId: string, options?: SnapshotCreateOptions): Promise<SnapshotInfo> {
@@ -376,7 +385,7 @@ class HTTPSnapshotService implements SnapshotService {
 				'sandbox.id': sandboxId,
 				'snapshot.name': options?.name ?? '',
 				'snapshot.tag': options?.tag ?? '',
-				'sandbox.orgId': options?.orgId ?? '',
+				'sandbox.orgId': options?.orgId ?? this.orgId ?? '',
 			},
 			() =>
 				snapshotCreate(this.client, {
@@ -385,14 +394,14 @@ class HTTPSnapshotService implements SnapshotService {
 					description: options?.description,
 					tag: options?.tag,
 					public: options?.public,
-					orgId: options?.orgId,
+					orgId: options?.orgId ?? this.orgId,
 				})
 		);
 	}
 
 	async get(snapshotId: string): Promise<SnapshotInfo> {
 		return withSpan('agentuity.sandbox.snapshot.get', { 'snapshot.id': snapshotId }, () =>
-			snapshotGet(this.client, { snapshotId })
+			snapshotGet(this.client, { snapshotId, orgId: this.orgId })
 		);
 	}
 
@@ -408,13 +417,14 @@ class HTTPSnapshotService implements SnapshotService {
 					sandboxId: params?.sandboxId,
 					limit: params?.limit,
 					offset: params?.offset,
+					orgId: this.orgId,
 				})
 		);
 	}
 
 	async delete(snapshotId: string): Promise<void> {
 		return withSpan('agentuity.sandbox.snapshot.delete', { 'snapshot.id': snapshotId }, () =>
-			snapshotDelete(this.client, { snapshotId })
+			snapshotDelete(this.client, { snapshotId, orgId: this.orgId })
 		);
 	}
 
@@ -425,7 +435,7 @@ class HTTPSnapshotService implements SnapshotService {
 				'snapshot.id': snapshotId,
 				'snapshot.tag': tag ?? '',
 			},
-			() => snapshotTag(this.client, { snapshotId, tag })
+			() => snapshotTag(this.client, { snapshotId, tag, orgId: this.orgId })
 		);
 	}
 }
@@ -436,16 +446,18 @@ class HTTPSnapshotService implements SnapshotService {
 export class HTTPSandboxService implements SandboxService {
 	private client: APIClient;
 	private streamBaseUrl: string;
+	private orgId?: string;
 
 	/**
 	 * Snapshot management operations
 	 */
 	public readonly snapshot: SnapshotService;
 
-	constructor(client: APIClient, streamBaseUrl: string) {
+	constructor(client: APIClient, streamBaseUrl: string, orgId?: string) {
 		this.client = client;
 		this.streamBaseUrl = streamBaseUrl;
-		this.snapshot = new HTTPSnapshotService(client);
+		this.orgId = orgId;
+		this.snapshot = new HTTPSnapshotService(client, orgId);
 	}
 
 	async run(options: SandboxRunOptions): Promise<SandboxRunResult> {
@@ -454,8 +466,9 @@ export class HTTPSandboxService implements SandboxService {
 			{
 				'sandbox.command': options.command?.exec?.join(' ') ?? '',
 				'sandbox.mode': 'oneshot',
+				'sandbox.orgId': this.orgId ?? '',
 			},
-			() => sandboxRun(this.client, { options })
+			() => sandboxRun(this.client, { options, orgId: this.orgId })
 		);
 	}
 
@@ -465,9 +478,10 @@ export class HTTPSandboxService implements SandboxService {
 			{
 				'sandbox.network': options?.network?.enabled ?? false,
 				'sandbox.snapshot': options?.snapshot ?? '',
+				'sandbox.orgId': this.orgId ?? '',
 			},
 			async () => {
-				const response = await sandboxCreate(this.client, { options });
+				const response = await sandboxCreate(this.client, { options, orgId: this.orgId });
 				return createSandboxInstance(
 					this.client,
 					response.sandboxId,
@@ -475,7 +489,8 @@ export class HTTPSandboxService implements SandboxService {
 					this.streamBaseUrl,
 					response.stdoutStreamId,
 					response.stderrStreamId,
-					response.auditStreamId
+					response.auditStreamId,
+					this.orgId
 				);
 			}
 		);
@@ -483,7 +498,7 @@ export class HTTPSandboxService implements SandboxService {
 
 	async get(sandboxId: string): Promise<SandboxInfo> {
 		return withSpan('agentuity.sandbox.get', { 'sandbox.id': sandboxId }, () =>
-			sandboxGet(this.client, { sandboxId })
+			sandboxGet(this.client, { sandboxId, orgId: this.orgId })
 		);
 	}
 
@@ -493,33 +508,34 @@ export class HTTPSandboxService implements SandboxService {
 			{
 				'sandbox.status': params?.status ?? '',
 				'sandbox.limit': params?.limit ?? 50,
+				'sandbox.orgId': this.orgId ?? '',
 			},
-			() => sandboxList(this.client, params)
+			() => sandboxList(this.client, { ...params, orgId: this.orgId })
 		);
 	}
 
 	async connect(sandboxId: string): Promise<Sandbox> {
 		return withSpan('agentuity.sandbox.connect', { 'sandbox.id': sandboxId }, async () => {
-			const info = await sandboxGet(this.client, { sandboxId });
-			return createSandboxInstanceFromInfo(this.client, info);
+			const info = await sandboxGet(this.client, { sandboxId, orgId: this.orgId });
+			return createSandboxInstanceFromInfo(this.client, info, this.orgId);
 		});
 	}
 
 	async destroy(sandboxId: string): Promise<void> {
 		return withSpan('agentuity.sandbox.destroy', { 'sandbox.id': sandboxId }, () =>
-			sandboxDestroy(this.client, { sandboxId })
+			sandboxDestroy(this.client, { sandboxId, orgId: this.orgId })
 		);
 	}
 
 	async pause(sandboxId: string): Promise<SandboxPauseResult> {
 		return withSpan('agentuity.sandbox.pause', { 'sandbox.id': sandboxId }, () =>
-			sandboxPause(this.client, { sandboxId })
+			sandboxPause(this.client, { sandboxId, orgId: this.orgId })
 		);
 	}
 
 	async resume(sandboxId: string): Promise<void> {
 		return withSpan('agentuity.sandbox.resume', { 'sandbox.id': sandboxId }, () =>
-			sandboxResume(this.client, { sandboxId })
+			sandboxResume(this.client, { sandboxId, orgId: this.orgId })
 		);
 	}
 }

--- a/packages/runtime/src/services/sandbox/http.ts
+++ b/packages/runtime/src/services/sandbox/http.ts
@@ -376,6 +376,7 @@ class HTTPSnapshotService implements SnapshotService {
 				'sandbox.id': sandboxId,
 				'snapshot.name': options?.name ?? '',
 				'snapshot.tag': options?.tag ?? '',
+				'sandbox.orgId': options?.orgId ?? '',
 			},
 			() =>
 				snapshotCreate(this.client, {
@@ -384,6 +385,7 @@ class HTTPSnapshotService implements SnapshotService {
 					description: options?.description,
 					tag: options?.tag,
 					public: options?.public,
+					orgId: options?.orgId,
 				})
 		);
 	}

--- a/packages/runtime/test/sandbox-snapshot.test.ts
+++ b/packages/runtime/test/sandbox-snapshot.test.ts
@@ -95,6 +95,37 @@ describe('HTTPSandboxService.snapshot', () => {
 			expect(snapshot.tag).toBe('v1.0');
 			expect(snapshot.public).toBe(true);
 		});
+
+		test('should forward orgId when creating a snapshot', async () => {
+			mockFetch(async (url, opts) => {
+				if (opts?.method === 'POST' && url.includes('/snapshot')) {
+					expect(url).toContain('/sandbox/sbx_abc123/snapshot?orgId=org_123');
+
+					return new Response(
+						JSON.stringify({
+							success: true,
+							data: {
+								snapshotId: 'snp_789',
+								name: 'org-snapshot',
+								tag: 'latest',
+								sizeBytes: 4096,
+								fileCount: 30,
+								createdAt: '2025-01-26T12:00:00Z',
+							},
+						}),
+						{ status: 200, headers: { 'content-type': 'application/json' } }
+					);
+				}
+				return new Response(null, { status: 404 });
+			});
+
+			const service = createService();
+			const snapshot = await service.snapshot.create('sbx_abc123', {
+				orgId: 'org_123',
+			});
+
+			expect(snapshot.snapshotId).toBe('snp_789');
+		});
 	});
 
 	describe('snapshot.get', () => {

--- a/packages/runtime/test/sandbox-snapshot.test.ts
+++ b/packages/runtime/test/sandbox-snapshot.test.ts
@@ -15,9 +15,9 @@ describe('HTTPSandboxService.snapshot', () => {
 		process.env = { ...originalEnv };
 	});
 
-	function createService(): HTTPSandboxService {
+	function createService(orgId?: string): HTTPSandboxService {
 		const client = new APIClient('https://api.example.com', createMockLogger(), 'test-api-key');
-		return new HTTPSandboxService(client, 'https://stream.example.com');
+		return new HTTPSandboxService(client, 'https://stream.example.com', orgId);
 	}
 
 	describe('snapshot.create', () => {
@@ -126,6 +126,35 @@ describe('HTTPSandboxService.snapshot', () => {
 
 			expect(snapshot.snapshotId).toBe('snp_789');
 		});
+
+		test('should forward service orgId when creating a snapshot', async () => {
+			mockFetch(async (url, opts) => {
+				if (opts?.method === 'POST' && url.includes('/snapshot')) {
+					expect(url).toContain('/sandbox/sbx_abc123/snapshot?orgId=org_service');
+
+					return new Response(
+						JSON.stringify({
+							success: true,
+							data: {
+								snapshotId: 'snp_890',
+								name: 'service-org-snapshot',
+								tag: 'latest',
+								sizeBytes: 4096,
+								fileCount: 30,
+								createdAt: '2025-01-26T12:00:00Z',
+							},
+						}),
+						{ status: 200, headers: { 'content-type': 'application/json' } }
+					);
+				}
+				return new Response(null, { status: 404 });
+			});
+
+			const service = createService('org_service');
+			const snapshot = await service.snapshot.create('sbx_abc123');
+
+			expect(snapshot.snapshotId).toBe('snp_890');
+		});
 	});
 
 	describe('snapshot.get', () => {
@@ -166,6 +195,35 @@ describe('HTTPSandboxService.snapshot', () => {
 			expect(snapshot.name).toBe('test-snapshot');
 			expect(snapshot.files).toHaveLength(1);
 			expect(snapshot.files?.[0].path).toBe('index.ts');
+		});
+
+		test('should forward service orgId when getting snapshot details', async () => {
+			mockFetch(async (url, opts) => {
+				if (opts?.method === 'GET' && url.includes('/snapshots/snp_123')) {
+					expect(url).toContain('/sandbox/snapshots/snp_123?orgId=org_service');
+
+					return new Response(
+						JSON.stringify({
+							success: true,
+							data: {
+								snapshotId: 'snp_123',
+								name: 'test-snapshot',
+								tag: 'latest',
+								sizeBytes: 1024,
+								fileCount: 10,
+								createdAt: '2025-01-26T12:00:00Z',
+							},
+						}),
+						{ status: 200, headers: { 'content-type': 'application/json' } }
+					);
+				}
+				return new Response(null, { status: 404 });
+			});
+
+			const service = createService('org_service');
+			const snapshot = await service.snapshot.get('snp_123');
+
+			expect(snapshot.snapshotId).toBe('snp_123');
 		});
 	});
 
@@ -377,6 +435,75 @@ describe('HTTPSandboxService.snapshot', () => {
 			expect(typeof service.snapshot.list).toBe('function');
 			expect(typeof service.snapshot.delete).toBe('function');
 			expect(typeof service.snapshot.tag).toBe('function');
+		});
+	});
+
+	describe('sandbox orgId forwarding', () => {
+		test('should forward service orgId when getting a sandbox', async () => {
+			mockFetch(async (url, opts) => {
+				if (opts?.method === 'GET' && url.includes('/sandbox/sbx_abc123')) {
+					expect(url).toContain('/sandbox/sbx_abc123?orgId=org_service');
+
+					return new Response(
+						JSON.stringify({
+							success: true,
+							data: {
+								sandboxId: 'sbx_abc123',
+								status: 'idle',
+								createdAt: '2025-01-26T12:00:00Z',
+								executions: 0,
+								org: { id: 'org_service', name: 'Test Org' },
+							},
+						}),
+						{ status: 200, headers: { 'content-type': 'application/json' } }
+					);
+				}
+				return new Response(null, { status: 404 });
+			});
+
+			const service = createService('org_service');
+			const sandbox = await service.get('sbx_abc123');
+
+			expect(sandbox.sandboxId).toBe('sbx_abc123');
+		});
+
+		test('should forward service orgId from created sandbox instance methods', async () => {
+			mockFetch(async (url, opts) => {
+				if (opts?.method === 'POST' && url.includes('/sandbox')) {
+					expect(url).toContain('/sandbox?orgId=org_service');
+
+					return new Response(
+						JSON.stringify({
+							success: true,
+							data: {
+								sandboxId: 'sbx_abc123',
+								status: 'idle',
+							},
+						}),
+						{ status: 200, headers: { 'content-type': 'application/json' } }
+					);
+				}
+
+				if (opts?.method === 'POST' && url.includes('/fs/sbx_abc123')) {
+					expect(url).toContain('/fs/sbx_abc123?orgId=org_service');
+
+					return new Response(
+						JSON.stringify({
+							success: true,
+							data: { filesWritten: 1 },
+						}),
+						{ status: 200, headers: { 'content-type': 'application/json' } }
+					);
+				}
+
+				return new Response(null, { status: 404 });
+			});
+
+			const service = createService('org_service');
+			const sandbox = await service.create();
+			await sandbox.writeFiles([{ path: 'index.ts', content: Buffer.from('console.log(1);') }]);
+
+			expect(sandbox.id).toBe('sbx_abc123');
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- ensure leaf command options are available on CLI context so `--org-id` is honored during org resolution
- expose and forward `orgId` through sandbox snapshot create options
- add runtime coverage for snapshot create requests with explicit org context

Fixes #1431

## Verification
- bun test packages/runtime/test/sandbox-snapshot.test.ts
- bun run --cwd packages/core typecheck
- bun run --cwd packages/runtime typecheck
- bun run --cwd packages/cli typecheck
- bunx biome check packages/cli/src/cli.ts packages/core/src/services/sandbox/types.ts packages/core/src/services/sandbox/api-reference.ts packages/runtime/src/services/sandbox/http.ts packages/runtime/test/sandbox-snapshot.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI command options are now applied consistently across all subcommand execution paths.

* **New Features**
  * Snapshot and sandbox APIs now accept and forward an optional organization ID so requests can be scoped to an org.

* **Tests**
  * Added and updated tests verifying organization ID is forwarded on snapshot and sandbox requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->