### PR TITLE
fix(docs): prevent theme hydration mismatch flash on full refresh

### DIFF
--- a/docs/src/web/components/ThemeContext.test.tsx
+++ b/docs/src/web/components/ThemeContext.test.tsx
@@ -1,0 +1,65 @@
+import { expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ThemeProvider, useTheme } from './ThemeContext';
+
+// Surfaces the theme context values as attributes so the server render can be
+// compared byte-for-byte against the client's first (hydration) render.
+function ThemeProbe() {
+	const { theme, resolvedTheme } = useTheme();
+	return <span data-theme={theme} data-resolved-theme={resolvedTheme} />;
+}
+
+// Emulates a browser whose visitor has explicitly chosen a non-default theme.
+// The real SSR server has no window/localStorage/matchMedia, so getStoredTheme()
+// returns 'system' and getSystemTheme() returns 'dark' there.
+function withStoredPreference(stored: string, prefersDark: boolean, run: () => void) {
+	const g = globalThis as Record<string, unknown>;
+	g.window = globalThis;
+	g.localStorage = { getItem: () => stored, setItem: () => {}, removeItem: () => {} };
+	g.matchMedia = () => ({
+		matches: prefersDark,
+		addEventListener: () => {},
+		removeEventListener: () => {},
+	});
+	try {
+		run();
+	} finally {
+		delete g.window;
+		delete g.localStorage;
+		delete g.matchMedia;
+	}
+}
+
+function renderProbe(): string {
+	return renderToStaticMarkup(
+		<ThemeProvider>
+			<ThemeProbe />
+		</ThemeProvider>
+	);
+}
+
+// Regression: a stored Light/Dark preference must not make the first client
+// render diverge from the server render. If it does, React throws away the
+// server-rendered DOM and regenerates the tree on the client, which is the
+// full-page flash on hard refresh (React #418).
+test('first client render matches server render when Dark is stored (no hydration flash)', () => {
+	const serverHtml = renderProbe();
+
+	let clientHtml = '';
+	withStoredPreference('dark', false, () => {
+		clientHtml = renderProbe();
+	});
+
+	expect(clientHtml).toBe(serverHtml);
+});
+
+test('first client render matches server render when Light is stored (no hydration flash)', () => {
+	const serverHtml = renderProbe();
+
+	let clientHtml = '';
+	withStoredPreference('light', true, () => {
+		clientHtml = renderProbe();
+	});
+
+	expect(clientHtml).toBe(serverHtml);
+});

--- a/docs/src/web/components/ThemeContext.tsx
+++ b/docs/src/web/components/ThemeContext.tsx
@@ -37,19 +37,27 @@ function applyTheme(resolved: 'light' | 'dark') {
 }
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-	const [theme, setThemeState] = useState<Theme>(getStoredTheme);
-	const [resolvedTheme, setResolvedTheme] = useState<'light' | 'dark'>(() => {
-		const stored = getStoredTheme();
-		return stored === 'system' ? getSystemTheme() : stored;
-	});
+	// Initialize to the values the SSR server produces. The server has no
+	// window, so getStoredTheme() returns 'system' and getSystemTheme() returns
+	// 'dark'. Reading the real preference during the first client render would
+	// diverge from the server HTML; React rejects the mismatch (#418) and
+	// recovers by discarding the server-rendered DOM for that tree and
+	// re-rendering it on the client — the flash on hard refresh. The persisted
+	// preference is adopted after mount instead (React's two-pass pattern).
+	const [theme, setThemeState] = useState<Theme>('system');
+	const [resolvedTheme, setResolvedTheme] = useState<'light' | 'dark'>('dark');
 
-	// Apply theme on mount and when it changes
+	// After hydration, adopt the persisted preference and resolve the system
+	// theme. The inline bootstrap script in __root.tsx applies the Tailwind
+	// `dark` class to <html> before paint, so page colors don't flash; only
+	// resolvedTheme-driven UI (e.g. theme-image) reconciles after this runs.
 	useEffect(() => {
-		const resolved = theme === 'system' ? getSystemTheme() : theme;
+		const stored = getStoredTheme();
+		const resolved = stored === 'system' ? getSystemTheme() : stored;
+		setThemeState(stored);
 		setResolvedTheme(resolved);
 		applyTheme(resolved);
-		localStorage.setItem(STORAGE_KEY, theme);
-	}, [theme]);
+	}, []);
 
 	// Listen for system theme changes
 	useEffect(() => {
@@ -65,18 +73,20 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 		return () => mediaQuery.removeEventListener('change', handleChange);
 	}, [theme]);
 
+	// Persist + apply on explicit user action. Persisting lives here, not in an
+	// effect, so the mount-time adoption above never clobbers the stored value.
 	const setTheme = useCallback((newTheme: Theme) => {
+		const resolved = newTheme === 'system' ? getSystemTheme() : newTheme;
+		localStorage.setItem(STORAGE_KEY, newTheme);
 		setThemeState(newTheme);
+		setResolvedTheme(resolved);
+		applyTheme(resolved);
 	}, []);
 
 	// Cycle: light → dark → system → light
 	const cycleTheme = useCallback(() => {
-		setThemeState((current) => {
-			if (current === 'light') return 'dark';
-			if (current === 'dark') return 'system';
-			return 'light';
-		});
-	}, []);
+		setTheme(theme === 'light' ? 'dark' : theme === 'dark' ? 'system' : 'light');
+	}, [theme, setTheme]);
 
 	return (
 		<ThemeContext.Provider value={{ theme, resolvedTheme, setTheme, cycleTheme }}>


### PR DESCRIPTION
## Summary

> Stops the docs full-refresh flash for visitors with a saved Light/Dark theme.

- Initializes `theme`/`resolvedTheme` to the values SSR produces (`system`/`dark`)
- Adopts the stored preference in a post-mount effect instead of during render
- Persists in `setTheme` so the mount-time adoption never clobbers storage
- Adds a unit test asserting the first client render equals the server render

## Why

`ThemeContext` read `localStorage`/`matchMedia` during the first client render. SSR has no `window`, so it always renders `theme='system'` / `resolvedTheme='dark'`. A visitor with a stored `dark`/`light` preference produced a different first render (`ModeToggle`: `<Laptop/>` vs `<Sun/><Moon/>`), so React rejected the hydration mismatch (#418) and recovered by discarding the server-rendered DOM for that tree and re-rendering on the client — the flash.

Follow-up to #1540 / #1541: those switched SSR from streaming to non-streaming `renderToString`, which fixed SSR *content* but not this client-side hydration mismatch, so the flash persisted. This PR fixes the mismatch at its source in the shared theme provider.

## Verification

Local production build (`bun run build` + `bun dist/server.js`), real browser, fresh profile per run; metric = React #418 count on load:

| Theme | Before | After |
|-------|--------|-------|
| `system` | 0 | 0 |
| `dark` stored | 1 | 0 |
| `light` stored | 1 | 0 |

- 0 across `/`, `/services/ai-gateway`, `/build/agents`, `/services/storage/object`
- Theme toggle still switches and persists (`light` removes the `dark` class; reload clean)
- `bun test docs/src/web/components/ThemeContext.test.tsx` — red before, green after
- `bunx tsc --noEmit`, `bunx biome check`, `bun run build` pass

## Scope

Fixes the hydration teardown flash. A ~1-frame post-hydration correction can remain for `resolvedTheme`-driven UI (e.g. `theme-image`) on stored Light; a cookie-backed theme snapshot is the follow-up if zero post-hydration theme correction is required. The `server.ts` non-streaming change from #1540 / #1541 is already on `main` and is left unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved theme initialization consistency to prevent flash of unstyled content when refreshing pages with stored theme preferences.

* **Tests**
  * Added regression tests to ensure server and client theme rendering remain synchronized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->