### PR TITLE
Fix snapshot create sandbox org resolution

### DIFF
--- a/packages/cli/src/cmd/cloud/sandbox/snapshot/create.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/snapshot/create.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { getCommand } from '../../../../command-prefix';
 import * as tui from '../../../../tui';
 import { createCommand } from '../../../../types';
-import { createSandboxClient, getSandboxRegion } from '../util';
+import { createSandboxClient, resolveSandboxTarget } from '../util';
 
 const SNAPSHOT_NAME_REGEX = /^[a-zA-Z0-9_-]+$/;
 const SNAPSHOT_TAG_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
@@ -88,15 +88,15 @@ export const createSubcommand = createCommand({
 		}
 
 		const profileName = config?.name;
-		const region = await getSandboxRegion(
+		const sandboxInfo = await resolveSandboxTarget(
 			logger,
 			auth,
-			profileName,
+			null,
 			args.sandboxId,
-			orgId,
+			profileName,
 			config
 		);
-		const client = createSandboxClient(logger, auth, region);
+		const client = createSandboxClient(logger, auth, sandboxInfo.region);
 
 		const snapshot = await snapshotCreate(client, {
 			sandboxId: args.sandboxId,
@@ -104,7 +104,7 @@ export const createSubcommand = createCommand({
 			description: opts.description,
 			tag: opts.tag,
 			public: opts.public,
-			orgId,
+			orgId: sandboxInfo.orgId ?? orgId,
 		});
 
 		if (!options.json) {


### PR DESCRIPTION
## Summary
- resolve the full sandbox target for `cloud sandbox snapshot create` instead of region only
- pass the cached/resolved sandbox org ID to Catalyst so snapshot creation works when the selected org differs from the sandbox org

## Reproduction
- created a sandbox in `org_38uEd1JNXIe89KMPaOwx1WJW43o` while the selected profile org differed
- `cloud sandbox snapshot create <sandbox-id> --json` returned 404
- setting `AGENTUITY_CLOUD_ORG_ID=org_38uEd1JNXIe89KMPaOwx1WJW43o` made the same command succeed
- after this change, the command succeeds without `--org-id` or `AGENTUITY_CLOUD_ORG_ID` by using the cached sandbox target

## Verification
- `bunx biome check packages/cli/src/cmd/cloud/sandbox/snapshot/create.ts`
- live verified `cloud sandbox snapshot create <sandbox-id> --json` succeeds without `--name` and without org env when the sandbox target is cached

## Notes
- `bun run --filter @agentuity/cli typecheck` currently fails on unrelated coder workspace API/type mismatches from current `origin/main` (`CoderUpdateWorkspaceRequest`, `updateWorkspace`, `refreshWorkspaceSnapshot`, dependency/setupScript fields).
- Test snapshot and sandbox created during reproduction were deleted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved sandbox target resolution in the `cloud sandbox snapshot create` command to better handle region and organization information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->