### PR TITLE
chore: harden dependency and workflow automation

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - blacksmith-2vcpu-ubuntu-2404
+    - blacksmith-4vcpu-ubuntu-2204

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,30 @@
+name: Actionlint
+
+on:
+  pull_request:
+    paths:
+      - '.github/actionlint.yaml'
+      - '.github/workflows/**'
+  push:
+    branches:
+      - main
+      - v2
+    paths:
+      - '.github/actionlint.yaml'
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+
+env:
+  GITHUB_TOKEN: ''
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca

--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -8,19 +8,27 @@ on:
       - "release/**"
   pull_request:
 
+permissions:
+  contents: read
+
+env:
+  GITHUB_TOKEN: ''
+
 jobs:
   check:
     name: Format & Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: "1.3.11"
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run Biome check
         run: bunx biome ci .

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,12 +7,16 @@ on:
          - v2
    pull_request:
 
+permissions:
+   contents: read
+
 concurrency:
    group: ${{ github.workflow }}-${{ github.ref }}
    cancel-in-progress: false
 
 env:
    CI: true
+   GITHUB_TOKEN: ''
    AGENTUITY_API_URL: https://api.agentuity.com
    AGENTUITY_APP_URL: https://app.agentuity.com
    AGENTUITY_TRANSPORT_URL: https://catalyst-usc.agentuity.cloud
@@ -32,19 +36,23 @@ jobs:
       env:
          AGENTUITY_USER_ID: ${{ vars.AGENTUITY_USER_ID }}
       steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+           with:
+              persist-credentials: false
          - name: Setup Bun
-           uses: oven-sh/setup-bun@v2
+           uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+           with:
+              bun-version: "1.3.11"
          - name: Install dependencies
            run: |
               set -eou pipefail
-              bun install
+              bun install --frozen-lockfile
          - name: Setup test credentials
            run: |
               # Generate CLI API key for whoami command
-              APIKEY=$(curl $AGENTUITY_API_URL/cli/auth/short-token -H 'Content-Type: application/json' --data "{\"secret\":\"${{ secrets.AGENTUITY_APITOKEN_SHARED_SECRET }}\",\"userId\":\"${{ env.AGENTUITY_USER_ID }}\"}" | jq -r '.data.apiKey')
+              APIKEY=$(curl "$AGENTUITY_API_URL/cli/auth/short-token" -H 'Content-Type: application/json' --data "{\"secret\":\"${{ secrets.AGENTUITY_APITOKEN_SHARED_SECRET }}\",\"userId\":\"${{ env.AGENTUITY_USER_ID }}\"}" | jq -r '.data.apiKey')
               echo "::add-mask::${APIKEY}"
-              echo "AGENTUITY_CLI_API_KEY=${APIKEY}" >> $GITHUB_ENV
+              echo "AGENTUITY_CLI_API_KEY=${APIKEY}" >> "$GITHUB_ENV"
          - name: Build and Test
            timeout-minutes: 15
            run: |

--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -17,6 +17,7 @@ concurrency:
 
 env:
    CI: true
+   GITHUB_TOKEN: ''
    AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
    AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
    AWS_ENDPOINT_URL_S3: ${{ vars.AWS_ENDPOINT_URL_S3 }}
@@ -29,15 +30,18 @@ jobs:
       timeout-minutes: 15
       name: Pack & Upload
       steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
            with:
+              persist-credentials: false
               ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
          - name: Setup Bun
-           uses: oven-sh/setup-bun@v2
+           uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+           with:
+              bun-version: "1.3.11"
 
          - name: Install dependencies
-           run: bun install
+           run: bun install --frozen-lockfile
 
          - name: Pack and Upload
            id: pack
@@ -45,7 +49,7 @@ jobs:
 
          - name: Comment on PR
            if: github.event_name == 'pull_request'
-           uses: actions/github-script@v7
+           uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
            with:
               script: |
                  const version = '${{ steps.pack.outputs.prerelease_version }}';

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,27 @@
+name: Gitleaks Scan
+
+on:
+  pull_request:
+  merge_group:
+  schedule:
+    - cron: "11 9 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: Gitleaks Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.github/workflows/osv-scanner-nightly.yml
+++ b/.github/workflows/osv-scanner-nightly.yml
@@ -1,0 +1,19 @@
+name: OSV-Scanner Nightly Scan
+
+on:
+  schedule:
+    - cron: "17 8 * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  scan-nightly:
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      scan-args: |-
+        --recursive
+        ./

--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -1,0 +1,76 @@
+name: OSV-Scanner PR Scan
+
+on:
+  pull_request:
+  merge_group:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  scan-pr:
+    name: OSV Scanner PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout target branch
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+        run: |
+          git checkout "$BASE_SHA"
+          git submodule update --recursive
+
+      - name: Run scanner on existing code
+        uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2
+        continue-on-error: true
+        with:
+          scan-args: |-
+            --format=json
+            --output=old-results.json
+            --recursive
+            ./
+
+      - name: Checkout current branch
+        run: |
+          git checkout -f "$GITHUB_SHA"
+          git submodule update --recursive
+
+      - name: Run scanner on new code
+        uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2
+        continue-on-error: true
+        with:
+          scan-args: |-
+            --format=json
+            --output=new-results.json
+            --recursive
+            ./
+
+      - name: Compare scanner results
+        id: compare
+        uses: google/osv-scanner-action/osv-reporter-action@9a498708959aeaef5ef730655706c5a1df1edbc2
+        continue-on-error: true
+        with:
+          scan-args: |-
+            --output=results.sarif
+            --old=old-results.json
+            --new=new-results.json
+            --gh-annotations=true
+            --fail-on-vuln=true
+
+      - name: Upload to code scanning
+        if: ${{ !cancelled() && hashFiles('results.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@cdefb33c0f6224e58673d9004f47f7cb3e328b89
+        with:
+          sarif_file: results.sarif
+
+      - name: Fail on newly introduced vulnerabilities
+        if: ${{ steps.compare.outcome == 'failure' }}
+        run: |
+          echo "::error::OSV-Scanner found newly introduced vulnerabilities."
+          exit 1

--- a/.github/workflows/package-smoke-test.yaml
+++ b/.github/workflows/package-smoke-test.yaml
@@ -7,12 +7,16 @@ on:
          - v2
    pull_request:
 
+permissions:
+   contents: read
+
 concurrency:
    group: ${{ github.workflow }}-${{ github.ref }}
    cancel-in-progress: true
 
 env:
    CI: true
+   GITHUB_TOKEN: ''
 
 jobs:
    smoke-test:
@@ -20,13 +24,17 @@ jobs:
       timeout-minutes: 15
       name: Package Installation & Usage Test
       steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+           with:
+              persist-credentials: false
 
          - name: Setup Bun
-           uses: oven-sh/setup-bun@v2
+           uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+           with:
+              bun-version: "1.3.11"
 
          - name: Install dependencies
-           run: bun install
+           run: bun install --frozen-lockfile
 
          - name: Run package smoke test
            run: bash scripts/test-package-install.sh
@@ -36,13 +44,17 @@ jobs:
       timeout-minutes: 10
       name: Postgres SSL Integration Test
       steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+           with:
+              persist-credentials: false
 
          - name: Setup Bun
-           uses: oven-sh/setup-bun@v2
+           uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+           with:
+              bun-version: "1.3.11"
 
          - name: Install dependencies
-           run: bun install
+           run: bun install --frozen-lockfile
 
          - name: Build packages
            run: bun run build
@@ -58,10 +70,14 @@ jobs:
       timeout-minutes: 5
       name: Installation Type Detection Test
       steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+           with:
+              persist-credentials: false
 
          - name: Setup Bun
-           uses: oven-sh/setup-bun@v2
+           uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+           with:
+              bun-version: "1.3.11"
 
          - name: Run installation type detection tests
            run: bash packages/cli/scripts/test-installation-type.sh
@@ -71,13 +87,17 @@ jobs:
       timeout-minutes: 5
       name: Standalone Agent Test
       steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+           with:
+              persist-credentials: false
 
          - name: Setup Bun
-           uses: oven-sh/setup-bun@v2
+           uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+           with:
+              bun-version: "1.3.11"
 
          - name: Install dependencies
-           run: bun install
+           run: bun install --frozen-lockfile
 
          - name: Build packages
            run: bun run build
@@ -95,13 +115,17 @@ jobs:
          AGENTUITY_CLOUD_ORG_ID: ${{ vars.AGENTUITY_CLOUD_ORG_ID }}
          AGENTUITY_REGION: usc
       steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+           with:
+              persist-credentials: false
 
          - name: Setup Bun
-           uses: oven-sh/setup-bun@v2
+           uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+           with:
+              bun-version: "1.3.11"
 
          - name: Install dependencies
-           run: bun install
+           run: bun install --frozen-lockfile
 
          - name: Prepare SDK for testing
            run: bash scripts/prepare-sdk-for-testing.sh
@@ -112,15 +136,17 @@ jobs:
          - name: Setup test credentials
            run: |
               # Generate CLI API key for authentication
-              APIKEY=$(curl $AGENTUITY_API_URL/cli/auth/short-token -H 'Content-Type: application/json' --data "{\"secret\":\"${{ secrets.AGENTUITY_APITOKEN_SHARED_SECRET }}\",\"userId\":\"${{ env.AGENTUITY_USER_ID }}\"}" | jq -r '.data.apiKey')
+              APIKEY=$(curl "$AGENTUITY_API_URL/cli/auth/short-token" -H 'Content-Type: application/json' --data "{\"secret\":\"${{ secrets.AGENTUITY_APITOKEN_SHARED_SECRET }}\",\"userId\":\"${{ env.AGENTUITY_USER_ID }}\"}" | jq -r '.data.apiKey')
               echo "::add-mask::${APIKEY}"
-              echo "AGENTUITY_CLI_API_KEY=${APIKEY}" >> $GITHUB_ENV
+              {
+                echo "AGENTUITY_CLI_API_KEY=${APIKEY}"
 
-              # Set SDK key for integration-suite tests
-              echo "AGENTUITY_SDK_KEY=${{ secrets.INTEGRATION_SUITE_AGENTUITY_SDK_KEY }}" >> $GITHUB_ENV
+                # Set SDK key for integration-suite tests
+                echo "AGENTUITY_SDK_KEY=${{ secrets.INTEGRATION_SUITE_AGENTUITY_SDK_KEY }}"
 
-              # Set OpenAI API key for embedding operations
-              echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> $GITHUB_ENV
+                # Set OpenAI API key for embedding operations
+                echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}"
+              } >> "$GITHUB_ENV"
 
          - name: Run integration test suite
            run: bash apps/testing/integration-suite/scripts/ci-test.sh
@@ -143,13 +169,17 @@ jobs:
          AGENTUITY_REGION: usc
          AGENTUITY_USER_ID: ${{ vars.AGENTUITY_USER_ID }}
       steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+           with:
+              persist-credentials: false
 
          - name: Setup Bun
-           uses: oven-sh/setup-bun@v2
+           uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+           with:
+              bun-version: "1.3.11"
 
          - name: Install dependencies
-           run: bun install
+           run: bun install --frozen-lockfile
 
          - name: Prepare SDK for testing
            run: bash scripts/prepare-sdk-for-testing.sh
@@ -160,15 +190,17 @@ jobs:
          - name: Setup test credentials
            run: |
               # Generate CLI API key for cloud operations
-              APIKEY=$(curl $AGENTUITY_API_URL/cli/auth/short-token -H 'Content-Type: application/json' --data "{\"secret\":\"${{ secrets.AGENTUITY_APITOKEN_SHARED_SECRET }}\",\"userId\":\"${{ env.AGENTUITY_USER_ID }}\"}" | jq -r '.data.apiKey')
+              APIKEY=$(curl "$AGENTUITY_API_URL/cli/auth/short-token" -H 'Content-Type: application/json' --data "{\"secret\":\"${{ secrets.AGENTUITY_APITOKEN_SHARED_SECRET }}\",\"userId\":\"${{ env.AGENTUITY_USER_ID }}\"}" | jq -r '.data.apiKey')
               echo "::add-mask::${APIKEY}"
-              echo "AGENTUITY_CLI_API_KEY=${APIKEY}" >> $GITHUB_ENV
+              {
+                echo "AGENTUITY_CLI_API_KEY=${APIKEY}"
 
-              # Set SDK key for runtime operations
-              echo "AGENTUITY_SDK_KEY=${{ secrets.CLOUD_DEPLOYMENT_AGENTUITY_SDK_KEY }}" >> $GITHUB_ENV
+                # Set SDK key for runtime operations
+                echo "AGENTUITY_SDK_KEY=${{ secrets.CLOUD_DEPLOYMENT_AGENTUITY_SDK_KEY }}"
 
-              # Set OpenAI API key for embedding operations
-              echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> $GITHUB_ENV
+                # Set OpenAI API key for embedding operations
+                echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}"
+              } >> "$GITHUB_ENV"
 
          - name: Create .env file for app runtime
            run: |
@@ -211,13 +243,17 @@ jobs:
       timeout-minutes: 30
       name: Template Integration Tests
       steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+           with:
+              persist-credentials: false
 
          - name: Setup Bun
-           uses: oven-sh/setup-bun@v2
+           uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+           with:
+              bun-version: "1.3.11"
 
          - name: Install dependencies
-           run: bun install
+           run: bun install --frozen-lockfile
 
          - name: Build packages
            run: bun run build
@@ -235,13 +271,17 @@ jobs:
          AGENTUITY_CLOUD_ORG_ID: ${{ vars.AGENTUITY_CLOUD_ORG_ID }}
          AGENTUITY_REGION: usc
       steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+           with:
+              persist-credentials: false
 
          - name: Setup Bun
-           uses: oven-sh/setup-bun@v2
+           uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+           with:
+              bun-version: "1.3.11"
 
          - name: Install dependencies
-           run: bun install
+           run: bun install --frozen-lockfile
 
          - name: Build packages
            run: bun run build
@@ -249,9 +289,9 @@ jobs:
          - name: Setup test credentials
            run: |
               # Generate CLI API key for authentication
-              APIKEY=$(curl $AGENTUITY_API_URL/cli/auth/short-token -H 'Content-Type: application/json' --data "{\"secret\":\"${{ secrets.AGENTUITY_APITOKEN_SHARED_SECRET }}\",\"userId\":\"${{ env.AGENTUITY_USER_ID }}\"}" | jq -r '.data.apiKey')
+              APIKEY=$(curl "$AGENTUITY_API_URL/cli/auth/short-token" -H 'Content-Type: application/json' --data "{\"secret\":\"${{ secrets.AGENTUITY_APITOKEN_SHARED_SECRET }}\",\"userId\":\"${{ env.AGENTUITY_USER_ID }}\"}" | jq -r '.data.apiKey')
               echo "::add-mask::${APIKEY}"
-              echo "AGENTUITY_CLI_API_KEY=${APIKEY}" >> $GITHUB_ENV
+              echo "AGENTUITY_CLI_API_KEY=${APIKEY}" >> "$GITHUB_ENV"
 
          - name: Run queue CLI tests
            run: bash scripts/test-queue.sh
@@ -261,13 +301,17 @@ jobs:
       timeout-minutes: 15
       name: Playwright E2E Smoke Test
       steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+           with:
+              persist-credentials: false
 
          - name: Setup Bun
-           uses: oven-sh/setup-bun@v2
+           uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+           with:
+              bun-version: "1.3.11"
 
          - name: Install dependencies
-           run: bun install
+           run: bun install --frozen-lockfile
 
          - name: Install Playwright browsers
            run: bunx playwright install --with-deps chromium
@@ -299,13 +343,17 @@ jobs:
       timeout-minutes: 15
       name: Framework Integration Tests (TanStack & Next.js)
       steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+           with:
+              persist-credentials: false
 
          - name: Setup Bun
-           uses: oven-sh/setup-bun@v2
+           uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+           with:
+              bun-version: "1.3.11"
 
          - name: Install dependencies
-           run: bun install
+           run: bun install --frozen-lockfile
 
          - name: Install Playwright browsers
            run: bunx playwright install --with-deps chromium

--- a/.github/workflows/release-next.yaml
+++ b/.github/workflows/release-next.yaml
@@ -15,6 +15,7 @@ concurrency:
 
 env:
   CI: true
+  GITHUB_TOKEN: ''
   NODE_ENV: production
 
 jobs:
@@ -35,13 +36,17 @@ jobs:
       AGENTUITY_REGION: usc
       AGENTUITY_USER_ID: ${{ vars.AGENTUITY_USER_ID }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+           persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+           bun-version: "1.3.11"
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Setup test credentials
         run: |
@@ -52,7 +57,7 @@ jobs:
             --data "{\"secret\":\"${{ secrets.AGENTUITY_APITOKEN_SHARED_SECRET }}\",\"userId\":\"${{ env.AGENTUITY_USER_ID }}\"}" \
             | jq -er '.data.apiKey')
           echo "::add-mask::${APIKEY}"
-          echo "AGENTUITY_CLI_API_KEY=${APIKEY}" >> $GITHUB_ENV
+          echo "AGENTUITY_CLI_API_KEY=${APIKEY}" >> "$GITHUB_ENV"
 
       - name: Build
         run: bun run build
@@ -77,16 +82,20 @@ jobs:
     timeout-minutes: 15
     needs: build-and-test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+           persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+           bun-version: "1.3.11"
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Setup Node.js for npm
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '24'
 
@@ -166,12 +175,14 @@ jobs:
       - name: Summary
         run: |
           VERSION=$(jq -r .version package.json)
-          echo "## 📦 Released to npm" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** \`$VERSION\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Tag:** \`next\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Install with:" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "npm install @agentuity/core@next" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## 📦 Released to npm"
+            echo ""
+            echo "**Version:** \`${VERSION}\`"
+            echo "**Tag:** \`next\`"
+            echo ""
+            echo "Install with:"
+            echo "\`\`\`bash"
+            echo "npm install @agentuity/core@next"
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -15,8 +15,12 @@ on:
             required: false
             default: 'dev'
 
+permissions:
+   contents: read
+
 env:
    CI: true
+   GITHUB_TOKEN: ''
    AGENTUITY_API_URL: https://api.agentuity.com
    AGENTUITY_APP_URL: https://app.agentuity.com
    AGENTUITY_ORG_ID: org_2u8RgDTwcZWrZrZ3sZh24T5FCtz
@@ -30,24 +34,28 @@ jobs:
       env:
          AGENTUITY_USER_ID: ${{ vars.AGENTUITY_USER_ID }}
       steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+           with:
+              persist-credentials: false
 
          - name: Setup Bun
-           uses: oven-sh/setup-bun@v2
+           uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+           with:
+              bun-version: "1.3.11"
 
          - name: Install Agentuity CLI
            run: curl -fsSL https://agentuity.sh | sh
 
          - name: Generate CLI Auth Token
            run: |
-              APIKEY=$(curl $AGENTUITY_API_URL/cli/auth/short-token -H 'Content-Type: application/json' --data "{\"secret\":\"${{ secrets.AGENTUITY_APITOKEN_SHARED_SECRET }}\",\"userId\":\"${{ env.AGENTUITY_USER_ID }}\"}" | jq -r '.data.apiKey')
+              APIKEY=$(curl "$AGENTUITY_API_URL/cli/auth/short-token" -H 'Content-Type: application/json' --data "{\"secret\":\"${{ secrets.AGENTUITY_APITOKEN_SHARED_SECRET }}\",\"userId\":\"${{ env.AGENTUITY_USER_ID }}\"}" | jq -r '.data.apiKey')
               echo "::add-mask::${APIKEY}"
-              echo "AGENTUITY_CLI_API_KEY=${APIKEY}" >> $GITHUB_ENV
+              echo "AGENTUITY_CLI_API_KEY=${APIKEY}" >> "$GITHUB_ENV"
 
          - name: Prepare build context
            run: |
               # Build SDK packages (needed for sdk-explorer)
-              bun install
+              bun install --frozen-lockfile
               bun run build
               cd apps/docs && bun run scripts/bundle-run-scripts.ts && cd ../..
 
@@ -68,6 +76,6 @@ jobs:
               for file in snapshots/*.yaml; do
                 name=$(basename "$file" .yaml)
                 echo "::group::Building snapshot: $name"
-                agentuity cloud sandbox snapshot build --org-id $AGENTUITY_ORG_ID --confirm --metadata VERSION="$VERSION" --file "$file" .
+                agentuity cloud sandbox snapshot build --org-id "$AGENTUITY_ORG_ID" --confirm --metadata VERSION="$VERSION" --file "$file" .
                 echo "::endgroup::"
               done

--- a/.github/workflows/sync-docs-full.yml
+++ b/.github/workflows/sync-docs-full.yml
@@ -3,11 +3,19 @@ name: Full Docs Sync to Vector Store
 on:
    workflow_dispatch:
 
+permissions:
+   contents: read
+
+env:
+   GITHUB_TOKEN: ''
+
 jobs:
    full-sync:
       runs-on: ubuntu-latest
       steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+           with:
+              persist-credentials: false
 
          - name: Collect all files
            run: |

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -17,12 +17,19 @@ on:
             required: false
             type: string
 
+permissions:
+   contents: read
+
+env:
+   GITHUB_TOKEN: ''
+
 jobs:
    sync:
       runs-on: ubuntu-latest
       steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
            with:
+              persist-credentials: false
               fetch-depth: 0
 
          - name: Set commit variables
@@ -39,12 +46,12 @@ jobs:
                   AFTER_COMMIT="$(git rev-parse HEAD)"
                 fi
 
-                echo "before_commit=$BEFORE_COMMIT" >> $GITHUB_OUTPUT
-                echo "after_commit=$AFTER_COMMIT" >> $GITHUB_OUTPUT
+                echo "before_commit=$BEFORE_COMMIT" >> "$GITHUB_OUTPUT"
+                echo "after_commit=$AFTER_COMMIT" >> "$GITHUB_OUTPUT"
                 echo "Manual run: $BEFORE_COMMIT -> $AFTER_COMMIT"
               else
-                echo "before_commit=${{ github.event.before }}" >> $GITHUB_OUTPUT
-                echo "after_commit=${{ github.sha }}" >> $GITHUB_OUTPUT
+                echo "before_commit=${{ github.event.before }}" >> "$GITHUB_OUTPUT"
+                echo "after_commit=${{ github.sha }}" >> "$GITHUB_OUTPUT"
                 echo "Push run: ${{ github.event.before }} -> ${{ github.sha }}"
               fi
 

--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -17,12 +17,16 @@ on:
          - 'scripts/test-bun-check.sh'
          - '.github/workflows/test-install.yaml'
 
+permissions:
+   contents: read
+
 concurrency:
    group: ${{ github.workflow }}-${{ github.ref }}
    cancel-in-progress: true
 
 env:
    CI: true
+   GITHUB_TOKEN: ''
 
 jobs:
    # Test on native macOS and Linux runners
@@ -40,12 +44,14 @@ jobs:
                - macos-14
       steps:
          - name: Checkout
-           uses: actions/checkout@v4
+           uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+           with:
+              persist-credentials: false
 
          - name: Setup Bun
-           uses: oven-sh/setup-bun@v2
+           uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
            with:
-              bun-version: latest
+              bun-version: "1.3.11"
 
          - name: Test install script
            run: |
@@ -88,30 +94,32 @@ jobs:
          matrix:
             distro:
                - name: Debian 12 (Bookworm)
-                 image: debian:12
+                 image: debian:12@sha256:8c181802d706019b2ee6237441b3fb8691b92b5705daf7c4294e7405576c4a0d
                  setup: 'apt-get update -qq && apt-get install -y -qq curl unzip'
                - name: Debian 11 (Bullseye)
-                 image: debian:11
+                 image: debian:11@sha256:cd3d9e8ec611d6fb11058fbcc4dbd9c27843f09b21623c4c81fb7a1bafc335ca
                  setup: 'apt-get update -qq && apt-get install -y -qq curl unzip'
                - name: Ubuntu 24.04
-                 image: ubuntu:24.04
+                 image: ubuntu:24.04@sha256:cdb5fd928fced577cfecf12c8966e830fcdf42ee481fb0b91904eeddc2fe5eff
                  setup: 'apt-get update -qq && apt-get install -y -qq curl unzip'
                - name: Ubuntu 22.04
-                 image: ubuntu:22.04
+                 image: ubuntu:22.04@sha256:14be402d3f1eeeb5e7da73d3260322c68e7b51c88388f53e88eb21d6450bd520
                  setup: 'apt-get update -qq && apt-get install -y -qq curl unzip'
                - name: Ubuntu 20.04
-                 image: ubuntu:20.04
+                 image: ubuntu:20.04@sha256:c664f8f86ed5a386b0a340d981b8f81714e21a8b9c73f658c4bea56aa179d54a
                  setup: 'apt-get update -qq && apt-get install -y -qq curl unzip'
                - name: Fedora Latest
-                 image: fedora:latest
+                 image: fedora:latest@sha256:f717d3f59ea0dc45d3c024c9477e786bab7d418d26636920d17b48016f1e69ca
                  setup: 'dnf install -y -q curl unzip'
                - name: Amazon Linux 2023
-                 image: amazonlinux:2023
+                 image: amazonlinux:2023@sha256:41e9b88745672d658868717255dcccbe531d82b88d6dd0ce5de04530b38b35fa
                  setup: 'yum install -y -q gzip unzip'
 
       steps:
          - name: Checkout
-           uses: actions/checkout@v4
+           uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+           with:
+              persist-credentials: false
 
          - name: Test on ${{ matrix.distro.name }}
            run: |
@@ -132,7 +140,7 @@ jobs:
 
               # Install Bun first (required for new install script)
               echo "Installing Bun..."
-              curl -fsSL https://bun.sh/install | bash > /dev/null 2>&1
+              curl -fsSL https://bun.sh/install | bash -s -- "bun-v1.3.11" > /dev/null 2>&1
               export PATH="$HOME/.bun/bin:$PATH"
 
               # Verify bun is installed
@@ -180,7 +188,9 @@ jobs:
       timeout-minutes: 20
       steps:
          - name: Checkout
-           uses: actions/checkout@v4
+           uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+           with:
+              persist-credentials: false
 
          - name: Run Bun version check tests
            run: |
@@ -198,11 +208,11 @@ jobs:
             scenario:
                - name: Force reinstall
                  test: |
-                    docker run --rm -e CI=true -v "$PWD:/app" -w /app ubuntu:latest sh -c '
+                    docker run --rm -e CI=true -v "$PWD:/app" -w /app ubuntu:latest@sha256:d31acef2a964b6df1f2b7e20a1525c4f2378024e087a4f8a8a9a4247e6a79573 sh -c '
                       apt-get update -qq && apt-get install -y -qq curl unzip > /dev/null 2>&1
                       
                       # Install Bun
-                      curl -fsSL https://bun.sh/install | bash > /dev/null 2>&1
+                      curl -fsSL https://bun.sh/install | bash -s -- "bun-v1.3.11" > /dev/null 2>&1
                       export PATH="$HOME/.bun/bin:$PATH"
                       
                       # First install
@@ -220,11 +230,11 @@ jobs:
 
                - name: Non-interactive with CI env
                  test: |
-                    docker run --rm -e CI=true -v "$PWD:/app" -w /app ubuntu:latest sh -c '
+                    docker run --rm -e CI=true -v "$PWD:/app" -w /app ubuntu:latest@sha256:d31acef2a964b6df1f2b7e20a1525c4f2378024e087a4f8a8a9a4247e6a79573 sh -c '
                       apt-get update -qq && apt-get install -y -qq curl unzip > /dev/null 2>&1
                       
                       # Install Bun
-                      curl -fsSL https://bun.sh/install | bash > /dev/null 2>&1
+                      curl -fsSL https://bun.sh/install | bash -s -- "bun-v1.3.11" > /dev/null 2>&1
                       export PATH="$HOME/.bun/bin:$PATH"
                       
                       # Install without -y flag (should still work in CI)
@@ -242,11 +252,11 @@ jobs:
 
                - name: Upgrade command available
                  test: |
-                    docker run --rm -e CI=true -v "$PWD:/app" -w /app ubuntu:latest sh -c '
+                    docker run --rm -e CI=true -v "$PWD:/app" -w /app ubuntu:latest@sha256:d31acef2a964b6df1f2b7e20a1525c4f2378024e087a4f8a8a9a4247e6a79573 sh -c '
                       apt-get update -qq && apt-get install -y -qq curl unzip > /dev/null 2>&1
                       
                       # Install Bun
-                      curl -fsSL https://bun.sh/install | bash > /dev/null 2>&1
+                      curl -fsSL https://bun.sh/install | bash -s -- "bun-v1.3.11" > /dev/null 2>&1
                       export PATH="$HOME/.bun/bin:$PATH"
                       
                       # Install CLI
@@ -275,11 +285,11 @@ jobs:
 
                - name: Legacy shim creation
                  test: |
-                    docker run --rm -e CI=true -v "$PWD:/app" -w /app ubuntu:latest sh -c '
+                    docker run --rm -e CI=true -v "$PWD:/app" -w /app ubuntu:latest@sha256:d31acef2a964b6df1f2b7e20a1525c4f2378024e087a4f8a8a9a4247e6a79573 sh -c '
                       apt-get update -qq && apt-get install -y -qq curl unzip > /dev/null 2>&1
                       
                       # Install Bun
-                      curl -fsSL https://bun.sh/install | bash > /dev/null 2>&1
+                      curl -fsSL https://bun.sh/install | bash -s -- "bun-v1.3.11" > /dev/null 2>&1
                       export PATH="$HOME/.bun/bin:$PATH"
                       
                       # Create legacy directory and add to PATH to trigger shim creation
@@ -308,11 +318,11 @@ jobs:
 
                - name: Legacy shim cleanup when not on PATH
                  test: |
-                    docker run --rm -e CI=true -v "$PWD:/app" -w /app ubuntu:latest sh -c '
+                    docker run --rm -e CI=true -v "$PWD:/app" -w /app ubuntu:latest@sha256:d31acef2a964b6df1f2b7e20a1525c4f2378024e087a4f8a8a9a4247e6a79573 sh -c '
                       apt-get update -qq && apt-get install -y -qq curl unzip > /dev/null 2>&1
                       
                       # Install Bun
-                      curl -fsSL https://bun.sh/install | bash > /dev/null 2>&1
+                      curl -fsSL https://bun.sh/install | bash -s -- "bun-v1.3.11" > /dev/null 2>&1
                       export PATH="$HOME/.bun/bin:$PATH"
                       
                       # Create legacy directory but do NOT add to PATH
@@ -340,7 +350,9 @@ jobs:
 
       steps:
          - name: Checkout
-           uses: actions/checkout@v4
+           uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+           with:
+              persist-credentials: false
 
          - name: Test ${{ matrix.scenario.name }}
            run: |

--- a/.github/workflows/test-windows-wsl.yaml
+++ b/.github/workflows/test-windows-wsl.yaml
@@ -22,12 +22,16 @@ on:
          - '.github/workflows/test-windows-wsl.yaml'
    workflow_dispatch:
 
+permissions:
+   contents: read
+
 concurrency:
    group: ${{ github.workflow }}-${{ github.ref }}
    cancel-in-progress: true
 
 env:
    CI: true
+   GITHUB_TOKEN: ''
 
 jobs:
    windows-wsl-cli-test:
@@ -35,10 +39,12 @@ jobs:
       timeout-minutes: 30
       name: Windows WSL CLI Smoke Test
       steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+           with:
+              persist-credentials: false
 
          - name: Setup WSL
-           uses: Vampire/setup-wsl@v5
+           uses: Vampire/setup-wsl@3b46b44374d5d0ae94654c45d114a3ed7a0e07a8
            with:
               distribution: Ubuntu-24.04
               additional-packages: curl unzip jq
@@ -64,7 +70,7 @@ jobs:
               set -e
               
               # Install Bun
-              curl -fsSL https://bun.sh/install | bash
+              curl -fsSL https://bun.sh/install | bash -s -- "bun-v1.3.11"
               export PATH="$HOME/.bun/bin:$PATH"
               echo "Bun version: $(bun --version)"
 
@@ -74,7 +80,7 @@ jobs:
               cd ~/sdk
 
               # Install dependencies and build
-              bun install
+              bun install --frozen-lockfile
               bun run build
 
               # Verify CLI works

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,39 @@
+name: Trivy Scan
+
+on:
+  pull_request:
+  merge_group:
+  schedule:
+    - cron: "43 8 * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  trivy:
+    name: Trivy Filesystem Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "0"
+
+      - name: Upload Trivy SARIF
+        if: ${{ !cancelled() && hashFiles('trivy-results.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@cdefb33c0f6224e58673d9004f47f7cb3e328b89
+        with:
+          sarif_file: trivy-results.sarif

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "sdk-mono",
 	"version": "2.0.19",
 	"license": "Apache-2.0",
+	"packageManager": "bun@1.3.11",
 	"private": true,
 	"workspaces": [
 		"packages/*",

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,43 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": [
+		"config:best-practices",
+		":dependencyDashboard",
+		":semanticCommits",
+		":pinGitHubActionDigests",
+		"npm:unpublishSafe"
+	],
+	"enabledManagers": ["bun", "github-actions", "dockerfile", "docker-compose"],
+	"labels": ["dependencies"],
+	"minimumReleaseAge": "3 days",
+	"rangeStrategy": "bump",
+	"separateMajorMinor": true,
+	"separateMultipleMajor": true,
+	"vulnerabilityAlerts": {
+		"enabled": true,
+		"labels": ["security"]
+	},
+	"osvVulnerabilityAlerts": true,
+	"lockFileMaintenance": {
+		"enabled": true,
+		"schedule": ["before 5am on monday"],
+		"commitMessageAction": "Lock file maintenance"
+	},
+	"packageRules": [
+		{
+			"description": "Require human approval before Renovate raises major version updates.",
+			"matchUpdateTypes": ["major"],
+			"dependencyDashboardApproval": true
+		},
+		{
+			"description": "Keep Bun ecosystem updates behind the same age gate configured in bunfig.toml.",
+			"matchDatasources": ["npm"],
+			"minimumReleaseAge": "3 days"
+		},
+		{
+			"description": "Pin executable CI dependencies to immutable digests.",
+			"matchManagers": ["github-actions", "dockerfile", "docker-compose"],
+			"pinDigests": true
+		}
+	]
+}


### PR DESCRIPTION
## Summary
- add Renovate with a 3-day minimum release age aligned with bunfig.toml
- add OSV Scanner PR and nightly workflows
- add Actionlint and workflow config for custom runner labels
- pin GitHub Actions and Docker images to immutable refs
- restrict workflow permissions, disable persisted checkout credentials, blank GITHUB_TOKEN in shell workflows, and enforce frozen Bun installs

## Verification
- go run github.com/rhysd/actionlint/cmd/actionlint@latest -color=false
- npx --yes --package renovate renovate-config-validator renovate.json
- bun install --frozen-lockfile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated workflow checks including actionlint and OSV scans (PR and nightly) and a new dependency-management automation.

* **Chores**
  * Tightened CI security and reproducibility with explicit workflow permissions, token isolation, pinned action revisions, credential isolation, frozen dependency installs, and immutable container references.
  * Added package manager declaration and Renovate configuration for automated dependency updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentuity/sdk/pull/1471)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->