### PR TITLE
fix(cli): authenticate GitHub archive downloads on v2

### DIFF
--- a/packages/cli/src/cmd/build/ci.ts
+++ b/packages/cli/src/cmd/build/ci.ts
@@ -35,12 +35,64 @@ async function runCommand(cmd: string[], cwd: string): Promise<number> {
 	await proc.exited;
 	return proc.exitCode ?? 1;
 }
-async function downloadSource(url: string, targetPath: string): Promise<void> {
+
+const githubArchiveTokenEnv = 'GITHUB_ARCHIVE_TOKEN';
+const githubArchiveHosts = new Set(['api.github.com', 'codeload.github.com']);
+
+export function sourceDownloadHeaders(url: string): Record<string, string> | undefined {
+	const token = process.env[githubArchiveTokenEnv]?.trim();
+	if (!token) {
+		return undefined;
+	}
+
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return undefined;
+	}
+
+	if (!githubArchiveHosts.has(parsed.hostname.toLowerCase())) {
+		return undefined;
+	}
+
+	return {
+		Authorization: `Bearer ${token}`,
+		Accept: 'application/vnd.github+json',
+		'X-GitHub-Api-Version': '2022-11-28',
+	};
+}
+
+async function fetchSourceArchive(url: string): Promise<Response> {
+	let currentURL = url;
+
+	for (let redirectCount = 0; redirectCount <= 5; redirectCount++) {
+		const response = await fetch(currentURL, {
+			headers: sourceDownloadHeaders(currentURL),
+			redirect: 'manual',
+			signal: AbortSignal.timeout(60_000),
+		});
+
+		if (response.status < 300 || response.status >= 400) {
+			return response;
+		}
+
+		const location = response.headers.get('location');
+		if (!location) {
+			return response;
+		}
+		currentURL = new URL(location, currentURL).toString();
+	}
+
+	throw new Error('Download failed: too many redirects');
+}
+
+export async function downloadSource(url: string, targetPath: string): Promise<void> {
 	let lastError: unknown;
 
 	for (let attempt = 1; attempt <= 3; attempt++) {
 		try {
-			const response = await fetch(url, { signal: AbortSignal.timeout(60_000) });
+			const response = await fetchSourceArchive(url);
 			if (!response.ok) {
 				throw new Error(`Download failed with status ${response.status}`);
 			}

--- a/packages/cli/test/cmd/build/ci.test.ts
+++ b/packages/cli/test/cmd/build/ci.test.ts
@@ -1,9 +1,87 @@
 import { describe, expect, test } from 'bun:test';
-import { buildDeployArgs } from '../../../src/cmd/build/ci';
+import { Buffer } from 'node:buffer';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildDeployArgs, downloadSource, sourceDownloadHeaders } from '../../../src/cmd/build/ci';
 
 describe('build ci', () => {
 	test('passes skip DNS validation to nested deploy', () => {
 		const args = buildDeployArgs({ skipDnsValidation: true });
 		expect(args).toContain('--skip-dns-validation');
+	});
+
+	test('adds GitHub archive token only for GitHub archive hosts', () => {
+		const previous = process.env.GITHUB_ARCHIVE_TOKEN;
+		process.env.GITHUB_ARCHIVE_TOKEN = 'ghs_test_token';
+		try {
+			expect(
+				sourceDownloadHeaders('https://api.github.com/repos/agentuity/sdk/zipball/abc')
+			).toEqual({
+				Authorization: 'Bearer ghs_test_token',
+				Accept: 'application/vnd.github+json',
+				'X-GitHub-Api-Version': '2022-11-28',
+			});
+			expect(
+				sourceDownloadHeaders('https://codeload.github.com/agentuity/sdk/legacy.zip/abc')
+			).toEqual({
+				Authorization: 'Bearer ghs_test_token',
+				Accept: 'application/vnd.github+json',
+				'X-GitHub-Api-Version': '2022-11-28',
+			});
+			expect(sourceDownloadHeaders('https://example.com/source.zip')).toBeUndefined();
+		} finally {
+			if (previous === undefined) {
+				delete process.env.GITHUB_ARCHIVE_TOKEN;
+			} else {
+				process.env.GITHUB_ARCHIVE_TOKEN = previous;
+			}
+		}
+	});
+
+	test('follows GitHub archive redirects with installation token', async () => {
+		const previousToken = process.env.GITHUB_ARCHIVE_TOKEN;
+		const previousFetch = globalThis.fetch;
+		const calls: Array<{ url: string; authorization?: string | null }> = [];
+		process.env.GITHUB_ARCHIVE_TOKEN = 'ghs_test_token';
+		globalThis.fetch = (async (input, init) => {
+			const url = String(input);
+			const headers = new Headers(init?.headers);
+			calls.push({ url, authorization: headers.get('authorization') });
+			if (url === 'https://api.github.com/repos/agentuity/sdk/zipball/abc') {
+				return new Response(null, {
+					status: 302,
+					headers: {
+						location: 'https://codeload.github.com/agentuity/sdk/legacy.zip/abc',
+					},
+				});
+			}
+			return new Response(new Uint8Array([1, 2, 3]));
+		}) as typeof fetch;
+
+		const dir = await mkdtemp(join(tmpdir(), 'agentuity-ci-download-test-'));
+		try {
+			const target = join(dir, 'source.zip');
+			await downloadSource('https://api.github.com/repos/agentuity/sdk/zipball/abc', target);
+			expect(await readFile(target)).toEqual(Buffer.from([1, 2, 3]));
+			expect(calls).toEqual([
+				{
+					url: 'https://api.github.com/repos/agentuity/sdk/zipball/abc',
+					authorization: 'Bearer ghs_test_token',
+				},
+				{
+					url: 'https://codeload.github.com/agentuity/sdk/legacy.zip/abc',
+					authorization: 'Bearer ghs_test_token',
+				},
+			]);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+			globalThis.fetch = previousFetch;
+			if (previousToken === undefined) {
+				delete process.env.GITHUB_ARCHIVE_TOKEN;
+			} else {
+				process.env.GITHUB_ARCHIVE_TOKEN = previousToken;
+			}
+		}
 	});
 });

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -65,7 +65,15 @@ Description:
 
 Required Tools:
   gh                   GitHub CLI (https://cli.github.com/)
-  amp                  Amp CLI for release notes generation
+  opencode             OpenCode CLI for release notes generation
+
+npm Authentication:
+  npm publish no longer accepts OTP codes from authenticator apps.
+  Export an npm automation token before running this script:
+
+    export NPM_TOKEN=npm_...
+
+  Create tokens at https://www.npmjs.com/settings/~/tokens
 
 Examples:
   bun scripts/publish.ts                 # Publish to npm (interactive)
@@ -424,16 +432,53 @@ async function revertVersionChanges() {
 	);
 }
 
+function getNpmToken(): string | undefined {
+	return process.env.NPM_TOKEN?.trim() || undefined;
+}
+
+async function configureNpmAuth() {
+	const token = getNpmToken();
+	if (!token) return;
+	await $`npm config set //registry.npmjs.org/:_authToken ${token}`.quiet();
+}
+
+function printNpmAuthHelp() {
+	console.error('❌ Error: Not authenticated to npm registry.');
+	console.error('');
+	console.error('   npm no longer supports OTP from authenticator apps for publish.');
+	console.error('   Use an automation token (keeps write 2FA enabled):');
+	console.error('     1. Create at https://www.npmjs.com/settings/~/tokens');
+	console.error('     2. export NPM_TOKEN=npm_...');
+	console.error('     3. Re-run this script');
+	console.error('');
+	console.error('   Or disable "Require 2FA for write actions" in npm account settings,');
+	console.error('   then run npm logout && npm login.');
+}
+
+function isOtpRequiredError(errStr: string): boolean {
+	const lower = errStr.toLowerCase();
+	return (
+		lower.includes('one-time password') ||
+		lower.includes('one time password') ||
+		lower.includes('eotp') ||
+		(lower.includes('otp') && lower.includes('required'))
+	);
+}
+
 async function validateEnvironment(isDryRun: boolean) {
 	console.log('🔍 Validating environment...\n');
 
-	// Always check npm authentication (tokens expire frequently)
+	await configureNpmAuth();
+
 	try {
 		const user = (await $`npm whoami`.text()).trim();
-		console.log(`✓ Logged into npm as: ${user}`);
+		if (getNpmToken()) {
+			console.log(`✓ Authenticated to npm as: ${user} (via NPM_TOKEN)`);
+		} else {
+			console.log(`✓ Logged into npm as: ${user}`);
+		}
 	} catch {
-		console.error('❌ Error: Not logged into npm registry.');
-		console.error('   Run: npm login');
+		printNpmAuthHelp();
 		rl.close();
 		process.exit(1);
 	}
@@ -920,6 +965,13 @@ async function main() {
 					lastErr = err;
 					const shellErr = err as { stderr?: string; stdout?: string };
 					const errStr = `${shellErr.stderr || ''} ${shellErr.stdout || ''} ${String(err)}`;
+					if (isOtpRequiredError(errStr)) {
+						console.error(
+							'\n   npm requested an OTP, which is no longer supported for publish.'
+						);
+						printNpmAuthHelp();
+						break;
+					}
 					const isTransient = errStr.includes('404') || errStr.includes('Not Found');
 					if (isTransient && attempt < maxRetries) {
 						const delay = attempt * 5;

--- a/scripts/upgrade-canary.ts
+++ b/scripts/upgrade-canary.ts
@@ -23,22 +23,21 @@ function showHelp() {
 Usage: bun scripts/upgrade-canary.ts [options] [project-dir]
 
 Options:
-  --version <canary-version>  Canary version (e.g. 2.0.26-2956070). Required unless --pr is set.
-  --pr <number>               SDK PR number; resolves version from the canary bot comment
+  --version <canary-version>  Canary version from the SDK PR bot comment (e.g. 2.0.26-2956070). Required.
   --dry-run                   Print changes without writing files or installing
   --skip-install              Update package.json only; do not run bun install
   --help                      Show this help message
 
 Examples:
   bun scripts/upgrade-canary.ts --version 2.0.26-2956070 ../basic-agent
-  bun scripts/upgrade-canary.ts --pr 1552 ../basic-agent
+
+The version string is in the SDK PR canary bot comment: **version:** \`2.0.26-2956070\`
 `);
 }
 
 function parseArgs(argv: string[]) {
 	let projectDir = process.cwd();
 	let version = '';
-	let pr = 0;
 	let dryRun = false;
 	let skipInstall = false;
 
@@ -51,9 +50,6 @@ function parseArgs(argv: string[]) {
 		switch (arg) {
 			case '--version':
 				version = argv[++i] ?? '';
-				break;
-			case '--pr':
-				pr = Number.parseInt(argv[++i] ?? '', 10);
 				break;
 			case '--dry-run':
 				dryRun = true;
@@ -69,7 +65,7 @@ function parseArgs(argv: string[]) {
 		}
 	}
 
-	return { projectDir, version, pr, dryRun, skipInstall };
+	return { projectDir, version, dryRun, skipInstall };
 }
 
 function tarballToPackageName(tarball: string, version: string): string {
@@ -98,33 +94,6 @@ async function fetchManifest(version: string): Promise<Manifest> {
 		throw new Error(`Failed to fetch canary manifest (${response.status}): ${url}`);
 	}
 	return (await response.json()) as Manifest;
-}
-
-async function resolveVersionFromPr(pr: number): Promise<string> {
-	const response = await fetch(
-		`https://api.github.com/repos/agentuity/sdk/issues/${pr}/comments`,
-		{
-			headers: {
-				Accept: 'application/vnd.github+json',
-				'User-Agent': 'agentuity-upgrade-canary',
-			},
-		}
-	);
-	if (!response.ok) {
-		throw new Error(`Failed to fetch PR #${pr} comments (${response.status})`);
-	}
-	const comments = (await response.json()) as Array<{ body?: string }>;
-	const botComment = comments.find((comment) =>
-		comment.body?.includes('<!-- agentuity-canary-bot -->')
-	);
-	if (!botComment?.body) {
-		throw new Error(`No canary bot comment found on agentuity/sdk#${pr}`);
-	}
-	const match = botComment.body.match(/\*\*version:\*\* `([^`]+)`/);
-	if (!match) {
-		throw new Error(`Could not parse canary version from PR #${pr} comment`);
-	}
-	return match[1];
 }
 
 function collectAgentuityPackageNames(pkgJson: Record<string, unknown>) {
@@ -211,11 +180,7 @@ async function upgradeProject(options: UpgradeOptions) {
 
 async function main() {
 	const args = parseArgs(process.argv.slice(2));
-	let version = args.version.trim();
-	if (!version && args.pr > 0) {
-		version = await resolveVersionFromPr(args.pr);
-		console.log(`Resolved PR #${args.pr} canary version: ${version}`);
-	}
+	const version = args.version.trim();
 	if (!version) {
 		showHelp();
 		process.exit(1);

--- a/scripts/upgrade-canary.ts
+++ b/scripts/upgrade-canary.ts
@@ -1,0 +1,235 @@
+#!/usr/bin/env bun
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { $ } from 'bun';
+
+const CANARY_BASE_URL = 'https://agentuity-sdk-objects.t3.storageapi.dev/npm';
+
+interface Manifest {
+	version: string;
+	packages: string[];
+}
+
+interface UpgradeOptions {
+	projectDir: string;
+	version: string;
+	dryRun: boolean;
+	skipInstall: boolean;
+}
+
+function showHelp() {
+	console.log(`
+Usage: bun scripts/upgrade-canary.ts [options] [project-dir]
+
+Options:
+  --version <canary-version>  Canary version (e.g. 2.0.26-2956070). Required unless --pr is set.
+  --pr <number>               SDK PR number; resolves version from the canary bot comment
+  --dry-run                   Print changes without writing files or installing
+  --skip-install              Update package.json only; do not run bun install
+  --help                      Show this help message
+
+Examples:
+  bun scripts/upgrade-canary.ts --version 2.0.26-2956070 ../basic-agent
+  bun scripts/upgrade-canary.ts --pr 1552 ../basic-agent
+`);
+}
+
+function parseArgs(argv: string[]) {
+	let projectDir = process.cwd();
+	let version = '';
+	let pr = 0;
+	let dryRun = false;
+	let skipInstall = false;
+
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg === '--help' || arg === '-h') {
+			showHelp();
+			process.exit(0);
+		}
+		switch (arg) {
+			case '--version':
+				version = argv[++i] ?? '';
+				break;
+			case '--pr':
+				pr = Number.parseInt(argv[++i] ?? '', 10);
+				break;
+			case '--dry-run':
+				dryRun = true;
+				break;
+			case '--skip-install':
+				skipInstall = true;
+				break;
+			default:
+				if (!arg.startsWith('-')) {
+					projectDir = resolve(arg);
+				}
+				break;
+		}
+	}
+
+	return { projectDir, version, pr, dryRun, skipInstall };
+}
+
+function tarballToPackageName(tarball: string, version: string): string {
+	const prefix = 'agentuity-';
+	const suffix = `-${version}.tgz`;
+	if (!tarball.startsWith(prefix) || !tarball.endsWith(suffix)) {
+		throw new Error(`Unexpected tarball name: ${tarball}`);
+	}
+	return `@agentuity/${tarball.slice(prefix.length, -suffix.length)}`;
+}
+
+function buildCanaryMap(version: string, packages: string[]) {
+	const baseUrl = `${CANARY_BASE_URL}/${version}`;
+	const map = new Map<string, string>();
+	for (const tarball of packages) {
+		const name = tarballToPackageName(tarball, version);
+		map.set(name, `${baseUrl}/${tarball}`);
+	}
+	return map;
+}
+
+async function fetchManifest(version: string): Promise<Manifest> {
+	const url = `${CANARY_BASE_URL}/${version}/manifest.json`;
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(`Failed to fetch canary manifest (${response.status}): ${url}`);
+	}
+	return (await response.json()) as Manifest;
+}
+
+async function resolveVersionFromPr(pr: number): Promise<string> {
+	const response = await fetch(
+		`https://api.github.com/repos/agentuity/sdk/issues/${pr}/comments`,
+		{
+			headers: {
+				Accept: 'application/vnd.github+json',
+				'User-Agent': 'agentuity-upgrade-canary',
+			},
+		}
+	);
+	if (!response.ok) {
+		throw new Error(`Failed to fetch PR #${pr} comments (${response.status})`);
+	}
+	const comments = (await response.json()) as Array<{ body?: string }>;
+	const botComment = comments.find((comment) =>
+		comment.body?.includes('<!-- agentuity-canary-bot -->')
+	);
+	if (!botComment?.body) {
+		throw new Error(`No canary bot comment found on agentuity/sdk#${pr}`);
+	}
+	const match = botComment.body.match(/\*\*version:\*\* `([^`]+)`/);
+	if (!match) {
+		throw new Error(`Could not parse canary version from PR #${pr} comment`);
+	}
+	return match[1];
+}
+
+function collectAgentuityPackageNames(pkgJson: Record<string, unknown>) {
+	const names = new Set<string>();
+	for (const field of [
+		'dependencies',
+		'devDependencies',
+		'peerDependencies',
+		'optionalDependencies',
+	]) {
+		const section = pkgJson[field];
+		if (!section || typeof section !== 'object') {
+			continue;
+		}
+		for (const name of Object.keys(section as Record<string, string>)) {
+			if (name.startsWith('@agentuity/')) {
+				names.add(name);
+			}
+		}
+	}
+	return names;
+}
+
+async function upgradeProject(options: UpgradeOptions) {
+	const pkgJsonPath = join(options.projectDir, 'package.json');
+	const raw = await readFile(pkgJsonPath, 'utf-8');
+	const pkgJson = JSON.parse(raw) as Record<string, any>;
+
+	const manifest = await fetchManifest(options.version);
+	const canaryMap = buildCanaryMap(manifest.version, manifest.packages);
+	const directNames = collectAgentuityPackageNames(pkgJson);
+
+	console.log(`\n📦 Upgrading ${options.projectDir} to canary ${manifest.version}\n`);
+
+	let directUpdated = 0;
+	for (const field of ['dependencies', 'devDependencies']) {
+		if (!pkgJson[field]) {
+			continue;
+		}
+		for (const name of Object.keys(pkgJson[field])) {
+			if (!name.startsWith('@agentuity/')) {
+				continue;
+			}
+			const url = canaryMap.get(name);
+			if (!url) {
+				throw new Error(`Canary manifest missing package ${name}`);
+			}
+			pkgJson[field][name] = url;
+			directUpdated++;
+			console.log(`  ✓ ${field}.${name}`);
+		}
+	}
+
+	const overrides: Record<string, string> = {};
+	for (const [name, url] of canaryMap.entries()) {
+		overrides[name] = url;
+	}
+	pkgJson.overrides = overrides;
+	console.log(`  ✓ overrides (${Object.keys(overrides).length} @agentuity packages)`);
+
+	if (options.dryRun) {
+		console.log('\n[dry-run] package.json would be updated; skipping write/install');
+		return;
+	}
+
+	await writeFile(pkgJsonPath, `${JSON.stringify(pkgJson, null, 2)}\n`);
+	console.log(`\n✓ Updated package.json (${directUpdated} direct deps)`);
+
+	if (options.skipInstall) {
+		return;
+	}
+
+	console.log('\n📥 Running bun install...\n');
+	await $`bun install`.cwd(options.projectDir);
+
+	const lockRaw = await readFile(join(options.projectDir, 'bun.lock'), 'utf-8');
+	for (const name of directNames) {
+		if (!lockRaw.includes(name) || !lockRaw.includes(manifest.version)) {
+			console.warn(`  ⚠ verify ${name} in bun.lock`);
+		}
+	}
+	console.log('\n✓ bun install complete');
+}
+
+async function main() {
+	const args = parseArgs(process.argv.slice(2));
+	let version = args.version.trim();
+	if (!version && args.pr > 0) {
+		version = await resolveVersionFromPr(args.pr);
+		console.log(`Resolved PR #${args.pr} canary version: ${version}`);
+	}
+	if (!version) {
+		showHelp();
+		process.exit(1);
+	}
+
+	await upgradeProject({
+		projectDir: args.projectDir,
+		version,
+		dryRun: args.dryRun,
+		skipInstall: args.skipInstall,
+	});
+}
+
+main().catch((error) => {
+	console.error(`[upgrade-canary] ${error instanceof Error ? error.message : String(error)}`);
+	process.exit(1);
+});

--- a/skills/README.md
+++ b/skills/README.md
@@ -44,6 +44,15 @@ Set up and use the Workbench dev UI for interactive agent testing. Covers the bu
 - Setting up the dev testing UI
 - Embedding workbench components
 
+### agentuity-canary
+
+Upgrade an Agentuity app to SDK canary tarballs from a PR. Covers pinning all `@agentuity/*` packages via `scripts/upgrade-canary.ts`, overrides for transitive deps, and validating with `bun run build` before push.
+
+**Use when:**
+- Testing a SDK PR before merge
+- Pinning a project (e.g. `basic-agent`) to canary packages
+- Preparing a push to trigger webhook deploy against prerelease SDK bits
+
 ## Installation
 
 ```bash
@@ -66,6 +75,8 @@ Each skill follows the [Agent Skills specification](https://agentskills.io/speci
 ```
 skills/
 ├── agentuity-agents/
+│   └── SKILL.md
+├── agentuity-canary/
 │   └── SKILL.md
 ├── agentuity-routing/
 │   └── SKILL.md

--- a/skills/agentuity-canary/SKILL.md
+++ b/skills/agentuity-canary/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: agentuity-canary
+description: Upgrade an Agentuity app project to SDK canary tarballs published from an agentuity/sdk PR. Use when testing a SDK PR before merge, pinning all @agentuity/* packages to the same prerelease build, or preparing a project like basic-agent for canary webhook deploy validation.
+license: Apache-2.0
+metadata:
+  author: agentuity
+  version: "1.0.0"
+---
+
+# Agentuity Canary Upgrades
+
+SDK PRs publish matching `@agentuity/*` tarballs to Tigris. Every Agentuity package in the graph must share the **same canary version** or installs and builds fail in confusing ways.
+
+## When To Use
+
+- A SDK PR has the `<!-- agentuity-canary-bot -->` comment with tarball URLs
+- You need to validate a SDK change in a real app (for example `agentuity/basic-agent`) before merge
+- Webhook/CI builds must pick up a prerelease CLI change (paired with infra-side env like `GITHUB_ARCHIVE_TOKEN`)
+
+## Quick Path
+
+From the SDK repo:
+
+```bash
+# By PR number (reads the canary bot comment)
+bun scripts/upgrade-canary.ts --pr 1552 ../basic-agent
+
+# Or by explicit canary version
+bun scripts/upgrade-canary.ts --version 2.0.26-2956070 ../basic-agent
+```
+
+Then in the target project:
+
+```bash
+bun run typecheck
+bun run build
+git add package.json bun.lock
+git commit -m "chore: pin Agentuity packages to SDK canary <version>"
+git push
+```
+
+Push triggers the linked project's GitHub webhook deploy when auto-deploy is enabled.
+
+## What The Script Does
+
+1. Fetches `https://agentuity-sdk-objects.t3.storageapi.dev/npm/<version>/manifest.json`
+2. Rewrites every direct `@agentuity/*` entry in `dependencies` and `devDependencies` to tarball URLs
+3. Sets `overrides` for **all** packages in the manifest so transitive `@agentuity/*` deps stay on the same canary
+4. Runs `bun install`
+
+Always commit **both** `package.json` and `bun.lock`.
+
+## Rules
+
+- **Bun only** — never use npm/pnpm for Agentuity projects
+- **All `@agentuity/*` together** — do not pin only `@agentuity/cli` or only `@agentuity/runtime`; overrides exist because the graph is tightly coupled
+- **Use tarball URLs, not semver** — canary builds are not on npm `latest`
+- **Match the PR branch line** — v2 PRs publish `2.0.x-<sha>` canaries; main publishes `3.0.x-<sha>`
+
+## Find The Canary Version
+
+On the SDK PR, expand the bot comment **Packages** / **Install** section, or read:
+
+```bash
+curl -s "https://agentuity-sdk-objects.t3.storageapi.dev/npm/<version>/manifest.json" | jq .
+```
+
+## Dry Run
+
+```bash
+bun scripts/upgrade-canary.ts --pr 1552 ../basic-agent --dry-run
+```
+
+## Revert To npm
+
+Restore direct deps to `latest` (or a released semver), remove `overrides`, run `bun install`.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+| --- | --- |
+| Mixed `@agentuity/*` versions in `bun.lock` | Missing or incomplete `overrides` — rerun the script |
+| `Cannot find module '@agentuity/...'` after install | Canary expired (7-day TTL) or wrong version string |
+| Build ok locally, webhook deploy fails | Sandbox snapshot CLI not on canary — infra uses build snapshot / `VERSION=`, not app `package.json` |
+| 404 downloading GitHub source in webhook build | Infra passes `GITHUB_ARCHIVE_TOKEN` but sandbox CLI too old — need canary CLI in build snapshot or SDK fix merged |
+
+## Related
+
+- SDK canary publish workflow: `.github/workflows/canary.yaml`
+- Pack/upload script: `scripts/canary.ts`
+- Upgrade script: `scripts/upgrade-canary.ts`

--- a/skills/agentuity-canary/SKILL.md
+++ b/skills/agentuity-canary/SKILL.md
@@ -22,10 +22,7 @@ SDK PRs publish matching `@agentuity/*` tarballs to Tigris. Every Agentuity pack
 From the SDK repo:
 
 ```bash
-# By PR number (reads the canary bot comment)
-bun scripts/upgrade-canary.ts --pr 1552 ../basic-agent
-
-# Or by explicit canary version
+# Copy the version from the SDK PR canary bot comment, then:
 bun scripts/upgrade-canary.ts --version 2.0.26-2956070 ../basic-agent
 ```
 
@@ -68,7 +65,7 @@ curl -s "https://agentuity-sdk-objects.t3.storageapi.dev/npm/<version>/manifest.
 ## Dry Run
 
 ```bash
-bun scripts/upgrade-canary.ts --pr 1552 ../basic-agent --dry-run
+bun scripts/upgrade-canary.ts --version 2.0.26-2956070 ../basic-agent --dry-run
 ```
 
 ## Revert To npm


### PR DESCRIPTION
## Summary
- Read `GITHUB_ARCHIVE_TOKEN` during `agentuity build --ci --url` source downloads on the v2 line.
- Add GitHub archive auth headers only for `api.github.com` and `codeload.github.com`.
- Follow GitHub archive redirects manually so the installation token survives the API-to-codeload hop without leaking to non-GitHub hosts.

## Paired infra PR
- https://github.com/agentuity/infra/pull/658 (already merged — Ion passes `DOWNLOAD_URL` + `GITHUB_ARCHIVE_TOKEN` into build sandboxes)

## Context
Webhook builds against private repos (e.g. `agentuity/infra`) fail with `Download failed with status 404` when the sandbox CLI ignores `GITHUB_ARCHIVE_TOKEN`. Main got this in #1549 / 3.0.8; this backports the same behavior to v2.

## Test plan
- [x] `bun test packages/cli/test/cmd/build/ci.test.ts` (from `packages/cli`)
- [ ] Merge PR → canary workflow publishes prerelease tarball
- [ ] Pin project to canary CLI and push to trigger GitHub webhook build


Made with [Cursor](https://cursor.com)