### PR TITLE
fix(cli): authenticate GitHub archive downloads

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -372,6 +372,57 @@ install_cli() {
   print_message debug "Agentuity CLI installed successfully!"
 }
 
+# Bun installs the package's npm bin, whose shebang intentionally targets node
+# for npm/global Node users. The install.sh path requires Bun, so replace Bun's
+# global bin symlink with a Bun-backed shim while leaving the package untouched.
+create_bun_entrypoint_shim() {
+  cli_bin="$BUN_INSTALL_BIN/agentuity"
+
+  if [ ! -e "$cli_bin" ]; then
+    print_message warning "Could not create Bun shim - agentuity not found at $cli_bin"
+    return 0
+  fi
+
+  if [ ! -L "$cli_bin" ]; then
+    print_message debug "Skipping Bun shim creation; $cli_bin is not a symlink"
+    return 0
+  fi
+
+  cli_target=$(readlink "$cli_bin" 2>/dev/null || echo "")
+  if [ -z "$cli_target" ]; then
+    print_message warning "Could not resolve agentuity bin symlink at $cli_bin"
+    return 0
+  fi
+
+  case "$cli_target" in
+  /*) resolved_cli_target="$cli_target" ;;
+  *) resolved_cli_target="$(dirname "$cli_bin")/$cli_target" ;;
+  esac
+
+  if [ ! -f "$resolved_cli_target" ]; then
+    print_message warning "Could not create Bun shim - target not found at $resolved_cli_target"
+    return 0
+  fi
+
+  shim_tmp="$cli_bin.tmp.$$"
+  cat > "$shim_tmp" << EOF
+#!/bin/sh
+BUN_BIN="$BUN_EXEC_DIR/bun"
+if [ ! -x "\$BUN_BIN" ]; then
+  BUN_BIN=\$(command -v bun 2>/dev/null || true)
+fi
+if [ -z "\$BUN_BIN" ]; then
+  echo "Bun is required to run the Agentuity CLI installed by install.sh" >&2
+  exit 1
+fi
+exec "\$BUN_BIN" "$resolved_cli_target" "\$@"
+EOF
+  chmod 755 "$shim_tmp"
+  rm -f "$cli_bin"
+  mv "$shim_tmp" "$cli_bin"
+  print_message debug "Created Bun entrypoint shim at $cli_bin"
+}
+
 # Create a shim in ~/.agentuity/bin for backward compatibility
 # Only creates shim if the legacy directory is on PATH; otherwise cleans up
 create_legacy_shim() {
@@ -633,6 +684,10 @@ main() {
 
   # Install the CLI
   install_cli
+
+  # Ensure install.sh users run the CLI with Bun, even though the package bin
+  # remains Node-first for npm global installs.
+  create_bun_entrypoint_shim
   
   # Create backward compatibility shim if needed
   create_legacy_shim

--- a/packages/cli/src/cmd/build/ci.ts
+++ b/packages/cli/src/cmd/build/ci.ts
@@ -33,7 +33,7 @@ async function runCommand(cmd: string[], cwd: string): Promise<number> {
 const githubArchiveTokenEnv = 'GITHUB_ARCHIVE_TOKEN';
 const githubArchiveHosts = new Set(['api.github.com', 'codeload.github.com']);
 
-export function sourceDownloadHeaders(url: string): HeadersInit | undefined {
+export function sourceDownloadHeaders(url: string): Record<string, string> | undefined {
 	const token = process.env[githubArchiveTokenEnv]?.trim();
 	if (!token) {
 		return undefined;

--- a/packages/cli/src/cmd/build/ci.ts
+++ b/packages/cli/src/cmd/build/ci.ts
@@ -29,12 +29,64 @@ async function runCommand(cmd: string[], cwd: string): Promise<number> {
 	const { exitCode } = await spawnInherit({ cmd, cwd, env: { CI: 'true' } });
 	return exitCode ?? 1;
 }
-async function downloadSource(url: string, targetPath: string): Promise<void> {
+
+const githubArchiveTokenEnv = 'GITHUB_ARCHIVE_TOKEN';
+const githubArchiveHosts = new Set(['api.github.com', 'codeload.github.com']);
+
+export function sourceDownloadHeaders(url: string): HeadersInit | undefined {
+	const token = process.env[githubArchiveTokenEnv]?.trim();
+	if (!token) {
+		return undefined;
+	}
+
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return undefined;
+	}
+
+	if (!githubArchiveHosts.has(parsed.hostname.toLowerCase())) {
+		return undefined;
+	}
+
+	return {
+		Authorization: `Bearer ${token}`,
+		Accept: 'application/vnd.github+json',
+		'X-GitHub-Api-Version': '2022-11-28',
+	};
+}
+
+async function fetchSourceArchive(url: string): Promise<Response> {
+	let currentURL = url;
+
+	for (let redirectCount = 0; redirectCount <= 5; redirectCount++) {
+		const response = await fetch(currentURL, {
+			headers: sourceDownloadHeaders(currentURL),
+			redirect: 'manual',
+			signal: AbortSignal.timeout(60_000),
+		});
+
+		if (response.status < 300 || response.status >= 400) {
+			return response;
+		}
+
+		const location = response.headers.get('location');
+		if (!location) {
+			return response;
+		}
+		currentURL = new URL(location, currentURL).toString();
+	}
+
+	throw new Error('Download failed: too many redirects');
+}
+
+export async function downloadSource(url: string, targetPath: string): Promise<void> {
 	let lastError: unknown;
 
 	for (let attempt = 1; attempt <= 3; attempt++) {
 		try {
-			const response = await fetch(url, { signal: AbortSignal.timeout(60_000) });
+			const response = await fetchSourceArchive(url);
 			if (!response.ok) {
 				throw new Error(`Download failed with status ${response.status}`);
 			}

--- a/packages/cli/test/cmd/build/ci.test.ts
+++ b/packages/cli/test/cmd/build/ci.test.ts
@@ -1,9 +1,87 @@
 import { describe, expect, test } from 'bun:test';
-import { buildDeployArgs } from '../../../src/cmd/build/ci';
+import { Buffer } from 'node:buffer';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildDeployArgs, downloadSource, sourceDownloadHeaders } from '../../../src/cmd/build/ci';
 
 describe('build ci', () => {
 	test('passes skip DNS validation to nested deploy', () => {
 		const args = buildDeployArgs({ skipDnsValidation: true });
 		expect(args).toContain('--skip-dns-validation');
+	});
+
+	test('adds GitHub archive token only for GitHub archive hosts', () => {
+		const previous = process.env.GITHUB_ARCHIVE_TOKEN;
+		process.env.GITHUB_ARCHIVE_TOKEN = 'ghs_test_token';
+		try {
+			expect(
+				sourceDownloadHeaders('https://api.github.com/repos/agentuity/sdk/zipball/abc')
+			).toEqual({
+				Authorization: 'Bearer ghs_test_token',
+				Accept: 'application/vnd.github+json',
+				'X-GitHub-Api-Version': '2022-11-28',
+			});
+			expect(
+				sourceDownloadHeaders('https://codeload.github.com/agentuity/sdk/legacy.zip/abc')
+			).toEqual({
+				Authorization: 'Bearer ghs_test_token',
+				Accept: 'application/vnd.github+json',
+				'X-GitHub-Api-Version': '2022-11-28',
+			});
+			expect(sourceDownloadHeaders('https://example.com/source.zip')).toBeUndefined();
+		} finally {
+			if (previous === undefined) {
+				delete process.env.GITHUB_ARCHIVE_TOKEN;
+			} else {
+				process.env.GITHUB_ARCHIVE_TOKEN = previous;
+			}
+		}
+	});
+
+	test('follows GitHub archive redirects with installation token', async () => {
+		const previousToken = process.env.GITHUB_ARCHIVE_TOKEN;
+		const previousFetch = globalThis.fetch;
+		const calls: Array<{ url: string; authorization?: string | null }> = [];
+		process.env.GITHUB_ARCHIVE_TOKEN = 'ghs_test_token';
+		globalThis.fetch = (async (input, init) => {
+			const url = String(input);
+			const headers = new Headers(init?.headers);
+			calls.push({ url, authorization: headers.get('authorization') });
+			if (url === 'https://api.github.com/repos/agentuity/sdk/zipball/abc') {
+				return new Response(null, {
+					status: 302,
+					headers: {
+						location: 'https://codeload.github.com/agentuity/sdk/legacy.zip/abc',
+					},
+				});
+			}
+			return new Response(new Uint8Array([1, 2, 3]));
+		}) as typeof fetch;
+
+		const dir = await mkdtemp(join(tmpdir(), 'agentuity-ci-download-test-'));
+		try {
+			const target = join(dir, 'source.zip');
+			await downloadSource('https://api.github.com/repos/agentuity/sdk/zipball/abc', target);
+			expect(await readFile(target)).toEqual(Buffer.from([1, 2, 3]));
+			expect(calls).toEqual([
+				{
+					url: 'https://api.github.com/repos/agentuity/sdk/zipball/abc',
+					authorization: 'Bearer ghs_test_token',
+				},
+				{
+					url: 'https://codeload.github.com/agentuity/sdk/legacy.zip/abc',
+					authorization: 'Bearer ghs_test_token',
+				},
+			]);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+			globalThis.fetch = previousFetch;
+			if (previousToken === undefined) {
+				delete process.env.GITHUB_ARCHIVE_TOKEN;
+			} else {
+				process.env.GITHUB_ARCHIVE_TOKEN = previousToken;
+			}
+		}
 	});
 });


### PR DESCRIPTION
## Summary
- Read `GITHUB_ARCHIVE_TOKEN` during `agentuity build --ci --url` source downloads.
- Add GitHub archive auth headers only for `api.github.com` and `codeload.github.com`.
- Follow GitHub archive redirects manually so the installation token is preserved across the API-to-codeload redirect without leaking to non-GitHub hosts.
- Ensure `install.sh` users run the globally installed CLI through Bun instead of the package's Node shebang.

## Paired infra PR
- https://github.com/agentuity/infra/pull/658

## Test plan
- `bunx biome format --write packages/cli/src/cmd/build/ci.ts packages/cli/test/cmd/build/ci.test.ts`
- `bun test packages/cli/test/cmd/build/ci.test.ts`
- `bun run build`
- `sh -n install.sh`
- temp-home `./install.sh -y` smoke with `agentuity --version`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced GitHub archive downloads with optional token-based authentication
  * Improved redirect handling for archive fetches with manual follow-up (up to 5 redirects) and 60s per-request timeout
  * Installer now creates a Bun-backed entrypoint shim so the CLI runs via Bun when installed that way

* **Tests**
  * Expanded test coverage for authenticated archive downloads and redirect-following behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->