### PR TITLE
fix(docs): use Start `defaultRenderHandler` for SSR

### DIFF
--- a/docs/src/web/server.ts
+++ b/docs/src/web/server.ts
@@ -1,5 +1,4 @@
-import { defaultRenderHandler } from '@tanstack/react-router/ssr/server';
-import { createStartHandler } from '@tanstack/react-start/server';
+import { createStartHandler, defaultRenderHandler } from '@tanstack/react-start/server';
 import { createServerEntry } from '@tanstack/react-start/server-entry';
 import { docRedirectRules, getDemoRedirectTarget } from './lib/docs-redirects';
 


### PR DESCRIPTION
## Summary

> Fixes the docs reload flash without breaking Agentuity Cloud warmup.

- Imports `defaultRenderHandler` from `@tanstack/react-start/server`
- Keeps the non-streaming docs SSR path added for full page reloads
- Aligns the custom server entry with TanStack Start's own handler wiring

## Why

`createStartHandler` was paired with the router-level `defaultRenderHandler`, which warmed locally but failed to start in cloud deploys. TanStack Start's non-streaming handler lives in `@tanstack/react-start/server`, and using that handler preserves the reload fix while allowing the docs app to boot in Agentuity Cloud.

## Verification

- `cd docs && bun run typecheck`
- `cd docs && bun run build`
- Verified local baseline vs treatment on `/get-started/quickstart` using separate broken and fixed servers
- Baseline first response chunk: `32664` bytes, did not contain `Scaffold a Next.js starter`
- Treatment first response chunk: `65474` bytes, did contain `Scaffold a Next.js starter`
- Verified final rendered screenshots matched between baseline and treatment steady state
- Manually deployed the fixed build successfully: `deploy_c93594b4e15526aa7bb25eb42cc18537`
