### PR TITLE
fix(core): support Node streamed uploads

### DIFF
--- a/packages/core/src/services/api.ts
+++ b/packages/core/src/services/api.ts
@@ -17,6 +17,31 @@ function getUserAgent(): string {
 	return `Agentuity SDK/${getVersion()}`;
 }
 
+function isReadableStreamBody(body: unknown): body is ReadableStream<Uint8Array> {
+	return typeof ReadableStream !== 'undefined' && body instanceof ReadableStream;
+}
+
+function buildFetchInit(
+	method: string,
+	headers: Record<string, string>,
+	body: Uint8Array | ArrayBuffer | ReadableStream<Uint8Array> | string | Blob | undefined,
+	signal?: AbortSignal
+): RequestInit & { duplex?: 'half' } {
+	const init: RequestInit & { duplex?: 'half' } = {
+		method,
+		headers,
+		body,
+		signal,
+	};
+
+	// Node's fetch requires duplex when streaming request bodies.
+	if (isReadableStreamBody(body)) {
+		init.duplex = 'half';
+	}
+
+	return init;
+}
+
 export const APIClientConfigSchema = z.object({
 	skipVersionCheck: z
 		.boolean()
@@ -426,7 +451,7 @@ export class APIClient {
 			});
 		}
 
-		const canRetry = !(body instanceof ReadableStream); // we cannot safely retry a ReadableStream as body
+		const canRetry = !isReadableStreamBody(body); // we cannot safely retry a ReadableStream as body
 
 		let attempt = 0;
 		while (true) {
@@ -454,12 +479,7 @@ export class APIClient {
 						}
 					}
 
-					response = await fetch(url, {
-						method,
-						headers,
-						body: requestBody,
-						signal,
-					});
+					response = await fetch(url, buildFetchInit(method, headers, requestBody, signal));
 				} catch (ex) {
 					this.#logger.debug('fetch returned an error trying to access: %s. %s', url, ex);
 					const _ex = ex as { code?: string; name: string };
@@ -471,10 +491,14 @@ export class APIClient {
 						// TypeError from fetch typically indicates network issues
 						retryable = true;
 					}
-					if (retryable) {
+					if (retryable && canRetry) {
 						response = new Response(null, { status: 503 });
 					} else {
 						throw new APIError({
+							message:
+								ex instanceof Error && ex.message
+									? `Fetch failed: ${ex.message}`
+									: 'Fetch failed before receiving a response',
 							url,
 							status: 0,
 							cause: ex,
@@ -516,12 +540,10 @@ export class APIClient {
 							}
 						}
 
-						const regionalResponse = await fetch(regionalUrl, {
-							method,
-							headers,
-							body: requestBody,
-							signal,
-						});
+						const regionalResponse = await fetch(
+							regionalUrl,
+							buildFetchInit(method, headers, requestBody, signal)
+						);
 
 						// If the regional request also fails with 421, throw MisdirectedRequestError
 						if (regionalResponse.status === 421) {

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test, afterEach } from 'bun:test';
+import { APIClient, APIError } from '../src/services/api.ts';
+import type { Logger } from '../src/logger.ts';
+
+const OriginalFetch = globalThis.fetch;
+
+const logger: Logger = {
+	trace: () => {},
+	debug: () => {},
+	info: () => {},
+	warn: () => {},
+	error: () => {},
+	fatal: (message?: unknown): never => {
+		throw new Error(String(message ?? 'fatal'));
+	},
+	child: () => logger,
+};
+
+describe('APIClient', () => {
+	afterEach(() => {
+		globalThis.fetch = OriginalFetch;
+	});
+
+	test('sets half duplex for streamed raw uploads', async () => {
+		let init: RequestInit | undefined;
+		globalThis.fetch = ((_input: RequestInfo | URL, requestInit?: RequestInit) => {
+			init = requestInit;
+			return Promise.resolve(new Response(null, { status: 204 }));
+		}) as typeof fetch;
+
+		const client = new APIClient('https://api.example.com', logger);
+		const body = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(new Uint8Array([1, 2, 3]));
+				controller.close();
+			},
+		});
+
+		const response = await client.rawPut('/upload', body, 'application/gzip');
+
+		expect(response.status).toBe(204);
+		expect(init?.body).toBe(body);
+		expect((init as RequestInit & { duplex?: string })?.duplex).toBe('half');
+	});
+
+	test('preserves fetch errors for non-retryable streamed uploads', async () => {
+		const cause = new TypeError('RequestInit: duplex option is required when sending a body.');
+		globalThis.fetch = (() => Promise.reject(cause)) as typeof fetch;
+
+		const client = new APIClient('https://api.example.com', logger);
+		const body = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(new Uint8Array([1, 2, 3]));
+				controller.close();
+			},
+		});
+
+		await expect(client.rawPut('/upload', body, 'application/gzip')).rejects.toMatchObject({
+			_tag: 'APIErrorResponse',
+			message: `Fetch failed: ${cause.message}`,
+			status: 0,
+			cause,
+		});
+
+		await expect(client.rawPut('/upload', body, 'application/gzip')).rejects.toBeInstanceOf(
+			APIError
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- Add `duplex: 'half'` to fetch options when `APIClient` sends a `ReadableStream` request body, which Node requires for streamed uploads.
- Preserve non-retryable fetch failures as `APIError` causes instead of converting streamed request failures into synthetic 503 responses.
- Add regression coverage for streamed raw uploads and fetch error reporting.

## Test plan
- `bun test packages/core/test/api.test.ts`
- `bun run typecheck` from `packages/core`
- `bun run build` from `packages/core`
- `bunx biome check packages/core/src/services/api.ts packages/core/test/api.test.ts`
- Docker repro: Node 24 + Bun 1.3.14 + patched local CLI successfully built `agentuity-genesis-src:test-sdk-duplex-node` from `agentuity/genesis-mono@19e5b372e969403a86fb48d19f0df3ec6a4b8e10` under Node; disposable snapshot was deleted.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for streaming request bodies with improved reliability and proper configuration.

* **Bug Fixes**
  * Improved error messaging when requests fail.
  * Fixed retry behavior to properly handle streaming requests without unnecessary retries.

* **Tests**
  * Added test coverage for streaming request uploads and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->