### PR TITLE
fix(cli): skip upgrade prompt when installed version is newer than latest

### DIFF
--- a/packages/cli/src/version-check.ts
+++ b/packages/cli/src/version-check.ts
@@ -1,4 +1,5 @@
 import { tmpdir } from 'node:os';
+import { gt as semverGt, valid as semverValid } from 'semver';
 import { getExecutingAgent } from './agent-detection.ts';
 import { fetchLatestVersion } from './cmd/upgrade/index.ts';
 import { saveConfig } from './config.ts';
@@ -295,6 +296,25 @@ export async function checkForUpdates(
 			// Update timestamp - we confirmed we're on latest version
 			await updateCheckTimestamp(config, logger);
 			logger.trace('Already on latest version: %s', currentVersion);
+			return;
+		}
+
+		// Skip the prompt when the installed version is NEWER than the `latest`
+		// dist-tag. This happens while v3 ships on `next` and `latest` still
+		// points at v2: a globally-installed v3 (e.g. 3.0.4) would otherwise be
+		// told that 2.0.26 is "a new version available" and prompted to
+		// downgrade. Only nudge when there's genuinely a newer release.
+		if (
+			semverValid(normalizedCurrent) &&
+			semverValid(normalizedLatest) &&
+			semverGt(normalizedCurrent, normalizedLatest)
+		) {
+			await updateCheckTimestamp(config, logger);
+			logger.trace(
+				'Installed version %s is newer than latest %s; skipping upgrade prompt',
+				currentVersion,
+				latestVersion
+			);
 			return;
 		}
 


### PR DESCRIPTION
## Problem

While v3 ships on the `next` dist-tag and `latest` still points at v2 (2.0.26), a globally-installed **v3** (e.g. 3.0.4) hits the version check, fetches `latest` (2.0.26), sees `3.0.4 !== 2.0.26`, and prompts **"A new version of the CLI is available!"** — effectively nudging a v3 user to **downgrade** to v2. This is noisy and confusing (came up while testing the v2/v1 back-compat work).

## Fix

In `checkForUpdates` (`version-check.ts`), after the existing equality check, skip the prompt when semver says the **installed version is greater than** the fetched latest. The check timestamp is still refreshed so we don't re-check every invocation. We only nudge when there's genuinely a newer release.

```ts
if (semverValid(cur) && semverValid(latest) && semverGt(cur, latest)) {
  await updateCheckTimestamp(...);
  return; // installed is newer than `latest` (e.g. v3 on `next` vs v2 `latest`)
}
```

Uses `semver` (already a declared dep of `@agentuity/cli`, used in `runtime.ts`).

## Behavior matrix (verified)

| installed | latest | result |
|---|---|---|
| 3.0.4 | 2.0.26 | **skip** (was: prompt to downgrade) |
| 2.0.25 | 2.0.26 | prompt (unchanged) |
| 2.0.26 | 2.0.26 | skip (equal, unchanged) |
| 3.0.4 | 3.0.5 | prompt (unchanged) |
| 3.0.4-0 | 3.0.4 | prompt (unchanged) |

typecheck / lint / build green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version checking logic to correctly handle pre-release versions and prevent unnecessary update prompts when the installed version is newer than the latest stable release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->