### PR TITLE
fix(cli): upload TanStack dist client assets

### DIFF
--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -24,6 +24,7 @@ env:
    CI: true
    GITHUB_TOKEN: ''
    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+   NODE_VERSION: '24'
 
 jobs:
    detect-install-changes:
@@ -87,6 +88,12 @@ jobs:
            with:
               persist-credentials: false
 
+         - name: Setup Node.js
+           if: ${{ needs.detect-install-changes.outputs.should-run == 'true' }}
+           uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+           with:
+              node-version: ${{ env.NODE_VERSION }}
+
          - name: Setup Bun
            if: ${{ needs.detect-install-changes.outputs.should-run == 'true' }}
            uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
@@ -140,6 +147,12 @@ jobs:
            with:
               persist-credentials: false
 
+         - name: Setup Node.js
+           if: ${{ needs.detect-install-changes.outputs.should-run == 'true' }}
+           uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+           with:
+              node-version: ${{ env.NODE_VERSION }}
+
          - name: Setup Bun
            if: ${{ needs.detect-install-changes.outputs.should-run == 'true' }}
            uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
@@ -182,6 +195,11 @@ jobs:
            with:
               persist-credentials: false
 
+         - name: Setup Node.js
+           uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+           with:
+              node-version: ${{ env.NODE_VERSION }}
+
          - name: Test installer across Linux distros
            shell: bash
            run: |
@@ -194,6 +212,36 @@ jobs:
                 echo "Running setup commands..."
                 eval "$SETUP" > /dev/null 2>&1
               fi
+
+              install_node() {
+                node_major="${NODE_VERSION:-24}"
+                case "$(uname -m)" in
+                  x86_64) node_arch="x64" ;;
+                  aarch64 | arm64) node_arch="arm64" ;;
+                  *) echo "Unsupported Node architecture: $(uname -m)" && exit 1 ;;
+                esac
+
+                archive=$(curl -fsSL "https://nodejs.org/dist/latest-v${node_major}.x/SHASUMS256.txt" | awk -v arch="$node_arch" '$2 ~ "^node-v[0-9]+\\.[0-9]+\\.[0-9]+-linux-" arch "\\.tar\\.xz$" { print $2; exit }')
+                if [ -z "$archive" ]; then
+                  echo "Unable to resolve Node ${node_major} archive for ${node_arch}"
+                  exit 1
+                fi
+
+                curl -fsSLo "/tmp/${archive}" "https://nodejs.org/dist/latest-v${node_major}.x/${archive}"
+                mkdir -p /opt/node
+                tar -xJf "/tmp/${archive}" -C /opt/node --strip-components=1
+                export PATH="/opt/node/bin:$PATH"
+
+                installed_major=$(node -p 'Number(process.versions.node.split(".")[0])')
+                if [ "$installed_major" -lt "$node_major" ]; then
+                  echo "Expected Node ${node_major}+ but found $(node --version)"
+                  exit 1
+                fi
+
+                echo "Node version: $(node --version)"
+              }
+
+              install_node
 
               echo "Installing Bun..."
               curl -fsSL https://bun.sh/install | bash -s -- bun-v1.3.11 > /dev/null 2>&1
@@ -232,6 +280,7 @@ jobs:
                 echo "Testing ${name} (${image})..."
                 docker run --rm \
                   -e CI=true \
+                  -e NODE_VERSION="$NODE_VERSION" \
                   -e SETUP="$setup" \
                   -v "$PWD:/app" \
                   -w /app \
@@ -241,13 +290,13 @@ jobs:
                 echo "::endgroup::"
               }
 
-              run_distro 'Debian 12 (Bookworm)' 'debian:12@sha256:8c181802d706019b2ee6237441b3fb8691b92b5705daf7c4294e7405576c4a0d' 'apt-get update -qq && apt-get install -y -qq curl unzip'
-              run_distro 'Debian 11 (Bullseye)' 'debian:11@sha256:cd3d9e8ec611d6fb11058fbcc4dbd9c27843f09b21623c4c81fb7a1bafc335ca' 'apt-get update -qq && apt-get install -y -qq curl unzip'
-              run_distro 'Ubuntu 24.04' 'ubuntu:24.04@sha256:cdb5fd928fced577cfecf12c8966e830fcdf42ee481fb0b91904eeddc2fe5eff' 'apt-get update -qq && apt-get install -y -qq curl unzip'
-              run_distro 'Ubuntu 22.04' 'ubuntu:22.04@sha256:14be402d3f1eeeb5e7da73d3260322c68e7b51c88388f53e88eb21d6450bd520' 'apt-get update -qq && apt-get install -y -qq curl unzip'
-              run_distro 'Ubuntu 20.04' 'ubuntu:20.04@sha256:c664f8f86ed5a386b0a340d981b8f81714e21a8b9c73f658c4bea56aa179d54a' 'apt-get update -qq && apt-get install -y -qq curl unzip'
-              run_distro 'Fedora Latest' 'fedora:latest@sha256:f717d3f59ea0dc45d3c024c9477e786bab7d418d26636920d17b48016f1e69ca' 'dnf install -y -q curl unzip'
-              run_distro 'Amazon Linux 2023' 'amazonlinux:2023@sha256:41e9b88745672d658868717255dcccbe531d82b88d6dd0ce5de04530b38b35fa' 'yum install -y -q gzip unzip'
+              run_distro 'Debian 12 (Bookworm)' 'debian:12@sha256:8c181802d706019b2ee6237441b3fb8691b92b5705daf7c4294e7405576c4a0d' 'apt-get update -qq && apt-get install -y -qq curl unzip xz-utils'
+              run_distro 'Debian 11 (Bullseye)' 'debian:11@sha256:cd3d9e8ec611d6fb11058fbcc4dbd9c27843f09b21623c4c81fb7a1bafc335ca' 'apt-get update -qq && apt-get install -y -qq curl unzip xz-utils'
+              run_distro 'Ubuntu 24.04' 'ubuntu:24.04@sha256:cdb5fd928fced577cfecf12c8966e830fcdf42ee481fb0b91904eeddc2fe5eff' 'apt-get update -qq && apt-get install -y -qq curl unzip xz-utils'
+              run_distro 'Ubuntu 22.04' 'ubuntu:22.04@sha256:14be402d3f1eeeb5e7da73d3260322c68e7b51c88388f53e88eb21d6450bd520' 'apt-get update -qq && apt-get install -y -qq curl unzip xz-utils'
+              run_distro 'Ubuntu 20.04' 'ubuntu:20.04@sha256:c664f8f86ed5a386b0a340d981b8f81714e21a8b9c73f658c4bea56aa179d54a' 'apt-get update -qq && apt-get install -y -qq curl unzip xz-utils'
+              run_distro 'Fedora Latest' 'fedora:latest@sha256:f717d3f59ea0dc45d3c024c9477e786bab7d418d26636920d17b48016f1e69ca' 'dnf install -y -q curl unzip xz'
+              run_distro 'Amazon Linux 2023' 'amazonlinux:2023@sha256:41e9b88745672d658868717255dcccbe531d82b88d6dd0ce5de04530b38b35fa' 'yum install -y -q curl gzip unzip xz'
 
    test-bun-checks:
       name: Bun version checks
@@ -260,6 +309,11 @@ jobs:
            uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
            with:
               persist-credentials: false
+
+         - name: Setup Node.js
+           uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+           with:
+              node-version: ${{ env.NODE_VERSION }}
 
          - name: Run Bun version check tests
            run: |
@@ -278,6 +332,11 @@ jobs:
            with:
               persist-credentials: false
 
+         - name: Setup Node.js
+           uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+           with:
+              node-version: ${{ env.NODE_VERSION }}
+
          - name: Run installer scenarios
            shell: bash
            run: |
@@ -290,9 +349,26 @@ jobs:
                 local script="$2"
 
                 echo "::group::${name}"
-                docker run --rm -e CI=true -v "$PWD:/app" -w /app ubuntu:latest@sha256:d31acef2a964b6df1f2b7e20a1525c4f2378024e087a4f8a8a9a4247e6a79573 sh -c "
+                docker run --rm -e CI=true -e NODE_VERSION="$NODE_VERSION" -v "$PWD:/app" -w /app ubuntu:latest@sha256:d31acef2a964b6df1f2b7e20a1525c4f2378024e087a4f8a8a9a4247e6a79573 sh -c "
                   set -e
-                  apt-get update -qq && apt-get install -y -qq curl unzip > /dev/null 2>&1
+                  apt-get update -qq && apt-get install -y -qq curl unzip xz-utils > /dev/null 2>&1
+                  node_major=\"\${NODE_VERSION:-24}\"
+                  case \"\$(uname -m)\" in
+                    x86_64) node_arch=\"x64\" ;;
+                    aarch64 | arm64) node_arch=\"arm64\" ;;
+                    *) echo \"Unsupported Node architecture: \$(uname -m)\" && exit 1 ;;
+                  esac
+                  archive=\$(curl -fsSL \"https://nodejs.org/dist/latest-v\${node_major}.x/SHASUMS256.txt\" | awk -v arch=\"\$node_arch\" '\$2 ~ \"^node-v[0-9]+\\\\.[0-9]+\\\\.[0-9]+-linux-\" arch \"\\\\.tar\\\\.xz$\" { print \$2; exit }')
+                  curl -fsSLo \"/tmp/\${archive}\" \"https://nodejs.org/dist/latest-v\${node_major}.x/\${archive}\"
+                  mkdir -p /opt/node
+                  tar -xJf \"/tmp/\${archive}\" -C /opt/node --strip-components=1
+                  export PATH=\"/opt/node/bin:\$PATH\"
+                  installed_major=\$(node -p 'Number(process.versions.node.split(\".\")[0])')
+                  if [ \"\$installed_major\" -lt \"\$node_major\" ]; then
+                    echo \"Expected Node \${node_major}+ but found \$(node --version)\"
+                    exit 1
+                  fi
+                  echo \"Node version: \$(node --version)\"
                   curl -fsSL https://bun.sh/install | bash -s -- bun-v1.3.11 > /dev/null 2>&1
                   export PATH=\"\$HOME/.bun/bin:\$PATH\"
                   ${script}

--- a/packages/cli/src/cmd/build/adapters/generic.ts
+++ b/packages/cli/src/cmd/build/adapters/generic.ts
@@ -422,6 +422,7 @@ async function finishMonorepoBuild(
 		startCommand,
 		serverEntry,
 		staticDir: resolvedStaticDir,
+		staticAssetPublicPath: framework.staticAssetPublicPath,
 		port: framework.port,
 		duration: Date.now() - started,
 		logs,
@@ -623,6 +624,7 @@ export const genericAdapter: BuildAdapter = {
 			serverEntry,
 			staticDir:
 				resolvedStaticDir && existsSync(resolvedStaticDir) ? resolvedStaticDir : undefined,
+			staticAssetPublicPath: framework.staticAssetPublicPath,
 			port: framework.port,
 			duration: Date.now() - started,
 			logs,

--- a/packages/cli/src/cmd/build/adapters/nextjs.ts
+++ b/packages/cli/src/cmd/build/adapters/nextjs.ts
@@ -199,6 +199,7 @@ export const nextjsAdapter: BuildAdapter = {
 				startCommand: `node ${serverEntryRel}`,
 				serverEntry: serverEntryRel,
 				staticDir: packagedStaticDir,
+				staticAssetPublicPath: framework.staticAssetPublicPath,
 				port: framework.port ?? 3000,
 				duration: Date.now() - started,
 				logs,
@@ -223,6 +224,7 @@ export const nextjsAdapter: BuildAdapter = {
 			staticDir: existsSync(join(outputDir, '.next', 'static'))
 				? join(outputDir, '.next', 'static')
 				: undefined,
+			staticAssetPublicPath: framework.staticAssetPublicPath,
 			port: framework.port ?? 3000,
 			duration: Date.now() - started,
 			logs,

--- a/packages/cli/src/cmd/build/adapters/types.ts
+++ b/packages/cli/src/cmd/build/adapters/types.ts
@@ -26,6 +26,9 @@ export interface BuildResult {
 	/** Static/CDN assets directory (absolute path), for CDN upload enumeration */
 	staticDir?: string;
 
+	/** Public URL path prefix for files inside staticDir */
+	staticAssetPublicPath?: string;
+
 	/** Port the app listens on */
 	port?: number;
 

--- a/packages/cli/src/cmd/build/detect/frameworks.ts
+++ b/packages/cli/src/cmd/build/detect/frameworks.ts
@@ -97,6 +97,11 @@ export interface FrameworkDefinition {
 	 * - `undefined` (omitted) means no known static asset directory.
 	 */
 	staticDir?: string | null;
+	/**
+	 * Public URL path prefix for files inside staticDir.
+	 * Use an empty string when staticDir is the public web root.
+	 */
+	staticAssetPublicPath?: string;
 	/** Environment variable prefix for browser-inlined values */
 	envPrefix?: string;
 	/**
@@ -127,6 +132,7 @@ export const frameworkDefinitions: FrameworkDefinition[] = [
 		buildCommand: 'next build',
 		outputDirectory: null, // Dynamic — reads from next.config
 		staticDir: '.next/static', // Relative to project root (adapter handles standalone copy)
+		staticAssetPublicPath: '_next/static',
 		envPrefix: 'NEXT_PUBLIC_',
 		detectors: {
 			every: [{ matchPackage: 'next' }],
@@ -144,6 +150,7 @@ export const frameworkDefinitions: FrameworkDefinition[] = [
 		// so we preserve the .output/ tree intact.
 		outputDirectory: '.output',
 		staticDir: '.output/public',
+		staticAssetPublicPath: '',
 		envPrefix: 'NUXT_ENV_',
 		detectors: {
 			some: [
@@ -160,6 +167,7 @@ export const frameworkDefinitions: FrameworkDefinition[] = [
 		buildCommand: 'remix build',
 		outputDirectory: 'public',
 		staticDir: 'public/build', // Built browser bundles
+		staticAssetPublicPath: 'build',
 		detectors: {
 			some: [
 				{ matchPackage: '@remix-run/dev' },
@@ -174,6 +182,7 @@ export const frameworkDefinitions: FrameworkDefinition[] = [
 		buildCommand: 'react-router build',
 		outputDirectory: 'build',
 		staticDir: 'build/client', // Client-side assets
+		staticAssetPublicPath: '',
 		detectors: {
 			some: [
 				{ path: 'react-router.config.js' },
@@ -203,6 +212,7 @@ export const frameworkDefinitions: FrameworkDefinition[] = [
 		// we run.
 		outputDirectory: 'build',
 		staticDir: 'build/client',
+		staticAssetPublicPath: '',
 		detectors: {
 			every: [
 				{
@@ -224,6 +234,7 @@ export const frameworkDefinitions: FrameworkDefinition[] = [
 		runtimeDependencies: ['@astrojs/node'],
 		outputDirectory: 'dist',
 		staticDir: null, // Entire dist/ is static (SSG default); dist/client/ for SSR
+		staticAssetPublicPath: '',
 		envPrefix: 'PUBLIC_',
 		detectors: {
 			every: [{ matchPackage: 'astro' }],
@@ -235,6 +246,7 @@ export const frameworkDefinitions: FrameworkDefinition[] = [
 		buildCommand: 'vinxi build',
 		outputDirectory: '.output',
 		staticDir: '.output/public', // Nitro-based static assets
+		staticAssetPublicPath: '',
 		envPrefix: 'VITE_',
 		detectors: {
 			every: [{ matchPackage: 'solid-js' }, { matchPackage: '@solidjs/start' }],
@@ -265,6 +277,7 @@ export const frameworkDefinitions: FrameworkDefinition[] = [
 		// for an SSR build and 404s every route.
 		outputDirectory: '.output',
 		staticDir: '.output/public',
+		staticAssetPublicPath: '',
 		detectors: {
 			every: [{ matchPackage: '@tanstack/react-start' }],
 		},
@@ -275,6 +288,7 @@ export const frameworkDefinitions: FrameworkDefinition[] = [
 		buildCommand: 'yarn rw build',
 		outputDirectory: null, // Dynamic — depends on target
 		staticDir: 'web/dist', // Redwood web-side build output
+		staticAssetPublicPath: '',
 		envPrefix: 'REDWOOD_ENV_',
 		detectors: {
 			every: [{ matchPackage: '@redwoodjs/core' }],
@@ -289,6 +303,7 @@ export const frameworkDefinitions: FrameworkDefinition[] = [
 		buildCommand: 'gatsby build',
 		outputDirectory: 'public',
 		staticDir: null, // Entire public/ is static output
+		staticAssetPublicPath: '',
 		envPrefix: 'GATSBY_',
 		detectors: {
 			every: [{ matchPackage: 'gatsby' }],
@@ -300,6 +315,7 @@ export const frameworkDefinitions: FrameworkDefinition[] = [
 		buildCommand: 'npx @11ty/eleventy',
 		outputDirectory: '_site',
 		staticDir: null, // Entire _site/ is static output
+		staticAssetPublicPath: '',
 		detectors: {
 			every: [{ matchPackage: '@11ty/eleventy' }],
 		},
@@ -310,6 +326,7 @@ export const frameworkDefinitions: FrameworkDefinition[] = [
 		buildCommand: 'vitepress build docs',
 		outputDirectory: 'docs/.vitepress/dist',
 		staticDir: null, // Entire output is static
+		staticAssetPublicPath: '',
 		detectors: {
 			every: [{ matchPackage: 'vitepress' }],
 		},
@@ -320,6 +337,7 @@ export const frameworkDefinitions: FrameworkDefinition[] = [
 		buildCommand: 'vuepress build src',
 		outputDirectory: 'src/.vuepress/dist',
 		staticDir: null, // Entire output is static
+		staticAssetPublicPath: '',
 		detectors: {
 			every: [{ matchPackage: 'vuepress' }],
 		},
@@ -330,6 +348,7 @@ export const frameworkDefinitions: FrameworkDefinition[] = [
 		buildCommand: 'docusaurus build',
 		outputDirectory: 'build',
 		staticDir: null, // Entire build/ is static output
+		staticAssetPublicPath: '',
 		detectors: {
 			some: [{ matchPackage: '@docusaurus/core' }],
 		},
@@ -340,6 +359,7 @@ export const frameworkDefinitions: FrameworkDefinition[] = [
 		buildCommand: 'hexo generate',
 		outputDirectory: 'public',
 		staticDir: null, // Entire public/ is static output
+		staticAssetPublicPath: '',
 		detectors: {
 			every: [{ matchPackage: 'hexo' }],
 		},
@@ -390,6 +410,7 @@ export const frameworkDefinitions: FrameworkDefinition[] = [
 			}
 		},
 		staticDir: null, // Entire output dir is static (browser/ for v17+, project root pre-17)
+		staticAssetPublicPath: '',
 		// `ng serve` is the dev server — never a production start.
 		// Angular ships static assets; the generic adapter injects a
 		// static file server when `startCommand` is absent.
@@ -435,6 +456,7 @@ export const frameworkDefinitions: FrameworkDefinition[] = [
 		buildCommand: 'vue-cli-service build',
 		outputDirectory: 'dist',
 		staticDir: null, // Entire dist/ is static output
+		staticAssetPublicPath: '',
 		envPrefix: 'VUE_APP_',
 		detectors: {
 			every: [{ matchPackage: '@vue/cli-service' }],
@@ -446,6 +468,7 @@ export const frameworkDefinitions: FrameworkDefinition[] = [
 		buildCommand: 'react-scripts build',
 		outputDirectory: 'build',
 		staticDir: null, // Entire build/ is static output
+		staticAssetPublicPath: '',
 		envPrefix: 'REACT_APP_',
 		detectors: {
 			some: [{ matchPackage: 'react-scripts' }, { matchPackage: 'react-dev-utils' }],
@@ -457,6 +480,7 @@ export const frameworkDefinitions: FrameworkDefinition[] = [
 		buildCommand: 'preact build',
 		outputDirectory: 'build',
 		staticDir: null, // Entire build/ is static output
+		staticAssetPublicPath: '',
 		detectors: {
 			every: [{ matchPackage: 'preact-cli' }],
 		},
@@ -470,6 +494,7 @@ export const frameworkDefinitions: FrameworkDefinition[] = [
 		buildCommand: 'nitro build',
 		outputDirectory: 'dist',
 		staticDir: '.output/public', // Nitro static assets
+		staticAssetPublicPath: '',
 		detectors: {
 			some: [{ matchPackage: 'nitropack' }, { matchPackage: 'nitro' }],
 		},
@@ -483,6 +508,7 @@ export const frameworkDefinitions: FrameworkDefinition[] = [
 		buildCommand: 'vite build',
 		outputDirectory: 'dist',
 		staticDir: null, // Entire dist/ is static output
+		staticAssetPublicPath: '',
 		envPrefix: 'VITE_',
 		detectors: {
 			every: [{ matchPackage: 'vite' }],
@@ -494,6 +520,7 @@ export const frameworkDefinitions: FrameworkDefinition[] = [
 		buildCommand: 'parcel build',
 		outputDirectory: 'dist',
 		staticDir: null, // Entire dist/ is static output
+		staticAssetPublicPath: '',
 		detectors: {
 			every: [{ matchPackage: 'parcel' }],
 		},

--- a/packages/cli/src/cmd/build/detect/index.ts
+++ b/packages/cli/src/cmd/build/detect/index.ts
@@ -159,6 +159,7 @@ async function frameworkDefToDetected(
 		definition.staticDir === null
 			? resolvedOutputDir // null means entire output IS the static dir
 			: (definition.staticDir ?? undefined);
+	let resolvedStaticAssetPublicPath = definition.staticAssetPublicPath;
 
 	// Resolve the start command.
 	//
@@ -194,6 +195,7 @@ async function frameworkDefToDetected(
 	) {
 		resolvedOutputDir = 'dist';
 		resolvedStaticDir = 'dist/client';
+		resolvedStaticAssetPublicPath = '';
 	}
 
 	// Pick the runtime based on, in order:
@@ -246,6 +248,7 @@ async function frameworkDefToDetected(
 		buildCommand: resolvedBuildCommand,
 		buildOutput: resolvedOutputDir,
 		staticDir: resolvedStaticDir,
+		staticAssetPublicPath: resolvedStaticAssetPublicPath,
 		typegenCommand: definition.typegenCommand,
 		runtimeDependencies: definition.runtimeDependencies,
 		buildPreinstallDevDependencies: definition.buildPreinstallDevDependencies,

--- a/packages/cli/src/cmd/build/detect/index.ts
+++ b/packages/cli/src/cmd/build/detect/index.ts
@@ -149,13 +149,13 @@ async function frameworkDefToDetected(
 	const dynamicOutputDir = definition.resolveOutputDirectory
 		? await definition.resolveOutputDirectory(projectDir)
 		: null;
-	const resolvedOutputDir = dynamicOutputDir ?? definition.outputDirectory ?? '.';
+	let resolvedOutputDir = dynamicOutputDir ?? definition.outputDirectory ?? '.';
 
 	// Resolve static asset directory (relative to project root):
 	// - explicit string: path relative to project root (e.g., '.next/static', '.output/public')
 	// - null: the entire output directory is static (SSGs, SPAs) — use outputDirectory
 	// - undefined: no static assets known for this framework
-	const resolvedStaticDir =
+	let resolvedStaticDir =
 		definition.staticDir === null
 			? resolvedOutputDir // null means entire output IS the static dir
 			: (definition.staticDir ?? undefined);
@@ -186,6 +186,15 @@ async function frameworkDefToDetected(
 			: userStartIsProduction
 				? userStart
 				: frameworkDefault;
+
+	if (
+		definition.slug === 'tanstack-start' &&
+		resolvedStartCommand &&
+		/\bdist\/server\.js\b/.test(resolvedStartCommand)
+	) {
+		resolvedOutputDir = 'dist';
+		resolvedStaticDir = 'dist/client';
+	}
 
 	// Pick the runtime based on, in order:
 	//  1. The actual `start` script: `bun ...` / `bun run ...` =

--- a/packages/cli/src/cmd/build/detect/types.ts
+++ b/packages/cli/src/cmd/build/detect/types.ts
@@ -80,6 +80,12 @@ export interface DetectedFramework {
 	 */
 	staticDir?: string;
 
+	/**
+	 * Public URL path prefix for files inside staticDir.
+	 * Undefined preserves the historical behavior of using paths relative to outputDir.
+	 */
+	staticAssetPublicPath?: string;
+
 	/** Environment variables needed at build time */
 	buildEnv?: Record<string, string>;
 

--- a/packages/cli/src/cmd/cloud/deploy/upload.ts
+++ b/packages/cli/src/cmd/cloud/deploy/upload.ts
@@ -289,7 +289,8 @@ export function buildEncryptUploadStep(params: UploadStepParams): Step {
 				// closure; TS doesn't propagate narrowings of `build` /
 				// `instructions` across async callbacks, and we've already
 				// null-checked both above.
-				const assets = build.assets;
+				const assets: Array<(typeof build.assets)[number] & { sourcePath?: string }> =
+					build.assets;
 				const assetUrls = instructions.assets;
 				// v3 buildpack pipeline emits assets into `buildOutputDir`;
 				// fall back to `.agentuity/` for the legacy path.
@@ -298,9 +299,9 @@ export function buildEncryptUploadStep(params: UploadStepParams): Step {
 				try {
 					const uploadOne = async (asset: (typeof assets)[number]): Promise<void> => {
 						const assetUrl = assetUrls[asset.filename]!;
-						// Asset filename already includes the subdirectory
-						// (e.g., "client/assets/main-abc123.js").
-						const filePath = join(assetBaseDir, asset.filename);
+						// filename is the CDN key; sourcePath is the packaged
+						// file path when framework public paths differ.
+						const filePath = join(assetBaseDir, asset.sourcePath ?? asset.filename);
 
 						const headers: Record<string, string> = {
 							'Content-Type': asset.contentType,

--- a/packages/cli/src/deploy-metadata.ts
+++ b/packages/cli/src/deploy-metadata.ts
@@ -27,6 +27,7 @@ import { getVersion } from './version.ts';
  */
 interface AssetInfo {
 	filename: string;
+	sourcePath?: string;
 	kind: string;
 	contentType: string;
 	size: number;
@@ -63,7 +64,22 @@ const BUILD_INFRA_FILES = new Set([
 /**
  * Recursively enumerate static assets from a directory.
  */
-function enumerateAssets(dir: string, baseDir: string): AssetInfo[] {
+function toAssetPath(path: string): string {
+	return path.split('\\').join('/');
+}
+
+function joinAssetPath(prefix: string, path: string): string {
+	const cleanPrefix = prefix.replace(/^\/+|\/+$/g, '');
+	const cleanPath = path.replace(/^\/+/g, '');
+	return cleanPrefix ? `${cleanPrefix}/${cleanPath}` : cleanPath;
+}
+
+function enumerateAssets(
+	dir: string,
+	baseDir: string,
+	publicPathPrefix?: string,
+	staticRoot = dir
+): AssetInfo[] {
 	const assets: AssetInfo[] = [];
 
 	if (!existsSync(dir)) return assets;
@@ -74,7 +90,7 @@ function enumerateAssets(dir: string, baseDir: string): AssetInfo[] {
 		if (entry.isDirectory()) {
 			// Skip dot-directories and node_modules
 			if (entry.name.startsWith('.') || entry.name === 'node_modules') continue;
-			assets.push(...enumerateAssets(fullPath, baseDir));
+			assets.push(...enumerateAssets(fullPath, baseDir, publicPathPrefix, staticRoot));
 		} else {
 			// Skip dot-files and build/runtime metadata files.
 			if (entry.name.startsWith('.') || BUILD_INFRA_FILES.has(entry.name)) continue;
@@ -82,15 +98,23 @@ function enumerateAssets(dir: string, baseDir: string): AssetInfo[] {
 			const stats = statSync(fullPath);
 			if (stats.size === 0) continue;
 
-			const relativePath = relative(baseDir, fullPath);
+			const sourcePath = toAssetPath(relative(baseDir, fullPath));
+			const pathWithinStaticDir = toAssetPath(relative(staticRoot, fullPath));
+			const filename =
+				publicPathPrefix === undefined
+					? sourcePath
+					: joinAssetPath(publicPathPrefix, pathWithinStaticDir);
 			const contentType = getContentType(entry.name);
 
 			const asset: AssetInfo = {
-				filename: relativePath,
+				filename,
 				kind: getAssetKind(entry.name),
 				contentType,
 				size: stats.size,
 			};
+			if (sourcePath !== filename) {
+				asset.sourcePath = sourcePath;
+			}
 
 			if (shouldCompress(contentType)) {
 				asset.contentEncoding = 'gzip';
@@ -240,7 +264,11 @@ export async function generateDeployMetadata(
 	const assets: AssetInfo[] = [];
 	if (buildResult.staticDir && existsSync(buildResult.staticDir)) {
 		const outputDir = buildResult.outputDir;
-		const staticAssets = enumerateAssets(buildResult.staticDir, outputDir);
+		const staticAssets = enumerateAssets(
+			buildResult.staticDir,
+			outputDir,
+			buildResult.staticAssetPublicPath
+		);
 		assets.push(...staticAssets);
 		logger.debug(`Found ${assets.length} static assets in ${buildResult.staticDir}`);
 	}

--- a/packages/cli/test/cmd/build/detect/framework-detection.test.ts
+++ b/packages/cli/test/cmd/build/detect/framework-detection.test.ts
@@ -324,6 +324,26 @@ describe('Framework Detection', () => {
 			expect(result!.buildOutput).toBe('.output');
 		});
 
+		test('uses dist client assets when the start script launches dist/server.js', async () => {
+			writePackageJson(testDir, {
+				name: 'my-tanstack-app',
+				dependencies: {
+					'@tanstack/react-start': '^1.0.0',
+					'@tanstack/router-plugin': '^1.0.0',
+				},
+				scripts: {
+					build: 'vite build && bun run scripts/prepare-start-output.ts',
+					start: 'bun dist/server.js',
+				},
+			});
+
+			const result = await detectFramework(testDir);
+			expect(result!.name).toBe('tanstack-start');
+			expect(result!.startCommand).toBe('bun dist/server.js');
+			expect(result!.buildOutput).toBe('dist');
+			expect(result!.staticDir).toBe('dist/client');
+		});
+
 		test('defaults to the Nitro server entry when no start script exists', async () => {
 			// The hosting docs don't add a `start` script. Without a
 			// framework default, detection yields no start command and the

--- a/packages/cli/test/cmd/build/detect/framework-detection.test.ts
+++ b/packages/cli/test/cmd/build/detect/framework-detection.test.ts
@@ -342,6 +342,7 @@ describe('Framework Detection', () => {
 			expect(result!.startCommand).toBe('bun dist/server.js');
 			expect(result!.buildOutput).toBe('dist');
 			expect(result!.staticDir).toBe('dist/client');
+			expect(result!.staticAssetPublicPath).toBe('');
 		});
 
 		test('defaults to the Nitro server entry when no start script exists', async () => {

--- a/packages/cli/test/cmd/build/static-assets.test.ts
+++ b/packages/cli/test/cmd/build/static-assets.test.ts
@@ -276,6 +276,63 @@ describe('Static Asset CDN Upload', () => {
 		expect(filenames.some((f) => f.includes('entry.js'))).toBe(true);
 	}, 30_000);
 
+	test('TanStack Start dist/server.js builds enumerate dist/client assets', async () => {
+		writePackageJson(testDir, {
+			name: 'test-tanstack-dist-assets',
+			version: '1.0.0',
+			scripts: {
+				build: [
+					'mkdir -p dist/server dist/client/assets',
+					'echo "server" > dist/server/server.js',
+					'echo "launcher" > dist/server.js',
+					'echo "<html></html>" > dist/client/index.html',
+					'echo "body{}" > dist/client/assets/app-abcdef12.css',
+					'echo "app()" > dist/client/assets/app-abcdef12.js',
+				].join(' && '),
+				start: 'bun dist/server.js',
+			},
+			dependencies: {
+				'@tanstack/react-start': '^1.0.0',
+			},
+		});
+
+		const { framework, packageJson } = await detectFrameworkWithPackageJson(testDir);
+		expect(framework).not.toBeNull();
+		expect(framework!.name).toBe('tanstack-start');
+		expect(framework!.buildOutput).toBe('dist');
+		expect(framework!.staticDir).toBe('dist/client');
+
+		const adapter = getAdapter(framework!.name);
+		const buildResult = await adapter.build({
+			projectDir: testDir,
+			framework: framework!,
+			packageJson: packageJson!,
+			outputDir,
+			logger,
+		});
+
+		expect(buildResult.staticDir).toBeDefined();
+		expect(existsSync(buildResult.staticDir!)).toBe(true);
+
+		const packageResult = packageBuildOutput(framework!, buildResult, buildResult.outputDir);
+		const metadata = await generateDeployMetadata({
+			buildResult,
+			packageResult,
+			projectDir: testDir,
+			projectId: 'test-project',
+			orgId: 'test-org',
+			region: 'us-east-1',
+			deploymentId: 'test-deployment',
+			logger,
+		});
+
+		const filenames = metadata.assets.map((a) => a.filename);
+		expect(filenames).toContain('dist/client/index.html');
+		expect(filenames).toContain('dist/client/assets/app-abcdef12.css');
+		expect(filenames).toContain('dist/client/assets/app-abcdef12.js');
+		expect(filenames.some((f) => f.includes('server'))).toBe(false);
+	}, 30_000);
+
 	// ── No staticDir → no CDN assets ──
 
 	test('generic project without staticDir produces no CDN assets', async () => {

--- a/packages/cli/test/cmd/build/static-assets.test.ts
+++ b/packages/cli/test/cmd/build/static-assets.test.ts
@@ -327,10 +327,60 @@ describe('Static Asset CDN Upload', () => {
 		});
 
 		const filenames = metadata.assets.map((a) => a.filename);
-		expect(filenames).toContain('dist/client/index.html');
-		expect(filenames).toContain('dist/client/assets/app-abcdef12.css');
-		expect(filenames).toContain('dist/client/assets/app-abcdef12.js');
+		expect(filenames).toContain('index.html');
+		expect(filenames).toContain('assets/app-abcdef12.css');
+		expect(filenames).toContain('assets/app-abcdef12.js');
 		expect(filenames.some((f) => f.includes('server'))).toBe(false);
+
+		const script = metadata.assets.find((a) => a.filename === 'assets/app-abcdef12.js');
+		expect(script?.sourcePath).toBe('dist/client/assets/app-abcdef12.js');
+	}, 30_000);
+
+	test('framework public asset prefixes become CDN filenames', async () => {
+		writePackageJson(testDir, {
+			name: 'test-next-public-prefix',
+			version: '1.0.0',
+			scripts: {
+				build: [
+					'mkdir -p .next/static/chunks',
+					'echo "app()" > .next/static/chunks/app-abcdef12.js',
+				].join(' && '),
+				start: 'node server.js',
+			},
+		});
+
+		const { framework, packageJson } = await detectFrameworkWithPackageJson(testDir);
+		expect(framework).not.toBeNull();
+		framework!.buildOutput = '.next';
+		framework!.staticDir = '.next/static';
+		framework!.staticAssetPublicPath = '_next/static';
+
+		const adapter = getAdapter(framework!.name);
+		const buildResult = await adapter.build({
+			projectDir: testDir,
+			framework: framework!,
+			packageJson: packageJson!,
+			outputDir,
+			logger,
+		});
+
+		const packageResult = packageBuildOutput(framework!, buildResult, buildResult.outputDir);
+		const metadata = await generateDeployMetadata({
+			buildResult,
+			packageResult,
+			projectDir: testDir,
+			projectId: 'test-project',
+			orgId: 'test-org',
+			region: 'us-east-1',
+			deploymentId: 'test-deployment',
+			logger,
+		});
+
+		const script = metadata.assets.find(
+			(a) => a.filename === '_next/static/chunks/app-abcdef12.js'
+		);
+		expect(script).toBeDefined();
+		expect(script?.sourcePath).toBe('.next/static/chunks/app-abcdef12.js');
 	}, 30_000);
 
 	// ── No staticDir → no CDN assets ──

--- a/packages/core/src/services/project/deploy.ts
+++ b/packages/core/src/services/project/deploy.ts
@@ -141,6 +141,10 @@ export const BuildMetadataSchema = z.object({
 	assets: z.array(
 		z.object({
 			filename: z.string().describe('the relative path for the file'),
+			sourcePath: z
+				.string()
+				.optional()
+				.describe('the local path to read for upload, when different from filename'),
 			kind: z.string().describe('the type of asset'),
 			contentType: z.string().describe('the content-type for the file'),
 			contentEncoding: z.string().optional().describe('the content-encoding for the file'),

--- a/scripts/test-bun-check.sh
+++ b/scripts/test-bun-check.sh
@@ -4,6 +4,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 INSTALL_SCRIPT="$REPO_ROOT/install.sh"
+NODE_VERSION="${NODE_VERSION:-24}"
 
 # Colors
 RED='\033[0;31m'
@@ -38,6 +39,42 @@ cleanup_containers() {
   done
 }
 
+install_node_in_container() {
+  container_name="$1"
+
+  print_info "Installing Node ${NODE_VERSION}..."
+  docker exec -e NODE_VERSION="$NODE_VERSION" "$container_name" bash -c '
+    set -euo pipefail
+
+    case "$(uname -m)" in
+      x86_64) node_arch="x64" ;;
+      aarch64 | arm64) node_arch="arm64" ;;
+      *) echo "Unsupported Node architecture: $(uname -m)" && exit 1 ;;
+    esac
+
+    archive=$(curl -fsSL "https://nodejs.org/dist/latest-v${NODE_VERSION}.x/SHASUMS256.txt" | awk -v arch="$node_arch" '\''$2 ~ "^node-v[0-9]+\\.[0-9]+\\.[0-9]+-linux-" arch "\\.tar\\.xz$" { print $2; exit }'\'')
+    if [ -z "$archive" ]; then
+      echo "Unable to resolve Node ${NODE_VERSION} archive for ${node_arch}"
+      exit 1
+    fi
+
+    curl -fsSLo "/tmp/${archive}" "https://nodejs.org/dist/latest-v${NODE_VERSION}.x/${archive}"
+    mkdir -p /opt/node
+    tar -xJf "/tmp/${archive}" -C /opt/node --strip-components=1
+    ln -sf /opt/node/bin/node /usr/local/bin/node
+    ln -sf /opt/node/bin/npm /usr/local/bin/npm
+    ln -sf /opt/node/bin/npx /usr/local/bin/npx
+
+    installed_major=$(node -p '\''Number(process.versions.node.split(".")[0])'\'')
+    if [ "$installed_major" -lt "$NODE_VERSION" ]; then
+      echo "Expected Node ${NODE_VERSION}+ but found $(node --version)"
+      exit 1
+    fi
+
+    echo "Node version: $(node --version)"
+  '
+}
+
 test_no_bun_ci_mode() {
   print_header "Test: No Bun (CI Mode - Auto Install)"
   
@@ -46,9 +83,10 @@ test_no_bun_ci_mode() {
   print_info "Starting Debian container..."
   docker run -d --name "$container_name" debian:latest sleep infinity >/dev/null
   
-  print_info "Installing curl and unzip..."
+  print_info "Installing curl, unzip, and xz..."
   docker exec "$container_name" apt-get update -qq >/dev/null 2>&1
-  docker exec "$container_name" apt-get install -y -qq curl unzip >/dev/null 2>&1
+  docker exec "$container_name" apt-get install -y -qq curl unzip xz-utils >/dev/null 2>&1
+  install_node_in_container "$container_name"
   
   print_info "Copying install script..."
   docker cp "$INSTALL_SCRIPT" "$container_name:/tmp/install.sh"
@@ -87,9 +125,10 @@ test_bun_install_prompt() {
   print_info "Starting Debian container..."
   docker run -d --name "$container_name" debian:latest sleep infinity >/dev/null
   
-  print_info "Installing curl and unzip..."
+  print_info "Installing curl, unzip, and xz..."
   docker exec "$container_name" apt-get update -qq >/dev/null 2>&1
-  docker exec "$container_name" apt-get install -y -qq curl unzip >/dev/null 2>&1
+  docker exec "$container_name" apt-get install -y -qq curl unzip xz-utils >/dev/null 2>&1
+  install_node_in_container "$container_name"
   
   print_info "Copying install script..."
   docker cp "$INSTALL_SCRIPT" "$container_name:/tmp/install.sh"
@@ -128,9 +167,10 @@ test_bun_upgrade_prompt() {
   print_info "Starting Debian container..."
   docker run -d --name "$container_name" debian:latest sleep infinity >/dev/null
   
-  print_info "Installing curl and unzip..."
+  print_info "Installing curl, unzip, and xz..."
   docker exec "$container_name" apt-get update -qq >/dev/null 2>&1
-  docker exec "$container_name" apt-get install -y -qq curl unzip >/dev/null 2>&1
+  docker exec "$container_name" apt-get install -y -qq curl unzip xz-utils >/dev/null 2>&1
+  install_node_in_container "$container_name"
   
   print_info "Installing old Bun version 1.3.0..."
   docker exec "$container_name" bash -c 'curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.0"' >/dev/null 2>&1
@@ -166,9 +206,10 @@ test_decline_bun_install() {
   print_info "Starting Debian container..."
   docker run -d --name "$container_name" debian:latest sleep infinity >/dev/null
   
-  print_info "Installing curl and unzip..."
+  print_info "Installing curl, unzip, and xz..."
   docker exec "$container_name" apt-get update -qq >/dev/null 2>&1
-  docker exec "$container_name" apt-get install -y -qq curl unzip >/dev/null 2>&1
+  docker exec "$container_name" apt-get install -y -qq curl unzip xz-utils >/dev/null 2>&1
+  install_node_in_container "$container_name"
   
   print_info "Copying install script..."
   docker cp "$INSTALL_SCRIPT" "$container_name:/tmp/install.sh"
@@ -193,9 +234,10 @@ test_decline_bun_upgrade() {
   print_info "Starting Debian container..."
   docker run -d --name "$container_name" debian:latest sleep infinity >/dev/null
   
-  print_info "Installing curl and unzip..."
+  print_info "Installing curl, unzip, and xz..."
   docker exec "$container_name" apt-get update -qq >/dev/null 2>&1
-  docker exec "$container_name" apt-get install -y -qq curl unzip >/dev/null 2>&1
+  docker exec "$container_name" apt-get install -y -qq curl unzip xz-utils >/dev/null 2>&1
+  install_node_in_container "$container_name"
   
   print_info "Installing old Bun version 1.3.0..."
   docker exec "$container_name" bash -c 'curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.0"' >/dev/null 2>&1


### PR DESCRIPTION
## Summary
- Detect TanStack Start projects that launch `dist/server.js` as `dist` builds with `dist/client` static assets.
- Preserve the existing `.output/public` path for Nitro-style TanStack Start builds.
- Add detection and deploy-metadata regression coverage for CDN asset enumeration.

## Test plan
- `bun test packages/cli/test/cmd/build/detect/framework-detection.test.ts`
- `bun test packages/cli/test/cmd/build/static-assets.test.ts`
- `bun run --filter @agentuity/cli typecheck`
- `bunx biome lint packages/cli/src/cmd/build/detect/index.ts packages/cli/test/cmd/build/detect/framework-detection.test.ts packages/cli/test/cmd/build/static-assets.test.ts`
- `cd docs && bun /home/huijiro/Dev/agentuity/sdk/packages/cli/src/main.ts build --skip-type-check`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable public asset prefixes so packaged asset filenames reflect their public URL paths.
  * CDN upload can read assets from an alternate source path when packaged filenames differ.

* **Bug Fixes**
  * Improved framework detection for TanStack Start to correctly identify build output and static asset locations (including Bun layouts).

* **Tests**
  * Added tests for TanStack Start detection and static-asset enumeration with public-path prefixes.

* **Chores**
  * Standardized Node version in CI and enhanced Node-install test helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->