### PR TITLE
fix(publish): correct release tagging and pre-release flag for non-latest dist-tags

### DIFF
--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -71,9 +71,12 @@ Description:
     - Alpha prereleases are published with tag "alpha"
 
   GitHub Release:
-    - Creates/updates GitHub release with generated release notes
+    - Commits the version bump as "Release X.Y.Z", then tags that commit
+      (annotated) and pushes the tag
+    - Creates/updates the GitHub release against that tag with generated notes
     - Builds and uploads VS Code extension (.vsix) for manual installation
     - Marks pre-releases appropriately on GitHub
+    - Pushing the release branch is left to the operator
 
 Required Tools:
   gh                   GitHub CLI (https://cli.github.com/)
@@ -581,19 +584,29 @@ async function createOrUpdateGitHubRelease(
 		// Release doesn't exist, continue
 	}
 
-	// Pin the release (and the tag gh creates server-side) to the current
-	// HEAD. Without --target, gh defaults to the repository's default branch,
-	// which means a release cut from any non-default branch (e.g. v3) lands
-	// on the wrong commit and has to be retargeted by hand afterwards.
+	// Create and push an annotated tag pinned to the current HEAD (the
+	// "Release X.Y.Z" commit). This must run AFTER that commit exists.
+	//
+	// We create+push the tag ourselves rather than letting `gh release create`
+	// create it, for two reasons:
+	//   1. Without an explicit target, gh tags the repository's DEFAULT branch,
+	//      so a release cut from a non-default branch (e.g. v2) lands on the
+	//      wrong commit and has to be retargeted by hand.
+	//   2. `gh` creates a lightweight tag; our tooling and humans expect an
+	//      annotated release tag.
+	// Pushing the tag also uploads the release commit object to the remote even
+	// though its branch hasn't been pushed yet, so `gh release create` can
+	// attach to a tag that already resolves to the correct commit. Pushing the
+	// release *branch* is still left to the operator (see commitReleaseChanges).
 	const headSha = (await $`git rev-parse HEAD`.cwd(rootDir).text()).trim();
+	await $`git tag -f -a ${tag} -m ${`Release ${version}`} ${headSha}`.cwd(rootDir);
+	await $`git push origin ${tag} --force`.cwd(rootDir);
 
-	// Create the release
+	// Create the release against the tag we just pushed.
 	const args = [
 		'release',
 		'create',
 		tag,
-		'--target',
-		headSha,
 		'--title',
 		`Release ${version}`,
 		'--notes',
@@ -716,6 +729,13 @@ async function main() {
 					: 'next'
 			: 'latest');
 
+	// Mark the GitHub release as a pre-release whenever it isn't going to the
+	// `latest` dist-tag. This covers stable-looking semvers published to `next`
+	// (e.g. a v3 `3.0.2` while v2 is still `latest`): the version string isn't a
+	// prerelease, but the release must not grab GitHub's "Latest" badge away
+	// from the actual `latest` release. Only `latest` releases are non-pre.
+	const markAsPrerelease = distTag !== 'latest';
+
 	const confirmed = skipPrompts || (await confirmVersion(newVersion));
 	if (!confirmed) {
 		console.log('\n❌ Publish cancelled\n');
@@ -763,11 +783,6 @@ async function main() {
 
 		// Build VS Code extension
 		const vsixPath = await buildVSCodeExtension(newVersion);
-
-		// Create GitHub release before npm publish (skip in dry-run)
-		if (!isDryRun) {
-			await createOrUpdateGitHubRelease(newVersion, releaseNotes, isPreReleaseVersion, vsixPath);
-		}
 
 		const publishable = await getPublishablePackages();
 		const names = publishable.map((p) => `${p.dir}/${p.name}`).join(', ');
@@ -833,7 +848,21 @@ async function main() {
 			console.log('\n📥 Running bun install to pick up new versions...');
 			await $`bun install`.cwd(rootDir);
 
-			await commitReleaseChanges(newVersion);
+			// Commit the release BEFORE creating the GitHub release so the tag the
+			// release is attached to targets the "Release X.Y.Z" commit rather than
+			// whatever HEAD was before the version bump. createOrUpdateGitHubRelease
+			// tags HEAD and pushes that tag, so the commit must exist first.
+			const released = await commitReleaseChanges(newVersion);
+
+			if (!released) {
+				// No release commit was made (nothing changed); the release will be
+				// tagged at the current HEAD instead.
+				console.warn(
+					'   ⚠ No release commit was created; GitHub release will be tagged at current HEAD.'
+				);
+			}
+
+			await createOrUpdateGitHubRelease(newVersion, releaseNotes, markAsPrerelease, vsixPath);
 		}
 	} catch (err) {
 		console.error('\n❌ Publish failed:', err);
@@ -858,10 +887,12 @@ async function main() {
  *
  * Pushing is intentionally left to the operator: the npm publish has
  * already happened, but the operator may still want to review the
- * generated commit, retarget the tag, or pull in additional changes
- * before pushing.
+ * generated commit or pull in additional changes before pushing.
+ *
+ * @returns true if a release commit was created, false if there was
+ * nothing to commit or committing failed.
  */
-async function commitReleaseChanges(version: string) {
+async function commitReleaseChanges(version: string): Promise<boolean> {
 	console.log('\n📝 Committing release changes...');
 
 	// Only stage the files we know we touched. We intentionally avoid
@@ -883,7 +914,7 @@ async function commitReleaseChanges(version: string) {
 		await $`git add packages/claude-code/.claude-plugin/plugin.json`.cwd(rootDir).nothrow();
 	} catch (err) {
 		console.warn('   ⚠ Failed to stage release files:', err);
-		return;
+		return false;
 	}
 
 	// Bail out if there's actually nothing to commit (e.g. only the cli
@@ -892,15 +923,17 @@ async function commitReleaseChanges(version: string) {
 	const diff = await $`git diff --cached --name-only`.cwd(rootDir).text();
 	if (!diff.trim()) {
 		console.log('   ⊘ No release changes to commit.');
-		return;
+		return false;
 	}
 
 	const message = `Release ${version}`;
 	try {
 		await $`git commit -m ${message}`.cwd(rootDir);
-		console.log(`✓ Committed release ${version} (push manually when ready)`);
+		console.log(`✓ Committed release ${version} (push the branch manually when ready)`);
+		return true;
 	} catch (err) {
 		console.warn('   ⚠ Failed to commit release changes:', err);
+		return false;
 	}
 }
 


### PR DESCRIPTION
## Summary

Three release-process bugs surfaced while cutting **v2.0.23** and **v3.0.2**. All are in `scripts/publish.ts`.

### 1. Tag landed on the wrong commit
`createOrUpdateGitHubRelease` ran **before** the `Release X.Y.Z` commit existed. `gh release create` (without an explicit, valid target) tags the repository's **default branch**, so the tag landed on the pre-bump commit and had to be retargeted by hand after every release.

**Fix:** reorder so the release commit is created first, then create + push an **annotated** tag pinned to that commit and attach the release to it. Pushing the tag also uploads the release commit object to the remote, so the tag resolves to the right commit even though the **branch** push is still left to the operator.

### 2. Lightweight vs annotated tag
`gh release create` produces a lightweight tag; the rest of the tooling (and humans) expect an annotated release tag. We now create the annotated tag ourselves.

### 3. Pre-release flag ignored the dist-tag
The GitHub release was marked `--prerelease` only when the **version string** was a prerelease semver. A stable-looking version published to a non-`latest` dist-tag — e.g. v3 `3.0.2` on `next` while v2 is still `latest` — was created as a normal release and **grabbed GitHub's "Latest" badge away from the real latest (v2.0.23)**.

**Fix:** derive the flag from `distTag !== 'latest'`, so anything on `next`/`beta`/`alpha` is a pre-release on GitHub regardless of how the version string looks.

`commitReleaseChanges` now returns whether it committed, so the caller can warn (and fall back to tagging HEAD) when there's nothing to commit.

## Why now

Cutting v2.0.23 and v3.0.2 both required manual post-publish fixups:
- Re-pointing the `v2.0.23` / `v3.0.2` tags from the default-branch commit to the actual release commit.
- Re-marking `v3.0.2` as a pre-release so GitHub's "Latest" badge went back to `v2.0.23`.

This change removes the need for all of that.

## No behavioral change for normal `latest` releases
A standard `latest` release still: commits the bump, tags it (now annotated), creates a non-pre-release GitHub release on the correct commit.

## Already-published state
The live `v2.0.23` / `v3.0.2` GitHub releases were corrected manually (v3.0.2 re-marked pre-release, "Latest" badge restored to v2.0.23). This PR prevents recurrence.

## Verification
- `bunx biome lint scripts/publish.ts` — clean
- `bun build scripts/publish.ts` — parses/bundles cleanly
- Logic traced against both the `latest` path (v2) and the `--tag next` path (v3).

> Note: this fixes the **v3/`main`** copy of `publish.ts`. The `v2` branch has a diverged, older publish script; if v2 keeps cutting releases it should get the same treatment separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined release workflow automation and version-tagging procedures to improve deployment reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentuity/sdk/pull/1518?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->