### PR TITLE
Fix docs reload flash on full refresh

### DIFF
--- a/docs/src/web/server.ts
+++ b/docs/src/web/server.ts
@@ -1,5 +1,9 @@
-import handler, { createServerEntry } from '@tanstack/react-start/server-entry';
+import { defaultRenderHandler } from '@tanstack/react-router/ssr/server';
+import { createStartHandler } from '@tanstack/react-start/server';
+import { createServerEntry } from '@tanstack/react-start/server-entry';
 import { docRedirectRules, getDemoRedirectTarget } from './lib/docs-redirects';
+
+const startHandler = createStartHandler(defaultRenderHandler);
 
 const legacyRedirects = new Map<string, string>(
 	docRedirectRules.flatMap((rule) => rule.paths.map((path) => [path, rule.target] as const))
@@ -44,7 +48,7 @@ const startEntry = createServerEntry({
 			return redirect(target);
 		}
 
-		return handler.fetch(request, opts);
+		return startHandler(request, opts);
 	},
 });
 


### PR DESCRIPTION
## Summary

> Fixes the docs reload flash by rendering the full page before sending the response.

- Switches docs page requests to `defaultRenderHandler`
- Keeps the route article in the first HTML chunk
- Leaves `/api/*` handling and legacy redirects unchanged

## Why

The previous docs SSR path streamed the shell before the route article. On full reload, that let the sidebar and header paint while the main content area went blank.

## Verification

- `cd docs && bun run typecheck`
- `cd docs && bun run build`
- Verified local `/get-started/quickstart` now includes the article in the first HTML chunk
- Verified the pre-fix response streamed the shell before the article


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

- Improved internal server infrastructure for enhanced request processing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->