### PR TITLE
Pass GitHub integration ID when linking repos

### DIFF
--- a/packages/cli/src/cmd/git/api.ts
+++ b/packages/cli/src/cmd/git/api.ts
@@ -227,6 +227,7 @@ const ProjectLinkDataSchema = z.object({
 export interface LinkProjectOptions {
 	projectId: string;
 	repoFullName: string;
+	integrationId?: string;
 	branch: string;
 	autoDeploy: boolean;
 	previewDeploy: boolean;

--- a/packages/cli/src/cmd/git/link.ts
+++ b/packages/cli/src/cmd/git/link.ts
@@ -307,6 +307,7 @@ export async function runGitLink(options: RunGitLinkOptions): Promise<RunGitLink
 				linkProjectToRepo(apiClient, {
 					projectId,
 					repoFullName: selectedRepo.fullName,
+					integrationId: selectedRepo.integrationId,
 					branch,
 					autoDeploy: finalAutoDeploy,
 					previewDeploy: finalPreviewDeploy,
@@ -418,6 +419,16 @@ export const linkSubcommand = createSubcommand({
 			if (opts.repo && opts.confirm) {
 				const branch = opts.branch ?? 'main';
 				const directory = opts.root === '.' ? undefined : opts.root;
+				let integrationId: string | undefined;
+
+				try {
+					const repos = await listGithubRepos(apiClient);
+					integrationId = repos.find(
+						(repo) => repo.fullName.toLowerCase() === opts.repo!.toLowerCase()
+					)?.integrationId;
+				} catch (error) {
+					logger.trace('Unable to resolve GitHub integration for repository: %s', error);
+				}
 
 				await tui.spinner({
 					message: 'Linking repository...',
@@ -426,6 +437,7 @@ export const linkSubcommand = createSubcommand({
 						linkProjectToRepo(apiClient, {
 							projectId: project.projectId,
 							repoFullName: opts.repo!,
+							integrationId,
 							branch,
 							autoDeploy: opts.deploy !== false,
 							previewDeploy: opts.preview !== false,

--- a/packages/cli/src/cmd/project/remote-import.ts
+++ b/packages/cli/src/cmd/project/remote-import.ts
@@ -537,9 +537,15 @@ async function pushToRepo(
 		message: 'Pushing to remote repository...',
 		clearOnSuccess: true,
 		callback: async () => {
+			const gitEnv = {
+				...process.env,
+				GIT_TERMINAL_PROMPT: '0',
+			};
+
 			// Add remote origin
 			const addRemote = Bun.spawnSync(['git', 'remote', 'add', 'origin', remoteUrl], {
 				cwd: dest,
+				env: gitEnv,
 				stdout: 'pipe',
 				stderr: 'pipe',
 			});
@@ -548,6 +554,7 @@ async function pushToRepo(
 				// Remote might already exist, try set-url instead
 				const setUrl = Bun.spawnSync(['git', 'remote', 'set-url', 'origin', remoteUrl], {
 					cwd: dest,
+					env: gitEnv,
 					stdout: 'pipe',
 					stderr: 'pipe',
 				});
@@ -561,6 +568,7 @@ async function pushToRepo(
 			// Push to remote
 			const push = Bun.spawnSync(['git', 'push', '-u', 'origin', defaultBranch], {
 				cwd: dest,
+				env: gitEnv,
 				stdout: 'pipe',
 				stderr: 'pipe',
 			});


### PR DESCRIPTION
## Summary
- include the selected GitHub integration ID when linking a repository interactively
- resolve and include the integration ID for non-interactive repo linking when available

## Verification
- bun run typecheck (packages/cli)
- bun run build (packages/cli)

Note: root lint was run and reported existing unrelated findings outside the changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository linking so integration identifiers are correctly resolved and passed in both interactive and non-interactive flows.
  * Prevented Git operations from prompting for credentials by disabling terminal prompts during remote setup and push, improving non-interactive/import reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentuity/sdk/pull/1473)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->