### PR TITLE
feat(cli): pass `AGENTUITY_DEPLOYMENT_ID` to adapter builds

### DIFF
--- a/packages/cli/src/cmd/build/adapters/generic.ts
+++ b/packages/cli/src/cmd/build/adapters/generic.ts
@@ -468,11 +468,22 @@ export const genericAdapter: BuildAdapter = {
 			if (framework.buildCommand && framework.buildCommand !== '__agentuity_internal__') {
 				logger.debug(`Running build: ${framework.buildCommand}`);
 				const buildStart = Date.now();
+				// Expose the deploymentId to the build subprocess so custom
+				// builds can construct deployment-scoped URLs — e.g. a Vite
+				// `base` of `https://cdn.agentuity.com/<deploymentId>/client/`
+				// so static assets are served from the CDN. Native Agentuity
+				// builds get this via the Vite pipeline's `--base` injection;
+				// this is the equivalent contract for adapter builds. Unset
+				// outside a deploy (plain `agentuity build` has no deployment).
+				const buildEnv = {
+					...framework.buildEnv,
+					...(options.deploymentId ? { AGENTUITY_DEPLOYMENT_ID: options.deploymentId } : {}),
+				};
 				await runBuildCommand(
 					buildCwd,
 					framework.buildCommand,
 					framework.packageManager,
-					framework.buildEnv,
+					buildEnv,
 					logger,
 					options.monorepo ? [join(options.monorepo.root, 'node_modules', '.bin')] : []
 				);

--- a/packages/cli/src/cmd/build/adapters/generic.ts
+++ b/packages/cli/src/cmd/build/adapters/generic.ts
@@ -23,7 +23,7 @@ import type { MonorepoContext } from '../detect/monorepo.ts';
 async function runCommand(
 	cmd: string[],
 	cwd: string,
-	env?: Record<string, string>
+	env?: Record<string, string | undefined>
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
 	const result = await run({ cmd, cwd, env });
 	return {
@@ -187,7 +187,7 @@ export async function runBuildCommand(
 	projectDir: string,
 	buildCommand: string,
 	packageManager: string,
-	buildEnv?: Record<string, string>,
+	buildEnv?: Record<string, string | undefined>,
 	logger?: { debug: (...args: unknown[]) => void },
 	extraBinDirs: string[] = []
 ): Promise<{ stdout: string; stderr: string }> {
@@ -231,7 +231,7 @@ export async function runBuildCommand(
 	// `vite` end up at root rather than in the subpackage) still
 	// resolve when the build shells out from inside the subpackage.
 	const binDirs = [join(projectDir, 'node_modules', '.bin'), ...extraBinDirs];
-	const envWithLocalBin: Record<string, string> = {
+	const envWithLocalBin: Record<string, string | undefined> = {
 		...(buildEnv ?? {}),
 		PATH: `${binDirs.join(':')}:${buildEnv?.PATH ?? process.env.PATH ?? ''}`,
 	};
@@ -473,11 +473,13 @@ export const genericAdapter: BuildAdapter = {
 				// `base` of `https://cdn.agentuity.com/<deploymentId>/client/`
 				// so static assets are served from the CDN. Native Agentuity
 				// builds get this via the Vite pipeline's `--base` injection;
-				// this is the equivalent contract for adapter builds. Unset
-				// outside a deploy (plain `agentuity build` has no deployment).
+				// this is the equivalent contract for adapter builds. Outside
+				// a deploy, `undefined` actively unsets the variable (proc's
+				// env merge deletes undefined keys), so a stale value exported
+				// in the user's shell never leaks into the build.
 				const buildEnv = {
 					...framework.buildEnv,
-					...(options.deploymentId ? { AGENTUITY_DEPLOYMENT_ID: options.deploymentId } : {}),
+					AGENTUITY_DEPLOYMENT_ID: options.deploymentId || undefined,
 				};
 				await runBuildCommand(
 					buildCwd,

--- a/packages/cli/src/cmd/build/adapters/nextjs.ts
+++ b/packages/cli/src/cmd/build/adapters/nextjs.ts
@@ -121,8 +121,9 @@ export const nextjsAdapter: BuildAdapter = {
 			...getNextBuildEnv(monorepo?.root),
 			// Same contract as the generic adapter: expose the deploymentId
 			// so the build can construct deployment-scoped URLs (e.g. a CDN
-			// assetPrefix). Unset outside a deploy.
-			...(options.deploymentId ? { AGENTUITY_DEPLOYMENT_ID: options.deploymentId } : {}),
+			// assetPrefix). Outside a deploy, `undefined` actively unsets it
+			// so a stale value from the user's shell never leaks in.
+			AGENTUITY_DEPLOYMENT_ID: options.deploymentId || undefined,
 		};
 
 		logger.debug(`Running Next.js build: ${framework.buildCommand}`);

--- a/packages/cli/src/cmd/build/adapters/nextjs.ts
+++ b/packages/cli/src/cmd/build/adapters/nextjs.ts
@@ -119,6 +119,10 @@ export const nextjsAdapter: BuildAdapter = {
 		const buildEnv = {
 			...framework.buildEnv,
 			...getNextBuildEnv(monorepo?.root),
+			// Same contract as the generic adapter: expose the deploymentId
+			// so the build can construct deployment-scoped URLs (e.g. a CDN
+			// assetPrefix). Unset outside a deploy.
+			...(options.deploymentId ? { AGENTUITY_DEPLOYMENT_ID: options.deploymentId } : {}),
 		};
 
 		logger.debug(`Running Next.js build: ${framework.buildCommand}`);

--- a/packages/cli/test/cmd/build/adapters/deployment-env.test.ts
+++ b/packages/cli/test/cmd/build/adapters/deployment-env.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Deployment Env Injection Tests
+ *
+ * Custom (adapter-run) build commands need a stable, documented way to
+ * learn the deploymentId at build time — e.g. to set a Vite `base` of
+ * `https://cdn.agentuity.com/<deploymentId>/client/` so static assets
+ * are served from the CDN instead of the app container. Native
+ * Agentuity builds get this via the Vite pipeline's `--base` injection;
+ * these tests pin the equivalent contract for adapter builds:
+ *
+ * 1. When the pipeline has a deploymentId, the build subprocess sees it
+ *    as AGENTUITY_DEPLOYMENT_ID.
+ * 2. When there is no deploymentId (plain `agentuity build`), the
+ *    variable is not set.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { detectFrameworkWithPackageJson } from '../../../../src/cmd/build/detect';
+import { getAdapter } from '../../../../src/cmd/build/adapters';
+
+// ── Helpers ──
+
+function createTestDir(): string {
+	const dir = join(
+		tmpdir(),
+		`deployment-env-${Date.now()}-${Math.random().toString(36).slice(2)}`
+	);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+function writePackageJson(dir: string, content: Record<string, unknown>) {
+	writeFileSync(join(dir, 'package.json'), JSON.stringify(content, null, 2));
+}
+
+const logger = {
+	trace: () => {},
+	debug: () => {},
+	info: () => {},
+	warn: () => {},
+	error: () => {},
+	fatal: (() => {
+		throw new Error('fatal');
+	}) as never,
+	child: () => logger,
+};
+
+// The build script captures what the subprocess actually sees. `MISSING`
+// distinguishes "unset" from "set to empty string".
+const captureBuildScript = [
+	'mkdir -p dist',
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: shell parameter expansion, expanded by sh in the build subprocess, not JS
+	'echo "${AGENTUITY_DEPLOYMENT_ID:-MISSING}" > dist/env-capture.txt',
+	'echo "<html></html>" > dist/index.html',
+].join(' && ');
+
+// Read from the project's own dist/ (where the build script wrote it)
+// so the assertion is independent of the adapter's output-copy layout.
+function readCapture(projectDir: string): string {
+	return readFileSync(join(projectDir, 'dist', 'env-capture.txt'), 'utf-8').trim();
+}
+
+// ── Tests ──
+
+describe('Deployment env injection for adapter builds', () => {
+	let testDir: string;
+	let outputDir: string;
+
+	beforeEach(() => {
+		testDir = createTestDir();
+		outputDir = join(testDir, '.agentuity');
+	});
+
+	afterEach(() => {
+		rmSync(testDir, { recursive: true, force: true });
+	});
+
+	test('build subprocess sees AGENTUITY_DEPLOYMENT_ID when deploymentId is set', async () => {
+		writePackageJson(testDir, {
+			name: 'test-deployment-env',
+			version: '1.0.0',
+			scripts: {
+				build: captureBuildScript,
+			},
+			devDependencies: {
+				vite: '^6.0.0',
+			},
+		});
+
+		const { framework, packageJson } = await detectFrameworkWithPackageJson(testDir);
+		expect(framework).not.toBeNull();
+		expect(framework!.name).toBe('vite');
+
+		const adapter = getAdapter(framework!.name);
+		await adapter.build({
+			projectDir: testDir,
+			framework: framework!,
+			packageJson: packageJson!,
+			outputDir,
+			logger,
+			deploymentId: 'deploy_test_12345',
+		});
+
+		expect(readCapture(testDir)).toBe('deploy_test_12345');
+	});
+
+	test('AGENTUITY_DEPLOYMENT_ID is not set when there is no deploymentId', async () => {
+		writePackageJson(testDir, {
+			name: 'test-deployment-env-absent',
+			version: '1.0.0',
+			scripts: {
+				build: captureBuildScript,
+			},
+			devDependencies: {
+				vite: '^6.0.0',
+			},
+		});
+
+		const { framework, packageJson } = await detectFrameworkWithPackageJson(testDir);
+		expect(framework).not.toBeNull();
+
+		const adapter = getAdapter(framework!.name);
+		await adapter.build({
+			projectDir: testDir,
+			framework: framework!,
+			packageJson: packageJson!,
+			outputDir,
+			logger,
+		});
+
+		expect(readCapture(testDir)).toBe('MISSING');
+	});
+});

--- a/packages/cli/test/cmd/build/adapters/deployment-env.test.ts
+++ b/packages/cli/test/cmd/build/adapters/deployment-env.test.ts
@@ -18,6 +18,7 @@ import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { createMockLogger } from '@agentuity/test-utils';
 import { detectFrameworkWithPackageJson } from '../../../../src/cmd/build/detect';
 import { getAdapter } from '../../../../src/cmd/build/adapters';
 
@@ -36,17 +37,7 @@ function writePackageJson(dir: string, content: Record<string, unknown>) {
 	writeFileSync(join(dir, 'package.json'), JSON.stringify(content, null, 2));
 }
 
-const logger = {
-	trace: () => {},
-	debug: () => {},
-	info: () => {},
-	warn: () => {},
-	error: () => {},
-	fatal: (() => {
-		throw new Error('fatal');
-	}) as never,
-	child: () => logger,
-};
+const logger = createMockLogger();
 
 // The build script captures what the subprocess actually sees. `MISSING`
 // distinguishes "unset" from "set to empty string".
@@ -132,5 +123,40 @@ describe('Deployment env injection for adapter builds', () => {
 		});
 
 		expect(readCapture(testDir)).toBe('MISSING');
+	});
+
+	test('clears a stale AGENTUITY_DEPLOYMENT_ID inherited from the CLI process env', async () => {
+		// The build subprocess env inherits process.env, so a value
+		// exported in the user's shell must be actively unset for a
+		// non-deploy build — omitting the key is not enough.
+		process.env.AGENTUITY_DEPLOYMENT_ID = 'stale_from_shell';
+		try {
+			writePackageJson(testDir, {
+				name: 'test-deployment-env-stale',
+				version: '1.0.0',
+				scripts: {
+					build: captureBuildScript,
+				},
+				devDependencies: {
+					vite: '^6.0.0',
+				},
+			});
+
+			const { framework, packageJson } = await detectFrameworkWithPackageJson(testDir);
+			expect(framework).not.toBeNull();
+
+			const adapter = getAdapter(framework!.name);
+			await adapter.build({
+				projectDir: testDir,
+				framework: framework!,
+				packageJson: packageJson!,
+				outputDir,
+				logger,
+			});
+
+			expect(readCapture(testDir)).toBe('MISSING');
+		} finally {
+			delete process.env.AGENTUITY_DEPLOYMENT_ID;
+		}
 	});
 });


### PR DESCRIPTION
## Summary

> Custom (adapter-run) builds now receive the deployment id as `AGENTUITY_DEPLOYMENT_ID` in the build subprocess env, so they can construct deployment-scoped URLs at build time.

- The `generic` and `nextjs` adapters merge `AGENTUITY_DEPLOYMENT_ID` into the build command env when the deploy pipeline has a `deploymentId`
- The variable is unset outside a deploy (plain `agentuity build` creates no deployment record)
- Adds an adapter test pinning both the set and unset cases

## Why

Native Agentuity Vite builds get a CDN asset base injected automatically (`--base https://cdn.agentuity.com/<deploymentId>/client/`), so their static assets serve from the CDN. Builds that go through the framework adapters (Vite, Next.js, TanStack Start, etc.) had no stable way to learn the deployment id at build time, so custom-build apps serve every static asset from the app container instead of the CDN.

This is the CLI-side prerequisite for moving such apps' assets onto the CDN (e.g. the docs site); the per-app `base` configuration and asset upload alignment are separate follow-ups.

## Implementation

The deploy pipeline already threads the id from preflight into the adapters (`runBuildPipeline` → `BuildAdapterOptions.deploymentId`) — it just never crossed the subprocess boundary. The change is a conditional merge at the two `runBuildCommand` call sites:

```ts
// packages/cli/src/cmd/build/adapters/generic.ts
const buildEnv = {
	...framework.buildEnv,
	...(options.deploymentId ? { AGENTUITY_DEPLOYMENT_ID: options.deploymentId } : {}),
};
await runBuildCommand(buildCwd, framework.buildCommand, framework.packageManager, buildEnv, ...);
```

- **Why an env var:** the build runs as a `sh -c` / package-manager subprocess, so the environment is the only clean, framework-agnostic channel into arbitrary build tooling
- **Why the conditional spread:** the variable should be genuinely unset (not empty-string) outside deploys, so builds can use plain presence checks
- **Why not the existing blob:** the subprocess env inherits the deploy process env, which carries the internal `AGENTUITY_DEPLOYMENT` JSON (`{id, orgId, publicKey}`) — but that is an undocumented internal contract whose shape can change; this makes the id a first-class value instead
- **Why both adapters:** Next.js projects route through the `nextjs` adapter rather than `generic`, so it gets the same two lines (e.g. for a CDN `assetPrefix`)
- **Deliberately not injected:** `AGENTUITY_REGION` — that name already has a service-runtime meaning (API endpoint selection), so reusing it here risks collisions; can be added later if needed

A build consumes it like:

```ts
// vite.config.ts — point asset URLs at a deployment-scoped CDN base
export default defineConfig({
	base: process.env.AGENTUITY_DEPLOYMENT_ID
		? `https://cdn.agentuity.com/${process.env.AGENTUITY_DEPLOYMENT_ID}/client/`
		: '/',
});
```

## Verification

- New test `packages/cli/test/cmd/build/adapters/deployment-env.test.ts` fails on `main` (`Received: "MISSING"`) and passes with the change
- `bun test` in `packages/cli`: 688 pass / 0 fail (61 files)
- `bun run typecheck` in `packages/cli`: clean
- `biome check` on changed files: clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build scripts can now access deployment ID information during the build process via environment variables.
  * This capability is available for both generic and Next.js adapter builds.

* **Tests**
  * Added test coverage for deployment environment variable injection across adapters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->