### PR TITLE
Require snapshot name for sandbox snapshot creation

### DIFF
--- a/packages/cli/src/cmd/cloud/sandbox/snapshot/build.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/snapshot/build.ts
@@ -385,7 +385,7 @@ export const buildSubcommand = createCommand({
 				.array(z.string())
 				.optional()
 				.describe('Environment variable substitution (KEY=VALUE)'),
-			name: z.string().optional().describe('Snapshot name (overrides build file)'),
+			name: z.string().optional().describe('Snapshot name (required if build file omits name)'),
 			tag: z.string().optional().describe('Snapshot tag (defaults to "latest")'),
 			description: z.string().optional().describe('Snapshot description (overrides build file)'),
 			message: z.string().optional().describe('Build message for this snapshot'),
@@ -560,6 +560,9 @@ export const buildSubcommand = createCommand({
 
 		// Name and Description: CLI options override build file
 		const finalName = opts.name ?? buildConfig.name;
+		if (!finalName) {
+			logger.fatal('Snapshot name is required. Add --name or set name in the build file.');
+		}
 		const finalDescription = opts.description ?? buildConfig.description;
 
 		try {

--- a/packages/cli/src/cmd/cloud/sandbox/snapshot/create.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/snapshot/create.ts
@@ -27,11 +27,13 @@ export const createSubcommand = createCommand({
 	requires: { auth: true, org: true },
 	examples: [
 		{
-			command: getCommand('cloud sandbox snapshot create sbx_abc123'),
+			command: getCommand('cloud sandbox snapshot create sbx_abc123 --name my-snapshot'),
 			description: 'Create a snapshot from a sandbox',
 		},
 		{
-			command: getCommand('cloud sandbox snapshot create sbx_abc123 --tag latest'),
+			command: getCommand(
+				'cloud sandbox snapshot create sbx_abc123 --name my-snapshot --tag latest'
+			),
 			description: 'Create a tagged snapshot',
 		},
 		{
@@ -41,7 +43,9 @@ export const createSubcommand = createCommand({
 			description: 'Create a named snapshot with description',
 		},
 		{
-			command: getCommand('cloud sandbox snapshot create sbx_abc123 --public'),
+			command: getCommand(
+				'cloud sandbox snapshot create sbx_abc123 --name my-snapshot --public'
+			),
 			description: 'Create a public snapshot',
 		},
 	],
@@ -52,7 +56,6 @@ export const createSubcommand = createCommand({
 		options: z.object({
 			name: z
 				.string()
-				.optional()
 				.describe('Display name for the snapshot (letters, numbers, underscores, dashes only)'),
 			description: z.string().optional().describe('Description of the snapshot'),
 			tag: z.string().optional().describe('Tag for the snapshot (defaults to "latest")'),
@@ -68,7 +71,7 @@ export const createSubcommand = createCommand({
 	async handler(ctx) {
 		const { args, opts, options, auth, logger, orgId, config } = ctx;
 
-		if (opts.name && !SNAPSHOT_NAME_REGEX.test(opts.name)) {
+		if (!SNAPSHOT_NAME_REGEX.test(opts.name)) {
 			logger.fatal(
 				'Invalid snapshot name: must only contain letters, numbers, underscores, and dashes'
 			);

--- a/packages/cli/src/cmd/cloud/sandbox/snapshot/generate.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/snapshot/generate.ts
@@ -19,9 +19,8 @@ version: 1
 # Run 'agentuity cloud sandbox runtime list' to see available runtimes
 runtime: bun:1
 
-# Optional: Snapshot name (alphanumeric, underscores, dashes only)
-# If not provided, a unique name will be auto-generated
-# name: my-snapshot
+# Required unless provided with --name: Snapshot name (alphanumeric, underscores, dashes only)
+name: my-snapshot
 
 # Optional: Human-readable description
 # Can be overridden with --description flag


### PR DESCRIPTION
## Summary
- require `--name` for `cloud sandbox snapshot create` so the CLI fails before sending an invalid request
- require snapshot build names from either `--name` or the build file `name` field
- update snapshot examples and generated YAML template to show required names

Fixes #1422

## Verification
- `bun run --filter='./packages/cli' typecheck`
- `bun run --filter='./packages/cli' build`
- `bunx biome lint packages/cli/src/cmd/cloud/sandbox/snapshot/create.ts packages/cli/src/cmd/cloud/sandbox/snapshot/build.ts packages/cli/src/cmd/cloud/sandbox/snapshot/generate.ts`
- `bun packages/cli/bin/cli.ts cloud sandbox snapshot create sbx_abc123`
- `bun packages/cli/bin/cli.ts cloud sandbox snapshot create sbx_abc123 --name bad.name`
- `bun packages/cli/bin/cli.ts cloud sandbox snapshot build <tmpdir> --file <tmpfile> --dry-run --region usc`