### PR TITLE
chore(cli): remove Workbench from DevMode banner

### DIFF
--- a/apps/docs/src/web/content/reference/cli/development.mdx
+++ b/apps/docs/src/web/content/reference/cli/development.mdx
@@ -128,8 +128,9 @@ Agentuity's Gravity network handles this automatically. When you run `agentuity 
 **Example output:**
 ```
 ⨺ Agentuity DevMode
-  Local:   http://127.0.0.1:3500
-  Public:  https://abc123.devmode.agentuity.com
+  Local:      http://127.0.0.1:3500
+  Public:     https://abc123.devmode.agentuity.com
+  Dashboard:  https://app.agentuity.com/r/proj_xxx
 
   Press h for keyboard shortcuts
 ```

--- a/packages/cli/src/cmd/dev/index.ts
+++ b/packages/cli/src/cmd/dev/index.ts
@@ -499,10 +499,6 @@ export const command = createCommand({
 
 			// Calculate URLs for banner
 			const padding = 12;
-			const workbenchUrl =
-				auth && project?.projectId
-					? `${getAppBaseURL(config)}/w/${project.projectId}`
-					: `http://127.0.0.1:${opts.port}${workbench.config?.route ?? '/workbench'}`;
 
 			const devmodebody =
 				tui.muted(tui.padRight('Local:', padding)) +
@@ -510,9 +506,6 @@ export const command = createCommand({
 				'\n' +
 				tui.muted(tui.padRight('Public:', padding)) +
 				(devmode?.hostname ? tui.link(`https://${devmode.hostname}`) : tui.warn('Disabled')) +
-				'\n' +
-				tui.muted(tui.padRight('Workbench:', padding)) +
-				(workbench.hasWorkbench ? tui.link(workbenchUrl) : tui.warn('Disabled')) +
 				'\n' +
 				tui.muted(tui.padRight('Dashboard:', padding)) +
 				(appURL ? tui.link(appURL) : tui.warn('Disabled')) +


### PR DESCRIPTION
Closes #1442

Drops the Workbench row (and its now-unused `workbenchUrl` computation) from the `agentuity dev` banner.

Workbench config loading and file generation are unchanged — only the banner display is affected.

Before:
```
Local:      http://127.0.0.1:3500
Public:     https://...
Workbench:  http://...
Dashboard:  https://...
```

After:
```
Local:      http://127.0.0.1:3500
Public:     https://...
Dashboard:  https://...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the Workbench row from the development mode banner.
  * Dev command now resolves deployment IDs earlier to improve dev-mode behavior and reliability.

* **Documentation**
  * Updated CLI development docs: example output now includes a Dashboard URL and improved URL alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
