### PR TITLE
fix(cli): support explicit project config paths

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,5 +1,3 @@
-import { homedir } from 'node:os';
-import { resolve } from 'node:path';
 import { Command } from 'commander';
 import type {
 	CommandDefinition,
@@ -28,7 +26,13 @@ import { fetchRegionsWithCache } from './regions';
 import enquirer from 'enquirer';
 import * as tui from './tui';
 import { parseArgsSchema, parseOptionsSchema, buildValidationInputAsync } from './schema-parser';
-import { defaultProfileName, loadProjectConfig, saveProjectId, saveRegion } from './config';
+import {
+	defaultProfileName,
+	loadProjectConfig,
+	resolveProjectConfigPaths,
+	saveProjectId,
+	saveRegion,
+} from './config';
 import { APIClient, getAPIBaseURL, getAppBaseURL, type APIClient as APIClientType } from './api';
 import { ErrorCode, ExitCode, createError, exitWithError, formatErrorJSON } from './errors';
 import { getCommand } from './command-prefix';
@@ -1464,11 +1468,7 @@ async function registerSubcommand(
 			} else {
 				// Priority 2: Try to load from agentuity.json in directory
 				const dir = (options.dir as string | undefined) ?? process.cwd();
-				projectDir = dir;
-				if (projectDir.startsWith('~/')) {
-					projectDir = projectDir.replace('~/', homedir());
-				}
-				projectDir = resolve(projectDir);
+				projectDir = (await resolveProjectConfigPaths(dir, baseCtx.config)).projectDir;
 				try {
 					project = await loadProjectConfig(dir, baseCtx.config);
 				} catch (error) {
@@ -1479,6 +1479,21 @@ async function registerSubcommand(
 						error.name === 'ProjectConfigNotFoundException';
 
 					if (isConfigNotFound) {
+						if ('explicit' in error && error.explicit === true) {
+							const configPath =
+								'configPath' in error && typeof error.configPath === 'string'
+									? error.configPath
+									: dir;
+							exitWithError(
+								createError(
+									ErrorCode.PROJECT_NOT_FOUND,
+									`Project config not found: ${configPath}`
+								),
+								baseCtx.logger,
+								baseCtx.options.errorFormat
+							);
+						}
+
 						// Priority 3: Try global preference (only when no agentuity.json found)
 						const projectIdFromPreference = baseCtx.config?.preferences?.projectId as
 							| string

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -15,6 +15,7 @@ import { z } from 'zod';
 import { clearProfileCache } from './cache';
 import { getCatalystUrl } from './catalyst';
 import { readEnvFile, writeEnvFile } from './env-util';
+import { ErrorCode } from './errors';
 import {
 	deleteAuthFromKeychain,
 	getAuthFromKeychain,
@@ -603,6 +604,7 @@ export function generateYAMLTemplate(name: string): string {
 }
 
 export const ProjectConfigNotFoundException = StructuredError('ProjectConfigNotFoundException')<{
+	code?: ErrorCode;
 	configPath?: string;
 	explicit?: boolean;
 }>();
@@ -771,7 +773,12 @@ export async function updateProjectConfig(
 
 	const file = Bun.file(configPath);
 	if (!(await file.exists())) {
-		throw new Error(`Project config not found at ${configPath}`);
+		throw new ProjectConfigNotFoundException({
+			code: ErrorCode.PROJECT_NOT_FOUND,
+			message: `Project config not found at ${configPath}`,
+			configPath: resolved.configPath,
+			explicit: resolved.explicitConfigFile,
+		});
 	}
 
 	const text = await file.text();

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync } from 'node:fs';
-import { chmod, mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { basename, extname, join, normalize, resolve } from 'node:path';
+import { basename, dirname, extname, join, normalize, resolve } from 'node:path';
 import { type Logger, StructuredError } from '@agentuity/core';
 import {
 	type BuildMetadata,
@@ -151,10 +151,12 @@ function expandTilde(path: string): string {
 let cachedConfig: Config | null | undefined;
 // Track the resolved config path so saveConfig writes back to the same file
 let cachedConfigPath: string | undefined;
+const loadedProjectConfigPaths = new Map<string, string>();
 
 export function resetConfigCache(): void {
 	cachedConfig = undefined;
 	cachedConfigPath = undefined;
+	loadedProjectConfigPaths.clear();
 }
 
 export async function loadConfig(
@@ -600,23 +602,61 @@ export function generateYAMLTemplate(name: string): string {
 	return lines.join('\n');
 }
 
-export const ProjectConfigNotFoundException = StructuredError('ProjectConfigNotFoundException');
+export const ProjectConfigNotFoundException = StructuredError('ProjectConfigNotFoundException')<{
+	configPath?: string;
+	explicit?: boolean;
+}>();
 
 type ProjectConfig = z.infer<typeof ProjectSchema>;
+
+export type ResolvedProjectConfigPaths = {
+	projectDir: string;
+	configPath: string;
+	explicitConfigFile: boolean;
+};
+
+export async function resolveProjectConfigPaths(
+	path: string,
+	config?: Config | null
+): Promise<ResolvedProjectConfigPaths> {
+	const resolvedPath = resolve(expandTilde(path));
+	const pathStats = await stat(resolvedPath).catch(() => null);
+	const isExplicitJsonFile =
+		(pathStats?.isFile() || pathStats === null) && extname(resolvedPath) === '.json';
+
+	if (isExplicitJsonFile) {
+		return {
+			projectDir: dirname(resolvedPath),
+			configPath: resolvedPath,
+			explicitConfigFile: true,
+		};
+	}
+
+	const projectDir = resolvedPath;
+	let configPath = join(projectDir, 'agentuity.json');
+
+	if (config?.name) {
+		const profileConfigPath = join(projectDir, `agentuity.${config.name}.json`);
+		if (await Bun.file(profileConfigPath).exists()) {
+			configPath = profileConfigPath;
+		}
+	}
+
+	return {
+		projectDir,
+		configPath,
+		explicitConfigFile: false,
+	};
+}
 
 export async function loadProjectConfig(
 	dir: string,
 	config?: Config | null
 ): Promise<ProjectConfig> {
-	let configPath = join(dir, 'agentuity.json');
-
-	// Check for profile-specific override if config is provided
-	if (config?.name) {
-		const profileConfigPath = join(dir, `agentuity.${config.name}.json`);
-		if (await Bun.file(profileConfigPath).exists()) {
-			configPath = profileConfigPath;
-		}
-	}
+	const { projectDir, configPath, explicitConfigFile } = await resolveProjectConfigPaths(
+		dir,
+		config
+	);
 
 	const file = Bun.file(configPath);
 	if (!(await file.exists())) {
@@ -624,7 +664,13 @@ export async function loadProjectConfig(
 		// and then if so:
 		// 1. if authentication, offer to import the project
 		// 2. tell them that they need to login to use the command and import the project
-		throw new ProjectConfigNotFoundException({ message: 'project config not found' });
+		throw new ProjectConfigNotFoundException({
+			message: explicitConfigFile
+				? `Project config not found at ${configPath}`
+				: 'project config not found',
+			configPath,
+			explicit: explicitConfigFile,
+		});
 	}
 	const text = await file.text();
 	const parsedConfig = parseJSONC(text);
@@ -637,6 +683,7 @@ export async function loadProjectConfig(
 		}
 		process.exit(1);
 	}
+	loadedProjectConfigPaths.set(projectDir, configPath);
 	return result.data;
 }
 
@@ -717,14 +764,10 @@ export async function updateProjectConfig(
 	updates: Partial<z.infer<typeof ProjectSchema>>,
 	config?: Config | null
 ): Promise<void> {
-	let configPath = join(dir, 'agentuity.json');
-
-	if (config?.name) {
-		const profileConfigPath = join(dir, `agentuity.${config.name}.json`);
-		if (await Bun.file(profileConfigPath).exists()) {
-			configPath = profileConfigPath;
-		}
-	}
+	const resolved = await resolveProjectConfigPaths(dir, config);
+	const configPath = resolved.explicitConfigFile
+		? resolved.configPath
+		: (loadedProjectConfigPaths.get(resolved.projectDir) ?? resolved.configPath);
 
 	const file = Bun.file(configPath);
 	if (!(await file.exists())) {

--- a/packages/cli/test/config/project-config-paths.test.ts
+++ b/packages/cli/test/config/project-config-paths.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+	loadProjectConfig,
+	ProjectConfigNotFoundException,
+	resolveProjectConfigPaths,
+	updateProjectConfig,
+} from '../../src/config';
+import type { Config } from '../../src/types';
+
+let testDir: string;
+
+beforeEach(async () => {
+	testDir = await mkdtemp(join(tmpdir(), 'agentuity-project-config-paths-'));
+});
+
+afterEach(async () => {
+	await rm(testDir, { recursive: true, force: true });
+});
+
+function projectConfig(projectId: string, orgId = 'org_test123') {
+	return {
+		projectId,
+		orgId,
+		region: 'usc',
+	};
+}
+
+async function writeProjectConfig(path: string, projectId: string, orgId?: string) {
+	await Bun.write(path, JSON.stringify(projectConfig(projectId, orgId), null, 2) + '\n');
+}
+
+describe('project config path resolution', () => {
+	test('loads an explicit agentuity.json file and uses its parent as projectDir', async () => {
+		const configPath = join(testDir, 'agentuity.json');
+		await writeProjectConfig(configPath, 'proj_default');
+
+		const resolved = await resolveProjectConfigPaths(configPath);
+		const project = await loadProjectConfig(configPath);
+
+		expect(resolved.projectDir).toBe(testDir);
+		expect(resolved.configPath).toBe(configPath);
+		expect(resolved.explicitConfigFile).toBe(true);
+		expect(project.projectId).toBe('proj_default');
+	});
+
+	test('loads an explicit custom JSON file', async () => {
+		const configPath = join(testDir, 'agentuity.org-a.json');
+		await writeProjectConfig(configPath, 'proj_org_a', 'org_a');
+
+		const project = await loadProjectConfig(configPath, { name: 'production' });
+
+		expect(project.projectId).toBe('proj_org_a');
+		expect(project.orgId).toBe('org_a');
+	});
+
+	test('does not apply profile-specific fallback for explicit JSON files', async () => {
+		const config: Config = { name: 'staging' };
+		const explicitPath = join(testDir, 'custom.json');
+		const profilePath = join(testDir, 'agentuity.staging.json');
+		await writeProjectConfig(explicitPath, 'proj_explicit');
+		await writeProjectConfig(profilePath, 'proj_profile');
+
+		const project = await loadProjectConfig(explicitPath, config);
+
+		expect(project.projectId).toBe('proj_explicit');
+	});
+
+	test('keeps existing directories ending in .json as directories', async () => {
+		const jsonDir = join(testDir, 'fixture.json');
+		await mkdir(jsonDir);
+		await writeProjectConfig(join(jsonDir, 'agentuity.json'), 'proj_json_dir');
+
+		const resolved = await resolveProjectConfigPaths(jsonDir);
+		const project = await loadProjectConfig(jsonDir);
+
+		expect(resolved.projectDir).toBe(jsonDir);
+		expect(resolved.configPath).toBe(join(jsonDir, 'agentuity.json'));
+		expect(resolved.explicitConfigFile).toBe(false);
+		expect(project.projectId).toBe('proj_json_dir');
+	});
+
+	test('throws a clear error for a missing explicit JSON file', async () => {
+		const missingPath = join(testDir, 'missing.json');
+
+		expect(loadProjectConfig(missingPath)).rejects.toThrow(ProjectConfigNotFoundException);
+		expect(loadProjectConfig(missingPath)).rejects.toThrow(missingPath);
+	});
+
+	test('updates the exact explicit JSON file that was loaded', async () => {
+		const defaultPath = join(testDir, 'agentuity.json');
+		const explicitPath = join(testDir, 'custom.json');
+		await writeProjectConfig(defaultPath, 'proj_default');
+		await writeProjectConfig(explicitPath, 'proj_custom');
+
+		await loadProjectConfig(explicitPath);
+		await updateProjectConfig(testDir, { skipGitSetup: true });
+
+		const defaultConfig = await Bun.file(defaultPath).json();
+		const explicitConfig = await Bun.file(explicitPath).json();
+
+		expect(defaultConfig.skipGitSetup).toBeUndefined();
+		expect(explicitConfig.skipGitSetup).toBe(true);
+	});
+
+	test('updates an explicit JSON file path even when another config was loaded first', async () => {
+		const defaultPath = join(testDir, 'agentuity.json');
+		const explicitPath = join(testDir, 'custom.json');
+		await writeProjectConfig(defaultPath, 'proj_default');
+		await writeProjectConfig(explicitPath, 'proj_custom');
+
+		await loadProjectConfig(testDir);
+		await updateProjectConfig(explicitPath, { skipGitSetup: true });
+
+		const defaultConfig = await Bun.file(defaultPath).json();
+		const explicitConfig = await Bun.file(explicitPath).json();
+
+		expect(defaultConfig.skipGitSetup).toBeUndefined();
+		expect(explicitConfig.skipGitSetup).toBe(true);
+	});
+});

--- a/packages/cli/test/config/project-config-paths.test.ts
+++ b/packages/cli/test/config/project-config-paths.test.ts
@@ -8,6 +8,7 @@ import {
 	resolveProjectConfigPaths,
 	updateProjectConfig,
 } from '../../src/config';
+import { ErrorCode } from '../../src/errors';
 import type { Config } from '../../src/types';
 
 let testDir: string;
@@ -119,5 +120,23 @@ describe('project config path resolution', () => {
 
 		expect(defaultConfig.skipGitSetup).toBeUndefined();
 		expect(explicitConfig.skipGitSetup).toBe(true);
+	});
+
+	test('throws structured metadata when updating a missing explicit JSON file', async () => {
+		const missingPath = join(testDir, 'missing.json');
+		let thrown: unknown;
+
+		try {
+			await updateProjectConfig(missingPath, { skipGitSetup: true });
+		} catch (error) {
+			thrown = error;
+		}
+
+		expect(thrown).toBeInstanceOf(ProjectConfigNotFoundException);
+		expect(thrown).toMatchObject({
+			code: ErrorCode.PROJECT_NOT_FOUND,
+			configPath: missingPath,
+			explicit: true,
+		});
 	});
 });


### PR DESCRIPTION
## Summary
- allow project-aware `--dir` values to point directly at an explicit JSON project config
- keep `ctx.projectDir` rooted at the parent folder for explicit config files
- ensure project config mutations write back to the loaded explicit config file
- add focused tests for explicit config paths, profile fallback bypass, missing files, and `.json` directories

Fixes #1434

## Verification
- `bun test packages/cli/test/config/project-config-paths.test.ts`
- `bunx biome lint packages/cli/src/config.ts packages/cli/src/cli.ts packages/cli/test/config/project-config-paths.test.ts`
- `bun run --filter='./packages/cli' typecheck`
- `bun run --filter='./packages/cli' build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable project config path resolution and consistent selection of the intended config file.
  * Improved handling of explicitly-specified config files: failures now exit immediately with a clear PROJECT_NOT_FOUND error that includes the resolved config path.
  * Updates now target the exact config file that was resolved/loaded.

* **Tests**
  * Added tests covering config path resolution, explicit-file behavior, error metadata, and update targeting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->