### PR TITLE
Expose AI Gateway multimodal metadata and CLI defaults

### DIFF
--- a/packages/aigateway/src/index.ts
+++ b/packages/aigateway/src/index.ts
@@ -10,7 +10,11 @@ export {
 	type AIGatewayModels,
 	type AIGatewayModelsResponse,
 	type AIGatewayPricing,
+	type AIGatewayRequestOptions,
+	type AIGatewayRequestResponse,
 	type AIGatewayReasoning,
+	type AIGatewayResponseMetadata,
+	type AIGatewayStreamingCompletion,
 	AIGatewayChatCompletionParamsSchema,
 	AIGatewayChatCompletionSchema,
 	AIGatewayChatMessageSchema,
@@ -26,6 +30,9 @@ import {
 	type AIGatewayChatCompletion,
 	type AIGatewayChatCompletionParams,
 	type AIGatewayModels,
+	type AIGatewayRequestOptions,
+	type AIGatewayRequestResponse,
+	type AIGatewayStreamingCompletion,
 } from '@agentuity/core/aigateway';
 import { createMinimalLogger, getEnv } from '@agentuity/core';
 import { getServiceUrls } from '@agentuity/core/config';
@@ -78,5 +85,15 @@ export class AIGatewayClient {
 
 	async complete(params: AIGatewayChatCompletionParams): Promise<AIGatewayChatCompletion> {
 		return this.#service.complete(params);
+	}
+
+	async request<T = unknown>(
+		options: AIGatewayRequestOptions
+	): Promise<AIGatewayRequestResponse<T>> {
+		return this.#service.request<T>(options);
+	}
+
+	async streamRequest(options: AIGatewayRequestOptions): Promise<AIGatewayStreamingCompletion> {
+		return this.#service.streamRequest(options);
 	}
 }

--- a/packages/cli/src/cmd/cloud/aigateway/index.ts
+++ b/packages/cli/src/cmd/cloud/aigateway/index.ts
@@ -1,6 +1,13 @@
 import { createCommand } from '../../../types';
 import { getCommand } from '../../../command-prefix';
 import { completeSubcommand } from './complete';
+import {
+	embeddingsSubcommand,
+	imageSubcommand,
+	speechSubcommand,
+	transcriptionSubcommand,
+	videoSubcommand,
+} from './modalities';
 import { modelsSubcommand } from './models';
 import { requestSubcommand } from './request';
 
@@ -22,7 +29,16 @@ export const aigatewayCommand = createCommand({
 			description: 'Send an upstream-shaped request',
 		},
 	],
-	subcommands: [modelsSubcommand, completeSubcommand, requestSubcommand],
+	subcommands: [
+		modelsSubcommand,
+		completeSubcommand,
+		embeddingsSubcommand,
+		imageSubcommand,
+		speechSubcommand,
+		transcriptionSubcommand,
+		videoSubcommand,
+		requestSubcommand,
+	],
 });
 
 export default aigatewayCommand;

--- a/packages/cli/src/cmd/cloud/aigateway/index.ts
+++ b/packages/cli/src/cmd/cloud/aigateway/index.ts
@@ -2,6 +2,7 @@ import { createCommand } from '../../../types';
 import { getCommand } from '../../../command-prefix';
 import { completeSubcommand } from './complete';
 import { modelsSubcommand } from './models';
+import { requestSubcommand } from './request';
 
 export const aigatewayCommand = createCommand({
 	name: 'aigateway',
@@ -14,8 +15,14 @@ export const aigatewayCommand = createCommand({
 			command: getCommand('cloud aigateway complete --model openai/gpt-4.1-mini "Hello"'),
 			description: 'Run a completion',
 		},
+		{
+			command: getCommand(
+				'cloud aigateway request /v1/embeddings --body \'{"model":"openai/text-embedding-3-small","input":"Hello"}\''
+			),
+			description: 'Send an upstream-shaped request',
+		},
 	],
-	subcommands: [modelsSubcommand, completeSubcommand],
+	subcommands: [modelsSubcommand, completeSubcommand, requestSubcommand],
 });
 
 export default aigatewayCommand;

--- a/packages/cli/src/cmd/cloud/aigateway/modalities.ts
+++ b/packages/cli/src/cmd/cloud/aigateway/modalities.ts
@@ -1,10 +1,18 @@
 import { mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
-import type { AIGatewayService } from '@agentuity/core';
+import { StructuredError, type AIGatewayService } from '@agentuity/core';
 import { z } from 'zod';
 import { getCommand } from '../../../command-prefix';
+import { isJSONMode } from '../../../output';
+import * as tui from '../../../tui';
 import { createCommand } from '../../../types';
 import { createAIGatewayService } from './util';
+
+const AIGatewayModalityInputError = StructuredError('AIGatewayModalityInputError')<{
+	code: string;
+	context?: string;
+	value?: unknown;
+}>();
 
 const GenericResponseSchema = z.object({
 	model: z.string(),
@@ -38,16 +46,34 @@ async function resolveDefaultModel(
 		});
 	const selected = candidates[0];
 	if (!selected) {
-		throw new Error(`No default AI Gateway model found for ${use}. Pass --model explicitly.`);
+		throw new AIGatewayModalityInputError({
+			code: 'default_model_not_found',
+			context: use,
+			message: `No default AI Gateway model found for ${use}. Pass --model explicitly.`,
+		});
 	}
 	return selected.id;
 }
 
 function parseJsonObject(value: string | undefined): Record<string, unknown> | undefined {
 	if (!value) return undefined;
-	const parsed = JSON.parse(value);
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(value);
+	} catch (cause) {
+		throw new AIGatewayModalityInputError({
+			code: 'invalid_json',
+			value,
+			cause,
+			message: 'Expected valid JSON',
+		});
+	}
 	if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-		throw new Error('Expected a JSON object');
+		throw new AIGatewayModalityInputError({
+			code: 'invalid_json_object',
+			value,
+			message: 'Expected a JSON object',
+		});
 	}
 	return parsed as Record<string, unknown>;
 }
@@ -67,7 +93,10 @@ async function readTextInput(opts: {
 		const text = await Bun.stdin.text();
 		if (text.trim().length > 0) return text;
 	}
-	throw new Error('Input is required. Pass text, use --file, or pipe stdin.');
+	throw new AIGatewayModalityInputError({
+		code: 'input_required',
+		message: 'Input is required. Pass text, use --file, or pipe stdin.',
+	});
 }
 
 function firstImageBase64(payload: unknown): string | undefined {
@@ -107,8 +136,9 @@ async function saveBinary(path: string, data: unknown): Promise<number> {
 		await Bun.write(path, data);
 		return Buffer.byteLength(data);
 	}
-	await Bun.write(path, JSON.stringify(data, null, 2));
-	return Buffer.byteLength(JSON.stringify(data));
+	const json = JSON.stringify(data, null, 2);
+	await Bun.write(path, json);
+	return Buffer.byteLength(json);
 }
 
 export const embeddingsSubcommand = createCommand({
@@ -164,11 +194,11 @@ export const embeddingsSubcommand = createCommand({
 			data: response.data,
 			metadata: response.metadata,
 		};
-		if (!ctx.options.json) {
+		if (!isJSONMode(ctx.options)) {
 			if (ctx.opts.format === 'raw') {
-				console.log(JSON.stringify(response.data));
+				tui.json(JSON.stringify(response.data));
 			} else {
-				console.log(JSON.stringify(response.data, null, 2));
+				tui.json(response.data);
 			}
 		}
 		return result;
@@ -228,7 +258,11 @@ export const imageSubcommand = createCommand({
 		if (ctx.opts.save) {
 			const b64 = firstImageBase64(response.data);
 			if (!b64) {
-				throw new Error('Response did not include a base64 image to save.');
+				throw new AIGatewayModalityInputError({
+					code: 'base64_image_missing',
+					context: 'image.save',
+					message: 'Response did not include a base64 image to save.',
+				});
 			}
 			bytes = await saveBase64(ctx.opts.save, b64);
 		}
@@ -239,8 +273,8 @@ export const imageSubcommand = createCommand({
 			...(ctx.opts.save ? { saved: ctx.opts.save } : {}),
 			...(bytes !== undefined ? { bytes } : {}),
 		};
-		if (!ctx.options.json) {
-			console.log(JSON.stringify(result, null, 2));
+		if (!isJSONMode(ctx.options)) {
+			tui.json(result);
 		}
 		return result;
 	},
@@ -302,8 +336,8 @@ export const speechSubcommand = createCommand({
 			...(ctx.opts.save ? { saved: ctx.opts.save } : {}),
 			...(bytes !== undefined ? { bytes } : {}),
 		};
-		if (!ctx.options.json) {
-			console.log(JSON.stringify(result, null, 2));
+		if (!isJSONMode(ctx.options)) {
+			tui.json(result);
 		}
 		return result;
 	},
@@ -363,8 +397,8 @@ export const transcriptionSubcommand = createCommand({
 			data: response.data,
 			metadata: response.metadata,
 		};
-		if (!ctx.options.json) {
-			console.log(
+		if (!isJSONMode(ctx.options)) {
+			tui.json(
 				typeof response.data === 'string'
 					? response.data
 					: JSON.stringify(response.data, null, 2)
@@ -460,8 +494,8 @@ export const videoSubcommand = createCommand({
 			data,
 			metadata,
 		};
-		if (!ctx.options.json) {
-			console.log(JSON.stringify(result, null, 2));
+		if (!isJSONMode(ctx.options)) {
+			tui.json(result);
 		}
 		return result;
 	},

--- a/packages/cli/src/cmd/cloud/aigateway/modalities.ts
+++ b/packages/cli/src/cmd/cloud/aigateway/modalities.ts
@@ -1,0 +1,423 @@
+import { mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { z } from 'zod';
+import { getCommand } from '../../../command-prefix';
+import { createCommand } from '../../../types';
+import { createAIGatewayService } from './util';
+
+const GenericResponseSchema = z.object({
+	model: z.string(),
+	data: z.unknown().optional(),
+	metadata: z.unknown().optional(),
+	saved: z.string().optional(),
+	bytes: z.number().optional(),
+	operation: z.string().optional(),
+});
+
+async function ensureParent(path: string): Promise<void> {
+	await mkdir(dirname(path), { recursive: true });
+}
+
+function parseJsonObject(value: string | undefined): Record<string, unknown> | undefined {
+	if (!value) return undefined;
+	const parsed = JSON.parse(value);
+	if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+		throw new Error('Expected a JSON object');
+	}
+	return parsed as Record<string, unknown>;
+}
+
+async function readTextInput(opts: {
+	input?: string;
+	file?: string;
+	stdin?: boolean;
+}): Promise<string> {
+	if (opts.input !== undefined) {
+		return opts.input;
+	}
+	if (opts.file) {
+		return await Bun.file(opts.file).text();
+	}
+	if (opts.stdin || !process.stdin.isTTY) {
+		const text = await Bun.stdin.text();
+		if (text.trim().length > 0) return text;
+	}
+	throw new Error('Input is required. Pass text, use --file, or pipe stdin.');
+}
+
+function firstImageBase64(payload: unknown): string | undefined {
+	const data = (payload as { data?: unknown }).data;
+	if (!Array.isArray(data)) return undefined;
+	for (const item of data) {
+		const b64 = (item as { b64_json?: unknown }).b64_json;
+		if (typeof b64 === 'string' && b64.length > 0) {
+			return b64;
+		}
+	}
+}
+
+function providerlessModel(model: string): string {
+	const slash = model.indexOf('/');
+	return slash === -1 ? model : model.slice(slash + 1);
+}
+
+async function saveBase64(path: string, b64: string): Promise<number> {
+	await ensureParent(path);
+	const bytes = Buffer.from(b64, 'base64');
+	await Bun.write(path, bytes);
+	return bytes.byteLength;
+}
+
+async function saveBinary(path: string, data: unknown): Promise<number> {
+	await ensureParent(path);
+	if (data instanceof ArrayBuffer) {
+		await Bun.write(path, data);
+		return data.byteLength;
+	}
+	if (data instanceof Uint8Array) {
+		await Bun.write(path, data);
+		return data.byteLength;
+	}
+	if (typeof data === 'string') {
+		await Bun.write(path, data);
+		return Buffer.byteLength(data);
+	}
+	await Bun.write(path, JSON.stringify(data, null, 2));
+	return Buffer.byteLength(JSON.stringify(data));
+}
+
+export const embeddingsSubcommand = createCommand({
+	name: 'embeddings',
+	aliases: ['embed'],
+	description: 'Create embeddings through AI Gateway',
+	tags: ['write', 'slow', 'requires-auth', 'uses-stdin'],
+	requires: { auth: true },
+	optional: { project: true, region: true },
+	examples: [
+		{
+			command: getCommand(
+				'cloud aigateway embeddings --model openai/text-embedding-3-small "hello"'
+			),
+			description: 'Create an embedding for text',
+		},
+	],
+	schema: {
+		args: z.object({
+			input: z.string().optional().describe('text to embed'),
+		}),
+		options: z.object({
+			model: z.string().describe('embedding model id'),
+			file: z.string().optional().describe('read input text from a file'),
+			dimensions: z.number().optional().describe('embedding dimensions'),
+			extra: z
+				.string()
+				.optional()
+				.describe('extra JSON object fields to merge into the request'),
+			format: z.enum(['json', 'raw']).optional().describe('output format'),
+		}),
+		response: GenericResponseSchema,
+	},
+	async handler(ctx) {
+		const service = createAIGatewayService(ctx);
+		const input = await readTextInput({ input: ctx.args.input, file: ctx.opts.file });
+		const body = {
+			...parseJsonObject(ctx.opts.extra),
+			model: ctx.opts.model,
+			input,
+			...(ctx.opts.dimensions ? { dimensions: ctx.opts.dimensions } : {}),
+		};
+		const response = await service.request({
+			path: '/v1/embeddings',
+			body,
+		});
+		const result = {
+			model: ctx.opts.model,
+			data: response.data,
+			metadata: response.metadata,
+		};
+		if (!ctx.options.json) {
+			if (ctx.opts.format === 'raw') {
+				console.log(JSON.stringify(response.data));
+			} else {
+				console.log(JSON.stringify(response.data, null, 2));
+			}
+		}
+		return result;
+	},
+});
+
+export const imageSubcommand = createCommand({
+	name: 'image',
+	description: 'Generate an image through AI Gateway',
+	tags: ['write', 'slow', 'requires-auth', 'uses-stdin'],
+	requires: { auth: true },
+	optional: { project: true, region: true },
+	examples: [
+		{
+			command: getCommand(
+				'cloud aigateway image --model openai/gpt-image-1 --save out.png "A neon triangle logo"'
+			),
+			description: 'Generate and save an image when the provider returns base64 data',
+		},
+	],
+	schema: {
+		args: z.object({
+			prompt: z.string().optional().describe('image prompt'),
+		}),
+		options: z.object({
+			model: z.string().describe('image model id'),
+			file: z.string().optional().describe('read prompt from a file'),
+			save: z.string().optional().describe('write first base64 image to this file'),
+			size: z.string().optional().describe('provider image size, such as 1024x1024'),
+			quality: z.string().optional().describe('provider image quality'),
+			extra: z
+				.string()
+				.optional()
+				.describe('extra JSON object fields to merge into the request'),
+		}),
+		response: GenericResponseSchema,
+	},
+	async handler(ctx) {
+		const service = createAIGatewayService(ctx);
+		const prompt = await readTextInput({ input: ctx.args.prompt, file: ctx.opts.file });
+		const body = {
+			...parseJsonObject(ctx.opts.extra),
+			model: ctx.opts.model,
+			prompt,
+			...(ctx.opts.size ? { size: ctx.opts.size } : {}),
+			...(ctx.opts.quality ? { quality: ctx.opts.quality } : {}),
+		};
+		const response = await service.request({
+			path: '/v1/images/generations',
+			body,
+		});
+		let bytes: number | undefined;
+		if (ctx.opts.save) {
+			const b64 = firstImageBase64(response.data);
+			if (!b64) {
+				throw new Error('Response did not include a base64 image to save.');
+			}
+			bytes = await saveBase64(ctx.opts.save, b64);
+		}
+		const result = {
+			model: ctx.opts.model,
+			data: response.data,
+			metadata: response.metadata,
+			...(ctx.opts.save ? { saved: ctx.opts.save } : {}),
+			...(bytes !== undefined ? { bytes } : {}),
+		};
+		if (!ctx.options.json) {
+			console.log(JSON.stringify(result, null, 2));
+		}
+		return result;
+	},
+});
+
+export const speechSubcommand = createCommand({
+	name: 'speech',
+	aliases: ['tts'],
+	description: 'Generate speech audio through AI Gateway',
+	tags: ['write', 'slow', 'requires-auth', 'uses-stdin'],
+	requires: { auth: true },
+	optional: { project: true, region: true },
+	examples: [
+		{
+			command: getCommand(
+				'cloud aigateway speech --model openai/gpt-4o-mini-tts --voice alloy --save out.mp3 "hello"'
+			),
+			description: 'Generate speech and save it to a file',
+		},
+	],
+	schema: {
+		args: z.object({
+			input: z.string().optional().describe('text to synthesize'),
+		}),
+		options: z.object({
+			model: z.string().describe('speech model id'),
+			voice: z.string().default('alloy').describe('provider voice id'),
+			file: z.string().optional().describe('read input text from a file'),
+			save: z.string().optional().describe('write audio output to this file'),
+			format: z.string().optional().describe('provider audio format, such as mp3 or wav'),
+			extra: z
+				.string()
+				.optional()
+				.describe('extra JSON object fields to merge into the request'),
+		}),
+		response: GenericResponseSchema,
+	},
+	async handler(ctx) {
+		const service = createAIGatewayService(ctx);
+		const input = await readTextInput({ input: ctx.args.input, file: ctx.opts.file });
+		const response = await service.request({
+			path: '/v1/audio/speech',
+			body: {
+				...parseJsonObject(ctx.opts.extra),
+				model: ctx.opts.model,
+				voice: ctx.opts.voice,
+				input,
+				...(ctx.opts.format ? { response_format: ctx.opts.format } : {}),
+			},
+		});
+		const bytes = ctx.opts.save ? await saveBinary(ctx.opts.save, response.data) : undefined;
+		const result = {
+			model: ctx.opts.model,
+			metadata: response.metadata,
+			...(ctx.opts.save ? { saved: ctx.opts.save } : {}),
+			...(bytes !== undefined ? { bytes } : {}),
+		};
+		if (!ctx.options.json) {
+			console.log(JSON.stringify(result, null, 2));
+		}
+		return result;
+	},
+});
+
+export const transcriptionSubcommand = createCommand({
+	name: 'transcription',
+	aliases: ['transcribe'],
+	description: 'Transcribe audio through AI Gateway',
+	tags: ['write', 'slow', 'requires-auth'],
+	requires: { auth: true },
+	optional: { project: true, region: true },
+	examples: [
+		{
+			command: getCommand(
+				'cloud aigateway transcribe --model openai/gpt-4o-mini-transcribe --file audio.mp3'
+			),
+			description: 'Transcribe an audio file',
+		},
+	],
+	schema: {
+		args: z.object({}),
+		options: z.object({
+			model: z.string().describe('transcription model id'),
+			file: z.string().describe('audio file to upload'),
+			language: z.string().optional().describe('input language'),
+			prompt: z.string().optional().describe('optional transcription prompt'),
+			format: z.string().optional().describe('provider response format, such as json or text'),
+			extra: z
+				.string()
+				.optional()
+				.describe('extra JSON object fields to merge into the request'),
+		}),
+		response: GenericResponseSchema,
+	},
+	async handler(ctx) {
+		const service = createAIGatewayService(ctx);
+		const form = new FormData();
+		form.set('model', ctx.opts.model);
+		form.set('file', Bun.file(ctx.opts.file));
+		if (ctx.opts.language) form.set('language', ctx.opts.language);
+		if (ctx.opts.prompt) form.set('prompt', ctx.opts.prompt);
+		if (ctx.opts.format) form.set('response_format', ctx.opts.format);
+		for (const [key, value] of Object.entries(parseJsonObject(ctx.opts.extra) ?? {})) {
+			form.set(key, typeof value === 'string' ? value : JSON.stringify(value));
+		}
+		const response = await service.request({
+			path: '/v1/audio/transcriptions',
+			body: form,
+		});
+		const result = {
+			model: ctx.opts.model,
+			data: response.data,
+			metadata: response.metadata,
+		};
+		if (!ctx.options.json) {
+			console.log(
+				typeof response.data === 'string'
+					? response.data
+					: JSON.stringify(response.data, null, 2)
+			);
+		}
+		return result;
+	},
+});
+
+export const videoSubcommand = createCommand({
+	name: 'video',
+	description: 'Start or poll a video generation request through AI Gateway',
+	tags: ['write', 'slow', 'requires-auth', 'uses-stdin'],
+	requires: { auth: true },
+	optional: { project: true, region: true },
+	examples: [
+		{
+			command: getCommand(
+				'cloud aigateway video --model google/veo-3.1-fast-generate-preview "A robot drawing a triangle"'
+			),
+			description: 'Start a Google long-running video generation operation',
+		},
+	],
+	schema: {
+		args: z.object({
+			prompt: z.string().optional().describe('video prompt'),
+		}),
+		options: z.object({
+			model: z.string().describe('video model id'),
+			file: z.string().optional().describe('read prompt from a file'),
+			operation: z.string().optional().describe('poll an existing operation name instead'),
+			poll: z.boolean().optional().describe('poll until the operation is done'),
+			interval: z.number().default(10).describe('poll interval in seconds'),
+			timeout: z.number().default(300).describe('poll timeout in seconds'),
+			aspectRatio: z.string().optional().describe('video aspect ratio'),
+			resolution: z.string().optional().describe('video resolution'),
+			duration: z.number().optional().describe('duration in seconds'),
+			extra: z
+				.string()
+				.optional()
+				.describe('extra JSON object fields to merge into the request'),
+		}),
+		response: GenericResponseSchema,
+	},
+	async handler(ctx) {
+		const service = createAIGatewayService(ctx);
+		let operation = ctx.opts.operation;
+		let data: unknown;
+		let metadata: unknown;
+
+		if (!operation) {
+			const prompt = await readTextInput({ input: ctx.args.prompt, file: ctx.opts.file });
+			const response = await service.request<{ name?: string }>({
+				path: `/v1beta/models/${encodeURIComponent(providerlessModel(ctx.opts.model))}:predictLongRunning`,
+				body: {
+					...parseJsonObject(ctx.opts.extra),
+					instances: [{ prompt }],
+					parameters: {
+						...(ctx.opts.aspectRatio ? { aspectRatio: ctx.opts.aspectRatio } : {}),
+						...(ctx.opts.resolution ? { resolution: ctx.opts.resolution } : {}),
+						...(ctx.opts.duration ? { durationSeconds: ctx.opts.duration } : {}),
+					},
+				},
+			});
+			data = response.data;
+			metadata = response.metadata;
+			operation = response.data.name;
+		}
+
+		if (ctx.opts.poll && operation) {
+			const started = Date.now();
+			while (Date.now() - started < ctx.opts.timeout * 1000) {
+				const response = await service.request<{ done?: boolean }>({
+					path: `/v1beta/${operation}`,
+					method: 'GET',
+				});
+				data = response.data;
+				metadata = response.metadata;
+				if (response.data.done) {
+					break;
+				}
+				await Bun.sleep(ctx.opts.interval * 1000);
+			}
+		}
+
+		const result = {
+			model: ctx.opts.model,
+			...(operation ? { operation } : {}),
+			data,
+			metadata,
+		};
+		if (!ctx.options.json) {
+			console.log(JSON.stringify(result, null, 2));
+		}
+		return result;
+	},
+});

--- a/packages/cli/src/cmd/cloud/aigateway/modalities.ts
+++ b/packages/cli/src/cmd/cloud/aigateway/modalities.ts
@@ -1,5 +1,6 @@
 import { mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
+import type { AIGatewayService } from '@agentuity/core';
 import { z } from 'zod';
 import { getCommand } from '../../../command-prefix';
 import { createCommand } from '../../../types';
@@ -16,6 +17,30 @@ const GenericResponseSchema = z.object({
 
 async function ensureParent(path: string): Promise<void> {
 	await mkdir(dirname(path), { recursive: true });
+}
+
+async function resolveDefaultModel(
+	service: AIGatewayService,
+	use: string,
+	model?: string
+): Promise<string> {
+	if (model) {
+		return model;
+	}
+	const candidates = Object.values(await service.listModels())
+		.flat()
+		.filter((candidate) => {
+			return candidate.recommended && candidate.default_for?.includes(use);
+		})
+		.sort((a, b) => {
+			const byRank = (a.rank ?? Number.MAX_SAFE_INTEGER) - (b.rank ?? Number.MAX_SAFE_INTEGER);
+			return byRank || a.id.localeCompare(b.id);
+		});
+	const selected = candidates[0];
+	if (!selected) {
+		throw new Error(`No default AI Gateway model found for ${use}. Pass --model explicitly.`);
+	}
+	return selected.id;
 }
 
 function parseJsonObject(value: string | undefined): Record<string, unknown> | undefined {
@@ -106,7 +131,10 @@ export const embeddingsSubcommand = createCommand({
 			input: z.string().optional().describe('text to embed'),
 		}),
 		options: z.object({
-			model: z.string().describe('embedding model id'),
+			model: z
+				.string()
+				.optional()
+				.describe('embedding model id; defaults to the recommended catalog model'),
 			file: z.string().optional().describe('read input text from a file'),
 			dimensions: z.number().optional().describe('embedding dimensions'),
 			extra: z
@@ -119,10 +147,11 @@ export const embeddingsSubcommand = createCommand({
 	},
 	async handler(ctx) {
 		const service = createAIGatewayService(ctx);
+		const model = await resolveDefaultModel(service, 'embedding', ctx.opts.model);
 		const input = await readTextInput({ input: ctx.args.input, file: ctx.opts.file });
 		const body = {
 			...parseJsonObject(ctx.opts.extra),
-			model: ctx.opts.model,
+			model,
 			input,
 			...(ctx.opts.dimensions ? { dimensions: ctx.opts.dimensions } : {}),
 		};
@@ -131,7 +160,7 @@ export const embeddingsSubcommand = createCommand({
 			body,
 		});
 		const result = {
-			model: ctx.opts.model,
+			model,
 			data: response.data,
 			metadata: response.metadata,
 		};
@@ -165,7 +194,10 @@ export const imageSubcommand = createCommand({
 			prompt: z.string().optional().describe('image prompt'),
 		}),
 		options: z.object({
-			model: z.string().describe('image model id'),
+			model: z
+				.string()
+				.optional()
+				.describe('image model id; defaults to the recommended catalog model'),
 			file: z.string().optional().describe('read prompt from a file'),
 			save: z.string().optional().describe('write first base64 image to this file'),
 			size: z.string().optional().describe('provider image size, such as 1024x1024'),
@@ -179,10 +211,11 @@ export const imageSubcommand = createCommand({
 	},
 	async handler(ctx) {
 		const service = createAIGatewayService(ctx);
+		const model = await resolveDefaultModel(service, 'image', ctx.opts.model);
 		const prompt = await readTextInput({ input: ctx.args.prompt, file: ctx.opts.file });
 		const body = {
 			...parseJsonObject(ctx.opts.extra),
-			model: ctx.opts.model,
+			model,
 			prompt,
 			...(ctx.opts.size ? { size: ctx.opts.size } : {}),
 			...(ctx.opts.quality ? { quality: ctx.opts.quality } : {}),
@@ -200,7 +233,7 @@ export const imageSubcommand = createCommand({
 			bytes = await saveBase64(ctx.opts.save, b64);
 		}
 		const result = {
-			model: ctx.opts.model,
+			model,
 			data: response.data,
 			metadata: response.metadata,
 			...(ctx.opts.save ? { saved: ctx.opts.save } : {}),
@@ -233,7 +266,10 @@ export const speechSubcommand = createCommand({
 			input: z.string().optional().describe('text to synthesize'),
 		}),
 		options: z.object({
-			model: z.string().describe('speech model id'),
+			model: z
+				.string()
+				.optional()
+				.describe('speech model id; defaults to the recommended catalog model'),
 			voice: z.string().default('alloy').describe('provider voice id'),
 			file: z.string().optional().describe('read input text from a file'),
 			save: z.string().optional().describe('write audio output to this file'),
@@ -247,12 +283,13 @@ export const speechSubcommand = createCommand({
 	},
 	async handler(ctx) {
 		const service = createAIGatewayService(ctx);
+		const model = await resolveDefaultModel(service, 'speech', ctx.opts.model);
 		const input = await readTextInput({ input: ctx.args.input, file: ctx.opts.file });
 		const response = await service.request({
 			path: '/v1/audio/speech',
 			body: {
 				...parseJsonObject(ctx.opts.extra),
-				model: ctx.opts.model,
+				model,
 				voice: ctx.opts.voice,
 				input,
 				...(ctx.opts.format ? { response_format: ctx.opts.format } : {}),
@@ -260,7 +297,7 @@ export const speechSubcommand = createCommand({
 		});
 		const bytes = ctx.opts.save ? await saveBinary(ctx.opts.save, response.data) : undefined;
 		const result = {
-			model: ctx.opts.model,
+			model,
 			metadata: response.metadata,
 			...(ctx.opts.save ? { saved: ctx.opts.save } : {}),
 			...(bytes !== undefined ? { bytes } : {}),
@@ -290,7 +327,10 @@ export const transcriptionSubcommand = createCommand({
 	schema: {
 		args: z.object({}),
 		options: z.object({
-			model: z.string().describe('transcription model id'),
+			model: z
+				.string()
+				.optional()
+				.describe('transcription model id; defaults to the recommended catalog model'),
 			file: z.string().describe('audio file to upload'),
 			language: z.string().optional().describe('input language'),
 			prompt: z.string().optional().describe('optional transcription prompt'),
@@ -304,8 +344,9 @@ export const transcriptionSubcommand = createCommand({
 	},
 	async handler(ctx) {
 		const service = createAIGatewayService(ctx);
+		const model = await resolveDefaultModel(service, 'transcription', ctx.opts.model);
 		const form = new FormData();
-		form.set('model', ctx.opts.model);
+		form.set('model', model);
 		form.set('file', Bun.file(ctx.opts.file));
 		if (ctx.opts.language) form.set('language', ctx.opts.language);
 		if (ctx.opts.prompt) form.set('prompt', ctx.opts.prompt);
@@ -318,7 +359,7 @@ export const transcriptionSubcommand = createCommand({
 			body: form,
 		});
 		const result = {
-			model: ctx.opts.model,
+			model,
 			data: response.data,
 			metadata: response.metadata,
 		};
@@ -352,7 +393,10 @@ export const videoSubcommand = createCommand({
 			prompt: z.string().optional().describe('video prompt'),
 		}),
 		options: z.object({
-			model: z.string().describe('video model id'),
+			model: z
+				.string()
+				.optional()
+				.describe('video model id; defaults to the recommended catalog model'),
 			file: z.string().optional().describe('read prompt from a file'),
 			operation: z.string().optional().describe('poll an existing operation name instead'),
 			poll: z.boolean().optional().describe('poll until the operation is done'),
@@ -370,6 +414,7 @@ export const videoSubcommand = createCommand({
 	},
 	async handler(ctx) {
 		const service = createAIGatewayService(ctx);
+		const model = await resolveDefaultModel(service, 'video', ctx.opts.model);
 		let operation = ctx.opts.operation;
 		let data: unknown;
 		let metadata: unknown;
@@ -377,7 +422,7 @@ export const videoSubcommand = createCommand({
 		if (!operation) {
 			const prompt = await readTextInput({ input: ctx.args.prompt, file: ctx.opts.file });
 			const response = await service.request<{ name?: string }>({
-				path: `/v1beta/models/${encodeURIComponent(providerlessModel(ctx.opts.model))}:predictLongRunning`,
+				path: `/v1beta/models/${encodeURIComponent(providerlessModel(model))}:predictLongRunning`,
 				body: {
 					...parseJsonObject(ctx.opts.extra),
 					instances: [{ prompt }],
@@ -410,7 +455,7 @@ export const videoSubcommand = createCommand({
 		}
 
 		const result = {
-			model: ctx.opts.model,
+			model,
 			...(operation ? { operation } : {}),
 			data,
 			metadata,

--- a/packages/cli/src/cmd/cloud/aigateway/models.ts
+++ b/packages/cli/src/cmd/cloud/aigateway/models.ts
@@ -63,7 +63,14 @@ function getRecommendations(rows: z.infer<typeof ModelRowSchema>[]) {
 	return Array.from(recommendations.entries())
 		.sort(([a], [b]) => a.localeCompare(b))
 		.map(([use, model]) => {
-			return { use, model: model.id, name: model.name, rank: model.rank };
+			return {
+				use,
+				model: model.id.startsWith(`${model.provider}/`)
+					? model.id
+					: `${model.provider}/${model.id}`,
+				name: model.name,
+				rank: model.rank,
+			};
 		});
 }
 
@@ -131,6 +138,8 @@ export const modelsSubcommand = createCommand({
 				.string()
 				.optional()
 				.describe('filter by output modality, such as text or image'),
+			input: z.string().optional().describe('deprecated alias for --input-modality'),
+			output: z.string().optional().describe('deprecated alias for --output-modality'),
 			ids: z.boolean().optional().describe('only print model ids'),
 			simple: z.boolean().optional().describe('print a compact model list'),
 			recommended: z.boolean().optional().describe('show recommended models for common uses'),
@@ -152,22 +161,16 @@ export const modelsSubcommand = createCommand({
 		if (!cached) {
 			await setCachedAIGatewayModels(profile, cacheKey, catalog);
 		}
+		const inputModality = ctx.opts.inputModality ?? ctx.opts.input;
+		const outputModality = ctx.opts.outputModality ?? ctx.opts.output;
 		const rows = Object.entries(catalog).flatMap(([provider, models]) =>
 			models
 				.filter((model) => matchesProviderFilter(provider, model.id, ctx.opts.provider))
 				.filter((model) => matchesModelFilter(provider, model.id, ctx.opts.model))
 				.filter((model) => matchesNameFilter(model.id, model.name, ctx.opts.name))
 				.filter((model) => !ctx.opts.reasoning || model.reasoning)
-				.filter(
-					(model) =>
-						!ctx.opts.inputModality ||
-						model.input_modalities?.includes(ctx.opts.inputModality)
-				)
-				.filter(
-					(model) =>
-						!ctx.opts.outputModality ||
-						model.output_modalities?.includes(ctx.opts.outputModality)
-				)
+				.filter((model) => !inputModality || model.input_modalities?.includes(inputModality))
+				.filter((model) => !outputModality || model.output_modalities?.includes(outputModality))
 				.map((model) => ({
 					provider,
 					id: model.id,

--- a/packages/cli/src/cmd/cloud/aigateway/models.ts
+++ b/packages/cli/src/cmd/cloud/aigateway/models.ts
@@ -17,6 +17,9 @@ const ModelRowSchema = z.object({
 	pricingInput: z.number().optional(),
 	pricingOutput: z.number().optional(),
 	reasoning: z.boolean().optional(),
+	recommended: z.boolean().optional(),
+	defaultFor: z.array(z.string()).optional(),
+	rank: z.number().optional(),
 	contextWindow: z.number().optional(),
 	maxOutputTokens: z.number().optional(),
 });
@@ -25,33 +28,43 @@ const ModelsResponseSchema = z.object({
 	models: z.array(ModelRowSchema),
 	count: z.number(),
 	model: ModelRowSchema.nullable().optional(),
+	recommendations: z
+		.array(
+			z.object({
+				use: z.string(),
+				model: z.string(),
+				name: z.string(),
+				rank: z.number().optional(),
+			})
+		)
+		.optional(),
 });
-
-const recommendedModels = [
-	{ use: 'fast', candidates: ['openai/gpt-4o-mini', 'openai/gpt-4.1-mini'] },
-	{ use: 'reasoning', candidates: ['openai/gpt-5-mini', 'openai/o4-mini'] },
-	{ use: 'coding', candidates: ['anthropic/claude-opus-4-7', 'openai/gpt-5-codex'] },
-	{ use: 'cheap', candidates: ['openai/gpt-4.1-nano', 'openai/gpt-5-nano'] },
-];
 
 function isAgentOutputMode(): boolean {
 	return Boolean(getExecutingAgent()) && process.env.AGENTUITY_AIGATEWAY_AGENT_OUTPUT !== 'false';
 }
 
 function getRecommendations(rows: z.infer<typeof ModelRowSchema>[]) {
-	const byId = new Map(rows.map((row) => [normalizeModelId(row.id), row]));
-	return recommendedModels
-		.map((rec) => {
-			const model = rec.candidates.map((id) => byId.get(normalizeModelId(id))).find(Boolean);
-			return model ? { use: rec.use, model: model.id, name: model.name } : undefined;
-		})
-		.filter((row): row is { use: string; model: string; name: string } => Boolean(row));
-}
-
-function normalizeModelId(id: string): string {
-	const normalized = id.toLowerCase();
-	const parts = normalized.split('/');
-	return parts.length > 1 ? (parts.at(-1) ?? normalized) : normalized;
+	const recommendations = new Map<string, z.infer<typeof ModelRowSchema>>();
+	for (const row of rows) {
+		if (!row.recommended || !row.defaultFor || row.defaultFor.length === 0) {
+			continue;
+		}
+		for (const use of row.defaultFor) {
+			const existing = recommendations.get(use);
+			if (
+				!existing ||
+				(row.rank ?? Number.MAX_SAFE_INTEGER) < (existing.rank ?? Number.MAX_SAFE_INTEGER)
+			) {
+				recommendations.set(use, row);
+			}
+		}
+	}
+	return Array.from(recommendations.entries())
+		.sort(([a], [b]) => a.localeCompare(b))
+		.map(([use, model]) => {
+			return { use, model: model.id, name: model.name, rank: model.rank };
+		});
 }
 
 function matchesProviderFilter(
@@ -166,6 +179,9 @@ export const modelsSubcommand = createCommand({
 					pricingInput: model.pricing?.input,
 					pricingOutput: model.pricing?.output,
 					reasoning: model.reasoning,
+					recommended: model.recommended,
+					defaultFor: model.default_for,
+					rank: model.rank,
 					contextWindow: model.context_window,
 					maxOutputTokens: model.max_output_tokens,
 				}))
@@ -206,11 +222,12 @@ export const modelsSubcommand = createCommand({
 					Use: row.use,
 					Model: row.model,
 					Name: row.name,
+					Rank: row.rank ?? '-',
 				}));
 				if (recommendations.length === 0) {
 					tui.info('No recommended AI Gateway models found');
 				} else {
-					tui.table(recommendations, ['Use', 'Model', 'Name']);
+					tui.table(recommendations, ['Use', 'Model', 'Name', 'Rank']);
 				}
 			} else if (ctx.opts.simple) {
 				tui.table(
@@ -232,6 +249,7 @@ export const modelsSubcommand = createCommand({
 						Output: row.outputModalities?.join(',') ?? '-',
 						Unit: row.pricingUnit ?? '-',
 						Reasoning: row.reasoning ? 'yes' : 'no',
+						Default: row.defaultFor?.join(',') ?? '-',
 						Context: row.contextWindow ?? '-',
 					})),
 					[
@@ -243,12 +261,18 @@ export const modelsSubcommand = createCommand({
 						'Output',
 						'Unit',
 						'Reasoning',
+						'Default',
 						'Context',
 					]
 				);
 			}
 		}
 
-		return { models: rows, count: rows.length, model: selectedModel };
+		return {
+			models: rows,
+			count: rows.length,
+			model: selectedModel,
+			...(ctx.opts.recommended ? { recommendations: getRecommendations(rows) } : {}),
+		};
 	},
 });

--- a/packages/cli/src/cmd/cloud/aigateway/models.ts
+++ b/packages/cli/src/cmd/cloud/aigateway/models.ts
@@ -11,6 +11,11 @@ const ModelRowSchema = z.object({
 	id: z.string(),
 	name: z.string(),
 	api: z.string().optional(),
+	inputModalities: z.array(z.string()).optional(),
+	outputModalities: z.array(z.string()).optional(),
+	pricingUnit: z.string().optional(),
+	pricingInput: z.number().optional(),
+	pricingOutput: z.number().optional(),
 	reasoning: z.boolean().optional(),
 	contextWindow: z.number().optional(),
 	maxOutputTokens: z.number().optional(),
@@ -143,6 +148,11 @@ export const modelsSubcommand = createCommand({
 					id: model.id,
 					name: model.name,
 					api: model.api,
+					inputModalities: model.input_modalities,
+					outputModalities: model.output_modalities,
+					pricingUnit: model.pricing?.unit,
+					pricingInput: model.pricing?.input,
+					pricingOutput: model.pricing?.output,
 					reasoning: model.reasoning,
 					contextWindow: model.context_window,
 					maxOutputTokens: model.max_output_tokens,
@@ -206,10 +216,23 @@ export const modelsSubcommand = createCommand({
 						Model: row.id,
 						Name: row.name,
 						API: row.api ?? '-',
+						Input: row.inputModalities?.join(',') ?? '-',
+						Output: row.outputModalities?.join(',') ?? '-',
+						Unit: row.pricingUnit ?? '-',
 						Reasoning: row.reasoning ? 'yes' : 'no',
 						Context: row.contextWindow ?? '-',
 					})),
-					['Provider', 'Model', 'Name', 'API', 'Reasoning', 'Context']
+					[
+						'Provider',
+						'Model',
+						'Name',
+						'API',
+						'Input',
+						'Output',
+						'Unit',
+						'Reasoning',
+						'Context',
+					]
 				);
 			}
 		}

--- a/packages/cli/src/cmd/cloud/aigateway/models.ts
+++ b/packages/cli/src/cmd/cloud/aigateway/models.ts
@@ -110,8 +110,14 @@ export const modelsSubcommand = createCommand({
 				.optional()
 				.describe('show one model by id or display name with --provider'),
 			reasoning: z.boolean().optional().describe('only show reasoning models'),
-			input: z.string().optional().describe('filter by input modality, such as text or image'),
-			output: z.string().optional().describe('filter by output modality, such as text or image'),
+			inputModality: z
+				.string()
+				.optional()
+				.describe('filter by input modality, such as text or image'),
+			outputModality: z
+				.string()
+				.optional()
+				.describe('filter by output modality, such as text or image'),
 			ids: z.boolean().optional().describe('only print model ids'),
 			simple: z.boolean().optional().describe('print a compact model list'),
 			recommended: z.boolean().optional().describe('show recommended models for common uses'),
@@ -139,9 +145,15 @@ export const modelsSubcommand = createCommand({
 				.filter((model) => matchesModelFilter(provider, model.id, ctx.opts.model))
 				.filter((model) => matchesNameFilter(model.id, model.name, ctx.opts.name))
 				.filter((model) => !ctx.opts.reasoning || model.reasoning)
-				.filter((model) => !ctx.opts.input || model.input_modalities?.includes(ctx.opts.input))
 				.filter(
-					(model) => !ctx.opts.output || model.output_modalities?.includes(ctx.opts.output)
+					(model) =>
+						!ctx.opts.inputModality ||
+						model.input_modalities?.includes(ctx.opts.inputModality)
+				)
+				.filter(
+					(model) =>
+						!ctx.opts.outputModality ||
+						model.output_modalities?.includes(ctx.opts.outputModality)
 				)
 				.map((model) => ({
 					provider,

--- a/packages/cli/src/cmd/cloud/aigateway/request.ts
+++ b/packages/cli/src/cmd/cloud/aigateway/request.ts
@@ -1,0 +1,142 @@
+import { z } from 'zod';
+import { createCommand } from '../../../types';
+import { getCommand } from '../../../command-prefix';
+import { createAIGatewayService } from './util';
+
+const RequestResponseSchema = z.object({
+	path: z.string(),
+	method: z.string(),
+	stream: z.boolean().optional(),
+	data: z.unknown().optional(),
+	metadata: z.unknown().optional(),
+});
+
+async function readStdin(): Promise<string | undefined> {
+	if (process.stdin.isTTY) {
+		return undefined;
+	}
+	const text = await Bun.stdin.text();
+	const trimmed = text.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+async function readBody(opts: { body?: string; file?: string; raw?: boolean }): Promise<unknown> {
+	const text = opts.body ?? (opts.file ? await Bun.file(opts.file).text() : await readStdin());
+	if (text === undefined) {
+		return undefined;
+	}
+	if (opts.raw) {
+		return text;
+	}
+	try {
+		return JSON.parse(text);
+	} catch {
+		return text;
+	}
+}
+
+async function consumeRawStream(stream: ReadableStream<Uint8Array>): Promise<string> {
+	const text = await new Response(stream).text();
+	if (text) {
+		process.stdout.write(text);
+		if (!text.endsWith('\n')) {
+			process.stdout.write('\n');
+		}
+	}
+	return text;
+}
+
+export const requestSubcommand = createCommand({
+	name: 'request',
+	aliases: ['raw'],
+	description: 'Send an upstream-shaped request through the AI Gateway',
+	tags: ['write', 'slow', 'requires-auth', 'uses-stdin'],
+	requires: { auth: true },
+	optional: { project: true, region: true },
+	examples: [
+		{
+			command: getCommand(
+				'cloud aigateway request /v1/embeddings --body \'{"model":"openai/text-embedding-3-small","input":"hello"}\''
+			),
+			description: 'Run an embeddings request',
+		},
+		{
+			command: getCommand(
+				'cloud aigateway request /v1beta/models/gemini-3.1-flash-lite:streamGenerateContent --stream --body \'{"contents":[{"role":"user","parts":[{"text":"hello"}]}]}\''
+			),
+			description: 'Stream a Google Generative AI request',
+		},
+	],
+	schema: {
+		args: z.object({
+			path: z.string().min(1).describe('gateway-relative upstream path'),
+		}),
+		options: z.object({
+			method: z
+				.enum(['GET', 'PUT', 'POST', 'DELETE', 'HEAD', 'OPTIONS', 'PATCH'])
+				.optional()
+				.describe('HTTP method'),
+			body: z.string().optional().describe('request body; JSON is parsed automatically'),
+			file: z.string().optional().describe('read request body from a file'),
+			header: z.array(z.string()).optional().describe('additional header as name:value'),
+			rawBody: z.boolean().optional().describe('send body as plain text without JSON parsing'),
+			stream: z.boolean().optional().describe('treat the response as an SSE stream'),
+			format: z.enum(['json', 'raw']).optional().describe('output format'),
+		}),
+		response: RequestResponseSchema,
+	},
+	async handler(ctx) {
+		const service = createAIGatewayService(ctx);
+		const method = ctx.opts.method ?? 'POST';
+		const headers = Object.fromEntries(
+			(ctx.opts.header ?? []).map((header) => {
+				const index = header.indexOf(':');
+				return index === -1
+					? [header.trim(), '']
+					: [header.slice(0, index).trim(), header.slice(index + 1).trim()];
+			})
+		);
+		const body = await readBody({
+			body: ctx.opts.body,
+			file: ctx.opts.file,
+			raw: ctx.opts.rawBody,
+		});
+
+		if (ctx.opts.stream) {
+			const streamed = await service.streamRequest({
+				path: ctx.args.path,
+				method,
+				body,
+				...(Object.keys(headers).length > 0 ? { headers } : {}),
+			});
+			const text = await consumeRawStream(streamed.stream);
+			const metadata = await streamed.metadata;
+			const result = { path: ctx.args.path, method, stream: true, data: text, metadata };
+			if (!ctx.options.json && ctx.opts.format === 'json') {
+				console.log(JSON.stringify(result, null, 2));
+			}
+			return result;
+		}
+
+		const response = await service.request({
+			path: ctx.args.path,
+			method,
+			body,
+			...(Object.keys(headers).length > 0 ? { headers } : {}),
+		});
+		const result = {
+			path: ctx.args.path,
+			method,
+			data: response.data,
+			metadata: response.metadata,
+		};
+		if (!ctx.options.json) {
+			if (ctx.opts.format === 'raw' && typeof response.data === 'string') {
+				console.log(response.data);
+			} else {
+				console.log(JSON.stringify(response.data, null, 2));
+			}
+		}
+		return result;
+	},
+});

--- a/packages/cli/test/cmd/cloud/aigateway.test.ts
+++ b/packages/cli/test/cmd/cloud/aigateway.test.ts
@@ -46,6 +46,11 @@ describe('cloud aigateway command', () => {
 		expect(aigatewayCommand.subcommands?.map((cmd) => cmd.name)).toEqual([
 			'models',
 			'complete',
+			'embeddings',
+			'image',
+			'speech',
+			'transcription',
+			'video',
 			'request',
 		]);
 		expect(aigatewayCommand.requires?.auth).toBeUndefined();
@@ -249,6 +254,38 @@ describe('cloud aigateway command', () => {
 		expect(result.models[0]?.id).toBe('anthropic/claude-sonnet-4-5-20250929');
 	});
 
+	test('models handler returns fully-qualified recommendations', async () => {
+		server = Bun.serve({
+			port: 0,
+			fetch() {
+				return Response.json({
+					success: true,
+					data: {
+						openai: [
+							{
+								id: 'gpt-4.1-mini',
+								name: 'GPT 4.1 Mini',
+								recommended: true,
+								default_for: ['text'],
+								rank: 1,
+							},
+						],
+					},
+				});
+			},
+		});
+
+		const result = await modelsSubcommand.handler({
+			...baseCtx(`http://127.0.0.1:${server.port}`),
+			opts: { recommended: true },
+			args: {},
+		} as never);
+
+		expect(result.recommendations).toEqual([
+			{ use: 'text', model: 'openai/gpt-4.1-mini', name: 'GPT 4.1 Mini', rank: 1 },
+		]);
+	});
+
 	test('models handler returns a single model by full model id', async () => {
 		server = Bun.serve({
 			port: 0,
@@ -312,6 +349,10 @@ describe('cloud aigateway command', () => {
 		const shape = modelsSubcommand.schema?.options?.def.shape;
 		expect(shape?.model).toBeDefined();
 		expect(shape?.name).toBeDefined();
+		expect(shape?.input).toBeDefined();
+		expect(shape?.output).toBeDefined();
+		expect(shape?.inputModality).toBeDefined();
+		expect(shape?.outputModality).toBeDefined();
 		expect(shape?.ids).toBeDefined();
 		expect(shape?.simple).toBeDefined();
 		expect(shape?.recommended).toBeDefined();

--- a/packages/cli/test/cmd/cloud/aigateway.test.ts
+++ b/packages/cli/test/cmd/cloud/aigateway.test.ts
@@ -6,6 +6,7 @@ import { createMinimalLogger } from '@agentuity/core';
 import { aigatewayCommand } from '../../../src/cmd/cloud/aigateway';
 import { combinePromptInput, completeSubcommand } from '../../../src/cmd/cloud/aigateway/complete';
 import { modelsSubcommand } from '../../../src/cmd/cloud/aigateway/models';
+import { requestSubcommand } from '../../../src/cmd/cloud/aigateway/request';
 import { getCompletionText } from '../../../src/cmd/cloud/aigateway/util';
 
 let server: ReturnType<typeof Bun.serve> | undefined;
@@ -42,7 +43,11 @@ describe('cloud aigateway command', () => {
 	test('registers expected subcommands', () => {
 		expect(aigatewayCommand.name).toBe('aigateway');
 		expect(aigatewayCommand.aliases).toContain('ai-gateway');
-		expect(aigatewayCommand.subcommands?.map((cmd) => cmd.name)).toEqual(['models', 'complete']);
+		expect(aigatewayCommand.subcommands?.map((cmd) => cmd.name)).toEqual([
+			'models',
+			'complete',
+			'request',
+		]);
 		expect(aigatewayCommand.requires?.auth).toBeUndefined();
 	});
 
@@ -69,6 +74,19 @@ describe('cloud aigateway command', () => {
 		expect(shape?.format).toBeDefined();
 		expect(shape?.stdinMode).toBeDefined();
 		expect(shape?.cost).toBeDefined();
+	});
+
+	test('request subcommand exposes upstream path, body, and stream schemas', () => {
+		const shape = requestSubcommand.schema?.options?.def.shape;
+		expect(requestSubcommand.requires?.auth).toBe(true);
+		expect(requestSubcommand.optional?.region).toBe(true);
+		expect(requestSubcommand.tags).toContain('uses-stdin');
+		expect(requestSubcommand.schema?.args?.def.shape.path).toBeDefined();
+		expect(shape?.method).toBeDefined();
+		expect(shape?.body).toBeDefined();
+		expect(shape?.file).toBeDefined();
+		expect(shape?.header).toBeDefined();
+		expect(shape?.stream).toBeDefined();
 	});
 
 	test('extracts assistant text from OpenAI-compatible completion responses', () => {
@@ -118,6 +136,12 @@ describe('cloud aigateway command', () => {
 								reasoning: false,
 								input_modalities: ['text'],
 								output_modalities: ['text'],
+								pricing: {
+									input: 0.4,
+									output: 1.6,
+									unit: 'per_million_tokens',
+									currency: 'USD',
+								},
 							},
 							{
 								id: 'gpt-4.1-vision',
@@ -126,6 +150,12 @@ describe('cloud aigateway command', () => {
 								reasoning: false,
 								input_modalities: ['text', 'image'],
 								output_modalities: ['text'],
+								pricing: {
+									input: 2,
+									output: 8,
+									unit: 'per_million_tokens',
+									currency: 'USD',
+								},
 							},
 						],
 					},
@@ -145,6 +175,9 @@ describe('cloud aigateway command', () => {
 		expect(requests[0]!.headers.get('x-agentuity-orgid')).toBeNull();
 		expect(result.count).toBe(1);
 		expect(result.models[0]?.id).toBe('gpt-4.1-vision');
+		expect(result.models[0]?.inputModalities).toEqual(['text', 'image']);
+		expect(result.models[0]?.outputModalities).toEqual(['text']);
+		expect(result.models[0]?.pricingUnit).toBe('per_million_tokens');
 	});
 
 	test('models handler does not require auth, org, project, or region', async () => {
@@ -282,6 +315,59 @@ describe('cloud aigateway command', () => {
 		expect(shape?.ids).toBeDefined();
 		expect(shape?.simple).toBeDefined();
 		expect(shape?.recommended).toBeDefined();
+	});
+
+	test('request handler posts upstream-shaped JSON to a custom path', async () => {
+		let body: unknown;
+		let path: string | undefined;
+		server = Bun.serve({
+			port: 0,
+			async fetch(request) {
+				path = new URL(request.url).pathname;
+				body = await request.json();
+				return Response.json(
+					{ data: [{ embedding: [0.1, 0.2] }] },
+					{
+						headers: {
+							'x-gateway-cost': '0.000012',
+							'x-gateway-billing-unit': 'per_million_tokens',
+							'x-gateway-input-quantity': '3.000000',
+						},
+					}
+				);
+			},
+		});
+
+		const result = await requestSubcommand.handler({
+			...baseCtx(`http://127.0.0.1:${server.port}`),
+			opts: {
+				body: '{"model":"openai/text-embedding-3-small","input":"hello"}',
+			},
+			args: { path: '/v1/embeddings' },
+		} as never);
+
+		expect(path).toBe('/v1/embeddings');
+		expect(body).toEqual({
+			model: 'openai/text-embedding-3-small',
+			input: 'hello',
+		});
+		expect(result.data).toEqual({ data: [{ embedding: [0.1, 0.2] }] });
+		expect(result.metadata).toEqual({
+			headers: {
+				'x-gateway-cost': '0.000012',
+				'x-gateway-billing-unit': 'per_million_tokens',
+				'x-gateway-input-quantity': '3.000000',
+			},
+			cost: {
+				total: 0.000012,
+				unit: 'per_million_tokens',
+				inputQuantity: 3,
+				outputQuantity: undefined,
+				promptTokens: undefined,
+				completionTokens: undefined,
+				reasoningTokens: undefined,
+			},
+		});
 	});
 
 	test('complete handler posts an OpenAI-compatible chat completion request', async () => {

--- a/packages/core/src/services/_util.ts
+++ b/packages/core/src/services/_util.ts
@@ -140,7 +140,7 @@ const binaryContentType = 'application/octet-stream';
 const textContentType = 'text/plain';
 const jsonContentType = 'application/json';
 
-export async function toPayload(data: unknown): Promise<[Body, string]> {
+export async function toPayload(data: unknown): Promise<[Body, string | undefined]> {
 	if (data === undefined || data === null) {
 		return ['', textContentType];
 	}
@@ -168,6 +168,12 @@ export async function toPayload(data: unknown): Promise<[Body, string]> {
 			}
 			if (data instanceof Uint8Array) {
 				return [data.buffer as ArrayBuffer, binaryContentType];
+			}
+			if (data instanceof Blob) {
+				return [data, data.type || binaryContentType];
+			}
+			if (data instanceof FormData) {
+				return [data, undefined];
 			}
 			if (data instanceof ReadableStream) {
 				return [data, binaryContentType];

--- a/packages/core/src/services/adapter.ts
+++ b/packages/core/src/services/adapter.ts
@@ -33,9 +33,13 @@ export const BodySchema = z
 		z.string(),
 		z.custom<Uint8Array>((value) => value instanceof Uint8Array),
 		z.instanceof(ArrayBuffer),
+		z.instanceof(Blob),
+		z.instanceof(FormData),
 		z.custom<ReadableStream>((value) => value instanceof ReadableStream),
 	])
-	.describe('Request body content (string, Uint8Array, ArrayBuffer, or ReadableStream).');
+	.describe(
+		'Request body content (string, Uint8Array, ArrayBuffer, Blob, FormData, or ReadableStream).'
+	);
 
 export type Body = z.infer<typeof BodySchema>;
 

--- a/packages/core/src/services/aigateway/index.ts
+++ b/packages/core/src/services/aigateway/index.ts
@@ -21,6 +21,8 @@ export {
 	type AIGatewayModels,
 	type AIGatewayModelsResponse,
 	type AIGatewayPricing,
+	type AIGatewayRequestOptions,
+	type AIGatewayRequestResponse,
 	type AIGatewayReasoning,
 	type AIGatewayResponseMetadata,
 	type AIGatewayStreamingCompletion,

--- a/packages/core/src/services/aigateway/service.ts
+++ b/packages/core/src/services/aigateway/service.ts
@@ -94,13 +94,17 @@ export interface AIGatewayCompletionAdapterRequest {
 	systemPrompt?: string;
 }
 
-const missingCompletionInputMessage = 'input, prompt, or messages must be provided';
+const missingCompletionInputMessage = 'contents, input, prompt, or messages must be provided';
 
 function hasCompletionInput(params: {
+	contents?: unknown[];
 	input?: unknown;
 	prompt?: string | string[];
 	messages?: unknown[];
 }): boolean {
+	if (params.contents && params.contents.length > 0) {
+		return true;
+	}
 	if (params.messages && params.messages.length > 0) {
 		return true;
 	}
@@ -129,6 +133,7 @@ export const AIGatewayChatCompletionParamsSchema = z
 			.unknown()
 			.optional()
 			.describe('Responses-compatible input payload for models using the Responses API.'),
+		contents: z.array(z.unknown()).optional().describe('Google Generative AI contents payload.'),
 		messages: z.array(AIGatewayChatMessageSchema).optional().describe('Messages to complete.'),
 		prompt: z
 			.union([z.string(), z.array(z.string())])
@@ -169,6 +174,21 @@ function toResponsesInput(messages: AIGatewayChatMessage[], systemPrompt?: strin
 	}));
 }
 
+function toGoogleRole(role: AIGatewayChatMessage['role']): 'model' | 'user' {
+	return role === 'assistant' ? 'model' : 'user';
+}
+
+function toGoogleContents(messages: AIGatewayChatMessage[]) {
+	return messages.map((message) => ({
+		role: toGoogleRole(message.role),
+		parts: [{ text: typeof message.content === 'string' ? message.content : '' }],
+	}));
+}
+
+function toGoogleSystemInstruction(systemPrompt?: string) {
+	return systemPrompt ? { parts: [{ text: systemPrompt }] } : undefined;
+}
+
 function getMaxTokensParam(model: string, maxTokens?: number): Record<string, number> {
 	if (!maxTokens) return {};
 
@@ -197,6 +217,31 @@ function getReasoningBudget(reasoning?: AIGatewayReasoning): number | undefined 
 	const reasoningBudget = Number(reasoning);
 
 	return Number.isFinite(reasoningBudget) && reasoningBudget > 0 ? reasoningBudget : undefined;
+}
+
+function getGoogleThinkingLevel(
+	reasoning?: AIGatewayReasoning
+): 'HIGH' | 'MEDIUM' | 'MINIMAL' | undefined {
+	switch (reasoning) {
+		case 'low':
+			return 'MINIMAL';
+		case 'medium':
+			return 'MEDIUM';
+		case 'high':
+			return 'HIGH';
+		default:
+			return undefined;
+	}
+}
+
+function getGoogleThinkingConfig(reasoning?: AIGatewayReasoning) {
+	const reasoningBudget = getReasoningBudget(reasoning);
+	if (reasoningBudget) {
+		return { thinkingBudget: reasoningBudget };
+	}
+
+	const thinkingLevel = getGoogleThinkingLevel(reasoning);
+	return thinkingLevel ? { thinkingLevel } : undefined;
 }
 
 function isDeepSeekModel(model: string): boolean {
@@ -230,6 +275,7 @@ export function buildAIGatewayCompletionParams({
 }: AIGatewayCompletionAdapterRequest): AIGatewayChatCompletionParams {
 	const reasoningEffort = getOpenAIReasoningEffort(reasoning);
 	const reasoningBudget = getReasoningBudget(reasoning);
+	const googleThinkingConfig = getGoogleThinkingConfig(reasoning);
 
 	switch (api) {
 		case 'openai-responses':
@@ -255,12 +301,12 @@ export function buildAIGatewayCompletionParams({
 		case 'google-generative-ai':
 			return {
 				model,
-				messages,
-				...(systemPrompt ? { system_instruction: systemPrompt } : {}),
-				...(reasoningBudget
-					? { generationConfig: { thinkingConfig: { thinkingBudget: reasoningBudget } } }
-					: {}),
-				...getMaxTokensParam(model, maxTokens),
+				contents: toGoogleContents(messages),
+				...(systemPrompt ? { systemInstruction: toGoogleSystemInstruction(systemPrompt) } : {}),
+				generationConfig: {
+					...(maxTokens ? { maxOutputTokens: maxTokens } : {}),
+					...(googleThinkingConfig ? { thinkingConfig: googleThinkingConfig } : {}),
+				},
 			};
 		default:
 			return {
@@ -298,6 +344,15 @@ export const AIGatewayChatCompletionSchema = z
 				cost: z
 					.object({
 						total: z.number().optional().describe('Total estimated gateway cost in USD.'),
+						unit: z.string().optional().describe('Gateway billing unit.'),
+						inputQuantity: z
+							.number()
+							.optional()
+							.describe('Input quantity used for non-token gateway billing.'),
+						outputQuantity: z
+							.number()
+							.optional()
+							.describe('Output quantity used for non-token gateway billing.'),
 						promptTokens: z
 							.number()
 							.optional()
@@ -328,6 +383,9 @@ export const AIGatewayResponseMetadataSchema = z.object({
 	cost: z
 		.object({
 			total: z.number().optional(),
+			unit: z.string().optional(),
+			inputQuantity: z.number().optional(),
+			outputQuantity: z.number().optional(),
 			promptTokens: z.number().optional(),
 			completionTokens: z.number().optional(),
 			reasoningTokens: z.number().optional(),
@@ -341,6 +399,20 @@ export type AIGatewayStreamingCompletion = {
 	stream: ReadableStream<Uint8Array>;
 	metadata: Promise<AIGatewayResponseMetadata>;
 };
+
+export interface AIGatewayRequestOptions {
+	path: string;
+	method?: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'HEAD' | 'OPTIONS' | 'PATCH';
+	body?: unknown;
+	headers?: Record<string, string>;
+	stream?: boolean;
+}
+
+export interface AIGatewayRequestResponse<T = unknown> {
+	data: T;
+	response: Response;
+	metadata: AIGatewayResponseMetadata;
+}
 
 function parseNumber(value: string | undefined): number | undefined {
 	if (value === undefined || value.trim() === '') {
@@ -391,6 +463,9 @@ function extractGatewayMetadataFromHeaders(headers: Headers): AIGatewayResponseM
 	}
 
 	const total = parseNumber(captured['x-gateway-cost']);
+	const unit = captured['x-gateway-billing-unit'];
+	const inputQuantity = parseNumber(captured['x-gateway-input-quantity']);
+	const outputQuantity = parseNumber(captured['x-gateway-output-quantity']);
 	const promptTokens = parseNumber(captured['x-gateway-prompt-tokens']);
 	const completionTokens = parseNumber(captured['x-gateway-completion-tokens']);
 	const reasoningTokens =
@@ -400,10 +475,21 @@ function extractGatewayMetadataFromHeaders(headers: Headers): AIGatewayResponseM
 		positiveNumber(parseNumber(captured['x-agentuity-reasoning-token-count']));
 	const cost =
 		total !== undefined ||
+		unit !== undefined ||
+		inputQuantity !== undefined ||
+		outputQuantity !== undefined ||
 		promptTokens !== undefined ||
 		completionTokens !== undefined ||
 		reasoningTokens !== undefined
-			? { total, promptTokens, completionTokens, reasoningTokens }
+			? {
+					total,
+					unit,
+					inputQuantity,
+					outputQuantity,
+					promptTokens,
+					completionTokens,
+					reasoningTokens,
+				}
 			: undefined;
 
 	return {
@@ -665,6 +751,31 @@ export class AIGatewayService {
 		return AIGatewayChatCompletionSchema.parse(payload);
 	}
 
+	async request<T = unknown>(
+		options: AIGatewayRequestOptions
+	): Promise<AIGatewayRequestResponse<T>> {
+		const method = options.method ?? 'POST';
+		const url = buildUrl(this.baseUrl, options.path);
+		const payload =
+			options.body === undefined && (method === 'GET' || method === 'HEAD')
+				? undefined
+				: await toPayload(options.body);
+		const response = await this.adapter.invoke<T>(url, {
+			method,
+			...(payload ? { body: payload[0], contentType: payload[1] } : {}),
+			...(options.headers ? { headers: options.headers } : {}),
+			telemetry: { name: 'aigateway.request' },
+		});
+		if (!response.ok) {
+			throw await toServiceException(method, url, response.response);
+		}
+		return {
+			data: response.data,
+			response: response.response,
+			metadata: await extractGatewayMetadata(response.response),
+		};
+	}
+
 	async streamComplete(
 		params: AIGatewayChatCompletionParams
 	): Promise<ReadableStream<Uint8Array>> {
@@ -686,6 +797,38 @@ export class AIGatewayService {
 			headers: { Accept: 'text/event-stream' },
 			binary: true,
 			telemetry: { name: 'aigateway.completions.stream' },
+		});
+		if (!response.ok) {
+			throw await toServiceException(method, url, response.response);
+		}
+		if (!response.response.body) {
+			throw await toServiceException(
+				method,
+				url,
+				new Response('Streaming response did not include a body', { status: 502 })
+			);
+		}
+		const streamed = streamWithGatewayMetadata(response.response.body);
+		return {
+			stream: streamed.stream,
+			metadata: Promise.all([extractGatewayMetadata(response.response), streamed.metadata]).then(
+				([responseMetadata, streamMetadata]) =>
+					mergeGatewayMetadata(responseMetadata, streamMetadata)
+			),
+		};
+	}
+
+	async streamRequest(options: AIGatewayRequestOptions): Promise<AIGatewayStreamingCompletion> {
+		const method = options.method ?? 'POST';
+		const url = buildUrl(this.baseUrl, options.path);
+		const [body, contentType] = await toPayload(options.body);
+		const response = await this.adapter.invoke<never>(url, {
+			method,
+			body,
+			contentType,
+			headers: { Accept: 'text/event-stream', ...(options.headers ?? {}) },
+			binary: true,
+			telemetry: { name: 'aigateway.request.stream' },
 		});
 		if (!response.ok) {
 			throw await toServiceException(method, url, response.response);

--- a/packages/core/src/services/aigateway/service.ts
+++ b/packages/core/src/services/aigateway/service.ts
@@ -43,6 +43,9 @@ export const AIGatewayModelSchema = z.object({
 	temperature: z.boolean().optional().describe('Whether the model supports temperature.'),
 	knowledge: z.string().optional().describe('Knowledge cutoff or label.'),
 	open_weights: z.boolean().optional().describe('Whether the model has open weights.'),
+	recommended: z.boolean().optional().describe('Whether this model is recommended.'),
+	default_for: z.array(z.string()).optional().describe('Default use cases for this model.'),
+	rank: z.number().optional().describe('Recommendation rank; lower values are preferred.'),
 	provider: AIGatewayModelProviderSchema.optional().describe('Provider metadata.'),
 	pricing: AIGatewayPricingSchema.optional().describe('Model pricing.'),
 });

--- a/packages/core/test/aigateway.test.ts
+++ b/packages/core/test/aigateway.test.ts
@@ -68,6 +68,10 @@ describe('AIGatewayService', () => {
 		expect(calls[0]?.url).toBe(`${baseUrl}/models`);
 		expect(calls[0]?.options.method).toBe('GET');
 		expect(models.openai?.[0]?.id).toBe('gpt-4.1-mini');
+		expect(models.openai?.[0]?.api).toBeUndefined();
+		expect(models.openai?.[0]?.input_modalities).toEqual(['text']);
+		expect(models.openai?.[0]?.output_modalities).toEqual(['text']);
+		expect(models.openai?.[0]?.pricing?.unit).toBe('per_million_tokens');
 	});
 
 	test('creates completions through the AI Gateway auto-router endpoint', async () => {
@@ -246,6 +250,54 @@ describe('AIGatewayService', () => {
 		});
 	});
 
+	test('builds Google Generative AI-shaped params from model API metadata', () => {
+		expect(
+			buildAIGatewayCompletionParams({
+				api: 'google-generative-ai',
+				maxTokens: 1024,
+				messages: [
+					{ role: 'user', content: 'Say hello' },
+					{ role: 'assistant', content: 'Hello' },
+				],
+				model: 'googleai/gemini-2.5-flash',
+				reasoning: '1024',
+				systemPrompt: 'You are concise.',
+			})
+		).toEqual({
+			model: 'googleai/gemini-2.5-flash',
+			contents: [
+				{ role: 'user', parts: [{ text: 'Say hello' }] },
+				{ role: 'model', parts: [{ text: 'Hello' }] },
+			],
+			systemInstruction: {
+				parts: [{ text: 'You are concise.' }],
+			},
+			generationConfig: {
+				maxOutputTokens: 1024,
+				thinkingConfig: { thinkingBudget: 1024 },
+			},
+		});
+	});
+
+	test('builds Google thinkingLevel params for named reasoning levels', () => {
+		expect(
+			buildAIGatewayCompletionParams({
+				api: 'google-generative-ai',
+				maxTokens: 1024,
+				messages: [{ role: 'user', content: 'Say hello' }],
+				model: 'googleai/gemini-3.1-flash-lite',
+				reasoning: 'low',
+			})
+		).toEqual({
+			model: 'googleai/gemini-3.1-flash-lite',
+			contents: [{ role: 'user', parts: [{ text: 'Say hello' }] }],
+			generationConfig: {
+				maxOutputTokens: 1024,
+				thinkingConfig: { thinkingLevel: 'MINIMAL' },
+			},
+		});
+	});
+
 	test('builds DeepSeek OpenAI-compatible params with explicit thinking disabled', () => {
 		expect(
 			buildAIGatewayCompletionParams({
@@ -315,6 +367,110 @@ describe('AIGatewayService', () => {
 		expect(stream).toBeInstanceOf(ReadableStream);
 	});
 
+	test('sends upstream-shaped gateway requests to custom paths', async () => {
+		const { adapter, calls } = createMockAdapter([
+			{
+				ok: true,
+				data: {
+					embedding: [0.1, 0.2],
+				},
+				headers: {
+					'x-gateway-cost': '0.000012',
+					'x-gateway-billing-unit': 'per_million_tokens',
+					'x-gateway-input-quantity': '3.000000',
+					'x-gateway-output-quantity': '0.000000',
+				},
+			},
+		]);
+		const service = new AIGatewayService(baseUrl, adapter);
+
+		const result = await service.request<{ embedding: number[] }>({
+			path: '/v1/embeddings',
+			body: { model: 'openai/text-embedding-3-small', input: 'hello' },
+		});
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.url).toBe(`${baseUrl}/v1/embeddings`);
+		expect(calls[0]?.options.method).toBe('POST');
+		expect(calls[0]?.options.contentType).toBe('application/json');
+		expect(JSON.parse(String(calls[0]?.options.body))).toEqual({
+			model: 'openai/text-embedding-3-small',
+			input: 'hello',
+		});
+		expect(result.data.embedding).toEqual([0.1, 0.2]);
+		expect(result.metadata.cost).toEqual({
+			total: 0.000012,
+			unit: 'per_million_tokens',
+			inputQuantity: 3,
+			outputQuantity: 0,
+			promptTokens: undefined,
+			completionTokens: undefined,
+			reasoningTokens: undefined,
+		});
+	});
+
+	test('extracts non-token metered gateway metadata from headers', async () => {
+		const { adapter } = createMockAdapter([
+			{
+				ok: true,
+				data: { text: 'You' },
+				headers: {
+					'x-gateway-cost': '0.000120',
+					'x-gateway-billing-unit': 'per_minute_audio',
+					'x-gateway-input-quantity': '0.016667',
+				},
+			},
+		]);
+		const service = new AIGatewayService(baseUrl, adapter);
+
+		const result = await service.request({
+			path: '/v1/audio/transcriptions',
+			body: { model: 'openai/whisper-1' },
+		});
+
+		expect(result.metadata.cost).toEqual({
+			total: 0.00012,
+			unit: 'per_minute_audio',
+			inputQuantity: 0.016667,
+			outputQuantity: undefined,
+			promptTokens: undefined,
+			completionTokens: undefined,
+			reasoningTokens: undefined,
+		});
+	});
+
+	test('streams upstream-shaped gateway requests from custom paths', async () => {
+		const { adapter, calls } = createMockAdapter([
+			{
+				ok: true,
+				data: undefined,
+				headers: {
+					'content-type': 'text/event-stream',
+					'x-gateway-cost': '0.000045',
+				},
+				body: 'data: {"text":"hello"}\n\n',
+			},
+		]);
+		const service = new AIGatewayService(baseUrl, adapter);
+
+		const result = await service.streamRequest({
+			path: '/v1beta/models/gemini-3.1-flash-lite:streamGenerateContent',
+			body: {
+				contents: [{ role: 'user', parts: [{ text: 'hello' }] }],
+			},
+		});
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.url).toBe(
+			`${baseUrl}/v1beta/models/gemini-3.1-flash-lite:streamGenerateContent`
+		);
+		expect(calls[0]?.options.method).toBe('POST');
+		expect(calls[0]?.options.headers).toEqual({ Accept: 'text/event-stream' });
+		expect(calls[0]?.options.binary).toBe(true);
+		expect(await new Response(result.stream).text()).toContain('hello');
+		expect((await result.metadata).cost?.total).toBe(0.000045);
+	});
+
 	test('streams chat completions with gateway metadata', async () => {
 		const { adapter } = createMockAdapter([
 			{
@@ -361,7 +517,7 @@ describe('AIGatewayService', () => {
 				headers: { 'content-type': 'text/event-stream' },
 				body:
 					'data: {"type":"response.output_text.delta","delta":"Hello"}\n\n' +
-					'data: {"type":"response.completed","response":{"usage":{"output_tokens_details":{"reasoning_tokens":64}},"agentuity":{"headers":{"x-gateway-cost":"0.000498","x-gateway-prompt-tokens":"37","x-gateway-completion-tokens":"203"},"cost":{"total":0.000498,"promptTokens":37,"completionTokens":203}}}}\n\n',
+					'data: {"type":"response.completed","response":{"usage":{"output_tokens_details":{"reasoning_tokens":64}},"agentuity":{"headers":{"x-gateway-cost":"0.000498","x-gateway-prompt-tokens":"37","x-gateway-completion-tokens":"203","x-gateway-billing-unit":"per_million_tokens","x-gateway-input-quantity":"37.000000","x-gateway-output-quantity":"203.000000"},"cost":{"total":0.000498,"promptTokens":37,"completionTokens":203,"unit":"per_million_tokens","inputQuantity":37,"outputQuantity":203}}}}\n\n',
 			},
 		]);
 		const service = new AIGatewayService(baseUrl, adapter);
@@ -380,9 +536,15 @@ describe('AIGatewayService', () => {
 				'x-gateway-cost': '0.000498',
 				'x-gateway-prompt-tokens': '37',
 				'x-gateway-completion-tokens': '203',
+				'x-gateway-billing-unit': 'per_million_tokens',
+				'x-gateway-input-quantity': '37.000000',
+				'x-gateway-output-quantity': '203.000000',
 			},
 			cost: {
 				total: 0.000498,
+				unit: 'per_million_tokens',
+				inputQuantity: 37,
+				outputQuantity: 203,
 				promptTokens: 37,
 				completionTokens: 203,
 				reasoningTokens: 64,

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -274,6 +274,14 @@ function sanitizeModalities(modalities: string[] | undefined): ('text' | 'image'
 	return sanitized.length > 0 ? sanitized : ['text'];
 }
 
+function supportsPiTextChat(m: AIGatewayModel): boolean {
+	const inputModalities =
+		m.input_modalities && m.input_modalities.length > 0 ? m.input_modalities : ['text'];
+	const outputModalities =
+		m.output_modalities && m.output_modalities.length > 0 ? m.output_modalities : ['text'];
+	return inputModalities.includes('text') && outputModalities.includes('text');
+}
+
 function toPiModel(m: AIGatewayModel): ProviderModelConfig {
 	return {
 		id: m.id,
@@ -313,6 +321,9 @@ async function registerAIGatewayProviders(pi: ExtensionAPI) {
 	for (const m of allModels) {
 		const apiType = m.api;
 		if (!isKnownApi(apiType)) {
+			continue;
+		}
+		if (!supportsPiTextChat(m)) {
 			continue;
 		}
 		const existing = modelsByApi.get(apiType) ?? [];


### PR DESCRIPTION
## Summary
- expose AI Gateway model API, modality, pricing unit, and recommendation metadata through SDK/CLI types
- parse gateway billing unit and metered input/output quantities from response headers and SSE metadata
- add raw AI Gateway request/stream request helpers for upstream-shaped modality APIs
- add CLI modality subcommands for embeddings, image, speech, transcription, and video
- surface model modalities, pricing units, and catalog recommendations in the CLI model list
- allow modality CLI commands to omit `--model` and select catalog defaults from `recommended/default_for/rank`
- filter Pi AI Gateway plugin model choices to text-capable chat models

## Validation
- `bun run --filter='./packages/core' typecheck`
- `bun run --filter='./packages/cli' typecheck`
- `bun run --filter='./packages/cli' build`
- local gateway smoke tests with `AGENTUITY_PROFILE=local AGENTUITY_REGION=local`:
  - completion output piped into embeddings
  - speech output saved and fed into transcription
  - completion output piped into image generation
  - omitted `--model` for embeddings, speech, transcription, and image after catalog defaults were refreshed
