### PR TITLE
fix(migrate): emit SIGINT/SIGTERM handlers in generated src/index.ts

### DIFF
--- a/packages/migrate/src/transforms/v3/entry-point.ts
+++ b/packages/migrate/src/transforms/v3/entry-point.ts
@@ -78,10 +78,22 @@ export function generateEntryPoint(detection: V3DetectionResult): EntryPointTran
 		lines.push('');
 	}
 
+	lines.push('// `bun --hot` traps SIGINT/SIGTERM for its reload protocol, so the dev server');
+	lines.push('// otherwise survives Ctrl-C and the bash-backgrounded `bun run server:api &`');
+	lines.push("// in package.json's `dev` script orphans on every shutdown. Installing an");
+	lines.push("// explicit handler runs before Bun's trap and lets the process actually exit.");
+	lines.push('// Upstream: oven-sh/bun#5624, oven-sh/bun#12127.');
+	lines.push("process.on('SIGINT', () => process.exit(0));");
+	lines.push("process.on('SIGTERM', () => process.exit(0));");
+	lines.push('');
+
 	lines.push('export default app;');
 	lines.push('');
 
 	changes.push('Generated src/index.ts with Hono app (replaces app.ts + createApp)');
+	changes.push(
+		'Added SIGINT/SIGTERM handlers so `bun --hot` exits cleanly under backgrounded dev scripts'
+	);
 
 	return {
 		source: lines.join('\n'),

--- a/packages/migrate/src/transforms/v3/entry-point.ts
+++ b/packages/migrate/src/transforms/v3/entry-point.ts
@@ -83,8 +83,13 @@ export function generateEntryPoint(detection: V3DetectionResult): EntryPointTran
 	lines.push("// in package.json's `dev` script orphans on every shutdown. Installing an");
 	lines.push("// explicit handler runs before Bun's trap and lets the process actually exit.");
 	lines.push('// Upstream: oven-sh/bun#5624, oven-sh/bun#12127.');
-	lines.push("process.on('SIGINT', () => process.exit(0));");
-	lines.push("process.on('SIGTERM', () => process.exit(0));");
+	lines.push('// Guarded so `bun --hot` re-evaluations do not stack duplicate listeners.');
+	lines.push(
+		"if (process.listenerCount('SIGINT') === 0) process.on('SIGINT', () => process.exit(0));"
+	);
+	lines.push(
+		"if (process.listenerCount('SIGTERM') === 0) process.on('SIGTERM', () => process.exit(0));"
+	);
 	lines.push('');
 
 	lines.push('export default app;');


### PR DESCRIPTION
## What

The v2→v3 migrator-generated `src/index.ts` now includes:

```ts
// `bun --hot` traps SIGINT/SIGTERM for its reload protocol, so the dev server
// otherwise survives Ctrl-C and the bash-backgrounded `bun run server:api &`
// in package.json's `dev` script orphans on every shutdown. Installing an
// explicit handler runs before Bun's trap and lets the process actually exit.
// Upstream: oven-sh/bun#5624, oven-sh/bun#12127.
process.on('SIGINT', () => process.exit(0));
process.on('SIGTERM', () => process.exit(0));
```

## Why

`bun --hot` traps SIGINT/SIGTERM internally to drive its own reload protocol. The migrator's dev setup for Hono + Vite projects writes a backgrounded script:

```
"dev": "bun run server:api & vite dev"
"server:api": "PORT=3001 bun --hot src/index.ts"
```

Ctrl-C in that shell goes to the foreground (`vite dev`); the backgrounded `bun --hot` ignores its signals and stays alive, holding the port. The next `bun run dev` then boots a fresh Bun that hits `EADDRINUSE` — which is the failure mode reported in #1499. (The HMR-shim code in the screenshot there is a red herring; the `else` branch it crashes in is the *cold start* path of the new process, not a reload failure.)

Installing our own handlers runs before Bun's trap and lets the process exit cleanly, so no orphan, no `EADDRINUSE`.

## Scope

- Only changes `packages/migrate/src/transforms/v3/entry-point.ts` — the generator for the migrated entry point.
- New code is appended to the same file Bun re-evals, no API changes, no dependency changes.
- Verified by running `generateEntryPoint` and by running the existing migrate test suite (17 pass, 0 fail). Typecheck clean.

## Closes

Fixes #1499.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signal handling so backgrounded or interrupted development scripts exit cleanly.
  * Prevented duplicate interruption handlers during hot-reload/re-evaluation to avoid stacked listeners and unexpected behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentuity/sdk/pull/1500?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->