### PR TITLE
Handle array AI Gateway stream frames

### DIFF
--- a/packages/core/src/services/aigateway/service.ts
+++ b/packages/core/src/services/aigateway/service.ts
@@ -422,6 +422,9 @@ export function getAIGatewayTextFromParts(parts: unknown): string {
 }
 
 export function getAIGatewayStreamDeltaText(payload: unknown): string {
+	if (Array.isArray(payload)) {
+		return payload.map(getAIGatewayStreamDeltaText).join('');
+	}
 	if (!payload || typeof payload !== 'object') return '';
 
 	const type = (payload as { type?: unknown }).type;
@@ -493,6 +496,9 @@ export function getAIGatewayStreamDeltaText(payload: unknown): string {
 }
 
 export function getAIGatewayStreamReasoningText(payload: unknown): string {
+	if (Array.isArray(payload)) {
+		return payload.map(getAIGatewayStreamReasoningText).join('');
+	}
 	if (!payload || typeof payload !== 'object') return '';
 
 	const type = (payload as { type?: unknown }).type;

--- a/packages/core/test/aigateway.test.ts
+++ b/packages/core/test/aigateway.test.ts
@@ -335,6 +335,28 @@ describe('AIGatewayService', () => {
 				],
 			})
 		).toBe('Gemini');
+		expect(
+			getAIGatewayStreamDeltaText([
+				{
+					candidates: [
+						{
+							content: {
+								parts: [{ text: 'Gemini' }],
+							},
+						},
+					],
+				},
+				{
+					candidates: [
+						{
+							content: {
+								parts: [{ text: ' array' }],
+							},
+						},
+					],
+				},
+			])
+		).toBe('Gemini array');
 	});
 
 	test('extracts provider stream reasoning through AI Gateway adapters', () => {
@@ -367,6 +389,12 @@ describe('AIGatewayService', () => {
 				choices: [{ delta: { reasoning_content: 'DeepSeek thinking' } }],
 			})
 		).toBe('DeepSeek thinking');
+		expect(
+			getAIGatewayStreamReasoningText([
+				{ type: 'response.reasoning_text.delta', delta: 'Array' },
+				{ type: 'response.reasoning_text.delta', delta: ' reasoning' },
+			])
+		).toBe('Array reasoning');
 	});
 
 	test('builds DeepSeek OpenAI-compatible params with explicit thinking disabled', () => {


### PR DESCRIPTION
## Summary
- handle array-framed provider stream payloads in AI Gateway text extraction
- apply the same array handling to streamed reasoning extraction
- add coverage for Gemini-style candidate arrays and reasoning array frames

## Validation
- bun test packages/core/test/aigateway.test.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed text extraction when AI services return multiple response chunks; array-formatted payloads now properly concatenate results instead of silently failing
* Improved stream text processing to reliably handle complex response structures for delta and reasoning text retrieval scenarios

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentuity/sdk/pull/1469)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->