### PR TITLE
Add v2 docs version switcher

### DIFF
--- a/apps/docs/src/web/components/docs/app-sidebar.tsx
+++ b/apps/docs/src/web/components/docs/app-sidebar.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import { ChevronRight, SearchIcon, SparklesIcon } from 'lucide-react';
+import { ChevronRight, ExternalLink, SearchIcon, SparklesIcon } from 'lucide-react';
 import {
 	Collapsible,
 	CollapsibleContent,
 	Sidebar,
 	SidebarContent,
+	SidebarFooter,
 	SidebarGroup,
 	SidebarHeader,
 	SidebarMenu,
@@ -16,7 +17,9 @@ import {
 	SidebarRail,
 } from '../ui';
 import { cn } from '../../lib/utils';
+import { DOCS_VERSIONS } from '../../lib/docs-versions';
 import { navData, hasActiveChild, type NavItem, type NavSection } from './nav-data';
+import { DocsVersionPicker } from './docs-version-picker';
 
 interface AppSidebarProps extends React.ComponentProps<typeof Sidebar> {
 	currentPage: string;
@@ -294,6 +297,8 @@ export function AppSidebar({
 					</SidebarMenuItem>
 				</SidebarMenu>
 
+				<DocsVersionPicker />
+
 				<div className="flex items-center gap-1.5">
 					<button
 						type="button"
@@ -328,6 +333,20 @@ export function AppSidebar({
 			<SidebarContent>
 				<NavMain sections={navData} currentUrl={currentUrl} onNavigate={onNavigate} />
 			</SidebarContent>
+
+			<SidebarFooter className="border-t border-sidebar-border/70 pt-2 group-data-[collapsible=icon]:hidden">
+				<a
+					href={DOCS_VERSIONS.v3.url}
+					aria-label="Open v3 docs for new Agentuity apps"
+					className="group flex items-center gap-1.5 rounded-md px-2 py-2 text-xs leading-5 text-sidebar-foreground/75 transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring"
+				>
+					<span className="min-w-0 truncate">
+						Building a new app?{' '}
+						<span className="font-medium text-sidebar-foreground">Open v3 docs</span>
+					</span>
+					<ExternalLink className="size-3 shrink-0 text-sidebar-foreground/55 group-hover:text-sidebar-foreground/80" />
+				</a>
+			</SidebarFooter>
 
 			<SidebarRail />
 		</Sidebar>

--- a/apps/docs/src/web/components/docs/docs-version-picker.tsx
+++ b/apps/docs/src/web/components/docs/docs-version-picker.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { ExternalLink, GitBranch } from 'lucide-react';
+import {
+	Select,
+	SelectContent,
+	SelectGroup,
+	SelectItem,
+	SelectLabel,
+	SelectTrigger,
+	SelectValue,
+} from '../ui';
+import { cn } from '../../lib/utils';
+import { DOCS_VERSIONS, getCurrentVersion, isDocsVersion } from '../../lib/docs-versions';
+import type { DocsVersion } from '../../lib/docs-versions';
+
+interface DocsVersionPickerProps {
+	className?: string;
+}
+
+export function DocsVersionPicker({ className }: DocsVersionPickerProps) {
+	const [version, setVersion] = React.useState<DocsVersion>('v2');
+
+	React.useEffect(() => {
+		setVersion(getCurrentVersion());
+	}, []);
+
+	const handleVersionChange = React.useCallback((value: string) => {
+		if (!isDocsVersion(value)) return;
+
+		setVersion(value);
+		// Versions live on separate subdomains, so switch with a full navigation.
+		window.location.assign(DOCS_VERSIONS[value].url);
+	}, []);
+
+	return (
+		<div className={cn('w-full group-data-[collapsible=icon]:hidden', className)}>
+			<Select value={version} onValueChange={handleVersionChange}>
+				<SelectTrigger
+					aria-label="Choose docs version"
+					size="sm"
+					className="h-8 w-full justify-between border-transparent bg-transparent px-2 text-xs font-medium text-sidebar-foreground/75 shadow-none hover:border-sidebar-border/70 hover:bg-sidebar-accent/70 hover:text-sidebar-foreground data-[state=open]:border-sidebar-border data-[state=open]:bg-sidebar-accent"
+				>
+					<span className="flex min-w-0 items-center gap-2">
+						<GitBranch className="size-3.5 shrink-0 text-sidebar-foreground/60" />
+						<SelectValue />
+					</span>
+				</SelectTrigger>
+				<SelectContent align="start">
+					<SelectGroup>
+						<SelectLabel>Docs version</SelectLabel>
+						<SelectItem value="v2">{DOCS_VERSIONS.v2.label}</SelectItem>
+						<SelectItem value="v3">
+							<span className="flex items-center gap-1.5">
+								{DOCS_VERSIONS.v3.label}
+								<ExternalLink className="size-3 text-muted-foreground/75" />
+							</span>
+						</SelectItem>
+					</SelectGroup>
+				</SelectContent>
+			</Select>
+		</div>
+	);
+}

--- a/apps/docs/src/web/components/docs/index.ts
+++ b/apps/docs/src/web/components/docs/index.ts
@@ -1,6 +1,7 @@
 export { AppSidebar } from './app-sidebar';
 export { CopyPageDropdown } from './copy-page-dropdown';
 export { DocsLayout } from './docs-layout';
+export { DocsVersionPicker } from './docs-version-picker';
 export { FooterNav } from './footer-nav';
 export { HeaderLinks } from './header-links';
 export { MDXPage, getFrontmatterForRoute } from './mdx-page';

--- a/apps/docs/src/web/content/get-started/index.mdx
+++ b/apps/docs/src/web/content/get-started/index.mdx
@@ -5,6 +5,11 @@ description: Start building AI agents with Agentuity
 
 import { Rocket, Download, Zap, FolderTree, Settings } from 'lucide-react';
 
+<Callout type="info" title="Use v3 for new apps">
+These are the legacy v2 runtime docs. For the latest SDK and framework-first apps, use the [v3 docs](https://agentuity.dev/).
+Stay here when you maintain a v2 app or need v2-era guidance for runtime APIs like `@agentuity/runtime`, `createApp()`, and `createAgent()`. These docs also cover v2 service integrations, app configuration, database helpers, routes, and migration.
+</Callout>
+
 Welcome to Agentuity. Follow these guides to set up your environment and build your first agent.
 
 <Cards>

--- a/apps/docs/src/web/lib/docs-versions.ts
+++ b/apps/docs/src/web/lib/docs-versions.ts
@@ -1,0 +1,23 @@
+/**
+ * Single source of truth for documentation versions.
+ *
+ * The sidebar picker and legacy-docs callouts both use these URLs so launch
+ * routing stays consistent between the v2 and v3 docs apps.
+ */
+
+export const DOCS_VERSIONS = {
+	v3: { url: 'https://agentuity.dev/', label: 'Latest · v3' },
+	v2: { url: 'https://v2.agentuity.dev/', label: 'Legacy · v2' },
+} as const;
+
+export type DocsVersion = keyof typeof DOCS_VERSIONS;
+
+// v2 docs are deployed on v2.agentuity.dev and default to v2 during local dev.
+export function getCurrentVersion(): DocsVersion {
+	if (typeof window === 'undefined') return 'v2';
+	return window.location.hostname === 'agentuity.dev' ? 'v3' : 'v2';
+}
+
+export function isDocsVersion(value: string): value is DocsVersion {
+	return value === 'v2' || value === 'v3';
+}


### PR DESCRIPTION
## Summary

Adds a small v2 docs affordance for readers who should be on v3.

- Adds a sidebar docs version picker with `Legacy · v2` first
- Links `Latest · v3` to the current v3 docs domain
- Adds a persistent `Building a new app? Open v3 docs` sidebar link
- Adds a Get Started callout that explains when to stay on v2

## Verification

- `bun run typecheck`
- `git diff --cached --check`
