### PR TITLE
Ensure required CI checks report on every PR

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -2,16 +2,11 @@ name: Actionlint
 
 on:
   pull_request:
-    paths:
-      - '.github/actionlint.yaml'
-      - '.github/workflows/**'
+  merge_group:
   push:
     branches:
       - main
       - v2
-    paths:
-      - '.github/actionlint.yaml'
-      - '.github/workflows/**'
 
 permissions:
   contents: read

--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -11,11 +11,7 @@ on:
          - 'packages/cli/**'
          - '.github/workflows/test-install.yaml'
    pull_request:
-      paths:
-         - 'install.sh'
-         - 'scripts/test-install.sh'
-         - 'scripts/test-bun-check.sh'
-         - '.github/workflows/test-install.yaml'
+   merge_group:
 
 permissions:
    contents: read
@@ -30,22 +26,75 @@ env:
    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+   detect-install-changes:
+      name: Detect install test changes
+      runs-on: ubuntu-latest
+      outputs:
+         should-run: ${{ steps.changed-files.outputs.should-run }}
+      steps:
+         - name: Checkout
+           uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+           with:
+              fetch-depth: 0
+              persist-credentials: false
+
+         - name: Detect changed files
+           id: changed-files
+           shell: bash
+           env:
+              BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+              HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+           run: |
+              set -euo pipefail
+
+              if [ -z "${BASE_SHA}" ] || [ "${BASE_SHA}" = "0000000000000000000000000000000000000000" ]; then
+                echo "should-run=true" >> "$GITHUB_OUTPUT"
+                echo "Unable to determine a base SHA; running install tests."
+                exit 0
+              fi
+
+              git diff --name-only "$BASE_SHA" "$HEAD_SHA" > changed-files.txt
+              cat changed-files.txt
+
+              if grep -E '^(install\.sh|scripts/test-install\.sh|scripts/test-bun-check\.sh|packages/cli/|\.github/workflows/test-install\.yaml)' changed-files.txt > /dev/null; then
+                echo "should-run=true" >> "$GITHUB_OUTPUT"
+                echo "Install-related files changed; running install tests."
+              else
+                echo "should-run=false" >> "$GITHUB_OUTPUT"
+                echo "No install-related files changed; skipping install test work."
+              fi
+
    test-native-linux:
       name: Native install (Linux)
+      needs: detect-install-changes
+      if: always()
       runs-on: ubuntu-latest
       timeout-minutes: 10
       steps:
+         - name: Check change detection
+           if: ${{ needs.detect-install-changes.result != 'success' }}
+           run: |
+              echo "Install change detection failed"
+              exit 1
+
+         - name: Skip install test
+           if: ${{ needs.detect-install-changes.outputs.should-run != 'true' }}
+           run: echo "No install-related files changed; skipping Native install (Linux)."
+
          - name: Checkout
+           if: ${{ needs.detect-install-changes.outputs.should-run == 'true' }}
            uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
            with:
               persist-credentials: false
 
          - name: Setup Bun
+           if: ${{ needs.detect-install-changes.outputs.should-run == 'true' }}
            uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
            with:
               bun-version: "1.3.11"
 
          - name: Test install script
+           if: ${{ needs.detect-install-changes.outputs.should-run == 'true' }}
            run: |
               set -euo pipefail
 
@@ -70,20 +119,35 @@ jobs:
 
    test-native-macos:
       name: Native install (macOS)
+      needs: detect-install-changes
+      if: always()
       runs-on: macos-latest
       timeout-minutes: 10
       steps:
+         - name: Check change detection
+           if: ${{ needs.detect-install-changes.result != 'success' }}
+           run: |
+              echo "Install change detection failed"
+              exit 1
+
+         - name: Skip install test
+           if: ${{ needs.detect-install-changes.outputs.should-run != 'true' }}
+           run: echo "No install-related files changed; skipping Native install (macOS)."
+
          - name: Checkout
+           if: ${{ needs.detect-install-changes.outputs.should-run == 'true' }}
            uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
            with:
               persist-credentials: false
 
          - name: Setup Bun
+           if: ${{ needs.detect-install-changes.outputs.should-run == 'true' }}
            uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
            with:
               bun-version: "1.3.11"
 
          - name: Test install script
+           if: ${{ needs.detect-install-changes.outputs.should-run == 'true' }}
            run: |
               set -euo pipefail
 
@@ -108,6 +172,8 @@ jobs:
 
    test-linux-distros:
       name: Linux distro install smoke
+      needs: detect-install-changes
+      if: ${{ needs.detect-install-changes.outputs.should-run == 'true' }}
       runs-on: ubuntu-latest
       timeout-minutes: 40
       steps:
@@ -185,6 +251,8 @@ jobs:
 
    test-bun-checks:
       name: Bun version checks
+      needs: detect-install-changes
+      if: ${{ needs.detect-install-changes.outputs.should-run == 'true' }}
       runs-on: ubuntu-latest
       timeout-minutes: 20
       steps:
@@ -200,6 +268,8 @@ jobs:
 
    test-scenarios:
       name: Installer scenarios
+      needs: detect-install-changes
+      if: ${{ needs.detect-install-changes.outputs.should-run == 'true' }}
       runs-on: ubuntu-latest
       timeout-minutes: 30
       steps:
@@ -303,6 +373,7 @@ jobs:
       name: Install test summary
       runs-on: ubuntu-latest
       needs:
+         - detect-install-changes
          - test-native-linux
          - test-native-macos
          - test-linux-distros
@@ -312,6 +383,16 @@ jobs:
       steps:
          - name: Check results
            run: |
+              if [ "${{ needs.detect-install-changes.result }}" != "success" ]; then
+                echo "❌ Install change detection failed"
+                exit 1
+              fi
+
+              if [ "${{ needs.detect-install-changes.outputs.should-run }}" != "true" ]; then
+                echo "✅ No install-related files changed; install tests skipped"
+                exit 0
+              fi
+
               if [ "${{ needs.test-native-linux.result }}" != "success" ] || \
                  [ "${{ needs.test-native-macos.result }}" != "success" ] || \
                  [ "${{ needs.test-linux-distros.result }}" != "success" ] || \


### PR DESCRIPTION
## Summary

> Prevents required GitHub Actions checks from staying pending when a PR does not touch workflow or installer files.

- run `actionlint` on every PR and `merge_group`
- run install checks on every PR and `merge_group`
- detect installer-related file changes inside CI
- keep native install checks reporting when tests skip
- gate expensive install smoke jobs behind detection

Related to https://github.com/agentuity/sdk/pull/1508

Does not address https://github.com/agentuity/sdk/issues/1509, because that is the separate WSL stale-package smoke test failure.

## Why

Required checks cannot be hidden behind `pull_request.paths`. When GitHub skips the entire workflow, the required check context is never reported and the PR stays blocked waiting for a status that will not arrive.

This keeps the required workflow checks visible on every PR, then decides inside the workflow whether the expensive install test work is relevant.

## Implementation

The required workflows now create check runs for every PR and merge queue candidate:

```yaml
on:
   pull_request:
   merge_group:
```

`test-install.yaml` moves filtering into the workflow with a small detector job:

```yaml
detect-install-changes:
   outputs:
      should-run: ${{ steps.changed-files.outputs.should-run }}
```

Native install jobs always report, then either run the install test or exit through a clear no-op path:

```yaml
- name: Skip install test
  if: ${{ needs.detect-install-changes.outputs.should-run != 'true' }}
  run: echo "No install-related files changed; skipping Native install (Linux)."
```

The distro and scenario smoke jobs still depend on `should-run == 'true'`, so unrelated PRs avoid the expensive installer coverage while required native check names still complete.

## Sources

- [Skipped workflows][skipped-workflows]
- [Job conditions][job-conditions]
- [Required checks][required-checks]

[skipped-workflows]: https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs
[job-conditions]: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-jobs-with-conditions
[required-checks]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks

## Verification

- `git diff --cached --check`
- upstream `actionlint` v1.7.12 across all workflows

Not run: native install jobs locally, because they need the GitHub Actions runner environments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow triggers to support merge group events for better integration compatibility
  * Implemented intelligent test filtering to run only relevant install-related tests, improving workflow efficiency and reducing unnecessary test execution

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentuity/sdk/pull/1510?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->