### PR TITLE
Expose sandbox create options in coder SDK

### DIFF
--- a/packages/coder/src/index.ts
+++ b/packages/coder/src/index.ts
@@ -9,6 +9,13 @@ export {
 	type CoderCreateSessionRequest,
 	type CoderUpdateSessionRequest,
 	type CoderListSessionsParams,
+	type FileToWrite,
+	type SandboxCommand,
+	type SandboxCreateOptions,
+	type SandboxNetworkConfig,
+	type SandboxResources,
+	type SandboxStreamConfig,
+	type SandboxTimeoutConfig,
 	// Session domain types
 	type CoderSessionVisibility,
 	type CoderWorkflowMode,

--- a/packages/core/src/services/coder/index.ts
+++ b/packages/core/src/services/coder/index.ts
@@ -1,5 +1,15 @@
 export * from './types.ts';
 
+export type {
+	FileToWrite,
+	SandboxCommand,
+	SandboxCreateOptions,
+	SandboxNetworkConfig,
+	SandboxResources,
+	SandboxStreamConfig,
+	SandboxTimeoutConfig,
+} from '../sandbox/types.ts';
+
 export { discoverUrl, DiscoverCoderUrlDataSchema } from './discover.ts';
 
 export type {

--- a/packages/core/src/services/coder/sessions.ts
+++ b/packages/core/src/services/coder/sessions.ts
@@ -16,6 +16,7 @@ import {
 	type CoderSessionListResponse,
 	type CoderUpdateSessionRequest,
 } from './types.ts';
+import { base64Encode } from '../sandbox/base64.ts';
 
 type EncodedFileToWrite = {
 	path: string;
@@ -183,14 +184,14 @@ export async function coderCreateSession(
 		...params.body,
 		files: params.body.files?.map((f) => ({
 			path: f.path,
-			content: f.content.toString('base64'),
+			content: base64Encode(f.content),
 		})),
 		command: params.body.command
 			? {
 					...params.body.command,
 					files: params.body.command.files?.map((f) => ({
 						path: f.path,
-						content: f.content.toString('base64'),
+						content: base64Encode(f.content),
 					})),
 				}
 			: undefined,

--- a/packages/core/src/services/coder/sessions.ts
+++ b/packages/core/src/services/coder/sessions.ts
@@ -17,6 +17,37 @@ import {
 	type CoderUpdateSessionRequest,
 } from './types.ts';
 
+type EncodedFileToWrite = {
+	path: string;
+	content: string;
+};
+
+type CoderCreateSessionWireRequest = Omit<CoderCreateSessionRequest, 'files' | 'command'> & {
+	files?: EncodedFileToWrite[];
+	command?: Omit<NonNullable<CoderCreateSessionRequest['command']>, 'files'> & {
+		files?: EncodedFileToWrite[];
+	};
+};
+
+const EncodedFileToWriteSchema = z.object({
+	path: z.string(),
+	content: z.string(),
+});
+
+const CoderCreateSessionWireRequestSchema = CoderCreateSessionRequestSchema.omit({
+	files: true,
+	command: true,
+}).extend({
+	files: z.array(EncodedFileToWriteSchema).optional(),
+	command: z
+		.object({
+			exec: z.array(z.string()),
+			files: z.array(EncodedFileToWriteSchema).optional(),
+			mode: z.enum(['oneshot', 'interactive']).optional(),
+		})
+		.optional(),
+});
+
 const CoderHubSessionListResponseSchema = z.object({
 	sessions: z.object({
 		websocket: z.array(CoderSessionListItemSchema),
@@ -148,11 +179,28 @@ export async function coderCreateSession(
 	client: APIClient,
 	params: CoderCreateSessionParams
 ): Promise<CoderCreateSessionResponse> {
-	return client.post<CoderCreateSessionResponse, CoderCreateSessionRequest>(
+	const body: CoderCreateSessionWireRequest = {
+		...params.body,
+		files: params.body.files?.map((f) => ({
+			path: f.path,
+			content: f.content.toString('base64'),
+		})),
+		command: params.body.command
+			? {
+					...params.body.command,
+					files: params.body.command.files?.map((f) => ({
+						path: f.path,
+						content: f.content.toString('base64'),
+					})),
+				}
+			: undefined,
+	};
+
+	return client.post<CoderCreateSessionResponse, CoderCreateSessionWireRequest>(
 		'/hub/session',
-		params.body,
+		body,
 		CoderCreateSessionResponseSchema,
-		CoderCreateSessionRequestSchema
+		CoderCreateSessionWireRequestSchema
 	);
 }
 

--- a/packages/core/src/services/coder/types.ts
+++ b/packages/core/src/services/coder/types.ts
@@ -1,4 +1,12 @@
 import { z } from 'zod/v4';
+import {
+	FileToWriteSchema,
+	SandboxCommandSchema,
+	SandboxNetworkConfigSchema,
+	SandboxResourcesSchema,
+	SandboxStreamConfigSchema,
+	SandboxTimeoutConfigSchema,
+} from '../sandbox/types.ts';
 
 export const CoderSessionVisibilitySchema = z
 	.enum(['private', 'organization', 'collaborate'])
@@ -651,14 +659,59 @@ export const CoderCreateSessionRequestSchema = z
 			.string()
 			.optional()
 			.describe('Workspace identifier associated with the session'),
+		projectId: z.string().optional().describe('Project ID to associate the session sandbox with'),
+		runtime: z
+			.string()
+			.optional()
+			.describe('Runtime name for the session sandbox (e.g., "bun:1", "python:3.14")'),
+		runtimeId: z
+			.string()
+			.optional()
+			.describe('Runtime ID for the session sandbox (e.g., "srt_xxx")'),
+		name: z.string().optional().describe('Optional sandbox name'),
+		description: z.string().optional().describe('Optional sandbox description'),
+		resources: SandboxResourcesSchema.optional().describe(
+			'Resource limits for the session sandbox'
+		),
 		env: z
 			.record(z.string(), z.string())
 			.optional()
 			.describe('Environment variables injected into session runtime'),
+		network: SandboxNetworkConfigSchema.optional().describe(
+			'Network configuration for the session sandbox'
+		),
+		stream: SandboxStreamConfigSchema.optional().describe(
+			'Stream configuration for the session sandbox'
+		),
+		timeout: SandboxTimeoutConfigSchema.optional().describe(
+			'Timeout configuration for the session sandbox'
+		),
+		command: SandboxCommandSchema.optional().describe(
+			'Initial command to run in the session sandbox'
+		),
+		files: z
+			.array(FileToWriteSchema)
+			.optional()
+			.describe('Files to write to the session sandbox workspace on creation'),
+		snapshot: z.string().optional().describe('Snapshot ID or tag to restore the sandbox from'),
+		dependencies: z
+			.array(z.string())
+			.optional()
+			.describe('Apt packages to install when creating the session sandbox'),
+		packages: z
+			.array(z.string())
+			.optional()
+			.describe('npm/bun packages to install globally when creating the session sandbox'),
 		metadata: z
-			.record(z.string(), z.string())
+			.record(z.string(), z.unknown())
 			.optional()
 			.describe('Arbitrary metadata associated with the session'),
+		scopes: z
+			.array(z.string())
+			.optional()
+			.describe(
+				'Permission scopes for automatic service access (e.g., "services:read", "services:write")'
+			),
 	})
 	.describe('Request body for creating a coder session');
 export type CoderCreateSessionRequest = z.infer<typeof CoderCreateSessionRequestSchema>;

--- a/packages/core/src/services/sandbox/base64.ts
+++ b/packages/core/src/services/sandbox/base64.ts
@@ -1,0 +1,14 @@
+export function base64Encode(bytes: Uint8Array): string {
+	const bufferCtor = globalThis.Buffer;
+	if (bufferCtor) {
+		return bufferCtor.from(bytes).toString('base64');
+	}
+
+	let binary = '';
+	const chunkSize = 0x8000;
+	for (let i = 0; i < bytes.length; i += chunkSize) {
+		const chunk = bytes.subarray(i, i + chunkSize);
+		binary += String.fromCharCode(...chunk);
+	}
+	return btoa(binary);
+}

--- a/packages/core/src/services/sandbox/create.ts
+++ b/packages/core/src/services/sandbox/create.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { type APIClient, APIResponseSchema } from '../api.ts';
 import { NPM_PACKAGE_NAME_PATTERN } from './snapshot-build.ts';
 import { throwSandboxError } from './util.ts';
+import { base64Encode } from './base64.ts';
 
 export const SandboxCreateRequestSchema = z
 	.object({
@@ -224,14 +225,14 @@ export async function sandboxCreate(
 			mode: options.command.mode,
 			files: options.command.files?.map((f) => ({
 				path: f.path,
-				content: f.content.toString('base64'),
+				content: base64Encode(f.content),
 			})),
 		};
 	}
 	if (options.files && options.files.length > 0) {
 		body.files = options.files.map((f) => ({
 			path: f.path,
-			content: f.content.toString('base64'),
+			content: base64Encode(f.content),
 		}));
 	}
 	if (options.snapshot) {

--- a/packages/core/src/services/sandbox/execute.ts
+++ b/packages/core/src/services/sandbox/execute.ts
@@ -2,6 +2,7 @@ import type { ExecuteOptions, Execution, ExecutionStatus } from './types.ts';
 import { z } from 'zod';
 import type { APIClient } from '../api.ts';
 import { SandboxBusyError, SandboxNotFoundError, throwSandboxError } from './util.ts';
+import { base64Encode } from './base64.ts';
 
 export const ExecuteRequestSchema = z
 	.object({
@@ -87,7 +88,7 @@ export async function sandboxExecute(
 	if (options.files && options.files.length > 0) {
 		body.files = options.files.map((f) => ({
 			path: f.path,
-			content: f.content.toString('base64'),
+			content: base64Encode(f.content),
 		}));
 	}
 	if (options.timeout) {

--- a/packages/core/src/services/sandbox/files.ts
+++ b/packages/core/src/services/sandbox/files.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { APIClient } from '../api.ts';
 import { SandboxResponseError, throwSandboxError } from './util.ts';
 import type { FileToWrite } from './types.ts';
+import { base64Encode } from './base64.ts';
 
 export const FileToWriteSchema = z.object({
 	path: z.string().describe('Path to the file relative to the sandbox workspace'),
@@ -59,7 +60,7 @@ export async function sandboxWriteFiles(
 	const body: z.infer<typeof WriteFilesRequestSchema> = {
 		files: files.map((f) => ({
 			path: f.path,
-			content: f.content.toString('base64'),
+			content: base64Encode(f.content),
 		})),
 	};
 

--- a/packages/core/src/services/sandbox/types.ts
+++ b/packages/core/src/services/sandbox/types.ts
@@ -229,8 +229,8 @@ export type SandboxStreamConfig = z.infer<typeof SandboxStreamConfigSchema>;
 export const FileToWriteSchema = z.object({
 	/** Path to the file relative to the sandbox workspace */
 	path: z.string().describe('Path to the file relative to the sandbox workspace'),
-	/** File content as a Buffer */
-	content: z.instanceof(Buffer).describe('File content as a Buffer'),
+	/** File content as bytes */
+	content: z.instanceof(Uint8Array).describe('File content as bytes'),
 });
 export type FileToWrite = z.infer<typeof FileToWriteSchema>;
 

--- a/packages/core/test/coder-client.test.ts
+++ b/packages/core/test/coder-client.test.ts
@@ -601,6 +601,77 @@ describe('CoderClient enabled agent roster contract', () => {
 		});
 	});
 
+	test('createSession sends sandbox create options and base64-encoded files', async () => {
+		mockFetch(async (url, init) => {
+			expect(url).toBe('https://coder.example/api/hub/session');
+			expect(init?.method).toBe('POST');
+			expect(JSON.parse(String(init?.body))).toMatchObject({
+				task: 'Prepare sandbox',
+				runtime: 'bun:1',
+				resources: { memory: '1Gi', cpu: '1' },
+				network: { enabled: true, port: 3000 },
+				timeout: { idle: '30m' },
+				dependencies: ['git'],
+				packages: ['typescript'],
+				scopes: ['services:read'],
+				files: [
+					{
+						path: 'README.md',
+						content: Buffer.from('# Hello').toString('base64'),
+					},
+				],
+				command: {
+					exec: ['bun', 'run', 'dev'],
+					mode: 'interactive',
+					files: [
+						{
+							path: 'package.json',
+							content: Buffer.from('{"type":"module"}').toString('base64'),
+						},
+					],
+				},
+			});
+			return new Response(
+				JSON.stringify({
+					sessionId: 'codesess_sandbox_options',
+					status: 'creating',
+				}),
+				{
+					status: 201,
+					headers: { 'content-type': 'application/json' },
+				}
+			);
+		});
+
+		const client = new CoderClient({
+			apiKey: 'ag_test',
+			url: 'https://coder.example',
+			orgId: 'org_test',
+		});
+
+		await expect(
+			client.createSession({
+				task: 'Prepare sandbox',
+				runtime: 'bun:1',
+				resources: { memory: '1Gi', cpu: '1' },
+				network: { enabled: true, port: 3000 },
+				timeout: { idle: '30m' },
+				dependencies: ['git'],
+				packages: ['typescript'],
+				scopes: ['services:read'],
+				files: [{ path: 'README.md', content: Buffer.from('# Hello') }],
+				command: {
+					exec: ['bun', 'run', 'dev'],
+					mode: 'interactive',
+					files: [{ path: 'package.json', content: Buffer.from('{"type":"module"}') }],
+				},
+			})
+		).resolves.toMatchObject({
+			sessionId: 'codesess_sandbox_options',
+			status: 'creating',
+		});
+	});
+
 	test('updateSession sends enabledAgents in the request body', async () => {
 		mockFetch(async (url, init) => {
 			expect(url).toBe('https://coder.example/api/hub/session/codesess_enabled_update');


### PR DESCRIPTION
## Summary
- extend coder create-session request types with sandbox create options
- encode files and command.files buffer content to base64 before posting to /hub/session
- re-export sandbox create option types from the coder SDK entrypoints

## Verification
- bun test packages/core/test/coder-client.test.ts
- bun run typecheck

## Rollout
Release this after the Coder service PR is deployed so /hub/session accepts the expanded payload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded sandbox/session creation to accept richer options (resources, network, stream, timeout, command, snapshot, dependencies, packages, scopes) and initializing files.
* **Types**
  * Surface area expanded: additional sandbox-related types re-exported and request types updated to reflect new fields.
* **Tests**
  * Added tests confirming file contents and command-attached files are Base64-encoded when sent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentuity/sdk/pull/1475)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->