### PR TITLE
Sweep old gravity versions after successful startup

### DIFF
--- a/packages/cli/src/cmd/dev/download.ts
+++ b/packages/cli/src/cmd/dev/download.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir, platform } from 'node:os';
 import { join, dirname } from 'node:path';
 import * as tar from 'tar';
@@ -9,6 +9,37 @@ import { spinner } from '../../tui';
 interface GravityClient {
 	filename: string;
 	version: string;
+}
+
+/**
+ * Remove previously downloaded gravity version directories after a newer
+ * version has started successfully.
+ *
+ * Safety guard: only removes sibling directories that contain a gravity
+ * binary, leaving any unrelated files/folders untouched.
+ */
+export function sweepOldGravityVersions(gravityDir: string, currentVersion: string): string[] {
+	if (!existsSync(gravityDir)) {
+		return [];
+	}
+
+	const removed: string[] = [];
+	for (const entry of readdirSync(gravityDir, { withFileTypes: true })) {
+		if (!entry.isDirectory() || entry.name === currentVersion) {
+			continue;
+		}
+
+		const candidateDir = join(gravityDir, entry.name);
+		const candidateBinary = join(candidateDir, 'gravity');
+		if (!existsSync(candidateBinary)) {
+			continue;
+		}
+
+		rmSync(candidateDir, { recursive: true, force: true });
+		removed.push(candidateDir);
+	}
+
+	return removed;
 }
 
 const GravityVersionError = StructuredError('GravityVersionError')<{

--- a/packages/cli/src/cmd/dev/index.ts
+++ b/packages/cli/src/cmd/dev/index.ts
@@ -9,7 +9,7 @@ import * as tui from '../../tui';
 import { getCommand } from '../../command-prefix';
 import { generateEndpoint, type DevmodeResponse } from './api';
 import { APIClient, getAPIBaseURL, getAppBaseURL, getGravityDevModeURL } from '../../api';
-import { download } from './download';
+import { download, sweepOldGravityVersions } from './download';
 import { createDevmodeSyncService } from './sync';
 import { getDevmodeDeploymentId } from '../build/ids';
 import { getDefaultConfigDir, saveConfig, loadProjectSDKKey, getAuth } from '../../config';
@@ -411,6 +411,7 @@ export const command = createCommand({
 			let devmode: DevmodeResponse | undefined;
 			let gravityBin: string | undefined;
 			let gravityURL: string | undefined;
+			let gravitySweepTarget: { gravityDir: string; version: string } | null = null;
 			let appURL: string | undefined;
 			let savedPrivateKey: string | undefined = config?.devmode?.privateKey
 				? Buffer.from(config.devmode.privateKey, 'base64').toString('utf-8')
@@ -465,8 +466,12 @@ export const command = createCommand({
 				}
 
 				if (mustCheck) {
+					const previousGravityVersion = config?.gravity?.version;
 					const res = await download(gravityDir);
 					gravityBin = res.filename;
+					if (previousGravityVersion !== res.version) {
+						gravitySweepTarget = { gravityDir, version: res.version };
+					}
 					const _config = { ...config } as Config;
 					_config.gravity = {
 						checked: Date.now(),
@@ -1132,6 +1137,24 @@ export const command = createCommand({
 											};
 											sendHeartbeat();
 											gravityHeartbeatInterval = setInterval(sendHeartbeat, 5000);
+										}
+
+										if (gravitySweepTarget) {
+											try {
+												const removed = sweepOldGravityVersions(
+													gravitySweepTarget.gravityDir,
+													gravitySweepTarget.version
+												);
+												logger.debug(
+													'Swept %d old gravity version director%s after successful startup',
+													removed.length,
+													removed.length === 1 ? 'y' : 'ies'
+												);
+											} catch (error) {
+												logger.warn('Failed to sweep old gravity versions: %s', error);
+											} finally {
+												gravitySweepTarget = null;
+											}
 										}
 									} else if (trimmed) {
 										logger.debug('[gravity] %s', trimmed);

--- a/packages/cli/test/cmd/dev/download.test.ts
+++ b/packages/cli/test/cmd/dev/download.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { sweepOldGravityVersions } from '../../../src/cmd/dev/download';
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), 'agentuity-gravity-sweep-'));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe('sweepOldGravityVersions', () => {
+	test('removes old version directories that contain a gravity binary', () => {
+		const gravityDir = makeTempDir();
+
+		for (const version of ['1.0.0', '1.1.0', '1.2.0']) {
+			const versionDir = join(gravityDir, version);
+			mkdirSync(versionDir, { recursive: true });
+			writeFileSync(join(versionDir, 'gravity'), 'binary');
+		}
+
+		const removed = sweepOldGravityVersions(gravityDir, '1.2.0');
+
+		expect(removed.sort()).toEqual([join(gravityDir, '1.0.0'), join(gravityDir, '1.1.0')]);
+		expect(existsSync(join(gravityDir, '1.0.0', 'gravity'))).toBe(false);
+		expect(existsSync(join(gravityDir, '1.1.0', 'gravity'))).toBe(false);
+		expect(existsSync(join(gravityDir, '1.2.0', 'gravity'))).toBe(true);
+	});
+
+	test('leaves unrelated directories and files untouched', () => {
+		const gravityDir = makeTempDir();
+
+		mkdirSync(join(gravityDir, '1.0.0'), { recursive: true });
+		writeFileSync(join(gravityDir, '1.0.0', 'gravity'), 'binary');
+		mkdirSync(join(gravityDir, '1.1.0'), { recursive: true });
+		writeFileSync(join(gravityDir, '1.1.0', 'gravity'), 'binary');
+		mkdirSync(join(gravityDir, 'notes'), { recursive: true });
+		writeFileSync(join(gravityDir, 'notes', 'readme.txt'), 'keep me');
+		writeFileSync(join(gravityDir, 'manifest.json'), '{}');
+
+		const removed = sweepOldGravityVersions(gravityDir, '1.1.0');
+
+		expect(removed).toEqual([join(gravityDir, '1.0.0')]);
+		expect(existsSync(join(gravityDir, 'notes', 'readme.txt'))).toBe(true);
+		expect(existsSync(join(gravityDir, 'manifest.json'))).toBe(true);
+		expect(existsSync(join(gravityDir, '1.1.0', 'gravity'))).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary
- add a gravity version sweeper for cached dev binaries
- only sweep after a newer gravity version has started successfully
- add tests to ensure older version dirs are removed while unrelated files are preserved

## Details
Gravity binaries are cached under `~/.config/agentuity/gravity/<version>/gravity`.
This change defers cleanup until gravity has actually started and reported its heartbeat port, so failed downloads/extracts/startups do not remove the previous working version.

## Verification
- `bun run format`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun test packages/cli/test/cmd/dev/download.test.ts`
- `bun run test` *(fails due to an existing unrelated concurrent-session logging issue in `scripts/test-concurrent-sessions.ts`)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gravity client versions are now automatically cleaned up after a newer version successfully starts, reducing disk space usage over time. Old version directories containing Gravity binaries are safely removed while preserving other data.

* **Tests**
  * Added comprehensive test coverage for the version cleanup functionality, validating that old versions are properly removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->