### PR TITLE
fix(cli): skip upgrade prompt when not interactive (#1524) [v2]

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -534,6 +534,11 @@ export async function createCLI(version: string): Promise<Command> {
 		.option('--json', 'Output in JSON format (machine-readable)', false)
 		.option('--quiet', 'Suppress non-essential output', false)
 		.option('--no-progress', 'Disable progress indicators', false)
+		.option(
+			'--no-interactive',
+			'Disable interactive prompts (e.g. the upgrade prompt); fail instead of asking',
+			true
+		)
 		.option('--explain', 'Show what the command would do without executing', false)
 		.option('--dry-run', 'Execute command without making changes', false)
 		.option('--validate', 'Validate arguments and options without executing', false)

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -159,9 +159,20 @@ export function outputWarning(message: string, options: GlobalOptions): void {
  * Check if interactive prompts should be allowed
  */
 export function canPrompt(options: GlobalOptions): boolean {
-	// Disable prompts in JSON mode, quiet mode, or non-TTY
+	// Disable prompts in JSON mode, quiet mode, non-TTY, or when interactivity
+	// is explicitly turned off via --no-interactive / AGENTUITY_NON_INTERACTIVE / CI.
+	if (
+		options.interactive === false ||
+		process.env.AGENTUITY_NON_INTERACTIVE === '1' ||
+		process.env.CI
+	) {
+		return false;
+	}
 	return (
-		!isJSONMode(options) && !isQuietMode(options) && process.stdin.isTTY && process.stdout.isTTY
+		!isJSONMode(options) &&
+		!isQuietMode(options) &&
+		!!process.stdin.isTTY &&
+		!!process.stdout.isTTY
 	);
 }
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -315,6 +315,8 @@ export interface GlobalOptions {
 	json?: boolean;
 	quiet?: boolean;
 	noProgress?: boolean;
+	/** False when `--no-interactive` is passed: suppress prompts, fail instead of asking. */
+	interactive?: boolean;
 	color?: 'auto' | 'always' | 'never';
 	explain?: boolean;
 	dryRun?: boolean;

--- a/packages/cli/src/version-check.ts
+++ b/packages/cli/src/version-check.ts
@@ -23,6 +23,7 @@ function shouldSkipCheck(
 		validate?: boolean;
 		dryRun?: boolean;
 		skipVersionCheck?: boolean;
+		interactive?: boolean;
 	},
 	commandDef: CommandDefinition | undefined,
 	subcommandDef: SubcommandDefinition | undefined,
@@ -41,6 +42,17 @@ function shouldSkipCheck(
 
 	// Skip if no TTY (CI, redirected output, etc.)
 	if (!process.stdin.isTTY || !process.stdout.isTTY) {
+		return true;
+	}
+
+	// Skip when interactivity is explicitly disabled. `--no-interactive`
+	// (options.interactive === false) or AGENTUITY_NON_INTERACTIVE / CI mean
+	// "never prompt" even on a TTY — the upgrade prompt is a prompt, so honor it.
+	if (
+		options.interactive === false ||
+		process.env.AGENTUITY_NON_INTERACTIVE === '1' ||
+		process.env.CI
+	) {
 		return true;
 	}
 
@@ -254,6 +266,7 @@ export async function checkForUpdates(
 		validate?: boolean;
 		dryRun?: boolean;
 		skipVersionCheck?: boolean;
+		interactive?: boolean;
 	},
 	commandDef: CommandDefinition | undefined,
 	subcommandDef: SubcommandDefinition | undefined,


### PR DESCRIPTION
Fixes #1524 on the **v2** branch. (v3/`main` counterpart: #1528.)

## Problem

The CLI prompts for an upgrade before starting even in non-interactive mode (`--no-interactive`). The upgrade prompt previously only skipped on a non-TTY, so an explicit non-interactive request on a TTY still got prompted.

## Fix

- Add a global `--no-interactive` flag (`GlobalOptions.interactive`, defaults true).
- Honor it — plus `AGENTUITY_NON_INTERACTIVE=1` and `CI` — in:
  - `version-check.ts` `shouldSkipCheck` (the upgrade prompt), alongside the existing TTY check.
  - `output.ts` `canPrompt()`, so the whole CLI is consistent.

With `--no-interactive`, the CLI no longer prompts to upgrade before running.

## Testing

- `canPrompt` returns false for `--no-interactive`, `AGENTUITY_NON_INTERACTIVE=1`, `CI`, `--json`; true by default on a TTY.
- The four changed files are type-clean and lint-clean. (Pre-existing typecheck/lint errors elsewhere in the v2 branch are unrelated to this change — they come from the v3-built workspace deps in the monorepo checkout.)

Identical change to the v3 PR so behavior matches across major versions.