### PR TITLE
fix(cli): restore --no-public negation and let version delegate

### DIFF
--- a/packages/cli/bin/cli.js
+++ b/packages/cli/bin/cli.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 /**
  * Published CLI entry point for `@agentuity/cli`.
  *
@@ -6,26 +7,15 @@
  *   - npm uses it as the `agentuity` binary (see package.json `bin`).
  *   - The shebang lets the kernel launch Node directly when users run
  *     `agentuity` from a shell on macOS/Linux.
- *   - It hands off to the compiled CLI at `dist/src/main.js`.
+ *   - It hands off to the compiled CLI at `dist/main.js`.
  *
- * A small `--version` fast-path runs before the dynamic import so a
- * naked `agentuity --version` doesn't load 90% of the CLI's modules.
- * Anything beyond that is decided inside `src/main.ts`.
+ * The old `--version` fast-path that printed this package's version and
+ * exited is removed so version queries flow through main.ts like every
+ * other command. That lets them delegate to a project-local @agentuity/cli
+ * (v2 back-compat) instead of always reporting the global version.
  *
  * No build step rewrites this file. It ships as-is from the repo to
  * the published tarball.
  */
-
-import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const args = process.argv.slice(2);
-if (args.length === 1 && ['version', '-v', '--version', '-V'].includes(args[0])) {
-	const here = dirname(fileURLToPath(import.meta.url));
-	const pkg = JSON.parse(readFileSync(join(here, '..', 'package.json'), 'utf-8'));
-	console.log(pkg.version || 'dev');
-	process.exit(0);
-}
 
 await import('../dist/main.js');

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1218,7 +1218,16 @@ async function registerSubcommand(
 						cmd.addOption(negativeOption);
 					}
 				} else {
+					// Optional boolean (no default) — register both forms so
+					// --no-<flag> works even though the positive form is primary.
+					const baseDesc = desc.replace(/\s*\(use\s+--no-\S+\s+to\s+skip\)/i, '').trim();
+					const negatedDesc = baseDesc.toLowerCase().startsWith('run ')
+						? `Skip ${baseDesc.slice(4)}`
+						: `Do not ${baseDesc.charAt(0).toLowerCase()}${baseDesc.slice(1)}`;
 					cmd.option(flagSpec, desc);
+					const negativeOption = cmd.createOption(`--no-${flag}`, negatedDesc);
+					negativeOption.hideHelp();
+					cmd.addOption(negativeOption);
 				}
 			} else if (opt.type === 'number') {
 				const numDefault = opt.hasDefault


### PR DESCRIPTION
## Summary

Two related v2 back-compat fixes in the v3 CLI, found while debugging why `agentuity dev --no-public` failed in a v2 project running under the now-default v3 global CLI.

### 1. `--no-public` (and all optional boolean `--no-*` flags) restored

The CLI framework only registered `--no-<flag>` negations for boolean options that had a **default value**. Optional booleans (`z.boolean().optional()`) like `dev`'s `--public` only got the positive form, so `--no-public` errored with `unknown option '--no-public'` — even though it appears in the help text and examples.

The no-default branch now also registers a hidden `--no-<flag>`, mirroring the existing behavior for booleans with defaults. This unbreaks v2 dev scripts (e.g. `"dev:agentuity": "agentuity dev --no-public --no-interactive"`) and also fixes `--no-*` for every other optional boolean across the CLI (`--no-confirm`, `--no-stream`, `--no-sync`, etc.).

### 2. `version` now delegates like every other command

`bin/cli.js` had a `--version` fast-path that printed the **global** package version and exited before delegation could run. So in a v2 project, `agentuity version` / `--version` always showed `3.0.6` instead of the local CLI that actually handles the project.

Removing the fast-path lets version queries flow through `main.ts` like every other command, so the global CLI delegates to the project-local `@agentuity/cli` and reports the real version (e.g. `2.0.26`). Outside a v2 project, it still shows the global version. No special-casing — version is treated exactly like the rest of the commands.

## Testing

Verified against a real global install (copied the build into `~/.bun/install/global/...`) delegating to local v2 CLIs:

- `agentuity version` / `--version` in a v2 project (genesis-mono/apps/web) → `2.0.26` (delegated); in a non-v2 dir → `3.0.6` (global).
- `dev --help` / `--help` from a v2 project show the **v2** option/command set, proving delegation routes to the local CLI.
- `agentuity dev --no-public` is accepted (no more `unknown option`).
- `bun run typecheck`, `bun run lint`, and CLI exit-code tests pass.

## Notes

An earlier revision tried to make `version` report both global and local versions (`3.0.6 (delegating to local 2.0.26)`) by skipping delegation for version queries. That required brittle argv-scanning to catch `--version` after global options, so it was dropped in favor of simply letting version delegate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `--no-*` syntax for optional boolean CLI options.

* **Refactor**
  * Simplified CLI entrypoint delegation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->