### PR TITLE
Expose Coder session sandbox scopes

### DIFF
--- a/packages/core/src/services/coder/types.ts
+++ b/packages/core/src/services/coder/types.ts
@@ -659,6 +659,10 @@ export const CoderCreateSessionRequestSchema = z
 			.record(z.string(), z.string())
 			.optional()
 			.describe('Arbitrary metadata associated with the session'),
+		scopes: z
+			.array(z.string())
+			.optional()
+			.describe('Agentuity scopes requested for the sandbox-scoped token'),
 	})
 	.describe('Request body for creating a coder session');
 export type CoderCreateSessionRequest = z.infer<typeof CoderCreateSessionRequestSchema>;

--- a/packages/core/test/coder-client.test.ts
+++ b/packages/core/test/coder-client.test.ts
@@ -601,6 +601,43 @@ describe('CoderClient enabled agent roster contract', () => {
 		});
 	});
 
+	test('createSession sends sandbox scopes in the request body', async () => {
+		mockFetch(async (url, init) => {
+			expect(url).toBe('https://coder.example/api/hub/session');
+			expect(init?.method).toBe('POST');
+			expect(JSON.parse(String(init?.body))).toMatchObject({
+				task: 'Start delegated session',
+				scopes: ['genesis:identity:user_123'],
+			});
+			return new Response(
+				JSON.stringify({
+					sessionId: 'codesess_scoped_create',
+					status: 'creating',
+				}),
+				{
+					status: 201,
+					headers: { 'content-type': 'application/json' },
+				}
+			);
+		});
+
+		const client = new CoderClient({
+			apiKey: 'ag_test',
+			url: 'https://coder.example',
+			orgId: 'org_test',
+		});
+
+		await expect(
+			client.createSession({
+				task: 'Start delegated session',
+				scopes: ['genesis:identity:user_123'],
+			})
+		).resolves.toMatchObject({
+			sessionId: 'codesess_scoped_create',
+			status: 'creating',
+		});
+	});
+
 	test('updateSession sends enabledAgents in the request body', async () => {
 		mockFetch(async (url, init) => {
 			expect(url).toBe('https://coder.example/api/hub/session/codesess_enabled_update');


### PR DESCRIPTION
## Summary
- expose scopes on CoderCreateSessionRequestSchema
- verify createSession preserves sandbox scopes in request bodies

## Tests
- bun test packages/core/test/coder-client.test.ts
- bun run --filter='./packages/core' typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for session creation functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentuity/sdk/pull/1497?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->