### PR TITLE
Restore public `agentuity.json` schema validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # local config files
 agentuity.*.json
+!apps/docs/src/web/public/schemas/agentuity.json.schema.json
 
 # caches
 .eslintcache

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -6,14 +6,15 @@
 	"module": ".agentuity/app.js",
 	"type": "module",
 	"scripts": {
-		"predev": "bun run scripts/generate-api-reference.ts && bun run scripts/generate-nav-data.ts && bun run scripts/validate-routes.ts && bun run scripts/generate-markdown-files.ts",
-		"prebuild": "bun run scripts/generate-api-reference.ts && bun run scripts/generate-nav-data.ts && bun run scripts/validate-routes.ts && bun run scripts/generate-markdown-files.ts",
+		"predev": "bun run generate:schema && bun run scripts/generate-api-reference.ts && bun run scripts/generate-nav-data.ts && bun run scripts/validate-routes.ts && bun run scripts/generate-markdown-files.ts",
+		"prebuild": "bun run generate:schema && bun run scripts/generate-api-reference.ts && bun run scripts/generate-nav-data.ts && bun run scripts/validate-routes.ts && bun run scripts/generate-markdown-files.ts",
 		"predeploy": "cd ../../ && bun install && bun run build:packages && cd apps/docs && bun run prebuild",
 		"build": "bun ../../packages/cli/bin/cli.ts build --dir . --dev",
 		"dev": "bun ../../packages/cli/bin/cli.ts dev --dir .",
 		"start": "bun .agentuity/app.js",
 		"deploy": "bun ../../packages/cli/bin/cli.ts deploy --dir .",
 		"typecheck": "bunx tsc --noEmit",
+		"generate:schema": "bun run scripts/generate-agentuity-schema.ts",
 		"build:run": "bun run scripts/bundle-run-scripts.ts",
 		"generate:scripts": "bun run scripts/generate-sandbox-scripts.ts",
 		"reindex": "bun run scripts/reindex-vectors.ts"

--- a/apps/docs/scripts/generate-agentuity-schema.ts
+++ b/apps/docs/scripts/generate-agentuity-schema.ts
@@ -62,7 +62,7 @@ async function runCommand(
 
 async function generateSchema(): Promise<string> {
 	const stdout = await runCommand(
-		['bun', CLI_PATH, 'ai', 'schema', 'generate'],
+		['bun', CLI_PATH, '--quiet', 'ai', 'schema', 'generate'],
 		ROOT_DIR,
 		undefined
 	);

--- a/apps/docs/scripts/generate-agentuity-schema.ts
+++ b/apps/docs/scripts/generate-agentuity-schema.ts
@@ -3,37 +3,78 @@ import { dirname, join } from 'node:path';
 
 const ROOT_DIR = join(import.meta.dir, '..');
 const PUBLIC_DIR = join(ROOT_DIR, 'src/web/public');
+const REPO_DIR = join(ROOT_DIR, '../..');
 const CLI_PATH = join(ROOT_DIR, '../../packages/cli/bin/cli.ts');
 const SCHEMA_DRAFT_URL = 'https://json-schema.org/draft/2020-12/schema';
 const AGENTUITY_SCHEMA_URL = 'https://agentuity.dev/schema/cli/v1/agentuity.json';
+const CANONICAL_SCHEMA_PATH = join(PUBLIC_DIR, 'schema/cli/v1/agentuity.json');
+const LEGACY_SCHEMA_PATH = join(PUBLIC_DIR, 'schemas/agentuity.json.schema.json');
+const PROCESS_TIMEOUT_MS = 30_000;
 
-const OUTPUT_PATHS: readonly string[] = [
-	join(PUBLIC_DIR, 'schema/cli/v1/agentuity.json'),
-	join(PUBLIC_DIR, 'schemas/agentuity.json.schema.json'),
-];
+const OUTPUT_PATHS: readonly string[] = [CANONICAL_SCHEMA_PATH, LEGACY_SCHEMA_PATH];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-async function generateSchema(): Promise<string> {
-	const cliProcess = Bun.spawn(['bun', CLI_PATH, 'ai', 'schema', 'generate'], {
-		cwd: ROOT_DIR,
+async function runCommand(
+	command: readonly string[],
+	cwd: string,
+	input: string | undefined
+): Promise<string> {
+	const childProcess = Bun.spawn([...command], {
+		cwd,
+		stdin: input === undefined ? 'ignore' : 'pipe',
 		stdout: 'pipe',
 		stderr: 'pipe',
 	});
 
+	if (input !== undefined) {
+		childProcess.stdin.write(input);
+		childProcess.stdin.end();
+	}
+
+	let timedOut = false;
+	const timeoutId = setTimeout(() => {
+		timedOut = true;
+		childProcess.kill();
+	}, PROCESS_TIMEOUT_MS);
+
 	const [stdout, stderr, exitCode] = await Promise.all([
-		new Response(cliProcess.stdout).text(),
-		new Response(cliProcess.stderr).text(),
-		cliProcess.exited,
-	]);
+		new Response(childProcess.stdout).text(),
+		new Response(childProcess.stderr).text(),
+		childProcess.exited,
+	]).finally(() => clearTimeout(timeoutId));
+
+	if (timedOut) {
+		throw new Error(
+			`Timed out running ${command.join(' ')} after ${PROCESS_TIMEOUT_MS / 1000}s.`
+		);
+	}
 
 	if (exitCode !== 0) {
 		const details = stderr.trim() || stdout.trim();
-		throw new Error(`Failed to generate agentuity.json schema: ${details}`);
+		throw new Error(`Failed running ${command.join(' ')}: ${details}`);
 	}
 
+	return stdout;
+}
+
+async function generateSchema(): Promise<string> {
+	const stdout = await runCommand(
+		['bun', CLI_PATH, 'ai', 'schema', 'generate'],
+		ROOT_DIR,
+		undefined
+	);
+	return `${stdout.trimEnd()}\n`;
+}
+
+async function formatSchema(schemaText: string): Promise<string> {
+	const stdout = await runCommand(
+		['bunx', 'biome', 'format', '--stdin-file-path', CANONICAL_SCHEMA_PATH],
+		REPO_DIR,
+		schemaText
+	);
 	return `${stdout.trimEnd()}\n`;
 }
 
@@ -65,7 +106,10 @@ async function writeGeneratedFile(path: string, content: string): Promise<void> 
 }
 
 async function main(): Promise<void> {
-	const schemaText = await generateSchema();
+	const generatedSchemaText = await generateSchema();
+	validateSchema(generatedSchemaText);
+
+	const schemaText = await formatSchema(generatedSchemaText);
 	validateSchema(schemaText);
 
 	await Promise.all(OUTPUT_PATHS.map((path) => writeGeneratedFile(path, schemaText)));

--- a/apps/docs/scripts/generate-agentuity-schema.ts
+++ b/apps/docs/scripts/generate-agentuity-schema.ts
@@ -1,0 +1,80 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+const ROOT_DIR = join(import.meta.dir, '..');
+const PUBLIC_DIR = join(ROOT_DIR, 'src/web/public');
+const CLI_PATH = join(ROOT_DIR, '../../packages/cli/bin/cli.ts');
+const SCHEMA_DRAFT_URL = 'https://json-schema.org/draft/2020-12/schema';
+const AGENTUITY_SCHEMA_URL = 'https://agentuity.dev/schema/cli/v1/agentuity.json';
+
+const OUTPUT_PATHS: readonly string[] = [
+	join(PUBLIC_DIR, 'schema/cli/v1/agentuity.json'),
+	join(PUBLIC_DIR, 'schemas/agentuity.json.schema.json'),
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+async function generateSchema(): Promise<string> {
+	const cliProcess = Bun.spawn(['bun', CLI_PATH, 'ai', 'schema', 'generate'], {
+		cwd: ROOT_DIR,
+		stdout: 'pipe',
+		stderr: 'pipe',
+	});
+
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(cliProcess.stdout).text(),
+		new Response(cliProcess.stderr).text(),
+		cliProcess.exited,
+	]);
+
+	if (exitCode !== 0) {
+		const details = stderr.trim() || stdout.trim();
+		throw new Error(`Failed to generate agentuity.json schema: ${details}`);
+	}
+
+	return `${stdout.trimEnd()}\n`;
+}
+
+function validateSchema(schemaText: string): void {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(schemaText);
+	} catch (error: unknown) {
+		const message = error instanceof Error ? error.message : 'Unknown JSON parse error';
+		throw new Error(`Generated agentuity.json schema is not valid JSON: ${message}`);
+	}
+
+	if (!isRecord(parsed)) {
+		throw new Error('Generated agentuity.json schema must be a JSON object.');
+	}
+
+	if (parsed.$schema !== SCHEMA_DRAFT_URL) {
+		throw new Error(`Generated agentuity.json schema has unexpected $schema: ${parsed.$schema}`);
+	}
+
+	if (parsed.$id !== AGENTUITY_SCHEMA_URL) {
+		throw new Error(`Generated agentuity.json schema has unexpected $id: ${parsed.$id}`);
+	}
+}
+
+async function writeGeneratedFile(path: string, content: string): Promise<void> {
+	await mkdir(dirname(path), { recursive: true });
+	await writeFile(path, content, 'utf-8');
+}
+
+async function main(): Promise<void> {
+	const schemaText = await generateSchema();
+	validateSchema(schemaText);
+
+	await Promise.all(OUTPUT_PATHS.map((path) => writeGeneratedFile(path, schemaText)));
+
+	console.log(`Generated agentuity.json schema at ${OUTPUT_PATHS.length} public paths.`);
+}
+
+main().catch((error: unknown) => {
+	const message = error instanceof Error ? error.message : String(error);
+	console.error(message);
+	process.exit(1);
+});

--- a/apps/docs/src/web/content/reference/api/projects.mdx
+++ b/apps/docs/src/web/content/reference/api/projects.mdx
@@ -1001,7 +1001,7 @@ Deployment configuration payload.
   {
     "name": "mode.idle",
     "type": "string",
-    "description": "duration in seconds if on-demand",
+    "description": "Idle timeout duration when on-demand (e.g., \"10m\", \"1h\")",
     "required": false
   },
   {

--- a/apps/docs/src/web/public/schema/cli/v1/agentuity.json
+++ b/apps/docs/src/web/public/schema/cli/v1/agentuity.json
@@ -54,7 +54,7 @@
 							"enum": ["on-demand", "provisioned"]
 						},
 						"idle": {
-							"description": "duration in seconds if on-demand",
+							"description": "Idle timeout duration when on-demand (e.g., \"10m\", \"1h\")",
 							"type": "string"
 						}
 					},

--- a/apps/docs/src/web/public/schema/cli/v1/agentuity.json
+++ b/apps/docs/src/web/public/schema/cli/v1/agentuity.json
@@ -1,0 +1,203 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://agentuity.dev/schema/cli/v1/agentuity.json",
+	"$comment": "The agentuity.json configuration schema",
+	"type": "object",
+	"properties": {
+		"projectId": {
+			"type": "string",
+			"description": "the project id"
+		},
+		"orgId": {
+			"type": "string",
+			"description": "the organization id"
+		},
+		"region": {
+			"type": "string",
+			"description": "the region identifier that the project is deployed into"
+		},
+		"deployment": {
+			"description": "the deployment configuration",
+			"type": "object",
+			"properties": {
+				"resources": {
+					"description": "the resource requirements for your deployed project",
+					"type": "object",
+					"properties": {
+						"memory": {
+							"default": "500Mi",
+							"description": "The memory requirements",
+							"type": "string"
+						},
+						"cpu": {
+							"default": "500m",
+							"description": "The CPU requirements",
+							"type": "string"
+						},
+						"disk": {
+							"default": "500Mi",
+							"description": "The disk requirements",
+							"type": "string"
+						}
+					},
+					"required": ["memory", "cpu", "disk"],
+					"additionalProperties": false
+				},
+				"mode": {
+					"description": "the provisioning mode for the project",
+					"type": "object",
+					"properties": {
+						"type": {
+							"default": "on-demand",
+							"description": "on-demand or provisioned",
+							"type": "string",
+							"enum": ["on-demand", "provisioned"]
+						},
+						"idle": {
+							"description": "duration in seconds if on-demand",
+							"type": "string"
+						}
+					},
+					"required": ["type"],
+					"additionalProperties": false
+				},
+				"dependencies": {
+					"type": "array",
+					"items": {
+						"type": "string",
+						"description": "APT dependencies to install prior to launching your project"
+					}
+				},
+				"domains": {
+					"type": "array",
+					"items": {
+						"type": "string",
+						"description": "the custom domain"
+					}
+				}
+			},
+			"additionalProperties": false
+		},
+		"build": {
+			"description": "the CI/CD build configuration",
+			"type": "object",
+			"properties": {
+				"timeout": {
+					"description": "Build execution timeout (e.g. \"30m\")",
+					"type": "string"
+				},
+				"resources": {
+					"description": "Build sandbox resource limits",
+					"type": "object",
+					"properties": {
+						"memory": {
+							"description": "Build sandbox memory (e.g. \"4Gi\")",
+							"type": "string"
+						},
+						"cpu": {
+							"description": "Build sandbox CPU (e.g. \"2\")",
+							"type": "string"
+						},
+						"disk": {
+							"description": "Build sandbox disk (e.g. \"4Gi\")",
+							"type": "string"
+						}
+					},
+					"additionalProperties": false
+				}
+			},
+			"additionalProperties": false
+		},
+		"skipGitSetup": {
+			"description": "whether to skip the git integration setup prompt during deploy",
+			"type": "boolean"
+		},
+		"template": {
+			"description": "template metadata and requirements",
+			"type": "object",
+			"properties": {
+				"source": {
+					"description": "where the template came from (e.g. github.com/owner/repo)",
+					"type": "string"
+				},
+				"requirements": {
+					"description": "what the template requires to run",
+					"type": "object",
+					"properties": {
+						"resources": {
+							"description": "platform resources the project needs",
+							"type": "array",
+							"items": {
+								"type": "object",
+								"properties": {
+									"type": {
+										"type": "string",
+										"enum": ["database", "queue"],
+										"description": "the type of resource required"
+									},
+									"envVar": {
+										"type": "string",
+										"description": "the environment variable that holds the resource connection info"
+									},
+									"description": {
+										"description": "human-readable description of the resource",
+										"type": "string"
+									},
+									"defaultName": {
+										"description": "suggested default name when provisioning this resource",
+										"type": "string"
+									},
+									"queueType": {
+										"description": "queue type — required when type is \"queue\"",
+										"type": "string",
+										"enum": ["worker", "pubsub"]
+									}
+								},
+								"required": ["type", "envVar"],
+								"additionalProperties": false
+							}
+						},
+						"env": {
+							"description": "environment variables the project needs",
+							"type": "array",
+							"items": {
+								"type": "object",
+								"properties": {
+									"key": {
+										"type": "string",
+										"description": "the environment variable name"
+									},
+									"required": {
+										"type": "boolean",
+										"description": "whether this env var is required"
+									},
+									"description": {
+										"description": "human-readable description",
+										"type": "string"
+									},
+									"secret": {
+										"description": "whether this env var is a secret",
+										"type": "boolean"
+									},
+									"defaultValue": {
+										"description": "default or example value",
+										"type": "string"
+									}
+								},
+								"required": ["key", "required"],
+								"additionalProperties": false
+							}
+						}
+					},
+					"additionalProperties": false
+				}
+			},
+			"additionalProperties": false
+		},
+		"$schema": {
+			"type": "string"
+		}
+	},
+	"required": ["projectId", "orgId", "region"],
+	"additionalProperties": false
+}

--- a/apps/docs/src/web/public/schemas/agentuity.json.schema.json
+++ b/apps/docs/src/web/public/schemas/agentuity.json.schema.json
@@ -54,7 +54,7 @@
 							"enum": ["on-demand", "provisioned"]
 						},
 						"idle": {
-							"description": "duration in seconds if on-demand",
+							"description": "Idle timeout duration when on-demand (e.g., \"10m\", \"1h\")",
 							"type": "string"
 						}
 					},

--- a/apps/docs/src/web/public/schemas/agentuity.json.schema.json
+++ b/apps/docs/src/web/public/schemas/agentuity.json.schema.json
@@ -1,0 +1,203 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://agentuity.dev/schema/cli/v1/agentuity.json",
+	"$comment": "The agentuity.json configuration schema",
+	"type": "object",
+	"properties": {
+		"projectId": {
+			"type": "string",
+			"description": "the project id"
+		},
+		"orgId": {
+			"type": "string",
+			"description": "the organization id"
+		},
+		"region": {
+			"type": "string",
+			"description": "the region identifier that the project is deployed into"
+		},
+		"deployment": {
+			"description": "the deployment configuration",
+			"type": "object",
+			"properties": {
+				"resources": {
+					"description": "the resource requirements for your deployed project",
+					"type": "object",
+					"properties": {
+						"memory": {
+							"default": "500Mi",
+							"description": "The memory requirements",
+							"type": "string"
+						},
+						"cpu": {
+							"default": "500m",
+							"description": "The CPU requirements",
+							"type": "string"
+						},
+						"disk": {
+							"default": "500Mi",
+							"description": "The disk requirements",
+							"type": "string"
+						}
+					},
+					"required": ["memory", "cpu", "disk"],
+					"additionalProperties": false
+				},
+				"mode": {
+					"description": "the provisioning mode for the project",
+					"type": "object",
+					"properties": {
+						"type": {
+							"default": "on-demand",
+							"description": "on-demand or provisioned",
+							"type": "string",
+							"enum": ["on-demand", "provisioned"]
+						},
+						"idle": {
+							"description": "duration in seconds if on-demand",
+							"type": "string"
+						}
+					},
+					"required": ["type"],
+					"additionalProperties": false
+				},
+				"dependencies": {
+					"type": "array",
+					"items": {
+						"type": "string",
+						"description": "APT dependencies to install prior to launching your project"
+					}
+				},
+				"domains": {
+					"type": "array",
+					"items": {
+						"type": "string",
+						"description": "the custom domain"
+					}
+				}
+			},
+			"additionalProperties": false
+		},
+		"build": {
+			"description": "the CI/CD build configuration",
+			"type": "object",
+			"properties": {
+				"timeout": {
+					"description": "Build execution timeout (e.g. \"30m\")",
+					"type": "string"
+				},
+				"resources": {
+					"description": "Build sandbox resource limits",
+					"type": "object",
+					"properties": {
+						"memory": {
+							"description": "Build sandbox memory (e.g. \"4Gi\")",
+							"type": "string"
+						},
+						"cpu": {
+							"description": "Build sandbox CPU (e.g. \"2\")",
+							"type": "string"
+						},
+						"disk": {
+							"description": "Build sandbox disk (e.g. \"4Gi\")",
+							"type": "string"
+						}
+					},
+					"additionalProperties": false
+				}
+			},
+			"additionalProperties": false
+		},
+		"skipGitSetup": {
+			"description": "whether to skip the git integration setup prompt during deploy",
+			"type": "boolean"
+		},
+		"template": {
+			"description": "template metadata and requirements",
+			"type": "object",
+			"properties": {
+				"source": {
+					"description": "where the template came from (e.g. github.com/owner/repo)",
+					"type": "string"
+				},
+				"requirements": {
+					"description": "what the template requires to run",
+					"type": "object",
+					"properties": {
+						"resources": {
+							"description": "platform resources the project needs",
+							"type": "array",
+							"items": {
+								"type": "object",
+								"properties": {
+									"type": {
+										"type": "string",
+										"enum": ["database", "queue"],
+										"description": "the type of resource required"
+									},
+									"envVar": {
+										"type": "string",
+										"description": "the environment variable that holds the resource connection info"
+									},
+									"description": {
+										"description": "human-readable description of the resource",
+										"type": "string"
+									},
+									"defaultName": {
+										"description": "suggested default name when provisioning this resource",
+										"type": "string"
+									},
+									"queueType": {
+										"description": "queue type — required when type is \"queue\"",
+										"type": "string",
+										"enum": ["worker", "pubsub"]
+									}
+								},
+								"required": ["type", "envVar"],
+								"additionalProperties": false
+							}
+						},
+						"env": {
+							"description": "environment variables the project needs",
+							"type": "array",
+							"items": {
+								"type": "object",
+								"properties": {
+									"key": {
+										"type": "string",
+										"description": "the environment variable name"
+									},
+									"required": {
+										"type": "boolean",
+										"description": "whether this env var is required"
+									},
+									"description": {
+										"description": "human-readable description",
+										"type": "string"
+									},
+									"secret": {
+										"description": "whether this env var is a secret",
+										"type": "boolean"
+									},
+									"defaultValue": {
+										"description": "default or example value",
+										"type": "string"
+									}
+								},
+								"required": ["key", "required"],
+								"additionalProperties": false
+							}
+						}
+					},
+					"additionalProperties": false
+				}
+			},
+			"additionalProperties": false
+		},
+		"$schema": {
+			"type": "string"
+		}
+	},
+	"required": ["projectId", "orgId", "region"],
+	"additionalProperties": false
+}

--- a/packages/core/src/services/project/deploy.ts
+++ b/packages/core/src/services/project/deploy.ts
@@ -13,7 +13,7 @@ export const Mode = z.object({
 		.enum(['on-demand', 'provisioned'])
 		.default('on-demand')
 		.describe('on-demand or provisioned'),
-	idle: z.string().optional().describe('duration in seconds if on-demand'),
+	idle: z.string().optional().describe('Idle timeout duration when on-demand (e.g., "10m", "1h")'),
 });
 
 export const ProjectBuildConfig = z.object({


### PR DESCRIPTION
## Summary

> Restores the public `agentuity.json` schema endpoint used by editors for project config validation.

Generated Agentuity projects reference:

```text
https://agentuity.dev/schema/cli/v1/agentuity.json
```

That path should serve the JSON schema for `agentuity.json`, so editors can validate project configuration.

The docs app already serves static files from `apps/docs/src/web/public`, so this keeps the published schema tied to the same CLI schema generator that owns the config shape.

## What Changed

- Add `generate:schema` for the docs app.
- Run schema generation during docs `predev` and `prebuild`.
- Write the current schema path:
  - `/schema/cli/v1/agentuity.json`
- Write the legacy compatibility path:
  - `/schemas/agentuity.json.schema.json`
- Validate the generated `$schema` and `$id` before writing files.

## Verification

- Reproduced current deployed behavior:
  - `/schema/cli/v1/agentuity.json` returns `404`
  - `/schemas/agentuity.json.schema.json` returns `404`
  - `/llms.txt` returns `200`
- Served `src/web/public` locally and confirmed both schema paths return `200 application/json`.
- Confirmed both generated files contain:
  - `$schema: https://json-schema.org/draft/2020-12/schema`
  - `$id: https://agentuity.dev/schema/cli/v1/agentuity.json`
- `bun run --filter docs typecheck`
- `bun run prebuild`
- `bunx biome check apps/docs/scripts/generate-agentuity-schema.ts apps/docs/package.json`
- `git diff --check`

## Notes

The legacy schema copy is intentional for older generated projects that may still reference the previous URL.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON Schema files for Agentuity CLI configuration, specifying required fields and configuration structure for deployment, build, and template options.

* **Chores**
  * Updated pre-development and pre-build pipeline scripts.
  * Updated git ignore patterns for generated schema artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->