### PR TITLE
feat(cli): keep v2 projects on v2 behavior under a v3 global

### DIFF
--- a/packages/cli/src/cmd/build/detect/agentuity-v2.ts
+++ b/packages/cli/src/cmd/build/detect/agentuity-v2.ts
@@ -1,0 +1,115 @@
+/**
+ * Agentuity v2 runtime detector.
+ *
+ * v3 dropped `@agentuity/runtime` entirely, so the mere presence of
+ * `@agentuity/runtime` at a v2 major is an unambiguous signal that a project
+ * is a v2 app. v2 apps don't fit the generic buildpack model: they build with
+ * the v2 CLI's own `agentuity build` (which bundles a Bun server entry plus a
+ * client bundle into `.agentuity/`) and start with `bun .agentuity/app.js`.
+ *
+ * Without this detector the v3 pipeline mis-classifies a v2 app as a generic
+ * `vite` SPA, builds only the client, and ships a deploy that fails at warmup.
+ * Detecting it here lets the v3 CLI deploy a v2 app natively by driving the v2
+ * build + packaging the v2 server output.
+ *
+ * `agentuity build` is supplied by the project-local v2 CLI. The global→local
+ * delegation (and v2 self-heal) in `local-delegate.ts` ensures that local CLI
+ * is present; when deploying with a non-global v3 CLI the project must already
+ * have `@agentuity/cli` installed (v2 scaffolds do by default).
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { isAbsolute, join } from 'node:path';
+import { pathExists } from '../../../node-compat/fs.ts';
+import type { DetectedFramework, PackageJsonData } from './types.ts';
+
+/** The build output directory the v2 CLI writes to. */
+const V2_OUTPUT_DIR = '.agentuity';
+
+/**
+ * Resolve the project-local v2 CLI's executable from its package.json `bin`
+ * field, relative to `node_modules/@agentuity/cli`. Returns null when the
+ * local CLI isn't installed. We invoke this entry directly (via `bun`) rather
+ * than the bare `agentuity` command so the build adapter's anti-recursion
+ * guard — which refuses any literal `agentuity ...` build command — doesn't
+ * trip on a legitimate v2 build, and so we never accidentally shell back into
+ * the running v3 CLI.
+ */
+function resolveLocalCliEntry(projectDir: string): string | null {
+	const pkgDir = join(projectDir, 'node_modules', '@agentuity', 'cli');
+	const pkgJsonPath = join(pkgDir, 'package.json');
+	if (!existsSync(pkgJsonPath)) return null;
+	try {
+		const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf-8')) as {
+			bin?: string | Record<string, string>;
+		};
+		const binEntry = typeof pkg.bin === 'string' ? pkg.bin : pkg.bin?.agentuity;
+		if (!binEntry) return null;
+		const binPath = isAbsolute(binEntry) ? binEntry : join(pkgDir, binEntry);
+		return existsSync(binPath) ? binPath : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * The v2 runtime spec, if `@agentuity/runtime` is a declared dependency.
+ * Looks in both dependency maps.
+ */
+function v2RuntimeSpec(pkg: PackageJsonData): string | null {
+	const spec =
+		pkg.dependencies?.['@agentuity/runtime'] ?? pkg.devDependencies?.['@agentuity/runtime'];
+	if (!spec) return null;
+	// Only treat a concrete v2 major as a v2 app. A floating spec (`latest`,
+	// `*`, workspace/git refs) is ambiguous and could be anything, so we don't
+	// claim it here — let the normal detection path handle those.
+	return /^[\^~]?2\./.test(spec) ? spec : null;
+}
+
+/**
+ * Detect a v2 Agentuity runtime app. Returns a `DetectedFramework` describing
+ * how to build (`agentuity build`) and start (`bun .agentuity/app.js`) it, or
+ * null when the project isn't a v2 app.
+ */
+export async function detectAgentuityV2(
+	projectDir: string,
+	pkg: PackageJsonData
+): Promise<DetectedFramework | null> {
+	const spec = v2RuntimeSpec(pkg);
+	if (!spec) return null;
+
+	const warnings: string[] = [];
+	const localCliEntry = resolveLocalCliEntry(projectDir);
+	// `agentuity build` is provided by the project-local v2 CLI. Surface a hint
+	// when it isn't installed so the failure (if any) is self-explanatory.
+	if (!(await pathExists(join(projectDir, 'node_modules', '@agentuity', 'cli')))) {
+		warnings.push(
+			'v2 project detected but @agentuity/cli is not installed locally; ' +
+				'run `bun add -D @agentuity/cli@' +
+				spec +
+				'` so `agentuity build` is available.'
+		);
+	}
+
+	// Prefer invoking the resolved local CLI entry directly via bun. Falls
+	// back to the bare `agentuity` command (resolved from node_modules/.bin at
+	// build time) when the entry can't be resolved — e.g. the local CLI is
+	// installed after detection by the self-heal path.
+	const buildCommand = localCliEntry ? `bun ${localCliEntry} build` : 'agentuity build';
+
+	return {
+		name: 'agentuity-v2',
+		version: spec.replace(/^[\^~]/, ''),
+		runtime: 'bun',
+		packageManager: 'bun',
+		buildCommand,
+		buildOutput: V2_OUTPUT_DIR,
+		// The v2 build emits its client assets under `.agentuity/client`.
+		staticDir: join(V2_OUTPUT_DIR, 'client'),
+		startCommand: `bun ${join(V2_OUTPUT_DIR, 'app.js')}`,
+		serverEntry: 'app.js',
+		port: 3000,
+		confidence: 'high',
+		warnings: warnings.length > 0 ? warnings : undefined,
+	};
+}

--- a/packages/cli/src/cmd/build/detect/index.ts
+++ b/packages/cli/src/cmd/build/detect/index.ts
@@ -14,6 +14,7 @@ import { join } from 'node:path';
 import { pathExists } from '../../../node-compat/fs.ts';
 import type { DetectedFramework, PackageJsonData } from './types.ts';
 import { readPackageJson, detectPackageManager, isAgentuityCliInvocation } from './util.ts';
+import { detectAgentuityV2 } from './agentuity-v2.ts';
 import { frameworkDefinitions, type FrameworkDefinition } from './frameworks.ts';
 import { detectFromDatabase } from './engine.ts';
 import { genericDetector } from './generic.ts';
@@ -288,6 +289,11 @@ export async function detectFramework(projectDir: string): Promise<DetectedFrame
 		return (await detectCustomLauncher(projectDir, null)) ?? detectBareStaticHtml(projectDir);
 	}
 
+	// 0. Agentuity v2 runtime apps: detected before the database engine so a
+	// v2 app isn't mis-classified as a generic vite SPA.
+	const v2 = await detectAgentuityV2(projectDir, pkg);
+	if (v2) return v2;
+
 	// 1. Run through the framework database
 	const match = await detectFromDatabase(projectDir, pkg, frameworkDefinitions);
 	if (match) {
@@ -314,6 +320,11 @@ export async function detectFrameworkWithPackageJson(
 		if (custom) return { framework: custom, packageJson: null };
 		return { framework: await detectBareStaticHtml(projectDir), packageJson: null };
 	}
+
+	// 0. Agentuity v2 runtime apps: detected before the database engine so a
+	// v2 app isn't mis-classified as a generic vite SPA.
+	const v2 = await detectAgentuityV2(projectDir, pkg);
+	if (v2) return { framework: v2, packageJson: pkg };
 
 	// 1. Run through the framework database
 	const match = await detectFromDatabase(projectDir, pkg, frameworkDefinitions);

--- a/packages/cli/src/cmd/cloud/deploy.ts
+++ b/packages/cli/src/cmd/cloud/deploy.ts
@@ -40,7 +40,12 @@ import {
 } from '../../steps.ts';
 import * as tui from '../../tui.ts';
 import { createSubcommand, DeployOptionsSchema } from '../../types.ts';
+import type { Logger } from '../../types.ts';
 import { extractDependencies } from '../../utils/deps.ts';
+import { detectAgentuityV2 } from '../build/detect/agentuity-v2.ts';
+import { readPackageJson } from '../build/detect/util.ts';
+import { findLocalCli } from '../../local-delegate.ts';
+import { spawnInherit } from '../../node-compat/proc.ts';
 import { buildBuildStep } from './deploy/build.ts';
 import { buildDiscoverStep } from './deploy/discover.ts';
 import { PreflightAptValidationError, runPreflight } from './deploy/preflight.ts';
@@ -56,6 +61,67 @@ const DeploymentCancelledError = StructuredError(
 	'DeploymentCancelled',
 	'Deployment cancelled by user'
 );
+
+/**
+ * Loop guard so a handed-off v2 deploy doesn't try to hand off again (the
+ * project-local CLI might itself be a v3 in some odd setup).
+ */
+const V2_DEPLOY_HANDOFF_ENV = 'AGENTUITY_V2_DEPLOY_HANDOFF';
+
+/**
+ * When this (v3) CLI is asked to deploy a v2 Agentuity project, hand the
+ * whole deploy to the project-local v2 CLI's `deploy` and return its exit
+ * outcome. v2 apps can't go through the v3 buildpack pipeline because the v2
+ * build bakes route/agent ids keyed to the deployment id — only the v2
+ * `deploy` flow knows that id at build time.
+ *
+ * Returns a `DeployResponse`-shaped value when it handed off (the caller
+ * returns it and the process exits), or null to let the normal v3 pipeline
+ * run (not a v2 project).
+ *
+ * If the project IS v2 but no local v2 CLI is available to hand off to, we
+ * fatal with a clear, actionable message instead of letting the v3 pipeline
+ * ship a broken deploy.
+ */
+async function maybeHandoffV2Deploy(
+	projectDir: string,
+	logger: Logger
+): Promise<{ success: boolean; deploymentId: string; projectId: string } | null> {
+	if (process.env[V2_DEPLOY_HANDOFF_ENV]) return null;
+
+	const pkg = await readPackageJson(projectDir);
+	if (!pkg) return null;
+
+	const v2 = await detectAgentuityV2(projectDir, pkg);
+	if (!v2) return null; // not a v2 app — run the v3 pipeline as usual
+
+	const local = findLocalCli(projectDir);
+	if (!local) {
+		tui.fatal(
+			'This is an Agentuity v2 project (@agentuity/runtime ' +
+				`${v2.version}) which must be deployed with the v2 CLI. ` +
+				'Install it locally with `bun add -D @agentuity/cli@^2` and re-run ' +
+				'`agentuity deploy`, or migrate to v3 with `npx @agentuity/migrate@next`.',
+			ErrorCode.CONFIG_INVALID
+		);
+	}
+
+	tui.info(`Detected a v2 project — deploying with the local v2 CLI (${local.version}).`);
+	logger.debug('v2 deploy handoff: %s %s', local.binPath, process.argv.slice(2).join(' '));
+
+	const argv = process.argv.slice(2);
+	const { exitCode } = await spawnInherit({
+		cmd: [local.binPath, ...argv],
+		cwd: projectDir,
+		env: { [V2_DEPLOY_HANDOFF_ENV]: '1' },
+	});
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const exit = (globalThis as any).AGENTUITY_PROCESS_EXIT || process.exit;
+	exit(exitCode ?? 0);
+	// Unreachable, but satisfies the return type for callers that don't exit.
+	return { success: exitCode === 0, deploymentId: '', projectId: pkg.name ?? '' };
+}
 
 const DeployResponseSchema = z.object({
 	success: z.boolean().describe('Whether deployment succeeded'),
@@ -148,6 +214,39 @@ export const deploySubcommand = createSubcommand({
 
 	async handler(ctx) {
 		const { apiClient, projectDir, config, options, logger, opts, auth, orgId, region } = ctx;
+
+		// v2 handoff: a v2 Agentuity app cannot be deployed by the v3 buildpack
+		// pipeline (its `agentuity build` bakes route/agent ids keyed to the
+		// deployment id, which only the v2 `deploy` flow knows). When this v3
+		// CLI is asked to deploy a v2 project, hand the whole deploy to the
+		// project-local v2 CLI's `deploy` and exit with its code. Skipped when
+		// we're a forked child (the parent already handed off or this isn't v2)
+		// or already running as the handed-off v2 deploy.
+		const isForkedChild = opts.childMode || process.env.AGENTUITY_FORK_PARENT === '1';
+		if (!isForkedChild) {
+			// Pin any "latest"-pinned Agentuity deps to the version actually
+			// installed (from the lockfile) before anything else — including the
+			// v2 handoff below, so v2 apps get pinned too. Keeps the deploy
+			// reproducible and stops a "latest"-pinned v2 project from silently
+			// pulling v3 once v3 becomes the `latest` dist-tag.
+			try {
+				const { pinLatestAgentuityDeps } = await import('../../pin-latest.ts');
+				const pinned = await pinLatestAgentuityDeps(projectDir, logger);
+				if (pinned.length > 0) {
+					tui.info(
+						`Pinned ${pinned.length} Agentuity ${pinned.length === 1 ? 'dependency' : 'dependencies'} from "latest" to installed version:`
+					);
+					for (const { name, version } of pinned) {
+						tui.info(tui.muted(`  ${name} → ${version}`));
+					}
+				}
+			} catch (err) {
+				logger.debug('pin-latest: skipped due to error: %s', err);
+			}
+
+			const handed = await maybeHandoffV2Deploy(projectDir, logger);
+			if (handed) return handed as never;
+		}
 
 		// Mutable, shared accumulator threaded through the deploy steps.
 		// Each phase writes its own outputs onto this object so later steps

--- a/packages/cli/src/local-delegate.ts
+++ b/packages/cli/src/local-delegate.ts
@@ -16,8 +16,11 @@
  *   - Only runs when the invoked binary is a global install.
  *   - Only delegates when the local version differs from the global version
  *     (same version → run in-process, no extra spawn).
- *   - Never delegates `upgrade` (it manages the global install itself) or
- *     `--version` / `--help` (the user is introspecting the invoked binary).
+ *   - Delegates EVERYTHING with no command/flag exclusions: once we've decided
+ *     the project-local CLI owns this project, it should own every command,
+ *     including `--version` / `--help` / `--ai-help` (so introspection reflects
+ *     the CLI actually handling the project) and `upgrade` (so it upgrades the
+ *     CLI being used here).
  *   - A loop guard env var (`AGENTUITY_DELEGATED`) prevents the local CLI
  *     from delegating again.
  *
@@ -40,22 +43,6 @@ import { getVersion } from './version.ts';
 const DELEGATED_ENV = 'AGENTUITY_DELEGATED';
 const PACKAGE_NAME = '@agentuity/cli';
 
-/** Commands/flags that must always run with the invoked (global) binary. */
-const NON_DELEGATING_COMMANDS = new Set(['upgrade']);
-const NON_DELEGATING_FLAGS = new Set([
-	'--version',
-	'-V',
-	'version',
-	'--help',
-	'-h',
-	'help',
-	// Schema/introspection paths handled by main.ts's early exits — these must
-	// describe the actually-invoked binary, not a delegated one.
-	'--help=json',
-	'--ai-help',
-	'--describe',
-]);
-
 export interface LocalCli {
 	/** Absolute path to the local CLI's executable (the `bin.agentuity` entry). */
 	binPath: string;
@@ -76,27 +63,6 @@ function dirFromArgs(args: string[]): string | undefined {
 			const next = args[i + 1];
 			if (next !== undefined && !next.startsWith('-')) return next;
 		}
-	}
-	return undefined;
-}
-
-/**
- * The first positional token (the command name) in argv, skipping the
- * `--dir`/`--dir=` flag and its value so a path value like `--dir upgrade`
- * isn't mistaken for the `upgrade` command. We only need to skip `--dir`
- * here because it's the sole global option whose value could be a bare word
- * — every other global option we exclude is matched by flag, not position.
- */
-function firstCommand(args: string[]): string | undefined {
-	for (let i = 0; i < args.length; i++) {
-		const arg = args[i];
-		if (arg === undefined) continue;
-		if (arg === '--dir') {
-			i++; // skip its value
-			continue;
-		}
-		if (arg.startsWith('-')) continue;
-		return arg;
 	}
 	return undefined;
 }
@@ -248,11 +214,6 @@ export async function maybeDelegateToLocal(argv: string[]): Promise<void> {
 
 	// Only a global install should defer to a project-local one.
 	if (getInstallationType() !== 'global') return;
-
-	// Never delegate commands that introspect or manage the global binary.
-	if (argv.some((a) => NON_DELEGATING_FLAGS.has(a))) return;
-	const command = firstCommand(argv);
-	if (command && NON_DELEGATING_COMMANDS.has(command)) return;
 
 	const projectDir = dirFromArgs(argv) ?? process.cwd();
 

--- a/packages/cli/src/local-delegate.ts
+++ b/packages/cli/src/local-delegate.ts
@@ -1,0 +1,279 @@
+/**
+ * Global → local CLI delegation.
+ *
+ * When the CLI is invoked from a **global** install but the current project
+ * has its own locally-installed `@agentuity/cli` whose version differs from
+ * the running global one, we re-exec the local binary with the same argv and
+ * exit with its code.
+ *
+ * Why: v2 projects pin `@agentuity/cli` in their devDependencies. Once v3
+ * becomes the `latest` dist-tag, a v2 user's global `agentuity` would be v3
+ * and would mis-handle their v2 project (wrong build, broken deploy). By
+ * deferring to the project-local CLI, a v2 user who never upgrades keeps v2
+ * behavior even with a v3 binary on their PATH.
+ *
+ * Scope and guards:
+ *   - Only runs when the invoked binary is a global install.
+ *   - Only delegates when the local version differs from the global version
+ *     (same version → run in-process, no extra spawn).
+ *   - Never delegates `upgrade` (it manages the global install itself) or
+ *     `--version` / `--help` (the user is introspecting the invoked binary).
+ *   - A loop guard env var (`AGENTUITY_DELEGATED`) prevents the local CLI
+ *     from delegating again.
+ *
+ * Self-heal (Feature 3): when a global v3 CLI runs inside a project that has
+ * `@agentuity/runtime` but NO `@agentuity/cli` dependency and no local
+ * install, we add `@agentuity/cli` to devDependencies (matching the
+ * runtime's spec) and install it, then fall through to delegation. This way
+ * v2 projects that were created without the CLI dep still get v2 behavior
+ * under a v3 global instead of being mis-handled.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { run, spawnInherit } from './node-compat/proc.ts';
+import * as tui from './tui.ts';
+import { getInstallationType } from './utils/installation-type.ts';
+import { getVersion } from './version.ts';
+
+const DELEGATED_ENV = 'AGENTUITY_DELEGATED';
+const PACKAGE_NAME = '@agentuity/cli';
+
+/** Commands/flags that must always run with the invoked (global) binary. */
+const NON_DELEGATING_COMMANDS = new Set(['upgrade']);
+const NON_DELEGATING_FLAGS = new Set([
+	'--version',
+	'-V',
+	'version',
+	'--help',
+	'-h',
+	'help',
+	// Schema/introspection paths handled by main.ts's early exits — these must
+	// describe the actually-invoked binary, not a delegated one.
+	'--help=json',
+	'--ai-help',
+	'--describe',
+]);
+
+export interface LocalCli {
+	/** Absolute path to the local CLI's executable (the `bin.agentuity` entry). */
+	binPath: string;
+	/** Version string from the local package's package.json. */
+	version: string;
+}
+
+/**
+ * Extract the `--dir`/`--dir=` value from argv, if present. Mirrors the
+ * helper in main.ts but kept local so delegation has no import cycle.
+ */
+function dirFromArgs(args: string[]): string | undefined {
+	for (let i = 0; i < args.length; i++) {
+		const arg = args[i];
+		if (arg === undefined) continue;
+		if (arg.startsWith('--dir=')) return arg.slice(6);
+		if (arg === '--dir' && i + 1 < args.length) {
+			const next = args[i + 1];
+			if (next !== undefined && !next.startsWith('-')) return next;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * The first positional token (the command name) in argv, skipping the
+ * `--dir`/`--dir=` flag and its value so a path value like `--dir upgrade`
+ * isn't mistaken for the `upgrade` command. We only need to skip `--dir`
+ * here because it's the sole global option whose value could be a bare word
+ * — every other global option we exclude is matched by flag, not position.
+ */
+function firstCommand(args: string[]): string | undefined {
+	for (let i = 0; i < args.length; i++) {
+		const arg = args[i];
+		if (arg === undefined) continue;
+		if (arg === '--dir') {
+			i++; // skip its value
+			continue;
+		}
+		if (arg.startsWith('-')) continue;
+		return arg;
+	}
+	return undefined;
+}
+
+/**
+ * Walk up from `startDir` looking for a locally-installed `@agentuity/cli`
+ * under `node_modules`. Returns its resolved bin path and version, or null.
+ */
+export function findLocalCli(startDir: string): LocalCli | null {
+	let dir = resolve(startDir);
+	// Bound the walk: stop at filesystem root.
+	while (true) {
+		const pkgDir = join(dir, 'node_modules', '@agentuity', 'cli');
+		const pkgJsonPath = join(pkgDir, 'package.json');
+		if (existsSync(pkgJsonPath)) {
+			try {
+				const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf-8')) as {
+					version?: string;
+					bin?: string | Record<string, string>;
+				};
+				const version = pkg.version;
+				const binEntry = typeof pkg.bin === 'string' ? pkg.bin : pkg.bin?.agentuity;
+				if (version && binEntry) {
+					const binPath = isAbsolute(binEntry) ? binEntry : join(pkgDir, binEntry);
+					if (existsSync(binPath)) {
+						return { binPath, version };
+					}
+				}
+			} catch {
+				// Unreadable/invalid local package.json — fall through and keep walking.
+			}
+		}
+		const parent = dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+}
+
+/**
+ * Walk up from `startDir` to the nearest directory containing a
+ * `package.json`. Returns null if none is found before the filesystem root.
+ */
+function findProjectRoot(startDir: string): string | null {
+	let dir = resolve(startDir);
+	while (true) {
+		if (existsSync(join(dir, 'package.json'))) return dir;
+		const parent = dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+}
+
+/**
+ * Read `@agentuity/runtime`'s spec from a project's package.json, looking in
+ * both `dependencies` and `devDependencies`. Returns the spec string (e.g.
+ * `^2.0.0`) or null if the runtime isn't a declared dependency.
+ */
+function runtimeSpec(pkg: {
+	dependencies?: Record<string, string>;
+	devDependencies?: Record<string, string>;
+}): string | null {
+	return (
+		pkg.dependencies?.['@agentuity/runtime'] ??
+		pkg.devDependencies?.['@agentuity/runtime'] ??
+		null
+	);
+}
+
+/**
+ * Self-heal a v2 project that has `@agentuity/runtime` but no
+ * `@agentuity/cli` dependency: add `@agentuity/cli` (matching the runtime's
+ * spec) to devDependencies and install it, so the project-local CLI exists
+ * for delegation to defer to.
+ *
+ * No-op (returns false) when: there's no project root, no runtime dep, a
+ * cli dep is already declared, or a local install already exists. Returns
+ * true when it installed the local CLI.
+ *
+ * v2 projects are Bun-only, so we install with `bun add -D`.
+ */
+async function ensureLocalCliForV2(projectDir: string): Promise<boolean> {
+	const root = findProjectRoot(projectDir);
+	if (!root) return false;
+
+	// Already have a local install — nothing to heal; delegation handles it.
+	if (findLocalCli(root)) return false;
+
+	const pkgPath = join(root, 'package.json');
+	let pkg: {
+		dependencies?: Record<string, string>;
+		devDependencies?: Record<string, string>;
+	};
+	try {
+		pkg = JSON.parse(await readFile(pkgPath, 'utf-8'));
+	} catch {
+		return false;
+	}
+
+	const spec = runtimeSpec(pkg);
+	if (!spec) return false; // not a v2-runtime project
+
+	// Only self-heal when the runtime is pinned to a concrete v2 range. A
+	// floating spec (`latest`, `*`, `workspace:*`, git/url) could resolve the
+	// CLI to v3 and defeat the whole point, so we bail and let the global CLI
+	// handle it rather than guess.
+	if (!/^[\^~]?2\./.test(spec)) {
+		return false;
+	}
+
+	// CLI already declared (any version) — respect the user's choice.
+	if (pkg.dependencies?.['@agentuity/cli'] || pkg.devDependencies?.['@agentuity/cli']) {
+		return false;
+	}
+
+	tui.info(
+		`Detected a v2 project (@agentuity/runtime ${spec}) without @agentuity/cli. Adding @agentuity/cli@${spec} so the local CLI handles this project.`
+	);
+
+	// `bun add -D` rewrites package.json + installs in one step, matching the
+	// runtime's spec. We pass the exact spec so the resolved range mirrors it.
+	const result = await run({
+		cmd: ['bun', 'add', '-D', `@agentuity/cli@${spec}`],
+		cwd: root,
+	});
+	if (result.exitCode !== 0) {
+		tui.warning(
+			`Failed to install @agentuity/cli locally (bun exited ${result.exitCode}). Continuing with the global CLI.`
+		);
+		return false;
+	}
+	return true;
+}
+
+/**
+ * If we're a global install sitting on top of a different project-local
+ * `@agentuity/cli`, re-exec the local one and exit. Returns without acting
+ * (so the caller continues in-process) when delegation doesn't apply.
+ *
+ * Before delegating, self-heals v2 projects missing the CLI dep (Feature 3):
+ * installs a project-local `@agentuity/cli` matching the runtime spec so the
+ * subsequent delegation has something to defer to.
+ *
+ * @param argv - The raw CLI args (without the runtime/script prefix), i.e.
+ *               `process.argv.slice(2)`.
+ */
+export async function maybeDelegateToLocal(argv: string[]): Promise<void> {
+	// Loop guard: a delegated child must never delegate again.
+	if (process.env[DELEGATED_ENV]) return;
+
+	// Only a global install should defer to a project-local one.
+	if (getInstallationType() !== 'global') return;
+
+	// Never delegate commands that introspect or manage the global binary.
+	if (argv.some((a) => NON_DELEGATING_FLAGS.has(a))) return;
+	const command = firstCommand(argv);
+	if (command && NON_DELEGATING_COMMANDS.has(command)) return;
+
+	const projectDir = dirFromArgs(argv) ?? process.cwd();
+
+	// Self-heal v2 projects that have the runtime but no CLI dep, so the
+	// delegation below has a local CLI to defer to.
+	await ensureLocalCliForV2(projectDir);
+
+	const local = findLocalCli(projectDir);
+	if (!local) return;
+
+	// Same version → no point spawning a second process.
+	if (local.version === getVersion()) return;
+
+	const { exitCode } = await spawnInherit({
+		cmd: [local.binPath, ...argv],
+		env: { [DELEGATED_ENV]: '1' },
+	});
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const exit = (globalThis as any).AGENTUITY_PROCESS_EXIT || process.exit;
+	exit(exitCode ?? 0);
+}
+
+export { PACKAGE_NAME as DELEGATE_PACKAGE_NAME };

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -20,6 +20,7 @@ import { generateAIHelp } from './ai-help.ts';
 import { setOutputOptions } from './output.ts';
 import type { Config, GlobalOptions } from './types.ts';
 import { ensureBunOnPath } from './bun-path.ts';
+import { maybeDelegateToLocal } from './local-delegate.ts';
 import { checkForUpdates } from './version-check.ts';
 import { closeDatabase } from './cache/index.ts';
 import { ErrorCode, createError, formatErrorJSON } from './errors.ts';
@@ -88,6 +89,13 @@ process.on('SIGTERM', () => {
 
 validateRuntime();
 await ensureBunOnPath();
+
+// If we're a global install running inside a project that pins its own
+// @agentuity/cli at a different version, hand off to the project-local CLI
+// and exit. This keeps v2 projects on v2 behavior even when the global
+// binary has been upgraded to v3. Runs before any command parsing so the
+// local CLI sees the original argv verbatim.
+await maybeDelegateToLocal(process.argv.slice(2));
 
 // Preprocess arguments to convert --help=json to --help json
 // Commander.js doesn't support --option=value syntax for optional values

--- a/packages/cli/src/pin-latest.ts
+++ b/packages/cli/src/pin-latest.ts
@@ -1,0 +1,113 @@
+/**
+ * Pin "latest" Agentuity dependencies to their installed version.
+ *
+ * v2 scaffolds (and some hand-written projects) pin Agentuity-owned packages
+ * with the floating spec `"latest"`. That's a footgun for deploys: the
+ * version that actually gets installed at warmup can drift from the version
+ * the user built and tested against — and once v3 becomes the `latest`
+ * dist-tag, a v2 project pinned to `"latest"` would silently pull v3 and
+ * break.
+ *
+ * On deploy we resolve the concrete version each `"latest"`-pinned
+ * `@agentuity/*` / `agentuity` dependency resolved to (from `bun.lock`) and
+ * rewrite the user's source `package.json` in place. Scope is limited to
+ * Agentuity-owned packages so we never touch the user's other deps.
+ *
+ * Only `bun.lock` is read: v2 Agentuity projects (the only ones that pin
+ * Agentuity deps to `"latest"`) are Bun-only, so there is no other lockfile
+ * format to account for.
+ */
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { pathExists } from './node-compat/fs.ts';
+import type { Logger } from './types.ts';
+import { parseBunLockFile } from './utils/deps.ts';
+
+const DEP_FIELDS = ['dependencies', 'devDependencies'] as const;
+
+/** True for `@agentuity/<x>` and the bare `agentuity` package. */
+function isAgentuityPackage(name: string): boolean {
+	return name === 'agentuity' || name.startsWith('@agentuity/');
+}
+
+/**
+ * Resolve the installed version of `name` from `bun.lock`. Returns null when
+ * the lockfile is missing or doesn't resolve the package.
+ */
+async function resolveInstalledVersion(projectDir: string, name: string): Promise<string | null> {
+	const path = join(projectDir, 'bun.lock');
+	if (!(await pathExists(path))) return null;
+	const parsed = parseBunLockFile(await readFile(path, 'utf-8'));
+	const entry = parsed?.packages?.[name];
+	if (!Array.isArray(entry) || typeof entry[0] !== 'string') return null;
+	// entry[0] is "name@version" (scoped names keep their leading '@').
+	const spec = entry[0];
+	const at = spec.lastIndexOf('@');
+	if (at <= 0) return null;
+	return spec.slice(at + 1) || null;
+}
+
+/**
+ * Rewrite `"latest"`-pinned Agentuity deps in the project's source
+ * package.json to the version resolved from the lockfile. Mutates the file in
+ * place. Safe no-op when there's no package.json, no `"latest"` Agentuity
+ * deps, or no lockfile to resolve from.
+ *
+ * @returns the list of `{ name, version }` that were pinned (empty if none).
+ */
+export async function pinLatestAgentuityDeps(
+	projectDir: string,
+	logger: Logger
+): Promise<Array<{ name: string; version: string }>> {
+	const pkgPath = join(projectDir, 'package.json');
+	if (!(await pathExists(pkgPath))) return [];
+
+	let raw: string;
+	try {
+		raw = await readFile(pkgPath, 'utf-8');
+	} catch (err) {
+		logger.debug('pin-latest: failed to read package.json: %s', err);
+		return [];
+	}
+
+	let pkg: Record<string, unknown>;
+	try {
+		pkg = JSON.parse(raw) as Record<string, unknown>;
+	} catch (err) {
+		logger.debug('pin-latest: package.json is not valid JSON, skipping: %s', err);
+		return [];
+	}
+
+	const pinned: Array<{ name: string; version: string }> = [];
+
+	for (const field of DEP_FIELDS) {
+		const deps = pkg[field] as Record<string, string> | undefined;
+		if (!deps) continue;
+		for (const [name, spec] of Object.entries(deps)) {
+			if (spec !== 'latest' || !isAgentuityPackage(name)) continue;
+			const version = await resolveInstalledVersion(projectDir, name);
+			if (!version) {
+				logger.debug(
+					'pin-latest: %s is "latest" but no bun.lock entry found; leaving as-is',
+					name
+				);
+				continue;
+			}
+			deps[name] = version;
+			pinned.push({ name, version });
+		}
+	}
+
+	if (pinned.length === 0) return [];
+
+	// Preserve the file's indentation style (tabs in our scaffolds) and trailing newline.
+	const indent = raw.includes('\t') ? '\t' : 2;
+	const trailingNewline = raw.endsWith('\n') ? '\n' : '';
+	await writeFile(pkgPath, JSON.stringify(pkg, null, indent) + trailingNewline);
+
+	for (const { name, version } of pinned) {
+		logger.debug('pin-latest: pinned %s "latest" -> %s', name, version);
+	}
+	return pinned;
+}

--- a/packages/cli/test/cmd/build/detect/framework-detection.test.ts
+++ b/packages/cli/test/cmd/build/detect/framework-detection.test.ts
@@ -371,6 +371,69 @@ describe('Framework Detection', () => {
 		});
 	});
 
+	// ── Agentuity v2 runtime ──
+
+	describe('Agentuity v2 runtime', () => {
+		test('detects a v2 app by @agentuity/runtime and builds via the v2 CLI', async () => {
+			writePackageJson(testDir, {
+				name: 'v2-app',
+				scripts: { build: 'agentuity build', start: 'bun .agentuity/app.js' },
+				dependencies: { '@agentuity/runtime': '^2.0.0' },
+			});
+
+			const result = await detectFramework(testDir);
+			expect(result).not.toBeNull();
+			expect(result!.name).toBe('agentuity-v2');
+			expect(result!.runtime).toBe('bun');
+			expect(result!.packageManager).toBe('bun');
+			expect(result!.buildOutput).toBe('.agentuity');
+			expect(result!.staticDir).toBe(join('.agentuity', 'client'));
+			expect(result!.startCommand).toBe(`bun ${join('.agentuity', 'app.js')}`);
+			// No local CLI installed in the test dir → falls back to bare command
+			// and surfaces a hint.
+			expect(result!.buildCommand).toBe('agentuity build');
+			expect(result!.warnings?.[0]).toContain('@agentuity/cli is not installed locally');
+		});
+
+		test('takes precedence over generic/vite detection', async () => {
+			writePackageJson(testDir, {
+				name: 'v2-vite-app',
+				scripts: { build: 'vite build' },
+				dependencies: { '@agentuity/runtime': '~2.1.0' },
+				devDependencies: { vite: '^7.0.0' },
+			});
+			writeFileSync(join(testDir, 'vite.config.ts'), 'export default {}');
+
+			const result = await detectFramework(testDir);
+			expect(result!.name).toBe('agentuity-v2');
+		});
+
+		test('does not claim a floating runtime spec (e.g. "latest")', async () => {
+			writePackageJson(testDir, {
+				name: 'ambiguous',
+				scripts: { build: 'vite build' },
+				dependencies: { '@agentuity/runtime': 'latest' },
+				devDependencies: { vite: '^7.0.0' },
+			});
+			writeFileSync(join(testDir, 'vite.config.ts'), 'export default {}');
+
+			const result = await detectFramework(testDir);
+			expect(result!.name).not.toBe('agentuity-v2');
+		});
+
+		test('does not claim a v3 app (no @agentuity/runtime)', async () => {
+			writePackageJson(testDir, {
+				name: 'v3-app',
+				scripts: { build: 'vite build' },
+				devDependencies: { vite: '^7.0.0' },
+			});
+			writeFileSync(join(testDir, 'vite.config.ts'), 'export default {}');
+
+			const result = await detectFramework(testDir);
+			expect(result!.name).not.toBe('agentuity-v2');
+		});
+	});
+
 	// ── Generic ──
 
 	describe('Generic fallback', () => {


### PR DESCRIPTION
## Why

Once v3 becomes the `latest` dist-tag, a v2 user's global `agentuity` upgrades to v3 (we have auto-upgrade) and would **mis-handle their v2 project** — the v3 buildpack pipeline detects a v2 app as a generic vite SPA, builds only the client, and ships a deploy that **fails at warmup**. This hurts users who are on v2 and have no intention of upgrading.

This PR adds four coordinated safety nets so v2 users keep v2 behavior, and so the v3 CLI can still deploy a v2 app.

## What

1. **Global → local delegation** (`src/local-delegate.ts`, wired in `src/main.ts`): a global install running inside a project with a local `@agentuity/cli` of a *different* version re-execs the local one with the same argv. Excludes `upgrade` / `--version` / `--help` / `--ai-help` / `--describe`; loop-guarded via `AGENTUITY_DELEGATED`.

2. **Self-heal v2-without-cli**: a global v3 in a v2 project (`@agentuity/runtime ^2.x`) with **no** `@agentuity/cli` dep runs `bun add -D @agentuity/cli@<runtime-spec>` (matching the runtime's spec) then delegates, so the local CLI handles the project. Skips floating specs and respects an existing cli dep.

3. **Pin "latest" Agentuity deps** (`src/pin-latest.ts`): on deploy, rewrites `@agentuity/*` / `agentuity` deps pinned to `"latest"` to the concrete version from `bun.lock`, in the user's source `package.json`. Stops a "latest"-pinned v2 project from silently pulling v3 once v3 is `latest`. Runs before the v2 handoff so v2 apps get pinned too.

4. **v2 deploy handoff** (`src/cmd/build/detect/agentuity-v2.ts` + `maybeHandoffV2Deploy` in `deploy.ts`): the v3 deploy detects a v2 app (signal = `@agentuity/runtime` at a concrete v2 major) and shells out to the project-local v2 CLI's full `deploy`. Fatals with a migrate/install hint when no local v2 CLI exists, instead of shipping a broken deploy.

### Why handoff instead of a native v2 build adapter

A half-native approach (run v2 `agentuity build`, then package via v3) **cannot work**: the v2 build bakes route/agent ids via `SHA1(projectId, deploymentId, …)`, and standalone `agentuity build` always uses `deploymentId=''` (only v2 `deploy` knows the real id at build time). The server then rejects the metadata (`expected id … but was …` / `Deployment has the incorrect id`), and the generic-adapter path warmup-fails with `Module not found ".agentuity/app.js"`. So we hand the whole deploy to v2 `deploy`.

## Testing

Verified end-to-end deploying a v2 app to a test org (all returned HTTP 200 / "warmup complete"):

- **source/local v3** on a v2 app → deploy-cmd handoff → v2 deploys ✓
- **global v3** → boot delegation → v2 deploys ✓
- **global v3** on a v2 app with **no cli dep** → self-heal install `@agentuity/cli@^2.0.0` → delegate → deploy ✓
- v2 deps pinned **"latest"** → pin rewrites `runtime`+`core` to `2.0.25` → handoff → deploy ✓

Added detector unit tests (`framework-detection.test.ts`, 40 pass). `typecheck` / `lint` / `build` / full cli `test` suite all green.

## Notes

- v2 is Bun-only, so the lockfile resolver and self-heal install only handle `bun.lock` / `bun add`.
- No behavior change for v3 projects (delegation is global-only + version-mismatch; v2 detection requires `@agentuity/runtime`, which v3 dropped).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect and configure Agentuity v2 runtime projects for Bun-based startup and build.
  * CLI will delegate to a project-local Agentuity CLI when present (early handoff).
  * Deployments for v2 apps can be handed off to a local v2 CLI.
  * "latest" Agentuity deps are pinned to concrete installed versions during deploy flow.

* **Tests**
  * Added tests covering Agentuity v2 detection, precedence, and warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->