### PR TITLE
fix(docs): redirect legacy `Coder` reference route

### DIFF
--- a/apps/docs/src/web/components/docs/nav-data.ts
+++ b/apps/docs/src/web/components/docs/nav-data.ts
@@ -661,8 +661,7 @@ export const navData: NavSection[] = [
 					{
 						title: 'AI Gateway',
 						url: '/reference/api/ai-gateway',
-						description:
-							'List supported LLM models and run OpenAI-compatible chat completions',
+						description: 'List supported LLM models and run routed AI Gateway completions',
 					},
 					{
 						title: 'API Keys',

--- a/apps/docs/src/web/content/reference/api/ai-gateway.mdx
+++ b/apps/docs/src/web/content/reference/api/ai-gateway.mdx
@@ -94,6 +94,18 @@ Completion request. Use `messages` for chat-compatible models and `prompt` for l
     "required": true
   },
   {
+    "name": "input",
+    "type": "any",
+    "description": "Responses-compatible input payload for models using the Responses API.",
+    "required": false
+  },
+  {
+    "name": "contents",
+    "type": "array",
+    "description": "Google Generative AI contents payload.",
+    "required": false
+  },
+  {
     "name": "messages",
     "type": "object[]",
     "description": "Messages to complete.",
@@ -240,6 +252,21 @@ Provider-compatible completion response.
     "description": "Total estimated gateway cost in USD."
   },
   {
+    "name": "agentuity.cost.unit",
+    "type": "string",
+    "description": "Gateway billing unit."
+  },
+  {
+    "name": "agentuity.cost.inputQuantity",
+    "type": "number",
+    "description": "Input quantity used for non-token gateway billing."
+  },
+  {
+    "name": "agentuity.cost.outputQuantity",
+    "type": "number",
+    "description": "Output quantity used for non-token gateway billing."
+  },
+  {
     "name": "agentuity.cost.promptTokens",
     "type": "number",
     "description": "Prompt token count used for gateway billing."
@@ -248,6 +275,11 @@ Provider-compatible completion response.
     "name": "agentuity.cost.completionTokens",
     "type": "number",
     "description": "Completion token count used for gateway billing."
+  },
+  {
+    "name": "agentuity.cost.reasoningTokens",
+    "type": "number",
+    "description": "Reasoning token count reported by the model provider when available."
   }
 ]} />
 
@@ -284,6 +316,18 @@ Completion request with `stream` set to `true`.
     "type": "string",
     "description": "Model to use for the completion.",
     "required": true
+  },
+  {
+    "name": "input",
+    "type": "any",
+    "description": "Responses-compatible input payload for models using the Responses API.",
+    "required": false
+  },
+  {
+    "name": "contents",
+    "type": "array",
+    "description": "Google Generative AI contents payload.",
+    "required": false
   },
   {
     "name": "messages",

--- a/apps/docs/src/web/content/reference/api/coder.mdx
+++ b/apps/docs/src/web/content/reference/api/coder.mdx
@@ -202,6 +202,12 @@ Session creation payload.
     "required": false
   },
   {
+    "name": "skills[].content",
+    "type": "string",
+    "description": "Inline SKILL.md content for custom skills",
+    "required": false
+  },
+  {
     "name": "repo",
     "type": "object",
     "description": "Primary repository mounted for the session",
@@ -388,15 +394,219 @@ Session creation payload.
     "required": false
   },
   {
+    "name": "projectId",
+    "type": "string",
+    "description": "Project ID to associate the session sandbox with",
+    "required": false
+  },
+  {
+    "name": "runtime",
+    "type": "string",
+    "description": "Runtime name for the session sandbox (e.g., \"bun:1\", \"python:3.14\")",
+    "required": false
+  },
+  {
+    "name": "runtimeId",
+    "type": "string",
+    "description": "Runtime ID for the session sandbox (e.g., \"srt_xxx\")",
+    "required": false
+  },
+  {
+    "name": "name",
+    "type": "string",
+    "description": "Optional sandbox name",
+    "required": false
+  },
+  {
+    "name": "description",
+    "type": "string",
+    "description": "Optional sandbox description",
+    "required": false
+  },
+  {
+    "name": "resources",
+    "type": "object",
+    "description": "Resource limits for the session sandbox",
+    "required": false
+  },
+  {
+    "name": "resources.memory",
+    "type": "string",
+    "description": "Memory limit (e.g., \"500Mi\", \"1Gi\")",
+    "required": false
+  },
+  {
+    "name": "resources.cpu",
+    "type": "string",
+    "description": "CPU limit in millicores (e.g., \"500m\", \"1000m\")",
+    "required": false
+  },
+  {
+    "name": "resources.disk",
+    "type": "string",
+    "description": "Disk limit (e.g., \"500Mi\", \"1Gi\")",
+    "required": false
+  },
+  {
     "name": "env",
     "type": "object",
     "description": "Environment variables injected into session runtime",
     "required": false
   },
   {
+    "name": "network",
+    "type": "object",
+    "description": "Network configuration for the session sandbox",
+    "required": false
+  },
+  {
+    "name": "network.enabled",
+    "type": "boolean",
+    "description": "Whether to enable outbound network access (default: false)",
+    "required": false
+  },
+  {
+    "name": "network.port",
+    "type": "number",
+    "description": "Port to expose from the sandbox to the outside Internet (1024-65535)",
+    "required": false
+  },
+  {
+    "name": "stream",
+    "type": "object",
+    "description": "Stream configuration for the session sandbox",
+    "required": false
+  },
+  {
+    "name": "stream.stdout",
+    "type": "string",
+    "description": "Stream ID for stdout (or \"ignore\" to discard)",
+    "required": false
+  },
+  {
+    "name": "stream.stderr",
+    "type": "string",
+    "description": "Stream ID for stderr (or \"ignore\" to discard)",
+    "required": false
+  },
+  {
+    "name": "stream.stdin",
+    "type": "string",
+    "description": "Stream ID for stdin input",
+    "required": false
+  },
+  {
+    "name": "stream.timestamps",
+    "type": "boolean",
+    "description": "Include timestamps in output (default: true)",
+    "required": false
+  },
+  {
+    "name": "timeout",
+    "type": "object",
+    "description": "Timeout configuration for the session sandbox",
+    "required": false
+  },
+  {
+    "name": "timeout.idle",
+    "type": "string",
+    "description": "Idle timeout before sandbox is reaped (e.g., \"10m\", \"1h\")",
+    "required": false
+  },
+  {
+    "name": "timeout.execution",
+    "type": "string",
+    "description": "Maximum execution time per command (e.g., \"5m\", \"1h\")",
+    "required": false
+  },
+  {
+    "name": "timeout.paused",
+    "type": "string",
+    "description": "Maximum duration a sandbox can remain paused before termination (e.g., \"24h\", \"0\" for infinite)",
+    "required": false
+  },
+  {
+    "name": "command",
+    "type": "object",
+    "description": "Initial command to run in the session sandbox",
+    "required": false
+  },
+  {
+    "name": "command.exec",
+    "type": "string[]",
+    "description": "Command and arguments to execute",
+    "required": true
+  },
+  {
+    "name": "command.files",
+    "type": "object[]",
+    "description": "Files to create before execution",
+    "required": false
+  },
+  {
+    "name": "command.files[].path",
+    "type": "string",
+    "description": "Path to the file relative to the sandbox workspace",
+    "required": true
+  },
+  {
+    "name": "command.files[].content",
+    "type": "any",
+    "description": "File content as bytes",
+    "required": true
+  },
+  {
+    "name": "command.mode",
+    "type": "string",
+    "description": "Execution mode: \"oneshot\" auto-destroys sandbox on exit",
+    "required": false
+  },
+  {
+    "name": "files",
+    "type": "object[]",
+    "description": "Files to write to the session sandbox workspace on creation",
+    "required": false
+  },
+  {
+    "name": "files[].path",
+    "type": "string",
+    "description": "Path to the file relative to the sandbox workspace",
+    "required": true
+  },
+  {
+    "name": "files[].content",
+    "type": "any",
+    "description": "File content as bytes",
+    "required": true
+  },
+  {
+    "name": "snapshot",
+    "type": "string",
+    "description": "Snapshot ID or tag to restore the sandbox from",
+    "required": false
+  },
+  {
+    "name": "dependencies",
+    "type": "string[]",
+    "description": "Apt packages to install when creating the session sandbox",
+    "required": false
+  },
+  {
+    "name": "packages",
+    "type": "string[]",
+    "description": "npm/bun packages to install globally when creating the session sandbox",
+    "required": false
+  },
+  {
     "name": "metadata",
     "type": "object",
     "description": "Arbitrary metadata associated with the session",
+    "required": false
+  },
+  {
+    "name": "scopes",
+    "type": "string[]",
+    "description": "Permission scopes for automatic service access (e.g., \"services:read\", \"services:write\")",
     "required": false
   }
 ]} />
@@ -940,6 +1150,11 @@ Returns a session list.
     "description": "Canonical URL for the skill repository or page"
   },
   {
+    "name": "sessions.websocket[].skills[].content",
+    "type": "string",
+    "description": "Inline SKILL.md content for custom skills"
+  },
+  {
     "name": "sessions.websocket[].enabledAgents",
     "type": "string[]",
     "description": "Enabled agent roster attached to the session"
@@ -1450,6 +1665,11 @@ Returns the full session object.
     "description": "Canonical URL for the skill repository or page"
   },
   {
+    "name": "skills[].content",
+    "type": "string",
+    "description": "Inline SKILL.md content for custom skills"
+  },
+  {
     "name": "enabledAgents",
     "type": "string[]",
     "description": "Enabled agent roster attached to the session"
@@ -1635,6 +1855,11 @@ Returns the full session object.
     "description": "Canonical URL for the skill repository or page"
   },
   {
+    "name": "builder.proposal.savedSkills[].content",
+    "type": "string",
+    "description": "Inline SKILL.md content for custom skills"
+  },
+  {
     "name": "builder.proposal.companionAgents",
     "type": "string[]",
     "description": "Proposed companion agents to auto-include"
@@ -1801,6 +2026,12 @@ Session update payload.
     "name": "skills[].url",
     "type": "string",
     "description": "Canonical URL for the skill repository or page",
+    "required": false
+  },
+  {
+    "name": "skills[].content",
+    "type": "string",
+    "description": "Inline SKILL.md content for custom skills",
     "required": false
   },
   {
@@ -2652,6 +2883,11 @@ Returns custom agents visible to the caller.
     "description": "Canonical URL for the skill repository or page"
   },
   {
+    "name": "agents[].savedSkills[].content",
+    "type": "string",
+    "description": "Inline SKILL.md content for custom skills"
+  },
+  {
     "name": "agents[].companionAgents",
     "type": "string[]",
     "description": "Companion agents auto-included alongside this custom agent"
@@ -2782,6 +3018,11 @@ Returns custom agents visible to the caller.
     "description": "Canonical URL for the skill repository or page"
   },
   {
+    "name": "agents[].published.savedSkills[].content",
+    "type": "string",
+    "description": "Inline SKILL.md content for custom skills"
+  },
+  {
     "name": "agents[].published.companionAgents",
     "type": "string[]",
     "description": "Companion agents auto-included alongside this custom agent"
@@ -2885,6 +3126,11 @@ Returns custom agents visible to the caller.
     "name": "agents[].draft.savedSkills[].url",
     "type": "string",
     "description": "Canonical URL for the skill repository or page"
+  },
+  {
+    "name": "agents[].draft.savedSkills[].content",
+    "type": "string",
+    "description": "Inline SKILL.md content for custom skills"
   },
   {
     "name": "agents[].draft.companionAgents",
@@ -3364,6 +3610,11 @@ Returns published versions for the custom agent.
     "name": "versions[].savedSkills[].url",
     "type": "string",
     "description": "Canonical URL for the skill repository or page"
+  },
+  {
+    "name": "versions[].savedSkills[].content",
+    "type": "string",
+    "description": "Inline SKILL.md content for custom skills"
   },
   {
     "name": "versions[].companionAgents",

--- a/apps/docs/src/web/lib/docs-redirects.ts
+++ b/apps/docs/src/web/lib/docs-redirects.ts
@@ -8,6 +8,7 @@ export const docsRedirects = {
 	frontendWorkbench: '/frontend',
 	agentsEvaluations: '/cookbook/patterns/llm-as-a-judge',
 	referenceApiEvaluations: '/reference/api',
+	referenceCoder: '/reference/sdk-reference/coder',
 	referenceSdkEvaluations: '/reference/sdk-reference',
 } as const;
 
@@ -32,6 +33,10 @@ export const docRedirectRules = [
 	{
 		paths: ['/reference/api/evaluations', '/reference/api/evaluations/'],
 		target: docsRedirects.referenceApiEvaluations,
+	},
+	{
+		paths: ['/reference/coder', '/reference/coder/'],
+		target: docsRedirects.referenceCoder,
 	},
 	{
 		paths: ['/reference/sdk-reference/evaluations', '/reference/sdk-reference/evaluations/'],

--- a/apps/docs/src/web/routeTree.gen.ts
+++ b/apps/docs/src/web/routeTree.gen.ts
@@ -62,6 +62,7 @@ import { Route as DocsReferenceStandalonePackagesRouteImport } from './routes/_d
 import { Route as DocsReferenceMigrationGuideRouteImport } from './routes/_docs/reference/migration-guide';
 import { Route as DocsReferenceGravityNetworkRouteImport } from './routes/_docs/reference/gravity-network';
 import { Route as DocsReferenceGithubAppRouteImport } from './routes/_docs/reference/github-app';
+import { Route as DocsReferenceCoderRouteImport } from './routes/_docs/reference/coder';
 import { Route as DocsGetStartedWhatIsAgentuityRouteImport } from './routes/_docs/get-started/what-is-agentuity';
 import { Route as DocsGetStartedQuickstartRouteImport } from './routes/_docs/get-started/quickstart';
 import { Route as DocsGetStartedProjectStructureRouteImport } from './routes/_docs/get-started/project-structure';
@@ -461,6 +462,11 @@ const DocsReferenceGravityNetworkRoute = DocsReferenceGravityNetworkRouteImport.
 const DocsReferenceGithubAppRoute = DocsReferenceGithubAppRouteImport.update({
 	id: '/reference/github-app',
 	path: '/reference/github-app',
+	getParentRoute: () => DocsRouteRoute,
+} as any);
+const DocsReferenceCoderRoute = DocsReferenceCoderRouteImport.update({
+	id: '/reference/coder',
+	path: '/reference/coder',
 	getParentRoute: () => DocsRouteRoute,
 } as any);
 const DocsGetStartedWhatIsAgentuityRoute = DocsGetStartedWhatIsAgentuityRouteImport.update({
@@ -1230,6 +1236,7 @@ export interface FileRoutesByFullPath {
 	'/get-started/project-structure': typeof DocsGetStartedProjectStructureRoute;
 	'/get-started/quickstart': typeof DocsGetStartedQuickstartRoute;
 	'/get-started/what-is-agentuity': typeof DocsGetStartedWhatIsAgentuityRoute;
+	'/reference/coder': typeof DocsReferenceCoderRoute;
 	'/reference/github-app': typeof DocsReferenceGithubAppRoute;
 	'/reference/gravity-network': typeof DocsReferenceGravityNetworkRoute;
 	'/reference/migration-guide': typeof DocsReferenceMigrationGuideRoute;
@@ -1418,6 +1425,7 @@ export interface FileRoutesByTo {
 	'/get-started/project-structure': typeof DocsGetStartedProjectStructureRoute;
 	'/get-started/quickstart': typeof DocsGetStartedQuickstartRoute;
 	'/get-started/what-is-agentuity': typeof DocsGetStartedWhatIsAgentuityRoute;
+	'/reference/coder': typeof DocsReferenceCoderRoute;
 	'/reference/github-app': typeof DocsReferenceGithubAppRoute;
 	'/reference/gravity-network': typeof DocsReferenceGravityNetworkRoute;
 	'/reference/migration-guide': typeof DocsReferenceMigrationGuideRoute;
@@ -1610,6 +1618,7 @@ export interface FileRoutesById {
 	'/_docs/get-started/project-structure': typeof DocsGetStartedProjectStructureRoute;
 	'/_docs/get-started/quickstart': typeof DocsGetStartedQuickstartRoute;
 	'/_docs/get-started/what-is-agentuity': typeof DocsGetStartedWhatIsAgentuityRoute;
+	'/_docs/reference/coder': typeof DocsReferenceCoderRoute;
 	'/_docs/reference/github-app': typeof DocsReferenceGithubAppRoute;
 	'/_docs/reference/gravity-network': typeof DocsReferenceGravityNetworkRoute;
 	'/_docs/reference/migration-guide': typeof DocsReferenceMigrationGuideRoute;
@@ -1802,6 +1811,7 @@ export interface FileRouteTypes {
 		| '/get-started/project-structure'
 		| '/get-started/quickstart'
 		| '/get-started/what-is-agentuity'
+		| '/reference/coder'
 		| '/reference/github-app'
 		| '/reference/gravity-network'
 		| '/reference/migration-guide'
@@ -1990,6 +2000,7 @@ export interface FileRouteTypes {
 		| '/get-started/project-structure'
 		| '/get-started/quickstart'
 		| '/get-started/what-is-agentuity'
+		| '/reference/coder'
 		| '/reference/github-app'
 		| '/reference/gravity-network'
 		| '/reference/migration-guide'
@@ -2181,6 +2192,7 @@ export interface FileRouteTypes {
 		| '/_docs/get-started/project-structure'
 		| '/_docs/get-started/quickstart'
 		| '/_docs/get-started/what-is-agentuity'
+		| '/_docs/reference/coder'
 		| '/_docs/reference/github-app'
 		| '/_docs/reference/gravity-network'
 		| '/_docs/reference/migration-guide'
@@ -2716,6 +2728,13 @@ declare module '@tanstack/react-router' {
 			path: '/reference/github-app';
 			fullPath: '/reference/github-app';
 			preLoaderRoute: typeof DocsReferenceGithubAppRouteImport;
+			parentRoute: typeof DocsRouteRoute;
+		};
+		'/_docs/reference/coder': {
+			id: '/_docs/reference/coder';
+			path: '/reference/coder';
+			fullPath: '/reference/coder';
+			preLoaderRoute: typeof DocsReferenceCoderRouteImport;
 			parentRoute: typeof DocsRouteRoute;
 		};
 		'/_docs/get-started/what-is-agentuity': {
@@ -3809,6 +3828,7 @@ interface DocsRouteRouteChildren {
 	DocsGetStartedProjectStructureRoute: typeof DocsGetStartedProjectStructureRoute;
 	DocsGetStartedQuickstartRoute: typeof DocsGetStartedQuickstartRoute;
 	DocsGetStartedWhatIsAgentuityRoute: typeof DocsGetStartedWhatIsAgentuityRoute;
+	DocsReferenceCoderRoute: typeof DocsReferenceCoderRoute;
 	DocsReferenceGithubAppRoute: typeof DocsReferenceGithubAppRoute;
 	DocsReferenceGravityNetworkRoute: typeof DocsReferenceGravityNetworkRoute;
 	DocsReferenceMigrationGuideRoute: typeof DocsReferenceMigrationGuideRoute;
@@ -3935,6 +3955,7 @@ const DocsRouteRouteChildren: DocsRouteRouteChildren = {
 	DocsGetStartedProjectStructureRoute: DocsGetStartedProjectStructureRoute,
 	DocsGetStartedQuickstartRoute: DocsGetStartedQuickstartRoute,
 	DocsGetStartedWhatIsAgentuityRoute: DocsGetStartedWhatIsAgentuityRoute,
+	DocsReferenceCoderRoute: DocsReferenceCoderRoute,
 	DocsReferenceGithubAppRoute: DocsReferenceGithubAppRoute,
 	DocsReferenceGravityNetworkRoute: DocsReferenceGravityNetworkRoute,
 	DocsReferenceMigrationGuideRoute: DocsReferenceMigrationGuideRoute,

--- a/apps/docs/src/web/routes/_docs/reference/coder.tsx
+++ b/apps/docs/src/web/routes/_docs/reference/coder.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute, redirect } from '@tanstack/react-router';
+import { RedirectFallback } from '../../../components/docs/RedirectFallback';
+import { docsRedirects } from '../../../lib/docs-redirects';
+
+const target = docsRedirects.referenceCoder;
+
+export const Route = createFileRoute('/_docs/reference/coder')({
+	beforeLoad: () => {
+		if (typeof window !== 'undefined') {
+			throw redirect({ to: target, replace: true, statusCode: 301 });
+		}
+	},
+	component: () => <RedirectFallback target={target} />,
+	staticData: { crumb: 'Coder' },
+});

--- a/bun.lock
+++ b/bun.lock
@@ -3026,7 +3026,7 @@
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
-    "gaxios": ["gaxios@7.1.4", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA=="],
+    "gaxios": ["gaxios@6.7.1", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "is-stream": "^2.0.0", "node-fetch": "^2.6.9", "uuid": "^9.0.1" } }, "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ=="],
 
     "gcp-metadata": ["gcp-metadata@6.1.1", "", { "dependencies": { "gaxios": "^6.1.1", "google-logging-utils": "^0.0.2", "json-bigint": "^1.0.0" } }, "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A=="],
 
@@ -3072,7 +3072,7 @@
 
     "google-auth-library": ["google-auth-library@10.6.2", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw=="],
 
-    "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
+    "google-logging-utils": ["google-logging-utils@0.0.2", "", {}, "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
@@ -3154,7 +3154,7 @@
 
     "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
-    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
@@ -3578,7 +3578,7 @@
 
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
-    "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
@@ -4310,7 +4310,41 @@
 
     "@agentuity/auth/@types/react": ["@types/react@18.3.28", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.2.2" } }, "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw=="],
 
+    "@agentuity/core/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@agentuity/core/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "@agentuity/drizzle/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@agentuity/drizzle/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
     "@agentuity/drizzle/drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
+
+    "@agentuity/frontend/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@agentuity/frontend/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "@agentuity/postgres/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@agentuity/postgres/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "@agentuity/react/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@agentuity/react/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "@agentuity/runtime/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@agentuity/runtime/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "@agentuity/schema/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@agentuity/schema/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "@agentuity/server/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@agentuity/server/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "@agentuity/test-utils/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@agentuity/workbench/@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
@@ -4566,6 +4600,8 @@
 
     "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
 
+    "d3-dsv/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
     "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
 
     "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
@@ -4590,6 +4626,8 @@
 
     "effect/uuid": ["uuid@13.0.2", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw=="],
 
+    "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
     "escodegen/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "extract-zip/yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
@@ -4598,11 +4636,13 @@
 
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
-    "gcp-metadata/gaxios": ["gaxios@6.7.1", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "is-stream": "^2.0.0", "node-fetch": "^2.6.9", "uuid": "^9.0.1" } }, "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ=="],
+    "gaxios/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
-    "gcp-metadata/google-logging-utils": ["google-logging-utils@0.0.2", "", {}, "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ=="],
+    "google-auth-library/gaxios": ["gaxios@7.1.4", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA=="],
 
     "google-auth-library/gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
+
+    "google-auth-library/google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
 
     "happy-dom/whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
@@ -4638,13 +4678,11 @@
 
     "mongodb-connection-string-url/whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
 
-    "mysql2/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
-
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "nextjs-app-agentuity/@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
-    "node-fetch/data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
+    "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "normalize-package-data/hosted-git-info": ["hosted-git-info@7.0.2", "", { "dependencies": { "lru-cache": "^10.0.1" } }, "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w=="],
 
@@ -4727,6 +4765,8 @@
     "vite-rsc-app-agentuity/@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
     "webrtc-test/@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
+
+    "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -4874,9 +4914,7 @@
 
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
-    "gcp-metadata/gaxios/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
-
-    "gcp-metadata/gaxios/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+    "google-auth-library/gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "hast-util-from-html/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
@@ -4899,6 +4937,10 @@
     "nextjs-app-agentuity/@vitejs/plugin-react/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 
     "nextjs-app-agentuity/@vitejs/plugin-react/react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+
+    "node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "normalize-package-data/hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
@@ -5110,7 +5152,7 @@
 
     "docs/ai/@ai-sdk/gateway/@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
 
-    "gcp-metadata/gaxios/node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+    "google-auth-library/gaxios/node-fetch/data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
     "prebuild-install/tar-fs/tar-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
@@ -5127,10 +5169,6 @@
     "create-agentuity/@agentuity/cli/@agentuity/auth/@agentuity/drizzle/@agentuity/postgres": ["@agentuity/postgres@2.0.17", "", { "dependencies": { "@agentuity/core": "2.0.17", "pg": "^8.13.1" }, "peerDependencies": { "@agentuity/runtime": "2.0.17" }, "optionalPeers": ["@agentuity/runtime"] }, "sha512-Y2rxsPOE7F40Sa8rGKoyJSKxGixOdkxgUNcjtzordCDAtMnMpAtrSvWMb2T/5jCLMEqQV3MzStMmgcddJg0eyQ=="],
 
     "create-agentuity/@agentuity/cli/@agentuity/auth/@agentuity/drizzle/drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
-
-    "gcp-metadata/gaxios/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
-
-    "gcp-metadata/gaxios/node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "archiver-utils/glob/jackspeak/@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 


### PR DESCRIPTION
## Summary

**IMPORTANT**: this _**might**_ not be the right fix...there might be a more subtle issue causing this, but this PR is up just in case it still applies...

---

> This PR redirects the legacy Coder reference URL to the current SDK Reference page so stale links do not leave users on a missing or malformed docs route.

- Adds `/reference/coder` and `/reference/coder/` redirects to `/reference/sdk-reference/coder`
- Adds a matching TanStack Router route for client-side navigation
- Regenerates the docs route tree for the new legacy route
- Includes generated API reference updates from `prebuild`

## Why

`/reference/coder` is no longer the canonical location for the Coder SDK reference. Hitting that route could leave the docs app in a bad reference-sidebar state until a hard refresh.

This change should be framed as a legacy URL redirect. It does not claim to resolve any separate stale deploy or CDN cache issue that could make the reference sidebar intermittently render old bundle state in production.

## Verification

- `bun run typecheck`
- `bun run build`
- Verified `http://127.0.0.1:3500/reference/coder` canonicalizes to `/reference/sdk-reference/coder`
- Verified `http://127.0.0.1:3500/reference/coder/` canonicalizes to `/reference/sdk-reference/coder`
- Verified `/reference/sdk-reference` renders with the SDK Reference children, including Coder
- Verified client-side navigation from `/reference` to `/reference/coder` canonicalizes to `/reference/sdk-reference/coder`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AI Gateway API reference to document additional optional request fields and enhanced billing metadata breakdown in completion responses.
  * Updated Coder API reference to include new content field documentation and expanded sandbox configuration details.

* **Chores**
  * Added redirect routing for Coder API reference documentation path.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentuity/sdk/pull/1496?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->