### PR TITLE
fix(cli): launch TanStack Start via its Nitro server, not a static server

### DIFF
--- a/packages/cli/src/cmd/build/detect/frameworks.ts
+++ b/packages/cli/src/cmd/build/detect/frameworks.ts
@@ -46,6 +46,22 @@ export interface FrameworkDefinition {
 	 */
 	preferDefaultStart?: boolean;
 	/**
+	 * Server-adapter requirement. Some frameworks only emit a deployable
+	 * Node server when a server/SSR adapter is configured; for the
+	 * Vite-based ones (TanStack Start) that's the `nitro()` plugin from
+	 * the `nitro` package. Without it, `vite build` emits a client-only
+	 * SPA, the `defaultStartCommand` server entry never exists, and any
+	 * backend routes (and SSR) are dropped. When `package` is absent from
+	 * the project's dependencies we surface `warning` at detect time so
+	 * the user can add it before they ship a broken deploy.
+	 */
+	requiresServerAdapter?: {
+		/** Package whose presence indicates the server adapter is configured. */
+		package: string;
+		/** Actionable guidance shown when the package is missing. */
+		warning: string;
+	};
+	/**
 	 * Override `outputDirectory` at detect time by inspecting the project.
 	 * Used by frameworks whose output path is determined by a config file
 	 * the user owns (e.g. Angular's `angular.json` for v17+ where the
@@ -228,12 +244,25 @@ export const frameworkDefinitions: FrameworkDefinition[] = [
 		name: 'TanStack Start',
 		slug: 'tanstack-start',
 		buildCommand: 'vite build',
+		defaultStartCommand: { command: 'HOST=0.0.0.0 node .output/server/index.mjs' },
+		requiresServerAdapter: {
+			package: 'nitro',
+			warning:
+				'TanStack Start needs the Nitro Vite plugin to build a deployable server. ' +
+				'Without it, `vite build` produces a client-only SPA and your SSR + server ' +
+				'routes are dropped, so the deploy 404s every route. Install `nitro` and add ' +
+				"`import { nitro } from 'nitro/vite'` to the plugins in your vite.config.ts.",
+		},
 		// With the `nitro()` Vite plugin (see hosting docs), TanStack
 		// Start emits a self-listening Node server at
 		// `.output/server/index.mjs` plus static assets under
-		// `.output/public/`. The user's package.json `start` script
-		// (`node .output/server/index.mjs`) is what we run; the generic
-		// adapter handles the rest.
+		// `.output/public/` — the same Nitro `node-server` preset Nuxt
+		// uses. The hosting docs don't add a `start` script, so we
+		// default to launching that server entry; a user-supplied
+		// production `start` script still wins via the resolver. Without
+		// this default, a project with no `start` script falls through to
+		// the static-file server injector, which has no root index.html
+		// for an SSR build and 404s every route.
 		outputDirectory: '.output',
 		staticDir: '.output/public',
 		detectors: {

--- a/packages/cli/src/cmd/build/detect/index.ts
+++ b/packages/cli/src/cmd/build/detect/index.ts
@@ -215,6 +215,20 @@ async function frameworkDefToDetected(
 		return 'node';
 	})();
 
+	// Flag frameworks that need a server adapter the project hasn't
+	// installed (e.g. TanStack Start without `nitro`). Skipped when the
+	// user ships their own production `start` script — that's a strong
+	// signal they've wired up server hosting some other way and don't
+	// need the nudge.
+	const warnings: string[] = [];
+	if (
+		definition.requiresServerAdapter &&
+		!hasPackage(pkg, definition.requiresServerAdapter.package) &&
+		!userStartIsProduction
+	) {
+		warnings.push(definition.requiresServerAdapter.warning);
+	}
+
 	return {
 		name: definition.slug,
 		runtime,
@@ -228,6 +242,7 @@ async function frameworkDefToDetected(
 		buildFileReplacements: definition.buildFileReplacements,
 		startCommand: resolvedStartCommand,
 		confidence: 'high',
+		warnings: warnings.length > 0 ? warnings : undefined,
 	};
 }
 

--- a/packages/cli/src/cmd/build/detect/types.ts
+++ b/packages/cli/src/cmd/build/detect/types.ts
@@ -88,6 +88,13 @@ export interface DetectedFramework {
 
 	/** Detection confidence: 'high' if config file found, 'low' if inferred */
 	confidence: 'high' | 'medium' | 'low';
+
+	/**
+	 * Non-fatal advisories surfaced to the user at build/deploy time
+	 * (e.g. a framework that needs a server adapter the project hasn't
+	 * installed). Empty/undefined when there's nothing to flag.
+	 */
+	warnings?: string[];
 }
 
 /**

--- a/packages/cli/src/cmd/build/index.ts
+++ b/packages/cli/src/cmd/build/index.ts
@@ -126,6 +126,9 @@ export const command = createCommand({
 				? `${framework.name} v${framework.version}`
 				: framework.name;
 			tui.success(`Detected ${tui.bold(frameworkLabel)} (${framework.runtime})`);
+			for (const warning of framework.warnings ?? []) {
+				tui.warning(warning);
+			}
 			if (monorepo) {
 				tui.info(
 					`Detected ${tui.bold(monorepo.packageManager)} workspace at ${tui.muted(monorepo.root)} (subpackage: ${tui.bold(monorepo.subpath)})`

--- a/packages/cli/src/cmd/cloud/deploy/build.ts
+++ b/packages/cli/src/cmd/cloud/deploy/build.ts
@@ -150,6 +150,9 @@ export function buildBuildStep(params: BuildStepParams): Step {
 					capturedOutput.push(
 						tui.muted(`✓ Detected ${frameworkLabel} (${framework.runtime})`)
 					);
+					for (const warning of framework.warnings ?? []) {
+						capturedOutput.push(`⚠ ${warning}`);
+					}
 					if (pipelineResult.monorepo) {
 						const { packageManager, root, subpath } = pipelineResult.monorepo;
 						capturedOutput.push(

--- a/packages/cli/src/cmd/cloud/deploy/discover.ts
+++ b/packages/cli/src/cmd/cloud/deploy/discover.ts
@@ -81,6 +81,9 @@ export function buildDiscoverStep(
 					summary.push(`Static:       ${framework.staticDir}`);
 				}
 				summary.push(`Pkg manager:  ${framework.packageManager}`);
+				for (const warning of framework.warnings ?? []) {
+					summary.push(`⚠ ${warning}`);
+				}
 
 				return stepSuccess(summary);
 			} catch (err) {

--- a/packages/cli/test/cmd/build/detect/framework-detection.test.ts
+++ b/packages/cli/test/cmd/build/detect/framework-detection.test.ts
@@ -323,6 +323,52 @@ describe('Framework Detection', () => {
 			expect(result!.startCommand).toBe('node .output/server/index.mjs');
 			expect(result!.buildOutput).toBe('.output');
 		});
+
+		test('defaults to the Nitro server entry when no start script exists', async () => {
+			// The hosting docs don't add a `start` script. Without a
+			// framework default, detection yields no start command and the
+			// generic adapter injects a static-file server, which 404s every
+			// route for an SSR build (no root index.html).
+			writePackageJson(testDir, {
+				name: 'my-tanstack-app',
+				dependencies: {
+					'@tanstack/react-start': '^1.0.0',
+					'@tanstack/router-plugin': '^1.0.0',
+				},
+				scripts: {
+					build: 'vite build',
+				},
+			});
+
+			const result = await detectFramework(testDir);
+			expect(result!.name).toBe('tanstack-start');
+			expect(result!.startCommand).toBe('HOST=0.0.0.0 node .output/server/index.mjs');
+			expect(result!.buildOutput).toBe('.output');
+		});
+
+		test('warns when nitro is missing (client-only SPA build)', async () => {
+			writePackageJson(testDir, {
+				name: 'my-tanstack-app',
+				dependencies: { '@tanstack/react-start': '^1.0.0' },
+				scripts: { build: 'vite build' },
+			});
+
+			const result = await detectFramework(testDir);
+			expect(result!.name).toBe('tanstack-start');
+			expect(result!.warnings?.some((w) => w.includes('Nitro'))).toBe(true);
+		});
+
+		test('does not warn when nitro is configured', async () => {
+			writePackageJson(testDir, {
+				name: 'my-tanstack-app',
+				dependencies: { '@tanstack/react-start': '^1.0.0', nitro: 'npm:nitro-nightly@latest' },
+				scripts: { build: 'vite build' },
+			});
+
+			const result = await detectFramework(testDir);
+			expect(result!.name).toBe('tanstack-start');
+			expect(result!.warnings).toBeUndefined();
+		});
 	});
 
 	// ── Generic ──


### PR DESCRIPTION
## Problem

Deploying a TanStack Start app (built with the `nitro()` Vite plugin) produced a deployment that **404s every route**.

Root cause is in framework detection/packaging, not TanStack:

- TanStack Start with `nitro()` emits a self-listening Node server at `.output/server/index.mjs` plus static assets at `.output/public/` — the same Nitro `node-server` preset Nuxt uses.
- The `tanstack-start` framework definition assumed the project's `package.json` ships a `start` script. The hosting docs don't add one.
- With no `start` script, detection produced **no `startCommand`**, so the generic adapter fell back to injecting the static-file server (`_serve.js`) and pointed `launch.json` at `node _serve.js`.
- For an SSR build there is no root `index.html`, so `_serve.js`'s SPA fallback fails and every route returns 404.

## Fix

1. **Give TanStack Start a `defaultStartCommand`** (`HOST=0.0.0.0 node .output/server/index.mjs`), mirroring Nuxt. A user-supplied production `start` script still wins via the existing resolver precedence. With a start command set, the generic adapter preserves the `.output/` tree and `launch.json` launches the Nitro server.

2. **Add a detect-time advisory for missing server adapters.** TanStack Start *without* the `nitro` package builds a client-only SPA (SSR + server routes dropped), which would 404 once deployed. A new optional `requiresServerAdapter` field on `FrameworkDefinition` surfaces an actionable warning through both `agentuity build` and `agentuity deploy` when the marker package is absent and the project has no production `start` script.

## Verification

- New unit tests in `framework-detection.test.ts`:
  - defaults to the Nitro server entry when no `start` script exists
  - warns when `nitro` is missing; no warning when configured
  - existing test (user-supplied `start` wins) still passes
- Full `framework-detection.test.ts` suite: **36 pass**.
- End-to-end (real CLI runtime): with the equivalent change applied, `agentuity build` on a TanStack Start app emits `launch.json` → `HOST=0.0.0.0 node .output/server/index.mjs`, preserves `.agentuity/.output/`, and running the launch command serves **HTTP 200** on `/`, `/early-access`, `/privacy`, `/terms` (previously all 404 via `_serve.js`).

## Notes

- SolidStart is also Nitro-based but its `vinxi build` bundles Nitro by default, so it isn't affected by the missing-adapter case; left unchanged to avoid false warnings.
- No new type errors introduced (pre-existing cross-package `tsc` errors are unrelated).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Framework detection now checks for missing required server adapters and displays warnings in build and deployment output when adapters are not configured. This helps users identify missing dependencies and provides guidance on resolving adapter configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->