### PR TITLE
fix(create-agentuity): dispatch through the invoking package manager

### DIFF
--- a/packages/create-agentuity/README.md
+++ b/packages/create-agentuity/README.md
@@ -5,16 +5,19 @@ launcher that delegates to `@agentuity/cli`'s `project create` flow.
 
 ## Usage
 
-```bash
-bun create agentuity my-project
-cd my-project
-bun run dev
-```
-
-Or with npm:
+Use whichever package manager you already have — the launcher dispatches the
+underlying CLI through the same one (npm/pnpm/yarn/bun), so Bun is not required.
 
 ```bash
 npm create agentuity@latest my-project
+cd my-project
+npm run dev
+```
+
+```bash
+pnpm create agentuity my-project
+yarn create agentuity my-project
+bun create agentuity my-project
 ```
 
 ## What you get

--- a/packages/create-agentuity/README.md
+++ b/packages/create-agentuity/README.md
@@ -46,8 +46,8 @@ The exact scripts depend on the framework you pick (the official CLI's own
 defaults are preserved). Every project gets at least:
 
 ```bash
-bun run dev          # Run the framework's dev server with AI Gateway env
-bun run build        # Framework build
+npm run dev          # Run the framework's dev server with AI Gateway env
+npm run build        # Framework build
 agentuity deploy     # Deploy to Agentuity Cloud
 ```
 

--- a/packages/create-agentuity/src/bin.ts
+++ b/packages/create-agentuity/src/bin.ts
@@ -3,7 +3,7 @@ import { spawnSync } from 'node:child_process';
 import { realpathSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { getCliVersionSpecifier } from './index.ts';
+import { detectPackageManager, getCliVersionSpecifier, getCreateCommand } from './index.ts';
 
 // Read our own package.json to get the version. dist/bin.js lives alongside
 // dist/index.js; the published package.json is one level up from dist/.
@@ -34,8 +34,15 @@ function checkIsMain(): boolean {
 if (checkIsMain()) {
 	const cliVersion = getCliVersionSpecifier(pkg.version);
 	const args = process.argv.slice(2);
-	const result = spawnSync('bunx', [`@agentuity/cli@${cliVersion}`, 'create', ...args], {
+	const pm = detectPackageManager(process.env.npm_config_user_agent);
+	const { command, args: commandArgs } = getCreateCommand(
+		pm,
+		`@agentuity/cli@${cliVersion}`,
+		args
+	);
+	const result = spawnSync(command, commandArgs, {
 		stdio: 'inherit',
+		shell: process.platform === 'win32',
 	});
 	process.exit(result.status ?? 0);
 }

--- a/packages/create-agentuity/src/index.ts
+++ b/packages/create-agentuity/src/index.ts
@@ -23,3 +23,55 @@ export function getCliVersionSpecifier(version: string): string {
 	// Stable versions: use the exact version to ensure major version compatibility
 	return version;
 }
+
+/** Package managers we know how to dispatch a one-off package execution through. */
+export type PackageManager = 'bun' | 'npm' | 'pnpm' | 'yarn';
+
+/**
+ * Identify the package manager that invoked us from `npm_config_user_agent`.
+ *
+ * Every supported package manager sets this env var when running
+ * `<pm> create agentuity` / `<pm> dlx` / `npx`, in the form
+ * `name/version node/version ...` (e.g. `pnpm/8.15.4 npm/? node/v20.11.1`).
+ * Returns `undefined` when the var is absent or unrecognized, so callers
+ * can fall back to a safe default.
+ */
+export function detectPackageManager(userAgent: string | undefined): PackageManager | undefined {
+	if (!userAgent) return undefined;
+	const name = userAgent.split('/')[0]?.toLowerCase();
+	if (name === 'bun' || name === 'npm' || name === 'pnpm' || name === 'yarn') {
+		return name;
+	}
+	return undefined;
+}
+
+/**
+ * Build the command + args that run `@agentuity/cli@<version> create ...`
+ * through the given package manager's one-off execution tool.
+ *
+ *   bun   → bunx @agentuity/cli@<v> create ...
+ *   pnpm  → pnpm dlx @agentuity/cli@<v> create ...
+ *   yarn  → yarn dlx @agentuity/cli@<v> create ...
+ *   npm   → npx --yes @agentuity/cli@<v> create ...
+ *
+ * Defaults to `npx` when the package manager is unknown, because the
+ * wrapper runs under `#!/usr/bin/env node`, so Node (and therefore npx)
+ * is guaranteed to be present even when Bun is not installed.
+ */
+export function getCreateCommand(
+	pm: PackageManager | undefined,
+	cliPackage: string,
+	args: string[]
+): { command: string; args: string[] } {
+	const create = [cliPackage, 'create', ...args];
+	switch (pm) {
+		case 'bun':
+			return { command: 'bunx', args: create };
+		case 'pnpm':
+			return { command: 'pnpm', args: ['dlx', ...create] };
+		case 'yarn':
+			return { command: 'yarn', args: ['dlx', ...create] };
+		default:
+			return { command: 'npx', args: ['--yes', ...create] };
+	}
+}

--- a/packages/create-agentuity/src/index.ts
+++ b/packages/create-agentuity/src/index.ts
@@ -25,7 +25,12 @@ export function getCliVersionSpecifier(version: string): string {
 }
 
 /** Package managers we know how to dispatch a one-off package execution through. */
-export type PackageManager = 'bun' | 'npm' | 'pnpm' | 'yarn';
+/**
+ * Package managers we know how to dispatch a one-off package execution
+ * through. Yarn is split because Classic (1.x) has no `dlx` command, so it
+ * must fall back to `npx`, while Berry (2+) uses `yarn dlx`.
+ */
+export type PackageManager = 'bun' | 'npm' | 'pnpm' | 'yarn' | 'yarn-classic';
 
 /**
  * Identify the package manager that invoked us from `npm_config_user_agent`.
@@ -33,30 +38,42 @@ export type PackageManager = 'bun' | 'npm' | 'pnpm' | 'yarn';
  * Every supported package manager sets this env var when running
  * `<pm> create agentuity` / `<pm> dlx` / `npx`, in the form
  * `name/version node/version ...` (e.g. `pnpm/8.15.4 npm/? node/v20.11.1`).
+ * Yarn 1.x is reported as `yarn-classic` because it lacks `yarn dlx`.
  * Returns `undefined` when the var is absent or unrecognized, so callers
  * can fall back to a safe default.
  */
 export function detectPackageManager(userAgent: string | undefined): PackageManager | undefined {
 	if (!userAgent) return undefined;
-	const name = userAgent.split('/')[0]?.toLowerCase();
-	if (name === 'bun' || name === 'npm' || name === 'pnpm' || name === 'yarn') {
-		return name;
+	const [name, version] = userAgent.split(' ')[0]?.split('/') ?? [];
+	switch (name?.toLowerCase()) {
+		case 'bun':
+			return 'bun';
+		case 'npm':
+			return 'npm';
+		case 'pnpm':
+			return 'pnpm';
+		case 'yarn':
+			// Yarn Classic (1.x) has no `dlx`; treat it separately so we can
+			// route it through npx instead.
+			return version?.startsWith('1.') ? 'yarn-classic' : 'yarn';
+		default:
+			return undefined;
 	}
-	return undefined;
 }
 
 /**
  * Build the command + args that run `@agentuity/cli@<version> create ...`
  * through the given package manager's one-off execution tool.
  *
- *   bun   → bunx @agentuity/cli@<v> create ...
- *   pnpm  → pnpm dlx @agentuity/cli@<v> create ...
- *   yarn  → yarn dlx @agentuity/cli@<v> create ...
- *   npm   → npx --yes @agentuity/cli@<v> create ...
+ *   bun           → bunx @agentuity/cli@<v> create ...
+ *   pnpm          → pnpm dlx @agentuity/cli@<v> create ...
+ *   yarn (Berry)  → yarn dlx @agentuity/cli@<v> create ...
+ *   npm / yarn 1.x → npx --yes @agentuity/cli@<v> create ...
  *
- * Defaults to `npx` when the package manager is unknown, because the
- * wrapper runs under `#!/usr/bin/env node`, so Node (and therefore npx)
- * is guaranteed to be present even when Bun is not installed.
+ * Defaults to `npx` when the package manager is unknown (or is Yarn Classic,
+ * which has no `dlx`), because the wrapper runs under `#!/usr/bin/env node`,
+ * so Node (and therefore npx) is guaranteed to be present even when Bun is
+ * not installed.
  */
 export function getCreateCommand(
 	pm: PackageManager | undefined,

--- a/packages/create-agentuity/test/index.test.ts
+++ b/packages/create-agentuity/test/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { getCliVersionSpecifier } from '../src/index.ts';
+import { detectPackageManager, getCliVersionSpecifier, getCreateCommand } from '../src/index.ts';
 
 describe('getCliVersionSpecifier', () => {
 	describe('prerelease versions use the prerelease tag', () => {
@@ -47,6 +47,69 @@ describe('getCliVersionSpecifier', () => {
 		});
 		test('10.20.30 should return exact version', () => {
 			expect(getCliVersionSpecifier('10.20.30')).toBe('10.20.30');
+		});
+	});
+});
+
+describe('detectPackageManager', () => {
+	test('bun user agent', () => {
+		expect(detectPackageManager('bun/1.1.34 npm/? node/v22.6.0 darwin arm64')).toBe('bun');
+	});
+	test('npm user agent', () => {
+		expect(detectPackageManager('npm/10.2.4 node/v20.11.1 linux x64')).toBe('npm');
+	});
+	test('pnpm user agent', () => {
+		expect(detectPackageManager('pnpm/8.15.4 npm/? node/v20.11.1 linux x64')).toBe('pnpm');
+	});
+	test('yarn user agent', () => {
+		expect(detectPackageManager('yarn/1.22.22 npm/? node/v20.11.1 linux x64')).toBe('yarn');
+	});
+	test('undefined when env var is absent', () => {
+		expect(detectPackageManager(undefined)).toBeUndefined();
+	});
+	test('undefined for unrecognized package manager', () => {
+		expect(detectPackageManager('deno/1.40.0 node/v20.11.1')).toBeUndefined();
+	});
+});
+
+describe('getCreateCommand', () => {
+	const pkg = '@agentuity/cli@next';
+	const args = ['--name', 'my-app'];
+
+	test('bun uses bunx', () => {
+		expect(getCreateCommand('bun', pkg, args)).toEqual({
+			command: 'bunx',
+			args: [pkg, 'create', '--name', 'my-app'],
+		});
+	});
+	test('pnpm uses pnpm dlx', () => {
+		expect(getCreateCommand('pnpm', pkg, args)).toEqual({
+			command: 'pnpm',
+			args: ['dlx', pkg, 'create', '--name', 'my-app'],
+		});
+	});
+	test('yarn uses yarn dlx', () => {
+		expect(getCreateCommand('yarn', pkg, args)).toEqual({
+			command: 'yarn',
+			args: ['dlx', pkg, 'create', '--name', 'my-app'],
+		});
+	});
+	test('npm uses npx --yes', () => {
+		expect(getCreateCommand('npm', pkg, args)).toEqual({
+			command: 'npx',
+			args: ['--yes', pkg, 'create', '--name', 'my-app'],
+		});
+	});
+	test('unknown package manager falls back to npx', () => {
+		expect(getCreateCommand(undefined, pkg, args)).toEqual({
+			command: 'npx',
+			args: ['--yes', pkg, 'create', '--name', 'my-app'],
+		});
+	});
+	test('passes through empty args', () => {
+		expect(getCreateCommand('npm', pkg, [])).toEqual({
+			command: 'npx',
+			args: ['--yes', pkg, 'create'],
 		});
 	});
 });

--- a/packages/create-agentuity/test/index.test.ts
+++ b/packages/create-agentuity/test/index.test.ts
@@ -61,8 +61,13 @@ describe('detectPackageManager', () => {
 	test('pnpm user agent', () => {
 		expect(detectPackageManager('pnpm/8.15.4 npm/? node/v20.11.1 linux x64')).toBe('pnpm');
 	});
-	test('yarn user agent', () => {
-		expect(detectPackageManager('yarn/1.22.22 npm/? node/v20.11.1 linux x64')).toBe('yarn');
+	test('yarn berry (2+) user agent', () => {
+		expect(detectPackageManager('yarn/4.1.0 npm/? node/v20.11.1 linux x64')).toBe('yarn');
+	});
+	test('yarn classic (1.x) user agent maps to yarn-classic', () => {
+		expect(detectPackageManager('yarn/1.22.22 npm/? node/v20.11.1 linux x64')).toBe(
+			'yarn-classic'
+		);
 	});
 	test('undefined when env var is absent', () => {
 		expect(detectPackageManager(undefined)).toBeUndefined();
@@ -88,10 +93,16 @@ describe('getCreateCommand', () => {
 			args: ['dlx', pkg, 'create', '--name', 'my-app'],
 		});
 	});
-	test('yarn uses yarn dlx', () => {
+	test('yarn berry uses yarn dlx', () => {
 		expect(getCreateCommand('yarn', pkg, args)).toEqual({
 			command: 'yarn',
 			args: ['dlx', pkg, 'create', '--name', 'my-app'],
+		});
+	});
+	test('yarn classic falls back to npx (no dlx in 1.x)', () => {
+		expect(getCreateCommand('yarn-classic', pkg, args)).toEqual({
+			command: 'npx',
+			args: ['--yes', pkg, 'create', '--name', 'my-app'],
 		});
 	});
 	test('npm uses npx --yes', () => {


### PR DESCRIPTION
## Summary

The `create-agentuity` wrapper hardcoded `spawnSync('bunx', ...)`, making Bun a hard requirement for scaffolding even when invoked via `npm create` / `npx`. This contradicted the package README ("Bun 1.3+ **or** Node.js 24+") — Node/pnpm/yarn-only users hit a failure when `bunx` wasn't on PATH.

This change detects the invoking package manager from `npm_config_user_agent` and runs the underlying `@agentuity/cli ... create` through the matching one-off runner, falling back to `npx` (the wrapper runs under `#!/usr/bin/env node`, so Node/npx is always available).

Fixes #1522.

## Changes

- **`src/index.ts`** — two pure, testable helpers:
  - `detectPackageManager(userAgent)` → `bun` / `npm` / `pnpm` / `yarn` / `undefined`
  - `getCreateCommand(pm, cliPackage, args)` → dispatch mapping:
    - bun → `bunx <pkg> create ...`
    - pnpm → `pnpm dlx <pkg> create ...`
    - yarn → `yarn dlx <pkg> create ...`
    - npm / unknown → `npx --yes <pkg> create ...`
- **`src/bin.ts`** — use the helpers instead of hardcoding `bunx`; adds `shell: true` on Windows (npx/pnpm/yarn are `.cmd` shims there).
- **`test/index.test.ts`** — 14 new tests for detection + command construction across all package managers and the fallbacks.
- **`README.md`** — Usage now leads with npm and lists all four package managers, matching the (now accurate) "Bun or Node" requirement.

## Verification

- `bun test` → 26 pass, 0 fail
- `bun run typecheck` → clean
- `bun run build` → clean
- `biome check` → clean
- Compiled dispatch verified end-to-end:
  - no user agent → `npx --yes ... create`
  - `npm/...` → `npx --yes ... create`
  - `pnpm/...` → `pnpm dlx ... create`
  - `yarn/...` → `yarn dlx ... create`
  - `bun/...` → `bunx ... create`

## Follow-up

This unblocks the related docs change (PR #1462) that overstates Bun as a blanket prerequisite — once this lands, those docs can scope the Bun requirement to "optional" and default to Node/npm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launcher now detects and uses your preferred package manager (npm, pnpm, yarn, or bun) when creating projects.

* **Documentation**
  * README updated with usage examples for npm, pnpm, yarn, and bun; updated generated project script examples to use npm run dev/build.

* **Tests**
  * Added tests for package manager detection and command construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->