### PR TITLE
fix(cli): stop upgrade prompt looping for project-local installs in bun workspaces

### DIFF
--- a/packages/cli/src/utils/installation-type.ts
+++ b/packages/cli/src/utils/installation-type.ts
@@ -23,25 +23,18 @@ function resolveRealPath(path: string): string {
 }
 
 /**
- * Determines the installation type based on how the CLI is being executed
+ * Pure classification of installation type from already-resolved paths.
+ * Exported for testing — `getInstallationType()` gathers the runtime paths and delegates here.
  *
- * @returns 'global' - Installed globally via `bun add -g @agentuity/cli`
- * @returns 'local' - Running from project's node_modules (bunx or direct)
- * @returns 'source' - Running from source code (development)
+ * @param mainPath - The resolved entry path (Bun.main), POSIX-normalized.
+ * @param home - The resolved home directory, POSIX-normalized (may be '').
+ * @param bunInstall - The resolved bun install dir (~/.bun or $BUN_INSTALL), POSIX-normalized (may be '').
  */
-export function getInstallationType(): InstallationType {
-	// Bun.main already returns the resolved real path, just normalize separators
-	const mainPath = Bun.main.replace(/\\/g, '/');
-
-	// Get home directory reliably and resolve symlinks
-	// On macOS, os.homedir() returns /Users/xxx which is already real
-	const home = resolveRealPath(os.homedir() ?? process.env.HOME ?? process.env.USERPROFILE ?? '');
-
-	// Get bun install directory from BUN_INSTALL or default to ~/.bun
-	// Resolve symlinks to handle cases like BUN_INSTALL=/tmp/... on macOS where /tmp -> /private/tmp
-	const bunInstallRaw = process.env.BUN_INSTALL ?? (home ? `${home}/.bun` : '');
-	const bunInstall = resolveRealPath(bunInstallRaw);
-
+export function classifyInstallationType(
+	mainPath: string,
+	home: string,
+	bunInstall: string
+): InstallationType {
 	// GLOBAL DETECTION: Check if running from bun's global install location
 	// When installed via `bun add -g`, the CLI lives at ~/.bun/node_modules/@agentuity/cli/
 	// or ~/.bun/install/global/node_modules/@agentuity/cli/
@@ -66,6 +59,18 @@ export function getInstallationType(): InstallationType {
 		}
 	}
 
+	// LOCAL DETECTION (must run before the bun-global fallback below):
+	// A project/workspace install lives in bun's isolated store at
+	// `<project>/node_modules/.bun/<pkg>/node_modules/@agentuity/cli/`. That path contains
+	// both `/.bun/` and `/node_modules/@agentuity/cli/`, so the loose fallback below would
+	// otherwise misclassify it as `global` and prompt the user to upgrade a project
+	// dependency they can't change with `agentuity upgrade` — re-prompting on every run.
+	// The `/node_modules/.bun/` segment is unique to project stores; real bun-global installs
+	// live at `~/.bun/...` with no `node_modules/` ancestor before `.bun`.
+	if (mainPath.includes('/node_modules/.bun/')) {
+		return 'local';
+	}
+
 	// GLOBAL DETECTION: Fallback check for any path containing /.bun/ before node_modules
 	// This catches edge cases where BUN_INSTALL might not match the actual path
 	if (mainPath.includes('/.bun/') && mainPath.includes('/node_modules/@agentuity/cli/')) {
@@ -82,6 +87,29 @@ export function getInstallationType(): InstallationType {
 	// SOURCE DETECTION: Running from source code (development)
 	// This is when running directly from the monorepo: packages/cli/bin/cli.ts
 	return 'source';
+}
+
+/**
+ * Determines the installation type based on how the CLI is being executed
+ *
+ * @returns 'global' - Installed globally via `bun add -g @agentuity/cli`
+ * @returns 'local' - Running from project's node_modules (bunx or direct)
+ * @returns 'source' - Running from source code (development)
+ */
+export function getInstallationType(): InstallationType {
+	// Bun.main already returns the resolved real path, just normalize separators
+	const mainPath = Bun.main.replace(/\\/g, '/');
+
+	// Get home directory reliably and resolve symlinks
+	// On macOS, os.homedir() returns /Users/xxx which is already real
+	const home = resolveRealPath(os.homedir() ?? process.env.HOME ?? process.env.USERPROFILE ?? '');
+
+	// Get bun install directory from BUN_INSTALL or default to ~/.bun
+	// Resolve symlinks to handle cases like BUN_INSTALL=/tmp/... on macOS where /tmp -> /private/tmp
+	const bunInstallRaw = process.env.BUN_INSTALL ?? (home ? `${home}/.bun` : '');
+	const bunInstall = resolveRealPath(bunInstallRaw);
+
+	return classifyInstallationType(mainPath, home, bunInstall);
 }
 
 /**

--- a/packages/cli/test/installation-type.test.ts
+++ b/packages/cli/test/installation-type.test.ts
@@ -1,0 +1,70 @@
+import { describe, test, expect } from 'bun:test';
+import { classifyInstallationType } from '../src/utils/installation-type';
+
+const HOME = '/home/dev';
+const BUN_INSTALL = '/home/dev/.bun';
+
+describe('classifyInstallationType', () => {
+	test('classifies a bun global install (~/.bun/install/global) as global', () => {
+		expect(
+			classifyInstallationType(
+				`${BUN_INSTALL}/install/global/node_modules/@agentuity/cli/bin/cli.ts`,
+				HOME,
+				BUN_INSTALL
+			)
+		).toBe('global');
+	});
+
+	test('classifies the flat bun global layout (~/.bun/node_modules) as global', () => {
+		expect(
+			classifyInstallationType(
+				`${BUN_INSTALL}/node_modules/@agentuity/cli/bin/cli.ts`,
+				HOME,
+				BUN_INSTALL
+			)
+		).toBe('global');
+	});
+
+	test('classifies a legacy ~/.agentuity install as global', () => {
+		expect(
+			classifyInstallationType(
+				`${HOME}/.agentuity/node_modules/@agentuity/cli/bin/cli.ts`,
+				HOME,
+				BUN_INSTALL
+			)
+		).toBe('global');
+	});
+
+	test('classifies a project-local bun store install as local (regression: was misdetected as global)', () => {
+		// This is bun's isolated store layout for a workspace/project dependency.
+		// The path contains both `/.bun/` and `/node_modules/@agentuity/cli/`, which used to
+		// trip the loose global fallback and trigger an un-actionable upgrade prompt on every run.
+		const projectStore =
+			'/home/dev/code/genesis-mono/node_modules/.bun/@agentuity+cli@2.0.21+abc/node_modules/@agentuity/cli/bin/cli.js';
+		expect(classifyInstallationType(projectStore, HOME, BUN_INSTALL)).toBe('local');
+	});
+
+	test('classifies a plain project node_modules install as local', () => {
+		expect(
+			classifyInstallationType(
+				'/home/dev/code/app/node_modules/@agentuity/cli/bin/cli.ts',
+				HOME,
+				BUN_INSTALL
+			)
+		).toBe('local');
+	});
+
+	test('classifies a source checkout as source', () => {
+		expect(
+			classifyInstallationType('/home/dev/code/sdk/packages/cli/bin/cli.ts', HOME, BUN_INSTALL)
+		).toBe('source');
+	});
+
+	test('a project-local store under a custom BUN_INSTALL is still local, not global', () => {
+		// Even when BUN_INSTALL points somewhere unusual, a project store path
+		// (with /node_modules/.bun/) must never resolve to global.
+		const projectStore =
+			'/srv/ci/workspace/node_modules/.bun/@agentuity+cli@2.0.22+def/node_modules/@agentuity/cli/bin/cli.js';
+		expect(classifyInstallationType(projectStore, HOME, '/opt/bun')).toBe('local');
+	});
+});


### PR DESCRIPTION
## Summary

The CLI's upgrade prompt re-appears on every run inside any bun-workspace project that pins `@agentuity/cli` as a dependency (e.g. `genesis-mono`), even when the user's global CLI is already on the latest version. `agentuity upgrade` doesn't fix it because the prompt is about a *project* dependency, not the global install.

## Root cause

`getInstallationType()` misclassifies a project/workspace dependency as a **global** install. When the CLI runs from bun's isolated store, `Bun.main` looks like:

```
<project>/node_modules/.bun/@agentuity+cli@2.0.21+abc/node_modules/@agentuity/cli/bin/cli.js
```

That path contains both `/.bun/` and `/node_modules/@agentuity/cli/`, which trips the loose bun-global fallback at the end of the function:

```ts
if (mainPath.includes('/.bun/') && mainPath.includes('/node_modules/@agentuity/cli/')) {
    return 'global';
}
```

`version-check.ts` only prompts for `global` installs, so a project-local CLI gets the prompt. It compares the pinned project version against the release endpoint (`https://agentuity.sh/release/sdk/version` → `v2.0.22`) and prompts to upgrade — but `agentuity upgrade` only updates the global install, leaving the project version untouched, so the prompt comes back every run.

Confirmed on the real layout:

| path | before | after |
|---|---|---|
| `genesis-mono/node_modules/.bun/@agentuity+cli@.../bin/cli.js` | `global` ❌ | `local` ✅ |
| `~/.bun/install/global/node_modules/@agentuity/cli/bin/cli.ts` | `global` | `global` ✅ |

## Fix

Detect the `/node_modules/.bun/` segment — unique to project/workspace stores; a genuine bun-global install lives at `~/.bun/...` with no `node_modules/` ancestor before `.bun` — and return `local` **before** the loose fallback runs.

Also extracted the pure path classification into `classifyInstallationType(mainPath, home, bunInstall)` so it can be unit-tested without mocking `Bun.main`. `getInstallationType()` is now a thin wrapper that gathers the runtime paths and delegates.

## Verification

- `bun test packages/cli/test/installation-type.test.ts` → **7 pass** (incl. the regression case + custom `BUN_INSTALL` + all genuine global layouts still resolving to `global`)
- `bun test packages/cli/test/upgrade.test.ts` → **9 pass** (unchanged)
- `bun run --filter ./packages/cli typecheck` → clean
- `bunx biome lint` on changed files → clean
- Verified the exact observed `genesis-mono/apps/web` path now classifies as `local`.

Targets the **v2** branch.