### PR TITLE
fix(ci): use v3 project create in snapshot workflow

### DIFF
--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -77,9 +77,6 @@ jobs:
            with:
               bun-version: "1.3.11"
 
-         - name: Install Agentuity CLI
-           run: curl -fsSL https://agentuity.sh | sh
-
          - name: Generate CLI Auth Token
            run: |
               APIKEY=$(curl "$AGENTUITY_API_URL/cli/auth/short-token" -H 'Content-Type: application/json' --data "{\"secret\":\"${{ secrets.AGENTUITY_APITOKEN_SHARED_SECRET }}\",\"userId\":\"${{ env.AGENTUITY_USER_ID }}\"}" | jq -r '.data.apiKey')
@@ -95,7 +92,16 @@ jobs:
 
               # Scaffold demo project into tmp/demo-project (used by agentuity-demo-project.yaml via dir field)
               mkdir -p tmp
-              agentuity project create --template default --name demo-project --dir tmp/demo-project --no-register
+              node packages/cli/bin/cli.js project create \
+                --framework hono \
+                --name demo-project \
+                --dir tmp \
+                --package-manager bun \
+                --no-install \
+                --no-build \
+                --no-register \
+                --confirm
+              rm -rf tmp/demo-project/.git tmp/demo-project/node_modules
 
          - name: Build All Snapshots
            run: |
@@ -110,6 +116,11 @@ jobs:
               for file in snapshots/*.yaml; do
                 name=$(basename "$file" .yaml)
                 echo "::group::Building snapshot: $name"
-                agentuity cloud sandbox snapshot build --org-id "$AGENTUITY_ORG_ID" --confirm --metadata VERSION="$VERSION" --file "$file" .
+                node packages/cli/bin/cli.js cloud sandbox snapshot build \
+                  --org-id "$AGENTUITY_ORG_ID" \
+                  --confirm \
+                  --metadata VERSION="$VERSION" \
+                  --file "$file" \
+                  .
                 echo "::endgroup::"
               done


### PR DESCRIPTION
## Summary
- Stop installing and invoking the globally published `agentuity` binary in the snapshot workflow.
- Use the checked-out, just-built SDK CLI (`node packages/cli/bin/cli.js`) for both demo project scaffolding and snapshot builds.
- Replace the stale v2 `project create --template default` invocation with the v3 framework-first `--framework hono` flow, then remove generated `.git` and `node_modules` so the demo snapshot remains small.

## Why
The snapshot workflow kept calling:

```bash
agentuity project create --template default --name demo-project --dir tmp/demo-project --no-register
```

That command only worked because `curl https://agentuity.sh | sh` was still installing CLI `2.0.26` in the last successful run. After `3.0.7` became the installer target, the same workflow started using the v3 CLI, where `--template` was removed by the framework-first project-create rewrite (`1a6c2e17` / #1255). The workflow had been building v3 from source but testing/scaffolding with whatever global CLI version the installer served, so this drift was hidden until the installer advanced.

This change makes the workflow use the CLI it just built, so the snapshot job tracks the checked-out SDK surface instead of the latest published installer output.

## Test plan
- `bun install --frozen-lockfile`
- `bun run build`
- Locally ran the replacement `node packages/cli/bin/cli.js project create --framework hono --name demo-project --dir <tmp>/tmp --package-manager bun --no-install --no-build --no-register --confirm`, removed `.git`/`node_modules`, and verified the generated `tmp/demo-project/package.json` exists with a 48K cleaned project directory.
- `git diff --check`

Note: local `actionlint` was not installed, and `bunx actionlint` could not resolve an executable for that package in this repo.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to use the bundled CLI directly instead of external installation, improving build reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->