### PR TITLE
Fix storage bucket endpoint normalization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ node_modules
 out
 dist
 *.tgz
-/.agentuity/
+.agentuity/
 
 # code coverage
 coverage

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules
 out
 dist
 *.tgz
+/.agentuity/
 
 # code coverage
 coverage

--- a/packages/storage/src/node.ts
+++ b/packages/storage/src/node.ts
@@ -22,11 +22,11 @@
  *    sent on the wire.
  *
  * 3. **Bucket-in-endpoint addressing.** Agentuity buckets use
- *    virtual-host-style endpoints (`<bucket>.<host>`), so the bucket
- *    name is implicit in the URL. The SDK still requires a `Bucket`
- *    parameter on each command; we extract it from the endpoint's
- *    leading hostname label and rely on the endpoint override to route
- *    correctly. `forcePathStyle` is `false`.
+ *    virtual-host-style endpoints (`<bucket>.<host>`), but the AWS SDK
+ *    composes virtual-host requests from a shared endpoint plus the
+ *    command's `Bucket` parameter. We keep `forcePathStyle` false and
+ *    pass the SDK the shared endpoint so it does not prepend the bucket
+ *    twice.
  */
 
 import { Buffer } from 'node:buffer';
@@ -74,14 +74,7 @@ interface InternalState {
 }
 
 export function createS3Client(bucket: BucketConfig): S3ClientLike {
-	const endpoint = resolveEndpoint(bucket);
-
-	// The SDK's `Bucket` parameter is essentially a placeholder for our
-	// purposes — we always send virtual-hosted-style requests, so the
-	// `endpoint` URL is what actually routes. Prefer the explicit
-	// `bucket` field when supplied; otherwise fall back to parsing the
-	// leading hostname label out of the composed endpoint.
-	const bucketLabel = bucket.bucket ?? extractBucketLabel(endpoint);
+	const { endpoint, bucketLabel } = resolveSdkTarget(bucket);
 
 	const state: InternalState = {
 		endpoint,
@@ -222,6 +215,25 @@ export function createS3Client(bucket: BucketConfig): S3ClientLike {
 			await client.send(new sdk.DeleteObjectCommand({ Bucket: state.bucketLabel, Key: key }));
 		},
 	};
+}
+
+function resolveSdkTarget(bucket: BucketConfig): { endpoint: string; bucketLabel: string } {
+	// Resolve first so invalid BucketConfig shapes fail before SDK adaptation.
+	const canonicalEndpoint = resolveEndpoint(bucket);
+
+	if (bucket.host && bucket.bucket) {
+		return {
+			endpoint: sharedEndpointFromHost(bucket.host),
+			bucketLabel: bucket.bucket,
+		};
+	}
+
+	return splitBucketEndpoint(canonicalEndpoint);
+}
+
+function sharedEndpointFromHost(host: string): string {
+	const hostOnly = host.replace(/^https?:\/\//, '').replace(/\/+$/, '');
+	return `https://${hostOnly}`;
 }
 
 /**
@@ -375,18 +387,20 @@ function concatUint8Arrays(parts: Uint8Array[]): Uint8Array<ArrayBuffer> {
 	return out;
 }
 
-/**
- * Pull the leading hostname label off a virtual-hosted-style endpoint
- * URL. Falls back to `'bucket'` if parsing fails — which is fine
- * because the endpoint override controls actual routing; the SDK only
- * uses `Bucket` to construct path-style URLs (which we never do).
- */
-function extractBucketLabel(endpoint: string): string {
+function splitBucketEndpoint(endpoint: string): { endpoint: string; bucketLabel: string } {
 	try {
 		const url = new URL(endpoint);
-		const firstLabel = url.hostname.split('.')[0];
-		return firstLabel || 'bucket';
+		const [firstLabel, ...rest] = url.hostname.split('.');
+		if (!firstLabel || rest.length === 0) {
+			return { endpoint, bucketLabel: firstLabel || 'bucket' };
+		}
+
+		url.hostname = rest.join('.');
+		return {
+			endpoint: url.toString().replace(/\/$/, ''),
+			bucketLabel: firstLabel,
+		};
 	} catch {
-		return 'bucket';
+		return { endpoint, bucketLabel: 'bucket' };
 	}
 }

--- a/packages/storage/src/node.ts
+++ b/packages/storage/src/node.ts
@@ -388,19 +388,23 @@ function concatUint8Arrays(parts: Uint8Array[]): Uint8Array<ArrayBuffer> {
 }
 
 function splitBucketEndpoint(endpoint: string): { endpoint: string; bucketLabel: string } {
+	let url: URL;
 	try {
-		const url = new URL(endpoint);
-		const [firstLabel, ...rest] = url.hostname.split('.');
-		if (!firstLabel || rest.length === 0) {
-			return { endpoint, bucketLabel: firstLabel || 'bucket' };
-		}
-
-		url.hostname = rest.join('.');
-		return {
-			endpoint: url.toString().replace(/\/$/, ''),
-			bucketLabel: firstLabel,
-		};
+		url = new URL(endpoint);
 	} catch {
-		return { endpoint, bucketLabel: 'bucket' };
+		throw new Error(`Invalid bucket endpoint URL: ${endpoint}`);
 	}
+
+	const [firstLabel, ...rest] = url.hostname.split('.');
+	if (!firstLabel || rest.length === 0) {
+		throw new Error(
+			`Bucket endpoint must be bucket-scoped as \`<bucket>.<host>\`, got host \`${url.hostname}\` from endpoint \`${endpoint}\`. Use \`host\` + \`bucket\` for shared endpoints.`
+		);
+	}
+
+	url.hostname = rest.join('.');
+	return {
+		endpoint: url.toString().replace(/\/$/, ''),
+		bucketLabel: firstLabel,
+	};
 }

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -96,13 +96,13 @@ export function resolveEndpoint(bucket: BucketConfig): string {
 export function bucketConfigFromEnv(
 	env: Record<string, string | undefined> = process.env
 ): BucketConfig {
-	const host = env.AWS_ENDPOINT;
+	const rawEndpoint = env.AWS_ENDPOINT;
 	const bucket = env.AWS_BUCKET;
 	const access = env.AWS_ACCESS_KEY_ID;
 	const secret = env.AWS_SECRET_ACCESS_KEY;
-	if (host && bucket && access && secret) {
+	if (rawEndpoint && bucket && access && secret) {
 		return {
-			host,
+			host: normalizeHost(rawEndpoint, bucket),
 			bucket,
 			access_key: access,
 			secret_key: secret,
@@ -115,6 +115,12 @@ export function bucketConfigFromEnv(
 			'AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY. Provision an Agentuity ' +
 			'bucket or set them manually.'
 	);
+}
+
+function normalizeHost(endpoint: string, bucket: string): string {
+	const host = endpoint.replace(/^https?:\/\//, '').replace(/\/+$/, '');
+	const bucketPrefix = `${bucket}.`;
+	return host.startsWith(bucketPrefix) ? host.slice(bucketPrefix.length) : host;
 }
 
 /** Options for `list()`. */

--- a/packages/storage/test/node.test.ts
+++ b/packages/storage/test/node.test.ts
@@ -76,6 +76,53 @@ describe('Node S3 client endpoint resolution', () => {
 		});
 	});
 
+	test('splits explicit bucket-scoped endpoint for the AWS SDK', async () => {
+		const storage = createS3Client({
+			endpoint: 'https://example-bucket.storage.example.test',
+			access_key: 'access',
+			secret_key: 'secret',
+		});
+
+		await storage.list({ prefix: 'sdk-explorer/', maxKeys: 1 });
+
+		expect(captured.clientConfigs).toHaveLength(1);
+		expect(captured.clientConfigs).toContainEqual(
+			expect.objectContaining({
+				endpoint: 'https://storage.example.test',
+				forcePathStyle: false,
+			})
+		);
+		expect(captured.commands).toContainEqual({
+			input: expect.objectContaining({
+				Bucket: 'example-bucket',
+				Prefix: 'sdk-explorer/',
+				MaxKeys: 1,
+			}),
+		});
+	});
+
+	test('rejects explicit endpoints without a bucket label', () => {
+		expect(() =>
+			createS3Client({
+				endpoint: 'https://localhost',
+				access_key: 'access',
+				secret_key: 'secret',
+			})
+		).toThrow(
+			'Bucket endpoint must be bucket-scoped as `<bucket>.<host>`, got host `localhost` from endpoint `https://localhost`.'
+		);
+	});
+
+	test('rejects malformed explicit endpoint URLs', () => {
+		expect(() =>
+			createS3Client({
+				endpoint: 'https://',
+				access_key: 'access',
+				secret_key: 'secret',
+			})
+		).toThrow('Invalid bucket endpoint URL: https://');
+	});
+
 	test('rejects configs that mix endpoint and host bucket forms', () => {
 		expect(() =>
 			createS3Client({

--- a/packages/storage/test/node.test.ts
+++ b/packages/storage/test/node.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { createS3Client } from '../src/node.ts';
+import { bucketConfigFromEnv } from '../src/types.ts';
+
+interface CapturedState {
+	readonly clientConfigs: unknown[];
+	readonly commands: S3Command[];
+}
+
+const captured: CapturedState = {
+	clientConfigs: [],
+	commands: [],
+};
+
+class S3Command {
+	readonly input: unknown;
+
+	constructor(input: unknown) {
+		this.input = input;
+	}
+}
+
+mock.module('@aws-sdk/client-s3', () => {
+	class S3Client {
+		constructor(config: unknown) {
+			captured.clientConfigs.push(config);
+		}
+
+		async send(command: S3Command): Promise<Record<string, unknown>> {
+			captured.commands.push(command);
+			return { Contents: [], IsTruncated: false };
+		}
+	}
+
+	return {
+		S3Client,
+		ListObjectsV2Command: S3Command,
+		HeadObjectCommand: S3Command,
+		GetObjectCommand: S3Command,
+		PutObjectCommand: S3Command,
+		DeleteObjectCommand: S3Command,
+	};
+});
+
+describe('Node S3 client endpoint resolution', () => {
+	beforeEach(() => {
+		captured.clientConfigs.length = 0;
+		captured.commands.length = 0;
+	});
+
+	test('uses shared endpoint plus Bucket for linked bucket env vars', async () => {
+		const storage = createS3Client(
+			bucketConfigFromEnv({
+				AWS_BUCKET: 'example-bucket',
+				AWS_ENDPOINT: 'https://example-bucket.storage.example.test',
+				AWS_ACCESS_KEY_ID: 'access',
+				AWS_SECRET_ACCESS_KEY: 'secret',
+			})
+		);
+
+		await storage.list({ prefix: 'sdk-explorer/', maxKeys: 1 });
+
+		expect(captured.clientConfigs).toHaveLength(1);
+		expect(captured.clientConfigs).toContainEqual(
+			expect.objectContaining({
+				endpoint: 'https://storage.example.test',
+				forcePathStyle: false,
+			})
+		);
+		expect(captured.commands).toContainEqual({
+			input: expect.objectContaining({
+				Bucket: 'example-bucket',
+				Prefix: 'sdk-explorer/',
+				MaxKeys: 1,
+			}),
+		});
+	});
+
+	test('rejects configs that mix endpoint and host bucket forms', () => {
+		expect(() =>
+			createS3Client({
+				endpoint: 'https://example-bucket.storage.example.test',
+				host: 'storage.example.test',
+				bucket: 'example-bucket',
+				access_key: 'access',
+				secret_key: 'secret',
+			})
+		).toThrow('BucketConfig accepts either `endpoint` or `host`+`bucket`, not both.');
+	});
+});

--- a/packages/storage/test/types.test.ts
+++ b/packages/storage/test/types.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test';
+import { bucketConfigFromEnv, resolveEndpoint } from '../src/types.ts';
+
+describe('bucketConfigFromEnv', () => {
+	test('resolves shared AWS_ENDPOINT with bucket name', () => {
+		const config = bucketConfigFromEnv({
+			AWS_BUCKET: 'example-bucket',
+			AWS_ENDPOINT: 'https://storage.example.test',
+			AWS_ACCESS_KEY_ID: 'access',
+			AWS_SECRET_ACCESS_KEY: 'secret',
+		});
+
+		expect(resolveEndpoint(config)).toBe('https://example-bucket.storage.example.test');
+	});
+
+	test('resolves bucket-scoped AWS_ENDPOINT without duplicating the bucket', () => {
+		const config = bucketConfigFromEnv({
+			AWS_BUCKET: 'example-bucket',
+			AWS_ENDPOINT: 'https://example-bucket.storage.example.test',
+			AWS_ACCESS_KEY_ID: 'access',
+			AWS_SECRET_ACCESS_KEY: 'secret',
+		});
+
+		expect(resolveEndpoint(config)).toBe('https://example-bucket.storage.example.test');
+	});
+});

--- a/packages/storage/tsconfig.test.json
+++ b/packages/storage/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"composite": false,
+		"outDir": "./dist-test",
+		"rootDir": ".",
+		"types": ["bun-types"]
+	},
+	"include": ["test/**/*", "src/**/*"],
+	"references": []
+}


### PR DESCRIPTION
## Summary

> Fixes linked object storage env values that already include the bucket prefix.

- Normalizes `bucketConfigFromEnv()` when `AWS_ENDPOINT` is already bucket-scoped.
- Sends the Node AWS SDK a shared `endpoint` plus command `Bucket`.
- Adds focused storage tests and strict test typechecking for the package.
- Ignores root `/.agentuity/`, the SDK monorepo build output path.

Closes #1536.

## Why

The v3 Docs Explorer object-storage path surfaced linked bucket env vars where the endpoint already contained the bucket label:

```text
AWS_BUCKET=example-bucket
AWS_ENDPOINT=https://example-bucket.storage.example.test
```

The old env path treated `AWS_ENDPOINT` as a shared host. That could compose the bucket label twice:

```text
https://example-bucket.example-bucket.storage.example.test
```

The Node backend had the same class of risk one layer later. Passing a bucket-scoped `endpoint` while also setting `Bucket` gives the AWS SDK enough information to construct a double-prefixed virtual-host request.

This PR keeps the public storage config forms intact, but adapts the Node SDK target to the shape the AWS SDK expects:

```ts
endpoint: 'https://storage.example.test'
Bucket: 'example-bucket'
forcePathStyle: false
```

The `.agentuity/` ignore fills a repo hygiene gap found while verifying this fix. Agentuity project scaffolds already add `.agentuity/` to `.gitignore`, and the CLI monorepo build path stages output at `<monorepoRoot>/.agentuity`. The SDK root was missing the root-level ignore rule for that generated output.

```gitignore
/.agentuity/
```

## Review notes

- `resolveEndpoint()` still runs first so invalid `BucketConfig` shapes fail before SDK-specific endpoint adaptation.
- `bucketConfigFromEnv()` strips only the matching leading `<bucket>.` prefix from `AWS_ENDPOINT`.
- Storage tests now live under `packages/storage/test/` and import from `../src/`, matching the package test convention used elsewhere in the repo.
- `packages/storage/tsconfig.test.json` follows the strict test config shape used by packages such as `aigateway`, `server`, and `schema`.

## Verification

- `bun test packages/storage/test/types.test.ts packages/storage/test/node.test.ts`
- `bunx tsc -p packages/storage/tsconfig.test.json --noEmit`
- `cd packages/storage && bun run typecheck`
- `cd packages/storage && bun run build`
- `bunx biome check .gitignore packages/storage/tsconfig.test.json packages/storage/src/types.ts packages/storage/src/node.ts packages/storage/test/types.test.ts packages/storage/test/node.test.ts`
- `bun test packages/cli/test/cmd/build/staging-cleanliness.test.ts`
- `git diff --cached --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved S3 endpoint resolution to correctly handle shared endpoint and bucket-scoped configurations

* **Refactor**
  * Enhanced bucket endpoint handling logic in storage module

* **Tests**
  * Added test coverage for S3 client endpoint resolution and bucket configuration validation

* **Chores**
  * Updated project configuration files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->