### PR TITLE
fix(cli): skip upgrade prompt when not interactive (#1524)

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -526,6 +526,11 @@ export async function createCLI(version: string): Promise<Command> {
 		.option('--json', 'Output in JSON format (machine-readable)', false)
 		.option('--quiet', 'Suppress non-essential output', false)
 		.option('--no-progress', 'Disable progress indicators', false)
+		.option(
+			'--no-interactive',
+			'Disable interactive prompts (e.g. the upgrade prompt); fail instead of asking',
+			true
+		)
 		.option('--explain', 'Show what the command would do without executing', false)
 		.option('--dry-run', 'Execute command without making changes', false)
 		.option('--validate', 'Validate arguments and options without executing', false)

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -159,9 +159,20 @@ export function outputWarning(message: string, options: GlobalOptions): void {
  * Check if interactive prompts should be allowed
  */
 export function canPrompt(options: GlobalOptions): boolean {
-	// Disable prompts in JSON mode, quiet mode, or non-TTY
+	// Disable prompts in JSON mode, quiet mode, non-TTY, or when interactivity
+	// is explicitly turned off via --no-interactive / AGENTUITY_NON_INTERACTIVE / CI.
+	if (
+		options.interactive === false ||
+		process.env.AGENTUITY_NON_INTERACTIVE === '1' ||
+		process.env.CI
+	) {
+		return false;
+	}
 	return (
-		!isJSONMode(options) && !isQuietMode(options) && process.stdin.isTTY && process.stdout.isTTY
+		!isJSONMode(options) &&
+		!isQuietMode(options) &&
+		!!process.stdin.isTTY &&
+		!!process.stdout.isTTY
 	);
 }
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -98,6 +98,8 @@ export interface GlobalOptions {
 	json?: boolean;
 	quiet?: boolean;
 	noProgress?: boolean;
+	/** False when `--no-interactive` is passed: suppress prompts, fail instead of asking. */
+	interactive?: boolean;
 	color?: 'auto' | 'always' | 'never';
 	explain?: boolean;
 	dryRun?: boolean;

--- a/packages/cli/src/version-check.ts
+++ b/packages/cli/src/version-check.ts
@@ -24,6 +24,7 @@ function shouldSkipCheck(
 		validate?: boolean;
 		dryRun?: boolean;
 		skipVersionCheck?: boolean;
+		interactive?: boolean;
 	},
 	commandDef: CommandDefinition | undefined,
 	subcommandDef: SubcommandDefinition | undefined,
@@ -42,6 +43,17 @@ function shouldSkipCheck(
 
 	// Skip if no TTY (CI, redirected output, etc.)
 	if (!process.stdin.isTTY || !process.stdout.isTTY) {
+		return true;
+	}
+
+	// Skip when interactivity is explicitly disabled. `--no-interactive`
+	// (options.interactive === false) or AGENTUITY_NON_INTERACTIVE / CI mean
+	// "never prompt" even on a TTY — the upgrade prompt is a prompt, so honor it.
+	if (
+		options.interactive === false ||
+		process.env.AGENTUITY_NON_INTERACTIVE === '1' ||
+		process.env.CI
+	) {
 		return true;
 	}
 
@@ -250,6 +262,7 @@ export async function checkForUpdates(
 		validate?: boolean;
 		dryRun?: boolean;
 		skipVersionCheck?: boolean;
+		interactive?: boolean;
 	},
 	commandDef: CommandDefinition | undefined,
 	subcommandDef: SubcommandDefinition | undefined,


### PR DESCRIPTION
Fixes #1524.

## Problem

The CLI prompts for an upgrade before starting even when the user is running in non-interactive mode (`--no-interactive`). The upgrade prompt previously only skipped on a non-TTY (`!process.stdin.isTTY || !process.stdout.isTTY`), so an explicit non-interactive request on a TTY still got prompted.

## Fix

- Add a global `--no-interactive` flag (`GlobalOptions.interactive`, defaults true).
- Honor it — plus `AGENTUITY_NON_INTERACTIVE=1` and `CI` — in:
  - `version-check.ts` `shouldSkipCheck` (the upgrade prompt), alongside the existing TTY check.
  - `output.ts` `canPrompt()`, so the whole CLI is consistent (no prompts when non-interactive).

With `--no-interactive`, the CLI no longer prompts to upgrade before running.

## Testing

- `canPrompt` returns false for `--no-interactive`, `AGENTUITY_NON_INTERACTIVE=1`, `CI`, `--json`; true by default on a TTY.
- `--no-interactive` parses cleanly and shows in `--help`.
- typecheck / lint / build / full cli test suite green.

A matching PR targeting the `v2` branch will follow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--no-interactive` flag to disable interactive prompts throughout the CLI. The CLI will now fail instead of asking for input when this flag is used or when running in CI environments. Can also be controlled via the `AGENTUITY_NON_INTERACTIVE` environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->