### PR TITLE
fix(cli): avoid duplicate whoami json output

### DIFF
--- a/packages/cli/src/cmd/auth/whoami.ts
+++ b/packages/cli/src/cmd/auth/whoami.ts
@@ -50,9 +50,7 @@ export const whoamiCommand = createSubcommand({
 			organizations: user.organizations,
 		};
 
-		if (options.json) {
-			console.log(JSON.stringify(result, null, 2));
-		} else {
+		if (!options.json) {
 			const fullName = `${user.firstName} ${user.lastName}`;
 
 			tui.newline();

--- a/packages/cli/test/cmd/auth/whoami.test.ts
+++ b/packages/cli/test/cmd/auth/whoami.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, mock, test } from 'bun:test';
+import type { CommandContext } from '../../../src/types';
+
+mock.module('@agentuity/server', () => ({
+	whoami: mock(async () => ({
+		firstName: 'Test',
+		lastName: 'User',
+		organizations: [{ id: 'org_test', name: 'Test Org' }],
+	})),
+}));
+
+import { whoamiCommand } from '../../../src/cmd/auth/whoami';
+
+describe('auth whoami command', () => {
+	test('returns JSON data without writing duplicate JSON output', async () => {
+		const log = mock(() => {});
+		const originalLog = console.log;
+		console.log = log;
+
+		try {
+			const result = await whoamiCommand.handler({
+				apiClient: {},
+				auth: {
+					apiKey: 'ag_test',
+					userId: 'usr_test',
+					expires: new Date(Date.now() + 60_000),
+				},
+				options: { json: true },
+			} as CommandContext);
+
+			expect(result).toEqual({
+				userId: 'usr_test',
+				firstName: 'Test',
+				lastName: 'User',
+				organizations: [{ id: 'org_test', name: 'Test Org' }],
+			});
+			expect(log).not.toHaveBeenCalled();
+		} finally {
+			console.log = originalLog;
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- remove command-local JSON logging from auth whoami
- rely on the shared CLI JSON renderer to emit the returned response once
- add a regression test for JSON mode output behavior

Fixes #1478

## Verification
- bun test packages/cli/test/cmd/auth/whoami.test.ts
- bun run typecheck (packages/cli)
- bun run format
- bun run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the `auth whoami` command to properly respect the `--json` flag, ensuring only JSON output is displayed when the flag is used.

* **Tests**
  * Added test coverage for the `auth whoami` command with JSON output formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentuity/sdk/pull/1479)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->