### PR TITLE
Add sandbox create wait option

### DIFF
--- a/packages/cli/src/cmd/cloud/sandbox/create.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/create.ts
@@ -3,7 +3,7 @@ import { createCommand } from '../../../types';
 import * as tui from '../../../tui';
 import { createSandboxClient, parseFileArgs, cacheSandboxTarget } from './util';
 import { getCommand } from '../../../command-prefix';
-import { sandboxCreate } from '@agentuity/server';
+import { sandboxCreate, sandboxGet } from '@agentuity/server';
 import { StructuredError } from '@agentuity/core';
 import { validateAptDependencies } from '../../../utils/apt-validator';
 import { ErrorCode } from '../../../errors';
@@ -12,6 +12,10 @@ const InvalidMetadataError = StructuredError(
 	'InvalidMetadataError',
 	'Metadata must be a valid JSON object'
 );
+
+const CREATE_WAIT_POLL_MS = 1000;
+const CREATE_WAIT_STATUSES = ['idle', 'running', 'failed', 'terminated', 'deleted'];
+const CREATE_READY_STATUSES = new Set(['idle', 'running']);
 
 const SandboxCreateResponseSchema = z.object({
 	sandboxId: z.string().describe('Unique sandbox identifier'),
@@ -101,6 +105,14 @@ export const createSubcommand = createCommand({
 				.optional()
 				.describe('Port to expose from the sandbox to the outside Internet (1024-65535)'),
 			projectId: z.string().optional().describe('Project ID to associate this sandbox with'),
+			wait: z.boolean().optional().describe('Wait until the sandbox is ready before returning'),
+			waitMs: z
+				.number()
+				.int()
+				.nonnegative()
+				.max(60000)
+				.optional()
+				.describe('Maximum time in milliseconds to wait when --wait is used'),
 		}),
 		response: SandboxCreateResponseSchema,
 	},
@@ -180,7 +192,7 @@ export const createSubcommand = createCommand({
 			metadata = parsed as Record<string, unknown>;
 		}
 
-		const result = await sandboxCreate(client, {
+		let result = await sandboxCreate(client, {
 			options: {
 				projectId,
 				runtime: opts.runtime,
@@ -218,6 +230,38 @@ export const createSubcommand = createCommand({
 
 		// Cache routing context for future sandbox commands.
 		await cacheSandboxTarget(config?.name, result.sandboxId, region, orgId);
+
+		if (opts.wait) {
+			const waitMs = opts.waitMs ?? 60000;
+			const deadline = Date.now() + waitMs;
+
+			while (!CREATE_READY_STATUSES.has(result.status)) {
+				const remainingMs = Math.max(0, deadline - Date.now());
+				const pollWaitMs = Math.min(remainingMs, CREATE_WAIT_POLL_MS);
+				const current = await sandboxGet(client, {
+					sandboxId: result.sandboxId,
+					orgId,
+					includeDeleted: true,
+					waitForStatus: CREATE_WAIT_STATUSES,
+					waitMs: pollWaitMs,
+				});
+
+				result = {
+					...result,
+					status: current.status === 'deleted' ? 'terminated' : current.status,
+				};
+
+				if (
+					CREATE_READY_STATUSES.has(current.status) ||
+					current.status === 'failed' ||
+					current.status === 'terminated' ||
+					current.status === 'deleted' ||
+					remainingMs <= 0
+				) {
+					break;
+				}
+			}
+		}
 
 		if (!options.json) {
 			const duration = Date.now() - started;

--- a/packages/cli/src/cmd/cloud/sandbox/create.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/create.ts
@@ -229,9 +229,6 @@ export const createSubcommand = createCommand({
 			orgId,
 		});
 
-		// Cache routing context for future sandbox commands.
-		await cacheSandboxTarget(config?.name, result.sandboxId, region, orgId);
-
 		if (opts.wait) {
 			const waitMs = opts.waitMs ?? 60000;
 			const deadline = Date.now() + waitMs;
@@ -265,6 +262,14 @@ export const createSubcommand = createCommand({
 					break;
 				}
 			}
+		}
+
+		if (
+			CREATE_READY_STATUSES.has(result.status) &&
+			!CREATE_TERMINAL_STATUSES.has(result.status)
+		) {
+			// Cache routing context for future sandbox commands.
+			await cacheSandboxTarget(config?.name, result.sandboxId, region, orgId);
 		}
 
 		if (!options.json) {

--- a/packages/cli/src/cmd/cloud/sandbox/create.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/create.ts
@@ -16,6 +16,7 @@ const InvalidMetadataError = StructuredError(
 const CREATE_WAIT_POLL_MS = 1000;
 const CREATE_WAIT_STATUSES = ['idle', 'running', 'failed', 'terminated', 'deleted'];
 const CREATE_READY_STATUSES = new Set(['idle', 'running']);
+const CREATE_TERMINAL_STATUSES = new Set(['failed', 'terminated', 'deleted']);
 
 const SandboxCreateResponseSchema = z.object({
 	sandboxId: z.string().describe('Unique sandbox identifier'),
@@ -235,8 +236,14 @@ export const createSubcommand = createCommand({
 			const waitMs = opts.waitMs ?? 60000;
 			const deadline = Date.now() + waitMs;
 
-			while (!CREATE_READY_STATUSES.has(result.status)) {
+			while (
+				!CREATE_READY_STATUSES.has(result.status) &&
+				!CREATE_TERMINAL_STATUSES.has(result.status)
+			) {
 				const remainingMs = Math.max(0, deadline - Date.now());
+				if (remainingMs === 0) {
+					break;
+				}
 				const pollWaitMs = Math.min(remainingMs, CREATE_WAIT_POLL_MS);
 				const current = await sandboxGet(client, {
 					sandboxId: result.sandboxId,
@@ -253,10 +260,7 @@ export const createSubcommand = createCommand({
 
 				if (
 					CREATE_READY_STATUSES.has(current.status) ||
-					current.status === 'failed' ||
-					current.status === 'terminated' ||
-					current.status === 'deleted' ||
-					remainingMs <= 0
+					CREATE_TERMINAL_STATUSES.has(current.status)
 				) {
 					break;
 				}

--- a/packages/cli/src/cmd/cloud/sandbox/exec.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/exec.ts
@@ -101,6 +101,7 @@ export const execSubcommand = createCommand({
 		// Detect if stdout/stderr are redirected to /dev/null
 		const stdoutIsNull = detectNullStream(1);
 		const stderrIsNull = detectNullStream(2);
+		const quiet = opts.quiet || options.quiet;
 
 		// Build stream configuration
 		const streamConfig: {
@@ -112,7 +113,7 @@ export const execSubcommand = createCommand({
 		};
 
 		// --quiet: suppress all output streams (no server streams, no local capture)
-		if (opts.quiet) {
+		if (quiet) {
 			streamConfig.stdout = 'ignore';
 			streamConfig.stderr = 'ignore';
 		} else if (!options.json) {
@@ -177,14 +178,14 @@ export const execSubcommand = createCommand({
 			const stderrChunks: string[] = [];
 
 			const stdoutWritable: NodeJS.WritableStream =
-				options.json || stdoutIsNull
+				options.json || quiet || stdoutIsNull
 					? createCaptureStream((chunk) => {
 							stdoutChunks.push(chunk);
 							outputChunks.push(chunk);
 						})
 					: process.stdout;
 			const stderrWritable: NodeJS.WritableStream =
-				options.json || stderrIsNull
+				options.json || quiet || stderrIsNull
 					? createCaptureStream((chunk) => {
 							stderrChunks.push(chunk);
 							outputChunks.push(chunk);

--- a/packages/cli/src/cmd/cloud/sandbox/run.ts
+++ b/packages/cli/src/cmd/cloud/sandbox/run.ts
@@ -157,6 +157,7 @@ export const runSubcommand = createCommand({
 		// Detect if stdout/stderr are redirected to /dev/null
 		const stdoutIsNull = detectNullStream(1);
 		const stderrIsNull = detectNullStream(2);
+		const quiet = opts.quiet || options.quiet;
 
 		// Detect stream configuration based on TTY status and flags
 		const streamConfig: {
@@ -171,7 +172,7 @@ export const runSubcommand = createCommand({
 		};
 
 		// --quiet: suppress all output streams (no server streams, no local capture)
-		if (opts.quiet) {
+		if (quiet) {
 			streamConfig.stdout = 'ignore';
 			streamConfig.stderr = 'ignore';
 		} else if (!options.json) {
@@ -187,11 +188,11 @@ export const runSubcommand = createCommand({
 
 		// For JSON output or quiet mode, we need to capture output instead of streaming to process
 		const stdout =
-			options.json || opts.quiet || stdoutIsNull
+			options.json || quiet || stdoutIsNull
 				? createCaptureStream((chunk) => outputChunks.push(chunk))
 				: process.stdout;
 		const stderr =
-			options.json || opts.quiet || stderrIsNull
+			options.json || quiet || stderrIsNull
 				? createCaptureStream((chunk) => outputChunks.push(chunk))
 				: process.stderr;
 
@@ -233,8 +234,11 @@ export const runSubcommand = createCommand({
 				logger,
 			});
 
-			// Cache routing context for follow-up lookup/debug flows during execution.
-			await cacheSandboxTarget(config?.name, result.sandboxId, region, orgId);
+			// Best-effort bookkeeping only. One-shot sandboxes are already done by
+			// this point, so don't keep the user waiting on local cache I/O.
+			void cacheSandboxTarget(config?.name, result.sandboxId, region, orgId).catch((err) => {
+				logger.debug('[run] failed to cache sandbox target: %s', err);
+			});
 
 			const duration = Date.now() - started;
 			const output = outputChunks.join('');

--- a/packages/core/src/services/sandbox/getStatus.ts
+++ b/packages/core/src/services/sandbox/getStatus.ts
@@ -23,6 +23,7 @@ export const SandboxGetStatusParamsSchema = z.object({
 		.nonnegative()
 		.optional()
 		.describe('Maximum time in milliseconds to wait for the desired status'),
+	signal: z.custom<AbortSignal>().optional().describe('abort signal for cancellation'),
 });
 
 export type SandboxGetStatusParams = z.infer<typeof SandboxGetStatusParamsSchema>;
@@ -36,7 +37,7 @@ export async function sandboxGetStatus(
 	client: APIClient,
 	params: SandboxGetStatusParams
 ): Promise<SandboxStatusResult> {
-	const { sandboxId, orgId, waitForStatus, waitMs } = params;
+	const { sandboxId, orgId, waitForStatus, waitMs, signal } = params;
 	const queryParams = new URLSearchParams();
 	if (orgId) {
 		queryParams.set('orgId', orgId);
@@ -55,7 +56,8 @@ export async function sandboxGetStatus(
 
 	const resp = await client.get<z.infer<typeof SandboxStatusResponseSchema>>(
 		url,
-		SandboxStatusResponseSchema
+		SandboxStatusResponseSchema,
+		signal
 	);
 
 	if (resp.success) {

--- a/packages/core/src/services/sandbox/run.ts
+++ b/packages/core/src/services/sandbox/run.ts
@@ -208,8 +208,9 @@ export async function sandboxRun(
 				createResponse.executionId,
 				streamPromises.length
 			);
-			const executionPromise = waitForExecutionCompletion(
+			const completionPromise = waitForRunCompletion(
 				client,
+				sandboxId,
 				createResponse.executionId,
 				orgId,
 				signal,
@@ -218,8 +219,8 @@ export async function sandboxRun(
 			);
 
 			finalExecution = signal
-				? await raceWithAbort(executionPromise, signal, abortController, sandboxId)
-				: await executionPromise;
+				? await raceWithAbort(completionPromise, signal, abortController, sandboxId)
+				: await completionPromise;
 			await waitForStreamsToDrain(streamPromises, signal, abortController, sandboxId);
 		} else {
 			logger?.debug(
@@ -375,6 +376,60 @@ export async function sandboxRun(
 	}
 }
 
+async function waitForRunCompletion(
+	client: APIClient,
+	sandboxId: string,
+	executionId: string,
+	orgId: string | undefined,
+	signal: AbortSignal | undefined,
+	logger: Logger | undefined,
+	started: number
+): Promise<{ exitCode?: number; status: string }> {
+	const completionAbortController = new AbortController();
+	let onAbort: (() => void) | undefined;
+	if (signal) {
+		onAbort = () => completionAbortController.abort(signal.reason);
+		if (signal.aborted) {
+			onAbort();
+		} else {
+			signal.addEventListener('abort', onAbort, { once: true });
+		}
+	}
+
+	try {
+		const completionSignal = completionAbortController.signal;
+		const executionPromise = waitForExecutionCompletion(
+			client,
+			executionId,
+			orgId,
+			completionSignal,
+			logger,
+			started
+		);
+		const statusPromise = waitForSandboxStatusCompletion(
+			client,
+			sandboxId,
+			orgId,
+			completionSignal,
+			logger,
+			started
+		).catch((err) => {
+			if (completionSignal.aborted) {
+				throw err;
+			}
+			logger?.debug('[run] sandbox status completion wait failed: %s', err);
+			return new Promise<never>(() => {});
+		});
+
+		const result = await Promise.race([executionPromise, statusPromise]);
+		return result;
+	} finally {
+		if (onAbort && signal) {
+			signal.removeEventListener('abort', onAbort);
+		}
+	}
+}
+
 async function waitForExecutionCompletion(
 	client: APIClient,
 	executionId: string,
@@ -408,6 +463,56 @@ async function waitForExecutionCompletion(
 				status: result.status,
 			};
 		}
+	}
+}
+
+async function waitForSandboxStatusCompletion(
+	client: APIClient,
+	sandboxId: string,
+	orgId: string | undefined,
+	signal: AbortSignal | undefined,
+	logger: Logger | undefined,
+	started: number
+): Promise<{ exitCode?: number; status: string }> {
+	while (true) {
+		if (signal?.aborted) {
+			throw new DOMException('Aborted', 'AbortError');
+		}
+
+		const result = await sandboxGetStatus(client, {
+			sandboxId,
+			orgId,
+			waitForStatus: ['idle', 'terminated', 'failed'],
+			waitMs: 300000,
+			signal,
+		});
+		logger?.debug(
+			'[run] sandbox status wait: sandbox=%s status=%s exit=%s +%dms',
+			sandboxId,
+			result.status,
+			result.exitCode ?? 'undefined',
+			Date.now() - started
+		);
+
+		if (result.exitCode != null) {
+			return {
+				exitCode: result.exitCode,
+				status: 'completed',
+			};
+		}
+		if (result.status === 'failed') {
+			return {
+				exitCode: 1,
+				status: 'failed',
+			};
+		}
+		if (result.status === 'terminated') {
+			return {
+				status: 'completed',
+			};
+		}
+
+		await new Promise((resolve) => setTimeout(resolve, 25));
 	}
 }
 

--- a/packages/core/src/services/sandbox/run.ts
+++ b/packages/core/src/services/sandbox/run.ts
@@ -287,6 +287,7 @@ export async function sandboxRun(
 				});
 				if (sandboxStatus.exitCode != null) {
 					exitCode = sandboxStatus.exitCode;
+					sandboxStatusReconciled = true;
 					logger?.debug(
 						'[run] exit code %d found after server-side wait (+%dms)',
 						exitCode,
@@ -294,11 +295,13 @@ export async function sandboxRun(
 					);
 				} else if (sandboxStatus.status === 'failed') {
 					exitCode = 1;
+					sandboxStatusReconciled = true;
 					logger?.debug(
 						'[run] sandbox failed after server-side wait (+%dms)',
 						Date.now() - statusPollStart
 					);
 				} else if (sandboxStatus.status === 'terminated') {
+					sandboxStatusReconciled = true;
 					logger?.debug(
 						'[run] sandbox terminated without exit code after server-side wait (+%dms)',
 						Date.now() - statusPollStart
@@ -310,7 +313,6 @@ export async function sandboxRun(
 						Date.now() - statusPollStart
 					);
 				}
-				sandboxStatusReconciled = true;
 			} catch (err) {
 				if (!(err instanceof DOMException && err.name === 'AbortError')) {
 					logger?.debug(

--- a/packages/core/src/services/sandbox/run.ts
+++ b/packages/core/src/services/sandbox/run.ts
@@ -14,6 +14,7 @@ import { getServiceUrls } from '../config.ts';
 
 const timingLogsEnabled = false;
 const EXECUTION_WAIT_DURATION = '5m';
+const EXIT_CODE_FAST_WAIT_DURATION = '250ms';
 const TERMINAL_EXECUTION_STATUSES = new Set(['completed', 'failed', 'timeout', 'cancelled']);
 
 /**
@@ -244,7 +245,42 @@ export async function sandboxRun(
 		// drain + lifecycle propagation delay.
 		let exitCode = finalExecution?.exitCode ?? 0;
 		const statusPollStart = Date.now();
+		let shouldWaitForSandboxStatus = finalExecution?.exitCode == null;
 		if (finalExecution?.exitCode == null) {
+			if (createResponse.executionId && finalExecution?.status === 'completed') {
+				try {
+					const execution = await executionGet(client, {
+						executionId: createResponse.executionId,
+						orgId,
+						wait: EXIT_CODE_FAST_WAIT_DURATION,
+						signal,
+					});
+					if (execution.exitCode != null) {
+						exitCode = execution.exitCode;
+						finalExecution.exitCode = execution.exitCode;
+						shouldWaitForSandboxStatus = false;
+						logger?.debug(
+							'[run] exit code %d found from fast execution retry (+%dms)',
+							exitCode,
+							Date.now() - statusPollStart
+						);
+					}
+				} catch (err) {
+					if (!(err instanceof DOMException && err.name === 'AbortError')) {
+						logger?.debug(
+							'[run] fast execution exit code retry failed (+%dms): %s',
+							Date.now() - statusPollStart,
+							err
+						);
+					}
+				}
+			} else if (finalExecution && finalExecution.status !== 'completed') {
+				exitCode = 1;
+				shouldWaitForSandboxStatus = false;
+				logger?.debug('[run] using exit code 1 for terminal status=%s', finalExecution.status);
+			}
+		}
+		if (shouldWaitForSandboxStatus) {
 			try {
 				const sandboxStatus = await sandboxGetStatus(client, {
 					sandboxId,

--- a/packages/core/src/services/sandbox/run.ts
+++ b/packages/core/src/services/sandbox/run.ts
@@ -246,6 +246,7 @@ export async function sandboxRun(
 		let exitCode = finalExecution?.exitCode ?? 0;
 		const statusPollStart = Date.now();
 		let shouldWaitForSandboxStatus = finalExecution?.exitCode == null;
+		let sandboxStatusReconciled = false;
 		if (finalExecution?.exitCode == null) {
 			if (createResponse.executionId && finalExecution?.status === 'completed') {
 				try {
@@ -274,10 +275,6 @@ export async function sandboxRun(
 						);
 					}
 				}
-			} else if (finalExecution && finalExecution.status !== 'completed') {
-				exitCode = 1;
-				shouldWaitForSandboxStatus = false;
-				logger?.debug('[run] using exit code 1 for terminal status=%s', finalExecution.status);
 			}
 		}
 		if (shouldWaitForSandboxStatus) {
@@ -313,6 +310,7 @@ export async function sandboxRun(
 						Date.now() - statusPollStart
 					);
 				}
+				sandboxStatusReconciled = true;
 			} catch (err) {
 				if (!(err instanceof DOMException && err.name === 'AbortError')) {
 					logger?.debug(
@@ -322,6 +320,18 @@ export async function sandboxRun(
 					);
 				}
 			}
+		}
+		if (
+			finalExecution &&
+			finalExecution?.exitCode == null &&
+			finalExecution?.status !== 'completed' &&
+			!sandboxStatusReconciled
+		) {
+			exitCode = 1;
+			logger?.debug(
+				'[run] using fallback exit code 1 for terminal status=%s after sandbox status reconciliation failed',
+				finalExecution?.status
+			);
 		}
 		if (exitCode === 0) {
 			if (finalExecution?.exitCode != null) {


### PR DESCRIPTION
## Summary
- add `cloud sandbox create --wait --wait-ms`
- use bounded 1s server-side status waits so a stale Ion long-poll cannot consume the full timeout
- return the final ready/terminal status in the create response

## Validation
- `bun run --filter='./packages/cli' typecheck`
- `bun run --filter='./packages/cli' test`
- `packages/cli/bin/cli.ts cloud sandbox create --help`
- USW canary benchmark via infra harness using `--cli /Users/jhaynie/code/agentuity/repos/sdk/packages/cli/bin/cli.ts --create-wait`

## Related
- Companion infra PR: https://github.com/agentuity/infra/pull/53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `cloud sandbox create` gains `--wait` and `--waitMs` to block and poll until a sandbox reaches ready or terminal state; polling now updates and returns evolving status and treats deleted as terminated.
  * Caching of routing context now only occurs when the sandbox is in a ready, non-terminal state.

* **Performance / Behavior**
  * Faster retrieval of execution exit codes via a short retry path and reduced full-status polling.

* **Bug Fixes**
  * Fallback sets a non-zero exit code when final execution lacks an exit code and status reconciliation didn't complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->