### PR TITLE
Fix framework demo translations across AI Gateway response shapes

### DIFF
--- a/packages/aigateway/src/index.ts
+++ b/packages/aigateway/src/index.ts
@@ -1,6 +1,7 @@
 export {
 	AIGatewayService,
 	buildAIGatewayCompletionParams,
+	getAIGatewayCompletionText,
 	type AIGatewayChatCompletion,
 	type AIGatewayChatCompletionParams,
 	type AIGatewayChatMessage,

--- a/packages/core/src/services/aigateway/index.ts
+++ b/packages/core/src/services/aigateway/index.ts
@@ -9,6 +9,7 @@ export {
 	AIGatewayModelsSchema,
 	AIGatewayPricingSchema,
 	buildAIGatewayCompletionParams,
+	getAIGatewayCompletionText,
 	getAIGatewayStreamDeltaText,
 	getAIGatewayStreamReasoningText,
 	getAIGatewayTextFromParts,

--- a/packages/core/src/services/aigateway/service.ts
+++ b/packages/core/src/services/aigateway/service.ts
@@ -403,6 +403,10 @@ export type AIGatewayStreamingCompletion = {
 	metadata: Promise<AIGatewayResponseMetadata>;
 };
 
+function isUnknownRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}
+
 export function getAIGatewayTextFromParts(parts: unknown): string {
 	if (typeof parts === 'string') return parts;
 	if (!Array.isArray(parts)) return '';
@@ -419,6 +423,81 @@ export function getAIGatewayTextFromParts(parts: unknown): string {
 			return typeof text === 'string' ? text : '';
 		})
 		.join('');
+}
+
+function getAIGatewayChoiceText(choice: unknown): string {
+	if (!isUnknownRecord(choice)) return '';
+
+	const message = choice['message'];
+	if (isUnknownRecord(message)) {
+		const content = message['content'];
+		if (typeof content === 'string') return content;
+
+		const contentText = getAIGatewayTextFromParts(content);
+		if (contentText) return contentText;
+	}
+
+	const content = choice['content'];
+	if (typeof content === 'string') return content;
+
+	const contentText = getAIGatewayTextFromParts(content);
+	if (contentText) return contentText;
+
+	const text = choice['text'];
+
+	return typeof text === 'string' ? text : '';
+}
+
+function getAIGatewayResponseOutputText(output: unknown): string {
+	if (typeof output === 'string') return output;
+	if (!Array.isArray(output)) return '';
+
+	return output
+		.map((item) => {
+			if (typeof item === 'string') return item;
+			if (!isUnknownRecord(item)) return '';
+
+			const type = item['type'];
+			if (typeof type === 'string' && type.includes('reasoning')) return '';
+
+			const contentText = getAIGatewayTextFromParts(item['content']);
+			if (contentText) return contentText;
+
+			const text = item['text'];
+
+			return typeof text === 'string' ? text : '';
+		})
+		.join('');
+}
+
+function getAIGatewayCandidateText(candidate: unknown): string {
+	if (!isUnknownRecord(candidate)) return '';
+
+	const content = candidate['content'];
+	if (!isUnknownRecord(content)) return '';
+
+	return getAIGatewayTextFromParts(content['parts']);
+}
+
+export function getAIGatewayCompletionText(completion: unknown): string {
+	if (!isUnknownRecord(completion)) return '';
+
+	const choices = completion['choices'];
+	if (Array.isArray(choices)) {
+		const choicesText = choices.map(getAIGatewayChoiceText).join('');
+		if (choicesText) return choicesText;
+	}
+
+	const outputText = completion['output_text'];
+	if (typeof outputText === 'string') return outputText;
+
+	const output = getAIGatewayResponseOutputText(completion['output']);
+	if (output) return output;
+
+	const candidates = completion['candidates'];
+	if (!Array.isArray(candidates)) return '';
+
+	return candidates.map(getAIGatewayCandidateText).join('');
 }
 
 export function getAIGatewayStreamDeltaText(payload: unknown): string {

--- a/packages/core/test/aigateway.test.ts
+++ b/packages/core/test/aigateway.test.ts
@@ -4,6 +4,7 @@ import {
 	AIGatewayChatCompletionParamsSchema,
 	AIGatewayService,
 	buildAIGatewayCompletionParams,
+	getAIGatewayCompletionText,
 	getAIGatewayStreamDeltaText,
 	getAIGatewayStreamReasoningText,
 } from '../src/services/aigateway/index.ts';
@@ -173,6 +174,39 @@ describe('AIGatewayService', () => {
 			},
 		]);
 		expect(completion.agentuity?.cost?.reasoningTokens).toBe(64);
+	});
+
+	test('extracts completion text through AI Gateway adapters', () => {
+		expect(
+			getAIGatewayCompletionText({
+				choices: [{ message: { role: 'assistant', content: 'OpenAI text' } }],
+			})
+		).toBe('OpenAI text');
+		expect(
+			getAIGatewayCompletionText({
+				output: [
+					{
+						type: 'reasoning',
+						summary: [{ type: 'summary_text', text: 'Reasoned briefly.' }],
+					},
+					{
+						type: 'message',
+						content: [{ type: 'output_text', text: 'Responses text' }],
+					},
+				],
+			})
+		).toBe('Responses text');
+		expect(
+			getAIGatewayCompletionText({
+				candidates: [
+					{
+						content: {
+							parts: [{ text: 'Gemini text' }],
+						},
+					},
+				],
+			})
+		).toBe('Gemini text');
 	});
 
 	test('prefers provider reasoning token usage over zero gateway metadata', async () => {

--- a/tests/frameworks/nextjs-app/app/api/translate/route.ts
+++ b/tests/frameworks/nextjs-app/app/api/translate/route.ts
@@ -1,14 +1,9 @@
-import { AIGatewayClient } from '@agentuity/aigateway';
+import { AIGatewayClient, getAIGatewayCompletionText } from '@agentuity/aigateway';
 import { NextResponse } from 'next/server';
 
 // One client per worker; safe to reuse across requests.
-// The gateway requires an orgId header in addition to the SDK key. Other
-// service clients in the SDK take it as a constructor option only — pick
-// it up here from any of the env var names the platform already uses so
-// `agentuity dev` (which injects AGENTUITY_ORGID from agentuity.json) and
-// CI (which sets AGENTUITY_ORG_ID) both work.
-// Tracked at agentuity/infra#483 — if/when the gateway accepts SDK-key-only
-// auth on this route, the orgId option here becomes optional.
+// Unlinked demo projects use CLI-key fallback, and that auth path still needs
+// an org header. Read the env var names used by local linked projects and CI.
 const gateway = new AIGatewayClient({
 	orgId:
 		process.env.AGENTUITY_ORGID ??
@@ -35,10 +30,7 @@ export async function POST(request: Request) {
 		],
 	});
 
-	const choice = (completion.choices?.[0] ?? {}) as {
-		message?: { content?: string };
-	};
-	const translation = choice.message?.content ?? '';
+	const translation = getAIGatewayCompletionText(completion);
 	const usage = completion.usage as { total_tokens?: number } | undefined;
 
 	return NextResponse.json({

--- a/tests/frameworks/svelte-web/src/routes/api/translate/+server.ts
+++ b/tests/frameworks/svelte-web/src/routes/api/translate/+server.ts
@@ -1,14 +1,9 @@
-import { AIGatewayClient } from '@agentuity/aigateway';
+import { AIGatewayClient, getAIGatewayCompletionText } from '@agentuity/aigateway';
 import { json, type RequestHandler } from '@sveltejs/kit';
 
 // One client per worker; safe to reuse across requests.
-// The gateway requires an orgId header in addition to the SDK key. Other
-// service clients in the SDK take it as a constructor option only — pick
-// it up here from any of the env var names the platform already uses so
-// `agentuity dev` (which injects AGENTUITY_ORGID from agentuity.json) and
-// CI (which sets AGENTUITY_ORG_ID) both work.
-// Tracked at agentuity/infra#483 — if/when the gateway accepts SDK-key-only
-// auth on this route, the orgId option here becomes optional.
+// Unlinked demo projects use CLI-key fallback, and that auth path still needs
+// an org header. Read the env var names used by local linked projects and CI.
 const gateway = new AIGatewayClient({
 	orgId:
 		process.env.AGENTUITY_ORGID ??
@@ -35,10 +30,7 @@ export const POST: RequestHandler = async ({ request }) => {
 		],
 	});
 
-	const choice = (completion.choices?.[0] ?? {}) as {
-		message?: { content?: string };
-	};
-	const translation = choice.message?.content ?? '';
+	const translation = getAIGatewayCompletionText(completion);
 	const usage = completion.usage as { total_tokens?: number } | undefined;
 
 	return json({

--- a/tests/frameworks/tanstack-start/src/routes/api/translate.ts
+++ b/tests/frameworks/tanstack-start/src/routes/api/translate.ts
@@ -1,14 +1,9 @@
-import { AIGatewayClient } from '@agentuity/aigateway';
+import { AIGatewayClient, getAIGatewayCompletionText } from '@agentuity/aigateway';
 import { createFileRoute } from '@tanstack/react-router';
 
 // One client per worker; safe to reuse across requests.
-// The gateway requires an orgId header in addition to the SDK key. Other
-// service clients in the SDK take it as a constructor option only — pick
-// it up here from any of the env var names the platform already uses so
-// `agentuity dev` (which injects AGENTUITY_ORGID from agentuity.json) and
-// CI (which sets AGENTUITY_ORG_ID) both work.
-// Tracked at agentuity/infra#483 — if/when the gateway accepts SDK-key-only
-// auth on this route, the orgId option here becomes optional.
+// Unlinked demo projects use CLI-key fallback, and that auth path still needs
+// an org header. Read the env var names used by local linked projects and CI.
 const gateway = new AIGatewayClient({
 	orgId:
 		process.env.AGENTUITY_ORGID ??
@@ -38,12 +33,7 @@ export const Route = createFileRoute('/api/translate')({
 					],
 				});
 
-				// The gateway returns an OpenAI-shaped response. Pull the assistant text
-				// out of the first choice and surface token usage when present.
-				const choice = (completion.choices?.[0] ?? {}) as {
-					message?: { content?: string };
-				};
-				const translation = choice.message?.content ?? '';
+				const translation = getAIGatewayCompletionText(completion);
 				const usage = completion.usage as { total_tokens?: number } | undefined;
 
 				return new Response(


### PR DESCRIPTION
## Summary

> Framework demo translation routes now read assistant text from the AI Gateway response shapes they can receive, instead of assuming every response is OpenAI Chat Completions-shaped.

- Adds `getAIGatewayCompletionText()` as the shared text extraction helper for AI Gateway completions.
- Handles OpenAI-compatible `choices`, Responses-style `output`, and Gemini-style `candidates`.
- Re-exports the helper from `@agentuity/aigateway`.
- Updates the TanStack Start, Next.js, and Svelte demo translation routes to use the shared helper.
- Adds focused core test coverage for the supported response shapes.

Fixes agentuity/sdk#1506.

## Why

The framework demos were assuming translation text always lived here:

```ts
completion.choices?.[0]?.message?.content
```

That works for OpenAI Chat Completions-shaped responses, but AI Gateway can also return Responses-shaped output:

```ts
{
  output: [
    {
      type: "message",
      content: [{ type: "output_text", text: "Bonjour" }]
    }
  ]
}
```

When the demo received that valid response shape, the route produced an empty `translation`, so the UI kept showing the placeholder instead of the translated text.

Auth and org-context behavior is unchanged; this PR only updates SDK-side response text extraction.

## Implementation

Adds a small normalization helper:

```ts
const translation = getAIGatewayCompletionText(completion);
```

The helper currently extracts text from these shapes:

```ts
// OpenAI-compatible Chat Completions
choices[].message.content

// OpenAI Responses
output[].content[].text

// Gemini
candidates[].content.parts[].text
```

The framework routes now delegate to that helper instead of each route manually reaching into `choices[0].message.content`.

## Verification

- `bun test packages/core/test/aigateway.test.ts`
- `bun run --filter @agentuity/core typecheck`
- `bun run --filter @agentuity/aigateway typecheck`
- `cd tests/frameworks/tanstack-start && bun run typecheck`
- `cd tests/frameworks/svelte-web && bun run typecheck`
- `cd tests/frameworks/nextjs-app && bunx tsc --noEmit --allowImportingTsExtensions`
- `bunx biome lint <changed files>`

Note: the standard Next.js demo `bun run typecheck` still reports existing `TS5097` errors from test files that import `.ts` / `.tsx` paths without `allowImportingTsExtensions`; the new `@agentuity/aigateway` helper import typechecks with that existing condition accounted for.
