### PR TITLE
Fix AI Gateway demo org context and text extraction

### DIFF
--- a/packages/aigateway/src/index.ts
+++ b/packages/aigateway/src/index.ts
@@ -47,6 +47,20 @@ const isLogger = (val: unknown): val is Logger =>
 		(m) => typeof (val as Record<string, unknown>)[m] === 'function'
 	);
 
+function normalizeOrgId(orgId: string | undefined): string | undefined {
+	const trimmed = orgId?.trim();
+	return trimmed ? trimmed : undefined;
+}
+
+function resolveOrgId(orgId: string | undefined): string | undefined {
+	return (
+		normalizeOrgId(orgId) ??
+		normalizeOrgId(getEnv('AGENTUITY_ORGID')) ??
+		normalizeOrgId(getEnv('AGENTUITY_ORG_ID')) ??
+		normalizeOrgId(getEnv('AGENTUITY_CLOUD_ORG_ID'))
+	);
+}
+
 export const AIGatewayClientOptionsSchema = z.object({
 	apiKey: z.string().optional().describe('API key for authentication'),
 	url: z.string().optional().describe('Base URL for the AI Gateway API'),
@@ -73,7 +87,7 @@ export class AIGatewayClient {
 		const logger = validatedOptions.logger ?? createMinimalLogger();
 		const headers = buildClientHeaders({
 			apiKey,
-			orgId: validatedOptions.orgId,
+			orgId: resolveOrgId(validatedOptions.orgId),
 		});
 
 		const adapter = createServerFetchAdapter({ headers }, logger);

--- a/packages/aigateway/src/index.ts
+++ b/packages/aigateway/src/index.ts
@@ -1,6 +1,7 @@
 export {
 	AIGatewayService,
 	buildAIGatewayCompletionParams,
+	getAIGatewayCompletionText,
 	type AIGatewayChatCompletion,
 	type AIGatewayChatCompletionParams,
 	type AIGatewayChatMessage,

--- a/packages/aigateway/test/index.test.ts
+++ b/packages/aigateway/test/index.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { AIGatewayClient } from '../src/index.ts';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_ENV = {
+	AGENTUITY_AIGATEWAY_URL: process.env.AGENTUITY_AIGATEWAY_URL,
+	AGENTUITY_CLOUD_ORG_ID: process.env.AGENTUITY_CLOUD_ORG_ID,
+	AGENTUITY_ORG_ID: process.env.AGENTUITY_ORG_ID,
+	AGENTUITY_ORGID: process.env.AGENTUITY_ORGID,
+	AGENTUITY_REGION: process.env.AGENTUITY_REGION,
+	AGENTUITY_SDK_KEY: process.env.AGENTUITY_SDK_KEY,
+};
+
+function restoreEnv(): void {
+	for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+		if (value === undefined) {
+			delete process.env[key];
+		} else {
+			process.env[key] = value;
+		}
+	}
+}
+
+describe('AIGatewayClient', () => {
+	let requestHeaders: Headers | undefined;
+
+	beforeEach(() => {
+		restoreEnv();
+		process.env.AGENTUITY_AIGATEWAY_URL = 'https://aigateway.test';
+		process.env.AGENTUITY_SDK_KEY = 'key_test';
+		requestHeaders = undefined;
+		globalThis.fetch = async (_input, init) => {
+			requestHeaders = new Headers(init?.headers);
+			return Response.json({
+				choices: [{ message: { role: 'assistant', content: 'Bonjour' } }],
+			});
+		};
+	});
+
+	afterEach(() => {
+		globalThis.fetch = ORIGINAL_FETCH;
+		restoreEnv();
+	});
+
+	test('sends org header from AGENTUITY_ORGID', async () => {
+		process.env.AGENTUITY_ORGID = 'org_env';
+
+		const client = new AIGatewayClient();
+		await client.complete({
+			model: 'openai/gpt-4o-mini',
+			messages: [{ role: 'user', content: 'Hello' }],
+		});
+
+		expect(requestHeaders?.get('x-agentuity-orgid')).toBe('org_env');
+	});
+
+	test('prefers explicit orgId over env org', async () => {
+		process.env.AGENTUITY_ORGID = 'org_env';
+
+		const client = new AIGatewayClient({ orgId: 'org_explicit' });
+		await client.complete({
+			model: 'openai/gpt-4o-mini',
+			messages: [{ role: 'user', content: 'Hello' }],
+		});
+
+		expect(requestHeaders?.get('x-agentuity-orgid')).toBe('org_explicit');
+	});
+
+	test('ignores blank explicit orgId and falls back to env org', async () => {
+		process.env.AGENTUITY_ORGID = 'org_env';
+
+		const client = new AIGatewayClient({ orgId: '   ' });
+		await client.complete({
+			model: 'openai/gpt-4o-mini',
+			messages: [{ role: 'user', content: 'Hello' }],
+		});
+
+		expect(requestHeaders?.get('x-agentuity-orgid')).toBe('org_env');
+	});
+
+	test('falls back to AGENTUITY_CLOUD_ORG_ID', async () => {
+		process.env.AGENTUITY_CLOUD_ORG_ID = 'org_cloud';
+
+		const client = new AIGatewayClient();
+		await client.complete({
+			model: 'openai/gpt-4o-mini',
+			messages: [{ role: 'user', content: 'Hello' }],
+		});
+
+		expect(requestHeaders?.get('x-agentuity-orgid')).toBe('org_cloud');
+	});
+});

--- a/packages/cli/src/cmd/dev/index.ts
+++ b/packages/cli/src/cmd/dev/index.ts
@@ -47,6 +47,27 @@ import { killLingeringGravityProcesses, startGravity, type GravityHandle } from 
 const DEFAULT_PORT = 3000;
 const GRAVITY_CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1h
 
+interface ResolveDevOrgIdOptions {
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly projectConfig?: Pick<ProjectConfig, 'orgId'> | null;
+	readonly config?: Pick<Config, 'preferences'> | null;
+}
+
+function normalizeOrgId(orgId: string | undefined): string | undefined {
+	const trimmed = orgId?.trim();
+	return trimmed ? trimmed : undefined;
+}
+
+export function resolveDevOrgId(options: ResolveDevOrgIdOptions): string | undefined {
+	return (
+		normalizeOrgId(options.projectConfig?.orgId) ??
+		normalizeOrgId(options.env.AGENTUITY_ORGID) ??
+		normalizeOrgId(options.env.AGENTUITY_ORG_ID) ??
+		normalizeOrgId(options.env.AGENTUITY_CLOUD_ORG_ID) ??
+		normalizeOrgId(options.config?.preferences?.orgId)
+	);
+}
+
 export const command = createCommand({
 	name: 'dev',
 	description: 'Run the project development server',
@@ -158,8 +179,9 @@ export const command = createCommand({
 		// (pi, coder-tui) already read AGENTUITY_ORGID from env, so we match
 		// that name here.
 		const projectConfig = await tryLoadProjectConfig(rootDir, config);
-		if (projectConfig?.orgId && !env.AGENTUITY_ORGID) {
-			env.AGENTUITY_ORGID = projectConfig.orgId;
+		const orgId = resolveDevOrgId({ env, projectConfig, config });
+		if (orgId && !env.AGENTUITY_ORGID) {
+			env.AGENTUITY_ORGID = orgId;
 		}
 
 		// Inject AI Gateway env vars so LLM SDKs route through Agentuity

--- a/packages/cli/src/cmd/dev/index.ts
+++ b/packages/cli/src/cmd/dev/index.ts
@@ -180,7 +180,7 @@ export const command = createCommand({
 		// that name here.
 		const projectConfig = await tryLoadProjectConfig(rootDir, config);
 		const orgId = resolveDevOrgId({ env, projectConfig, config });
-		if (orgId && !env.AGENTUITY_ORGID) {
+		if (orgId && !normalizeOrgId(env.AGENTUITY_ORGID)) {
 			env.AGENTUITY_ORGID = orgId;
 		}
 

--- a/packages/cli/src/cmd/project/templates/astro/src/lib/translate.ts
+++ b/packages/cli/src/cmd/project/templates/astro/src/lib/translate.ts
@@ -1,4 +1,4 @@
-import { AIGatewayClient } from '@agentuity/aigateway';
+import { AIGatewayClient, getAIGatewayCompletionText } from '@agentuity/aigateway';
 
 
 export interface TranslateInput {
@@ -18,36 +18,6 @@ export interface TranslateResult {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null;
-}
-
-function textFromContent(content: unknown): string {
-	if (typeof content === 'string') return content;
-	if (!Array.isArray(content)) return '';
-	return content
-		.map((part) => {
-			if (typeof part === 'string') return part;
-			if (isRecord(part) && typeof part.text === 'string') return part.text;
-			return '';
-		})
-		.join('');
-}
-
-function getCompletionText(response: unknown): string {
-	if (!isRecord(response)) return '';
-	const choices = response.choices;
-	if (Array.isArray(choices) && choices.length > 0) {
-		const first = choices[0];
-		if (isRecord(first)) {
-			const message = first.message;
-			if (isRecord(message)) {
-				const messageText = textFromContent(message.content);
-				if (messageText) return messageText;
-			}
-			const choiceText = textFromContent(first.text);
-			if (choiceText) return choiceText;
-		}
-	}
-	return textFromContent(response.content);
 }
 
 function getTokenCount(response: unknown): number {
@@ -70,7 +40,7 @@ export async function translate(input: TranslateInput): Promise<TranslateResult>
 	});
 
 	const result: TranslateResult = {
-		translation: getCompletionText(completion),
+		translation: getAIGatewayCompletionText(completion),
 		tokens: getTokenCount(completion),
 		model: input.model,
 		toLanguage: input.toLanguage,

--- a/packages/cli/src/cmd/project/templates/hono/src/translate.ts
+++ b/packages/cli/src/cmd/project/templates/hono/src/translate.ts
@@ -1,4 +1,4 @@
-import { AIGatewayClient } from '@agentuity/aigateway';
+import { AIGatewayClient, getAIGatewayCompletionText } from '@agentuity/aigateway';
 
 
 export interface TranslateInput {
@@ -18,36 +18,6 @@ export interface TranslateResult {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null;
-}
-
-function textFromContent(content: unknown): string {
-	if (typeof content === 'string') return content;
-	if (!Array.isArray(content)) return '';
-	return content
-		.map((part) => {
-			if (typeof part === 'string') return part;
-			if (isRecord(part) && typeof part.text === 'string') return part.text;
-			return '';
-		})
-		.join('');
-}
-
-function getCompletionText(response: unknown): string {
-	if (!isRecord(response)) return '';
-	const choices = response.choices;
-	if (Array.isArray(choices) && choices.length > 0) {
-		const first = choices[0];
-		if (isRecord(first)) {
-			const message = first.message;
-			if (isRecord(message)) {
-				const messageText = textFromContent(message.content);
-				if (messageText) return messageText;
-			}
-			const choiceText = textFromContent(first.text);
-			if (choiceText) return choiceText;
-		}
-	}
-	return textFromContent(response.content);
 }
 
 function getTokenCount(response: unknown): number {
@@ -70,7 +40,7 @@ export async function translate(input: TranslateInput): Promise<TranslateResult>
 	});
 
 	const result: TranslateResult = {
-		translation: getCompletionText(completion),
+		translation: getAIGatewayCompletionText(completion),
 		tokens: getTokenCount(completion),
 		model: input.model,
 		toLanguage: input.toLanguage,

--- a/packages/cli/src/cmd/project/templates/nextjs/src/lib/translate.ts
+++ b/packages/cli/src/cmd/project/templates/nextjs/src/lib/translate.ts
@@ -1,4 +1,4 @@
-import { AIGatewayClient } from '@agentuity/aigateway';
+import { AIGatewayClient, getAIGatewayCompletionText } from '@agentuity/aigateway';
 
 
 export interface TranslateInput {
@@ -18,36 +18,6 @@ export interface TranslateResult {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null;
-}
-
-function textFromContent(content: unknown): string {
-	if (typeof content === 'string') return content;
-	if (!Array.isArray(content)) return '';
-	return content
-		.map((part) => {
-			if (typeof part === 'string') return part;
-			if (isRecord(part) && typeof part.text === 'string') return part.text;
-			return '';
-		})
-		.join('');
-}
-
-function getCompletionText(response: unknown): string {
-	if (!isRecord(response)) return '';
-	const choices = response.choices;
-	if (Array.isArray(choices) && choices.length > 0) {
-		const first = choices[0];
-		if (isRecord(first)) {
-			const message = first.message;
-			if (isRecord(message)) {
-				const messageText = textFromContent(message.content);
-				if (messageText) return messageText;
-			}
-			const choiceText = textFromContent(first.text);
-			if (choiceText) return choiceText;
-		}
-	}
-	return textFromContent(response.content);
 }
 
 function getTokenCount(response: unknown): number {
@@ -70,7 +40,7 @@ export async function translate(input: TranslateInput): Promise<TranslateResult>
 	});
 
 	const result: TranslateResult = {
-		translation: getCompletionText(completion),
+		translation: getAIGatewayCompletionText(completion),
 		tokens: getTokenCount(completion),
 		model: input.model,
 		toLanguage: input.toLanguage,

--- a/packages/cli/src/cmd/project/templates/nuxt/server/utils/translate.ts
+++ b/packages/cli/src/cmd/project/templates/nuxt/server/utils/translate.ts
@@ -1,4 +1,4 @@
-import { AIGatewayClient } from '@agentuity/aigateway';
+import { AIGatewayClient, getAIGatewayCompletionText } from '@agentuity/aigateway';
 
 
 export interface TranslateInput {
@@ -18,36 +18,6 @@ export interface TranslateResult {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null;
-}
-
-function textFromContent(content: unknown): string {
-	if (typeof content === 'string') return content;
-	if (!Array.isArray(content)) return '';
-	return content
-		.map((part) => {
-			if (typeof part === 'string') return part;
-			if (isRecord(part) && typeof part.text === 'string') return part.text;
-			return '';
-		})
-		.join('');
-}
-
-function getCompletionText(response: unknown): string {
-	if (!isRecord(response)) return '';
-	const choices = response.choices;
-	if (Array.isArray(choices) && choices.length > 0) {
-		const first = choices[0];
-		if (isRecord(first)) {
-			const message = first.message;
-			if (isRecord(message)) {
-				const messageText = textFromContent(message.content);
-				if (messageText) return messageText;
-			}
-			const choiceText = textFromContent(first.text);
-			if (choiceText) return choiceText;
-		}
-	}
-	return textFromContent(response.content);
 }
 
 function getTokenCount(response: unknown): number {
@@ -70,7 +40,7 @@ export async function translate(input: TranslateInput): Promise<TranslateResult>
 	});
 
 	const result: TranslateResult = {
-		translation: getCompletionText(completion),
+		translation: getAIGatewayCompletionText(completion),
 		tokens: getTokenCount(completion),
 		model: input.model,
 		toLanguage: input.toLanguage,

--- a/packages/cli/src/cmd/project/templates/sveltekit/src/lib/server/translate.ts
+++ b/packages/cli/src/cmd/project/templates/sveltekit/src/lib/server/translate.ts
@@ -1,4 +1,4 @@
-import { AIGatewayClient } from '@agentuity/aigateway';
+import { AIGatewayClient, getAIGatewayCompletionText } from '@agentuity/aigateway';
 
 
 export interface TranslateInput {
@@ -18,36 +18,6 @@ export interface TranslateResult {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null;
-}
-
-function textFromContent(content: unknown): string {
-	if (typeof content === 'string') return content;
-	if (!Array.isArray(content)) return '';
-	return content
-		.map((part) => {
-			if (typeof part === 'string') return part;
-			if (isRecord(part) && typeof part.text === 'string') return part.text;
-			return '';
-		})
-		.join('');
-}
-
-function getCompletionText(response: unknown): string {
-	if (!isRecord(response)) return '';
-	const choices = response.choices;
-	if (Array.isArray(choices) && choices.length > 0) {
-		const first = choices[0];
-		if (isRecord(first)) {
-			const message = first.message;
-			if (isRecord(message)) {
-				const messageText = textFromContent(message.content);
-				if (messageText) return messageText;
-			}
-			const choiceText = textFromContent(first.text);
-			if (choiceText) return choiceText;
-		}
-	}
-	return textFromContent(response.content);
 }
 
 function getTokenCount(response: unknown): number {
@@ -70,7 +40,7 @@ export async function translate(input: TranslateInput): Promise<TranslateResult>
 	});
 
 	const result: TranslateResult = {
-		translation: getCompletionText(completion),
+		translation: getAIGatewayCompletionText(completion),
 		tokens: getTokenCount(completion),
 		model: input.model,
 		toLanguage: input.toLanguage,

--- a/packages/cli/test/cmd/dev/org-id.test.ts
+++ b/packages/cli/test/cmd/dev/org-id.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+import { resolveDevOrgId } from '../../../src/cmd/dev/index.ts';
+
+describe('resolveDevOrgId', () => {
+	test('prefers project org ID over env and config values', () => {
+		expect(
+			resolveDevOrgId({
+				env: {
+					AGENTUITY_CLOUD_ORG_ID: 'org_cloud',
+					AGENTUITY_ORGID: 'org_env',
+				},
+				projectConfig: { orgId: 'org_project' },
+				config: { preferences: { orgId: 'org_config' } },
+			})
+		).toBe('org_project');
+	});
+
+	test('falls back to AGENTUITY_CLOUD_ORG_ID for unlinked projects', () => {
+		expect(
+			resolveDevOrgId({
+				env: { AGENTUITY_CLOUD_ORG_ID: 'org_cloud' },
+				projectConfig: null,
+				config: null,
+			})
+		).toBe('org_cloud');
+	});
+
+	test('falls back to CLI profile org for unlinked projects', () => {
+		expect(
+			resolveDevOrgId({
+				env: {},
+				projectConfig: null,
+				config: { preferences: { orgId: 'org_config' } },
+			})
+		).toBe('org_config');
+	});
+
+	test('ignores blank org IDs', () => {
+		expect(
+			resolveDevOrgId({
+				env: {
+					AGENTUITY_CLOUD_ORG_ID: '  ',
+					AGENTUITY_ORGID: '',
+					AGENTUITY_ORG_ID: 'org_alt',
+				},
+				projectConfig: { orgId: ' ' },
+				config: { preferences: { orgId: 'org_config' } },
+			})
+		).toBe('org_alt');
+	});
+});

--- a/packages/core/src/services/aigateway/index.ts
+++ b/packages/core/src/services/aigateway/index.ts
@@ -9,6 +9,7 @@ export {
 	AIGatewayModelsSchema,
 	AIGatewayPricingSchema,
 	buildAIGatewayCompletionParams,
+	getAIGatewayCompletionText,
 	getAIGatewayStreamDeltaText,
 	getAIGatewayStreamReasoningText,
 	getAIGatewayTextFromParts,

--- a/packages/core/src/services/aigateway/service.ts
+++ b/packages/core/src/services/aigateway/service.ts
@@ -403,6 +403,10 @@ export type AIGatewayStreamingCompletion = {
 	metadata: Promise<AIGatewayResponseMetadata>;
 };
 
+function isUnknownRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}
+
 export function getAIGatewayTextFromParts(parts: unknown): string {
 	if (typeof parts === 'string') return parts;
 	if (!Array.isArray(parts)) return '';
@@ -419,6 +423,81 @@ export function getAIGatewayTextFromParts(parts: unknown): string {
 			return typeof text === 'string' ? text : '';
 		})
 		.join('');
+}
+
+function getAIGatewayChoiceText(choice: unknown): string {
+	if (!isUnknownRecord(choice)) return '';
+
+	const message = choice['message'];
+	if (isUnknownRecord(message)) {
+		const content = message['content'];
+		if (typeof content === 'string') return content;
+
+		const contentText = getAIGatewayTextFromParts(content);
+		if (contentText) return contentText;
+	}
+
+	const content = choice['content'];
+	if (typeof content === 'string') return content;
+
+	const contentText = getAIGatewayTextFromParts(content);
+	if (contentText) return contentText;
+
+	const text = choice['text'];
+
+	return typeof text === 'string' ? text : '';
+}
+
+function getAIGatewayResponseOutputText(output: unknown): string {
+	if (typeof output === 'string') return output;
+	if (!Array.isArray(output)) return '';
+
+	return output
+		.map((item) => {
+			if (typeof item === 'string') return item;
+			if (!isUnknownRecord(item)) return '';
+
+			const type = item['type'];
+			if (typeof type === 'string' && type.includes('reasoning')) return '';
+
+			const contentText = getAIGatewayTextFromParts(item['content']);
+			if (contentText) return contentText;
+
+			const text = item['text'];
+
+			return typeof text === 'string' ? text : '';
+		})
+		.join('');
+}
+
+function getAIGatewayCandidateText(candidate: unknown): string {
+	if (!isUnknownRecord(candidate)) return '';
+
+	const content = candidate['content'];
+	if (!isUnknownRecord(content)) return '';
+
+	return getAIGatewayTextFromParts(content['parts']);
+}
+
+export function getAIGatewayCompletionText(completion: unknown): string {
+	if (!isUnknownRecord(completion)) return '';
+
+	const choices = completion['choices'];
+	if (Array.isArray(choices)) {
+		const choicesText = choices.map(getAIGatewayChoiceText).join('');
+		if (choicesText) return choicesText;
+	}
+
+	const outputText = completion['output_text'];
+	if (typeof outputText === 'string') return outputText;
+
+	const output = getAIGatewayResponseOutputText(completion['output']);
+	if (output) return output;
+
+	const candidates = completion['candidates'];
+	if (!Array.isArray(candidates)) return '';
+
+	return candidates.map(getAIGatewayCandidateText).join('');
 }
 
 export function getAIGatewayStreamDeltaText(payload: unknown): string {

--- a/packages/core/test/aigateway.test.ts
+++ b/packages/core/test/aigateway.test.ts
@@ -4,6 +4,7 @@ import {
 	AIGatewayChatCompletionParamsSchema,
 	AIGatewayService,
 	buildAIGatewayCompletionParams,
+	getAIGatewayCompletionText,
 	getAIGatewayStreamDeltaText,
 	getAIGatewayStreamReasoningText,
 } from '../src/services/aigateway/index.ts';
@@ -173,6 +174,39 @@ describe('AIGatewayService', () => {
 			},
 		]);
 		expect(completion.agentuity?.cost?.reasoningTokens).toBe(64);
+	});
+
+	test('extracts completion text through AI Gateway adapters', () => {
+		expect(
+			getAIGatewayCompletionText({
+				choices: [{ message: { role: 'assistant', content: 'OpenAI text' } }],
+			})
+		).toBe('OpenAI text');
+		expect(
+			getAIGatewayCompletionText({
+				output: [
+					{
+						type: 'reasoning',
+						summary: [{ type: 'summary_text', text: 'Reasoned briefly.' }],
+					},
+					{
+						type: 'message',
+						content: [{ type: 'output_text', text: 'Responses text' }],
+					},
+				],
+			})
+		).toBe('Responses text');
+		expect(
+			getAIGatewayCompletionText({
+				candidates: [
+					{
+						content: {
+							parts: [{ text: 'Gemini text' }],
+						},
+					},
+				],
+			})
+		).toBe('Gemini text');
 	});
 
 	test('prefers provider reasoning token usage over zero gateway metadata', async () => {

--- a/tests/frameworks/nextjs-app/app/api/translate/route.ts
+++ b/tests/frameworks/nextjs-app/app/api/translate/route.ts
@@ -1,14 +1,9 @@
-import { AIGatewayClient } from '@agentuity/aigateway';
+import { AIGatewayClient, getAIGatewayCompletionText } from '@agentuity/aigateway';
 import { NextResponse } from 'next/server';
 
 // One client per worker; safe to reuse across requests.
-// The gateway requires an orgId header in addition to the SDK key. Other
-// service clients in the SDK take it as a constructor option only — pick
-// it up here from any of the env var names the platform already uses so
-// `agentuity dev` (which injects AGENTUITY_ORGID from agentuity.json) and
-// CI (which sets AGENTUITY_ORG_ID) both work.
-// Tracked at agentuity/infra#483 — if/when the gateway accepts SDK-key-only
-// auth on this route, the orgId option here becomes optional.
+// Unlinked demo projects use CLI-key fallback, and that auth path still needs
+// an org header. Read the env var names used by local linked projects and CI.
 const gateway = new AIGatewayClient({
 	orgId:
 		process.env.AGENTUITY_ORGID ??
@@ -35,10 +30,7 @@ export async function POST(request: Request) {
 		],
 	});
 
-	const choice = (completion.choices?.[0] ?? {}) as {
-		message?: { content?: string };
-	};
-	const translation = choice.message?.content ?? '';
+	const translation = getAIGatewayCompletionText(completion);
 	const usage = completion.usage as { total_tokens?: number } | undefined;
 
 	return NextResponse.json({

--- a/tests/frameworks/nextjs-app/app/api/translate/route.ts
+++ b/tests/frameworks/nextjs-app/app/api/translate/route.ts
@@ -2,14 +2,7 @@ import { AIGatewayClient, getAIGatewayCompletionText } from '@agentuity/aigatewa
 import { NextResponse } from 'next/server';
 
 // One client per worker; safe to reuse across requests.
-// Unlinked demo projects use CLI-key fallback, and that auth path still needs
-// an org header. Read the env var names used by local linked projects and CI.
-const gateway = new AIGatewayClient({
-	orgId:
-		process.env.AGENTUITY_ORGID ??
-		process.env.AGENTUITY_ORG_ID ??
-		process.env.AGENTUITY_CLOUD_ORG_ID,
-});
+const gateway = new AIGatewayClient();
 
 export async function POST(request: Request) {
 	const body = (await request.json()) as {

--- a/tests/frameworks/nextjs-app/tests/e2e.pw.ts
+++ b/tests/frameworks/nextjs-app/tests/e2e.pw.ts
@@ -1,5 +1,30 @@
 import { expect, test } from '@playwright/test';
 
+interface TranslationResponse {
+	ok(): boolean;
+	text(): Promise<string>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}
+
+async function readTranslation(response: TranslationResponse): Promise<string> {
+	const responseText = await response.text();
+	expect(response.ok(), responseText).toBe(true);
+
+	const body: unknown = JSON.parse(responseText);
+	expect(isRecord(body)).toBe(true);
+	if (!isRecord(body)) throw new Error('Translation response body was not an object');
+
+	const translation = body.translation;
+	expect(typeof translation).toBe('string');
+	if (typeof translation !== 'string') throw new Error('Translation response was missing text');
+	expect(translation.trim().length).toBeGreaterThan(0);
+
+	return translation;
+}
+
 test.describe('Next.js + Agentuity', () => {
 	test('should load the home page with translation UI', async ({ page }) => {
 		page.on('console', (msg) => console.log('BROWSER LOG:', msg.text()));
@@ -16,29 +41,16 @@ test.describe('Next.js + Agentuity', () => {
 		await expect(page.locator('button:has-text("Translate")')).toBeVisible();
 	});
 
-	test('should translate text via AI Gateway', async ({ page }) => {
-		page.on('console', (msg) => console.log('BROWSER LOG:', msg.text()));
-		page.on('pageerror', (err) => console.error('PAGE ERROR:', err));
-
-		await page.goto('/');
-
-		// Fill in text
-		const input = page.locator('textarea');
-		await input.clear();
-		await input.fill('Hello from Playwright!');
-
-		// Select language
-		await page.locator('select').first().selectOption('French');
-
-		// Click translate
-		await page.locator('button:has-text("Translate")').click();
-
-		// Wait for result — the output div with translation text
-		const output = page.locator('.output');
-		await expect(output).toBeVisible({ timeout: 30000 });
-
-		// Verify translation result has actual content (not the placeholder)
-		await expect(output).not.toContainText('Translation will appear here');
+	test('should translate text via AI Gateway', async ({ request }) => {
+		const response = await request.post('/api/translate', {
+			data: {
+				text: 'Hello from Playwright!',
+				toLanguage: 'French',
+				model: 'openai/gpt-4o-mini',
+			},
+			timeout: 60000,
+		});
+		await readTranslation(response);
 	});
 
 	test('should navigate to about page', async ({ page }) => {

--- a/tests/frameworks/svelte-web/src/routes/api/translate/+server.ts
+++ b/tests/frameworks/svelte-web/src/routes/api/translate/+server.ts
@@ -1,14 +1,9 @@
-import { AIGatewayClient } from '@agentuity/aigateway';
+import { AIGatewayClient, getAIGatewayCompletionText } from '@agentuity/aigateway';
 import { json, type RequestHandler } from '@sveltejs/kit';
 
 // One client per worker; safe to reuse across requests.
-// The gateway requires an orgId header in addition to the SDK key. Other
-// service clients in the SDK take it as a constructor option only — pick
-// it up here from any of the env var names the platform already uses so
-// `agentuity dev` (which injects AGENTUITY_ORGID from agentuity.json) and
-// CI (which sets AGENTUITY_ORG_ID) both work.
-// Tracked at agentuity/infra#483 — if/when the gateway accepts SDK-key-only
-// auth on this route, the orgId option here becomes optional.
+// Unlinked demo projects use CLI-key fallback, and that auth path still needs
+// an org header. Read the env var names used by local linked projects and CI.
 const gateway = new AIGatewayClient({
 	orgId:
 		process.env.AGENTUITY_ORGID ??
@@ -35,10 +30,7 @@ export const POST: RequestHandler = async ({ request }) => {
 		],
 	});
 
-	const choice = (completion.choices?.[0] ?? {}) as {
-		message?: { content?: string };
-	};
-	const translation = choice.message?.content ?? '';
+	const translation = getAIGatewayCompletionText(completion);
 	const usage = completion.usage as { total_tokens?: number } | undefined;
 
 	return json({

--- a/tests/frameworks/svelte-web/src/routes/api/translate/+server.ts
+++ b/tests/frameworks/svelte-web/src/routes/api/translate/+server.ts
@@ -2,14 +2,7 @@ import { AIGatewayClient, getAIGatewayCompletionText } from '@agentuity/aigatewa
 import { json, type RequestHandler } from '@sveltejs/kit';
 
 // One client per worker; safe to reuse across requests.
-// Unlinked demo projects use CLI-key fallback, and that auth path still needs
-// an org header. Read the env var names used by local linked projects and CI.
-const gateway = new AIGatewayClient({
-	orgId:
-		process.env.AGENTUITY_ORGID ??
-		process.env.AGENTUITY_ORG_ID ??
-		process.env.AGENTUITY_CLOUD_ORG_ID,
-});
+const gateway = new AIGatewayClient();
 
 export const POST: RequestHandler = async ({ request }) => {
 	const body = (await request.json()) as {

--- a/tests/frameworks/svelte-web/tests/e2e.pw.ts
+++ b/tests/frameworks/svelte-web/tests/e2e.pw.ts
@@ -1,5 +1,30 @@
 import { expect, test } from '@playwright/test';
 
+interface TranslationResponse {
+	ok(): boolean;
+	text(): Promise<string>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}
+
+async function readTranslation(response: TranslationResponse): Promise<string> {
+	const responseText = await response.text();
+	expect(response.ok(), responseText).toBe(true);
+
+	const body: unknown = JSON.parse(responseText);
+	expect(isRecord(body)).toBe(true);
+	if (!isRecord(body)) throw new Error('Translation response body was not an object');
+
+	const translation = body.translation;
+	expect(typeof translation).toBe('string');
+	if (typeof translation !== 'string') throw new Error('Translation response was missing text');
+	expect(translation.trim().length).toBeGreaterThan(0);
+
+	return translation;
+}
+
 test.describe('SvelteKit + Agentuity', () => {
 	test('should load the home page with translation UI', async ({ page }) => {
 		page.on('console', (msg) => console.log('BROWSER LOG:', msg.text()));
@@ -16,29 +41,16 @@ test.describe('SvelteKit + Agentuity', () => {
 		await expect(page.locator('button:has-text("Translate")')).toBeVisible();
 	});
 
-	test('should translate text via AI Gateway', async ({ page }) => {
-		page.on('console', (msg) => console.log('BROWSER LOG:', msg.text()));
-		page.on('pageerror', (err) => console.error('PAGE ERROR:', err));
-
-		await page.goto('/');
-
-		// Fill in text
-		const input = page.locator('textarea');
-		await input.clear();
-		await input.fill('Hello from Playwright!');
-
-		// Select language
-		await page.locator('select').first().selectOption('French');
-
-		// Click translate
-		await page.locator('button:has-text("Translate")').click();
-
-		// Wait for result — the output div with translation text
-		const output = page.locator('.output');
-		await expect(output).toBeVisible({ timeout: 30000 });
-
-		// Verify translation result has actual content (not the placeholder)
-		await expect(output).not.toContainText('Translation will appear here');
+	test('should translate text via AI Gateway', async ({ request }) => {
+		const response = await request.post('/api/translate', {
+			data: {
+				text: 'Hello from Playwright!',
+				toLanguage: 'French',
+				model: 'openai/gpt-4o-mini',
+			},
+			timeout: 60000,
+		});
+		await readTranslation(response);
 	});
 
 	test('should navigate to about page', async ({ page }) => {

--- a/tests/frameworks/tanstack-start/src/routes/api/translate.ts
+++ b/tests/frameworks/tanstack-start/src/routes/api/translate.ts
@@ -1,14 +1,9 @@
-import { AIGatewayClient } from '@agentuity/aigateway';
+import { AIGatewayClient, getAIGatewayCompletionText } from '@agentuity/aigateway';
 import { createFileRoute } from '@tanstack/react-router';
 
 // One client per worker; safe to reuse across requests.
-// The gateway requires an orgId header in addition to the SDK key. Other
-// service clients in the SDK take it as a constructor option only — pick
-// it up here from any of the env var names the platform already uses so
-// `agentuity dev` (which injects AGENTUITY_ORGID from agentuity.json) and
-// CI (which sets AGENTUITY_ORG_ID) both work.
-// Tracked at agentuity/infra#483 — if/when the gateway accepts SDK-key-only
-// auth on this route, the orgId option here becomes optional.
+// Unlinked demo projects use CLI-key fallback, and that auth path still needs
+// an org header. Read the env var names used by local linked projects and CI.
 const gateway = new AIGatewayClient({
 	orgId:
 		process.env.AGENTUITY_ORGID ??
@@ -38,12 +33,7 @@ export const Route = createFileRoute('/api/translate')({
 					],
 				});
 
-				// The gateway returns an OpenAI-shaped response. Pull the assistant text
-				// out of the first choice and surface token usage when present.
-				const choice = (completion.choices?.[0] ?? {}) as {
-					message?: { content?: string };
-				};
-				const translation = choice.message?.content ?? '';
+				const translation = getAIGatewayCompletionText(completion);
 				const usage = completion.usage as { total_tokens?: number } | undefined;
 
 				return new Response(

--- a/tests/frameworks/tanstack-start/src/routes/api/translate.ts
+++ b/tests/frameworks/tanstack-start/src/routes/api/translate.ts
@@ -2,14 +2,7 @@ import { AIGatewayClient, getAIGatewayCompletionText } from '@agentuity/aigatewa
 import { createFileRoute } from '@tanstack/react-router';
 
 // One client per worker; safe to reuse across requests.
-// Unlinked demo projects use CLI-key fallback, and that auth path still needs
-// an org header. Read the env var names used by local linked projects and CI.
-const gateway = new AIGatewayClient({
-	orgId:
-		process.env.AGENTUITY_ORGID ??
-		process.env.AGENTUITY_ORG_ID ??
-		process.env.AGENTUITY_CLOUD_ORG_ID,
-});
+const gateway = new AIGatewayClient();
 
 export const Route = createFileRoute('/api/translate')({
 	server: {

--- a/tests/frameworks/tanstack-start/tests/e2e.pw.ts
+++ b/tests/frameworks/tanstack-start/tests/e2e.pw.ts
@@ -1,5 +1,30 @@
 import { test, expect } from '@playwright/test';
 
+interface TranslationResponse {
+	ok(): boolean;
+	text(): Promise<string>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}
+
+async function readTranslation(response: TranslationResponse): Promise<string> {
+	const responseText = await response.text();
+	expect(response.ok(), responseText).toBe(true);
+
+	const body: unknown = JSON.parse(responseText);
+	expect(isRecord(body)).toBe(true);
+	if (!isRecord(body)) throw new Error('Translation response body was not an object');
+
+	const translation = body.translation;
+	expect(typeof translation).toBe('string');
+	if (typeof translation !== 'string') throw new Error('Translation response was missing text');
+	expect(translation.trim().length).toBeGreaterThan(0);
+
+	return translation;
+}
+
 test.describe('TanStack Start + Agentuity', () => {
 	test('should load the home page with translation UI', async ({ page }) => {
 		page.on('console', (msg) => console.log('BROWSER LOG:', msg.text()));
@@ -16,29 +41,16 @@ test.describe('TanStack Start + Agentuity', () => {
 		await expect(page.locator('button:has-text("Translate")')).toBeVisible();
 	});
 
-	test('should translate text via AI Gateway', async ({ page }) => {
-		page.on('console', (msg) => console.log('BROWSER LOG:', msg.text()));
-		page.on('pageerror', (err) => console.error('PAGE ERROR:', err));
-
-		await page.goto('/');
-
-		// Fill in text
-		const input = page.locator('textarea');
-		await input.clear();
-		await input.fill('Hello from Playwright!');
-
-		// Select language
-		await page.locator('select').first().selectOption('French');
-
-		// Click translate
-		await page.locator('button:has-text("Translate")').click();
-
-		// Wait for result — the output div with translation text
-		const output = page.locator('.output');
-		await expect(output).toBeVisible({ timeout: 30000 });
-
-		// Verify translation result has actual content (not the placeholder)
-		await expect(output).not.toContainText('Translation will appear here');
+	test('should translate text via AI Gateway', async ({ request }) => {
+		const response = await request.post('/api/translate', {
+			data: {
+				text: 'Hello from Playwright!',
+				toLanguage: 'French',
+				model: 'openai/gpt-4o-mini',
+			},
+			timeout: 60000,
+		});
+		await readTranslation(response);
 	});
 
 	test('should navigate to about page', async ({ page }) => {


### PR DESCRIPTION
## Summary

> Fixes two SDK-side AI Gateway demo gaps: org context for unlinked dev projects, and completion text extraction across supported response shapes.

- Adds shared AI Gateway completion text extraction.
- Passes org context through `agentuity dev` for unlinked demo projects.
- Lets `AIGatewayClient` read org IDs from standard Agentuity env vars.
- Updates generated templates to use the shared extraction helper.
- Makes framework translation tests hit `/api/translate` directly.

Fixes agentuity/sdk#1506.

## Why

The failing demos had two separate problems that could look similar from the UI.

First, the demo routes assumed every completion looked like OpenAI Chat Completions:

```ts
completion.choices?.[0]?.message?.content
```

That misses other valid AI Gateway response shapes, so a successful completion could still become an empty `translation`.

Second, generated or test-suite projects may be unlinked. In `agentuity dev`, those projects can fall back to CLI-key auth, and that path still needs org context. The SDK should pass that context through when it already exists locally, rather than requiring every demo route to wire it by hand.

## Implementation

The route code stays small:

```ts
const gateway = new AIGatewayClient();
const completion = await gateway.complete(...);
const translation = getAIGatewayCompletionText(completion);
```

`agentuity dev` now resolves the org once for the child app process:

```ts
const orgId = resolveDevOrgId({ env, projectConfig, config });

if (orgId && !env.AGENTUITY_ORGID) {
  env.AGENTUITY_ORGID = orgId;
}
```

The AI Gateway client then uses the same org envs users already have:

```ts
orgId ??
  AGENTUITY_ORGID ??
  AGENTUITY_ORG_ID ??
  AGENTUITY_CLOUD_ORG_ID
```

Generated templates now call the shared helper too:

```ts
return getAIGatewayCompletionText(completion);
```

Framework Playwright tests now call the route directly:

```ts
const response = await request.post('/api/translate', {
  data: { text: 'Hello world' },
});
```

That keeps browser rendering separate from route/auth/AI Gateway behavior, so failures point at the real layer.

## Verification

- `bun test packages/aigateway/test/index.test.ts`
- `bun test packages/cli/test/cmd/dev/org-id.test.ts`
- `bun test packages/core/test/aigateway.test.ts`
- `bun run --filter @agentuity/core typecheck`
- `bun run --filter @agentuity/aigateway typecheck`
- `bun run --filter @agentuity/cli typecheck`
- `bun run --filter @agentuity/aigateway build`
- `bun run --filter @agentuity/cli build`
- `cd tests/frameworks/tanstack-start && bun run typecheck`
- `cd tests/frameworks/svelte-web && bun run typecheck`
- `cd tests/frameworks/nextjs-app && bunx tsc --noEmit --allowImportingTsExtensions`
- `bunx biome lint <changed files>`
- `scripts/test-framework-demos.sh --skip-build`

Note: the standard Next.js demo `bun run typecheck` still reports existing `TS5097` errors from test files that import `.ts` / `.tsx` paths without `allowImportingTsExtensions`; the supplemental Next.js typecheck above passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New text-extraction utility for AI Gateway completions that handles responses from major providers and unifies parsing across templates and apps.
  * Re-exported completion-text helper for easier import throughout the project.

* **Bug Fixes**
  * Client now normalizes org-id headers, trims blanks, and falls back to configured environment/profile values when an org-id is not provided.

* **Tests**
  * Added unit and e2e tests validating text extraction and org-id header selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentuity/sdk/pull/1508?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
