### PR TITLE
fix(cli): hide error codes from fatal output

### DIFF
--- a/packages/cli/src/composite-logger.ts
+++ b/packages/cli/src/composite-logger.ts
@@ -56,7 +56,11 @@ export class CompositeLogger implements Logger {
 			const formatArgs = args.slice(0, -1);
 			const formattedMessage = format(message, ...formatArgs);
 			for (const logger of this.loggers) {
-				logger.error(formattedMessage);
+				try {
+					logger.error(formattedMessage);
+				} catch {
+					// Keep fatal exits reliable even if one delegate cannot write.
+				}
 			}
 			process.exit(getExitCode(maybeErrorCode));
 		}

--- a/packages/cli/src/composite-logger.ts
+++ b/packages/cli/src/composite-logger.ts
@@ -7,6 +7,12 @@
  */
 
 import type { Logger } from '@agentuity/core';
+import { format } from 'node:util';
+import { ErrorCode, getExitCode } from './errors';
+
+function isErrorCode(value: unknown): value is ErrorCode {
+	return typeof value === 'string' && Object.values(ErrorCode).includes(value as ErrorCode);
+}
 
 /**
  * A logger that delegates to multiple child loggers
@@ -45,6 +51,16 @@ export class CompositeLogger implements Logger {
 	}
 
 	fatal(message: unknown, ...args: unknown[]): never {
+		const maybeErrorCode = args[args.length - 1];
+		if (isErrorCode(maybeErrorCode)) {
+			const formatArgs = args.slice(0, -1);
+			const formattedMessage = format(message, ...formatArgs);
+			for (const logger of this.loggers) {
+				logger.error(formattedMessage);
+			}
+			process.exit(getExitCode(maybeErrorCode));
+		}
+
 		// Call fatal on all loggers, but only the first one will exit
 		for (const logger of this.loggers) {
 			try {

--- a/packages/cli/test/composite-logger.test.ts
+++ b/packages/cli/test/composite-logger.test.ts
@@ -1,29 +1,9 @@
-import type { Logger } from '@agentuity/core';
+import { createMockLogger, createMockLoggerWithCapture } from '@agentuity/test-utils';
 import { afterEach, describe, expect, test } from 'bun:test';
 import { createCompositeLogger } from '../src/composite-logger';
 import { ErrorCode, getExitCode } from '../src/errors';
 
 const ORIGINAL_EXIT = process.exit;
-
-function makeLogger(messages: string[]): Logger {
-	const logger = {
-		trace() {},
-		debug() {},
-		info() {},
-		warn() {},
-		error(message: unknown, ...args: unknown[]) {
-			messages.push([message, ...args].map(String).join(' '));
-		},
-		fatal() {
-			throw new Error('unexpected fatal call');
-		},
-		child() {
-			return logger;
-		},
-	} as Logger;
-
-	return logger;
-}
 
 describe('CompositeLogger', () => {
 	afterEach(() => {
@@ -31,9 +11,10 @@ describe('CompositeLogger', () => {
 	});
 
 	test('uses ErrorCode arguments for exit status without printing them', () => {
-		const messages: string[] = [];
+		const first = createMockLoggerWithCapture();
+		const second = createMockLoggerWithCapture();
 		let exitCode: number | undefined;
-		const logger = createCompositeLogger(makeLogger(messages), makeLogger(messages));
+		const logger = createCompositeLogger(first.logger, second.logger);
 
 		process.exit = ((code?: number) => {
 			exitCode = code;
@@ -49,7 +30,49 @@ describe('CompositeLogger', () => {
 		expect(() => logger.fatal(message, ErrorCode.INVALID_ARGUMENT)).toThrow('__EXIT__');
 
 		expect(exitCode).toBe(getExitCode(ErrorCode.INVALID_ARGUMENT));
+		const messages = [...first.logs, ...second.logs];
 		expect(messages).toEqual([message, message]);
 		expect(messages.join('\n')).not.toContain('INVALID_ARGUMENT');
+	});
+
+	test('uses formatting arguments before trailing ErrorCode', () => {
+		const first = createMockLoggerWithCapture();
+		const second = createMockLoggerWithCapture();
+		let exitCode: number | undefined;
+		const logger = createCompositeLogger(first.logger, second.logger);
+
+		process.exit = ((code?: number) => {
+			exitCode = code;
+			throw new Error('__EXIT__');
+		}) as typeof process.exit;
+
+		expect(() =>
+			logger.fatal('No public key: %s', 'missing value', ErrorCode.INVALID_ARGUMENT)
+		).toThrow('__EXIT__');
+
+		const messages = [...first.logs, ...second.logs];
+		expect(exitCode).toBe(getExitCode(ErrorCode.INVALID_ARGUMENT));
+		expect(messages).toEqual(['No public key: missing value', 'No public key: missing value']);
+		expect(messages.join('\n')).not.toContain('INVALID_ARGUMENT');
+	});
+
+	test('exits after ErrorCode fatal even when a delegate throws', () => {
+		const throwingLogger = createMockLogger();
+		const { logger: captureLogger, logs } = createMockLoggerWithCapture();
+		let exitCode: number | undefined;
+		const logger = createCompositeLogger(throwingLogger, captureLogger);
+
+		throwingLogger.error = () => {
+			throw new Error('delegate failed');
+		};
+		process.exit = ((code?: number) => {
+			exitCode = code;
+			throw new Error('__EXIT__');
+		}) as typeof process.exit;
+
+		expect(() => logger.fatal('No public key', ErrorCode.INVALID_ARGUMENT)).toThrow('__EXIT__');
+
+		expect(exitCode).toBe(getExitCode(ErrorCode.INVALID_ARGUMENT));
+		expect(logs).toEqual(['No public key']);
 	});
 });

--- a/packages/cli/test/composite-logger.test.ts
+++ b/packages/cli/test/composite-logger.test.ts
@@ -1,0 +1,55 @@
+import type { Logger } from '@agentuity/core';
+import { afterEach, describe, expect, test } from 'bun:test';
+import { createCompositeLogger } from '../src/composite-logger';
+import { ErrorCode, getExitCode } from '../src/errors';
+
+const ORIGINAL_EXIT = process.exit;
+
+function makeLogger(messages: string[]): Logger {
+	const logger = {
+		trace() {},
+		debug() {},
+		info() {},
+		warn() {},
+		error(message: unknown, ...args: unknown[]) {
+			messages.push([message, ...args].map(String).join(' '));
+		},
+		fatal() {
+			throw new Error('unexpected fatal call');
+		},
+		child() {
+			return logger;
+		},
+	} as Logger;
+
+	return logger;
+}
+
+describe('CompositeLogger', () => {
+	afterEach(() => {
+		process.exit = ORIGINAL_EXIT;
+	});
+
+	test('uses ErrorCode arguments for exit status without printing them', () => {
+		const messages: string[] = [];
+		let exitCode: number | undefined;
+		const logger = createCompositeLogger(makeLogger(messages), makeLogger(messages));
+
+		process.exit = ((code?: number) => {
+			exitCode = code;
+			throw new Error('__EXIT__');
+		}) as typeof process.exit;
+
+		const message =
+			'No public key provided. Use --file to specify a file or pipe the key via stdin.\n\n' +
+			'Generate a key with:\n' +
+			'  openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 -pkeyopt ec_param_enc:named_curve -out private.pem\n' +
+			'  openssl pkey -in private.pem -pubout -out public.pem';
+
+		expect(() => logger.fatal(message, ErrorCode.INVALID_ARGUMENT)).toThrow('__EXIT__');
+
+		expect(exitCode).toBe(getExitCode(ErrorCode.INVALID_ARGUMENT));
+		expect(messages).toEqual([message, message]);
+		expect(messages.join('\n')).not.toContain('INVALID_ARGUMENT');
+	});
+});


### PR DESCRIPTION
## Summary
- Treat trailing CLI ErrorCode values passed to CompositeLogger.fatal as control metadata instead of printable log arguments
- Preserve mapped non-zero exit codes for helpful fatal messages
- Add a regression test that ensures INVALID_ARGUMENT does not leak into machine enrollment instructions

Fixes #1427

## Verification
- bun test packages/cli/test/composite-logger.test.ts
- bunx biome format --write packages/cli/src/composite-logger.ts packages/cli/test/composite-logger.test.ts
- bunx biome lint packages/cli/src/composite-logger.ts packages/cli/test/composite-logger.test.ts
- bun run --filter='./packages/cli' typecheck
- bun run --filter='./packages/cli' build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI fatal-error handling: exits with the appropriate error code and ensures delegates receive correctly formatted error messages even if a delegate fails.
* **Tests**
  * Added tests to verify fatal-error formatting, correct exit codes, and resilience when individual loggers throw.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->