### PR TITLE
Fix SDK Explorer demos and storage `env` guidance

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
 		"predev": "bun run generate:scripts && bun run generate:schema && bun run scripts/generate-api-reference.ts && bun run scripts/generate-nav-data.ts && bun run scripts/validate-routes.ts && bun run scripts/generate-markdown-files.ts",
 		"prebuild": "bun run generate:scripts && bun run generate:schema && bun run scripts/generate-api-reference.ts && bun run scripts/generate-nav-data.ts && bun run scripts/validate-routes.ts && bun run scripts/generate-markdown-files.ts",
 		"predeploy": "cd ../ && bun install --frozen-lockfile && bun run build && cd docs && bun run prebuild",
-		"build": "vite build && bun run scripts/prepare-start-output.ts",
+		"build": "vite build && bun run build:run && bun run scripts/prepare-start-output.ts",
 		"dev": "bun run scripts/dev.ts",
 		"dev:web": "vite dev --port 3000",
 		"server:api": "PORT=3001 bun --hot src/api/dev-server.ts",

--- a/docs/src/agent/objectstore/agent.ts
+++ b/docs/src/agent/objectstore/agent.ts
@@ -182,6 +182,17 @@ const agent = defineDemoAgent('objectstore', {
 				const expiresIn = input.expiresIn || 3600;
 
 				try {
+					const storage = createStorage();
+
+					// presign() signs locally without calling S3, so a URL for a missing
+					// object would look valid but 404 on open. Check existence first.
+					if (!(await objectExists(storage, key))) {
+						return {
+							success: false,
+							message: `File "${input.filename}" not found`,
+						};
+					}
+
 					const url = createObjectStoragePresignedUrl(key, expiresIn);
 
 					return {

--- a/docs/src/agent/objectstore/agent.ts
+++ b/docs/src/agent/objectstore/agent.ts
@@ -12,16 +12,20 @@
  * - storage.write(key, data) - Upload a file
  * - storage.file(key).text() / .arrayBuffer() - Download file contents
  * - storage.stat(key) - Check object metadata
- * - s3.presign(key, { expiresIn }) - Generate temporary shareable URL
+ * - Bun S3Client.presign(key, { expiresIn }) - Generate temporary shareable URL
  * - storage.list({ prefix }) - List files in a directory
  *
  * Docs: https://agentuity.dev/services/storage/object
  */
 import { defineDemoAgent } from '../demo-agent';
 import { s } from '@agentuity/schema';
-import { s3 } from 'bun';
 import type { S3ClientLike } from '@agentuity/storage';
-import { bucketConfigFromEnv, createS3Client } from '@agentuity/storage';
+import {
+	createObjectStorageClient,
+	createObjectStoragePresignedUrl,
+	isObjectStorageConfigurationError,
+	objectStorageNotConfiguredMessage,
+} from '../../lib/demo-object-storage';
 
 const prefix = 'sdk-explorer/';
 
@@ -34,7 +38,7 @@ const SAMPLE_FILE = {
 };
 
 function createStorage(): S3ClientLike {
-	return createS3Client(bucketConfigFromEnv());
+	return createObjectStorageClient();
 }
 
 function isMissingObjectError(error: unknown): boolean {
@@ -114,6 +118,13 @@ const agent = defineDemoAgent('objectstore', {
 						},
 					};
 				} catch (error) {
+					if (isObjectStorageConfigurationError(error)) {
+						return {
+							success: false,
+							message: objectStorageNotConfiguredMessage,
+						};
+					}
+
 					ctx.logger.error('Download failed', { error, key });
 					return {
 						success: false,
@@ -148,6 +159,15 @@ const agent = defineDemoAgent('objectstore', {
 							data: [],
 						};
 					}
+
+					if (isObjectStorageConfigurationError(error)) {
+						return {
+							success: false,
+							message: objectStorageNotConfiguredMessage,
+							data: [],
+						};
+					}
+
 					ctx.logger.error('List failed', { error });
 					return {
 						success: false,
@@ -162,19 +182,26 @@ const agent = defineDemoAgent('objectstore', {
 				const expiresIn = input.expiresIn || 3600;
 
 				try {
-					// `@agentuity/storage` does not expose presign yet; keep Bun's helper
-					// here while reads/writes/listing use the public storage client path.
-					const url = s3.presign(key, {
-						expiresIn,
-						method: 'GET',
-					});
+					const url = createObjectStoragePresignedUrl(key, expiresIn);
 
 					return {
 						success: true,
 						message: `Presigned URL for "${input.filename}" (expires in ${expiresIn}s)`,
-						data: { url, filename: input.filename, expiresIn },
+						data: {
+							url,
+							urlType: 'presigned',
+							filename: input.filename,
+							expiresIn,
+						},
 					};
 				} catch (error) {
+					if (isObjectStorageConfigurationError(error)) {
+						return {
+							success: false,
+							message: objectStorageNotConfiguredMessage,
+						};
+					}
+
 					ctx.logger.error('Presign failed', { error, key });
 					return {
 						success: false,
@@ -217,6 +244,13 @@ const agent = defineDemoAgent('objectstore', {
 						},
 					};
 				} catch (error) {
+					if (isObjectStorageConfigurationError(error)) {
+						return {
+							success: false,
+							message: objectStorageNotConfiguredMessage,
+						};
+					}
+
 					ctx.logger.error('Seed failed', { error, key });
 					return {
 						success: false,

--- a/docs/src/api/object-storage/route.ts
+++ b/docs/src/api/object-storage/route.ts
@@ -91,6 +91,8 @@ const router = new Hono<ApiEnv>()
 			if (!isObjectStorageConfigured()) {
 				return c.json(
 					{
+						success: false,
+						configured: false,
 						error: 'Object storage is not configured',
 						message: objectStorageNotConfiguredMessage,
 					},
@@ -201,7 +203,7 @@ const router = new Hono<ApiEnv>()
 			// object would look valid but 404 on open. Check existence first.
 			const storage = createObjectStorageClient();
 			if (!(await objectExists(storage, key))) {
-				return c.json({ success: false, error: 'File not found' }, 404);
+				return c.json({ success: false, configured: true, error: 'File not found' }, 404);
 			}
 
 			return c.json({

--- a/docs/src/api/object-storage/route.ts
+++ b/docs/src/api/object-storage/route.ts
@@ -111,7 +111,8 @@ const router = new Hono<ApiEnv>()
 			return c.body(data, {
 				headers: {
 					'content-type': stat?.type || 'application/octet-stream',
-					'content-disposition': `attachment; filename="${filename}"`,
+					// RFC 5987 encoding: stored keys may contain quotes or non-ASCII.
+					'content-disposition': `attachment; filename*=UTF-8''${encodeURIComponent(filename)}`,
 					'content-length': String(stat?.size || data.byteLength),
 				},
 			});
@@ -156,6 +157,7 @@ const router = new Hono<ApiEnv>()
 			if (isMissingObjectError(error)) {
 				return c.json({
 					success: true,
+					configured: true,
 					count: 0,
 					files: [],
 				});
@@ -193,6 +195,13 @@ const router = new Hono<ApiEnv>()
 					},
 					503
 				);
+			}
+
+			// presign() signs locally without calling S3, so a URL for a missing
+			// object would look valid but 404 on open. Check existence first.
+			const storage = createObjectStorageClient();
+			if (!(await objectExists(storage, key))) {
+				return c.json({ success: false, error: 'File not found' }, 404);
 			}
 
 			return c.json({

--- a/docs/src/api/object-storage/route.ts
+++ b/docs/src/api/object-storage/route.ts
@@ -19,6 +19,7 @@ import objectstoreAgent from '../../agent/objectstore/agent';
 import { Hono } from 'hono';
 
 const prefix = 'sdk-explorer/';
+type ObjectStat = Awaited<ReturnType<S3ClientLike['stat']>>;
 
 interface FileInfo {
 	key: string;
@@ -36,12 +37,11 @@ function isMissingObjectError(error: unknown): boolean {
 	);
 }
 
-async function objectExists(storage: S3ClientLike, key: string): Promise<boolean> {
+async function getObjectStat(storage: S3ClientLike, key: string): Promise<ObjectStat | null> {
 	try {
-		await storage.stat(key);
-		return true;
+		return await storage.stat(key);
 	} catch (error) {
-		if (isMissingObjectError(error)) return false;
+		if (isMissingObjectError(error)) return null;
 		throw error;
 	}
 }
@@ -102,13 +102,13 @@ const router = new Hono<ApiEnv>()
 
 			const storage = createObjectStorageClient();
 
-			if (!(await objectExists(storage, key))) {
-				return c.json({ error: 'File not found' }, 404);
+			const stat = await getObjectStat(storage, key);
+			if (!stat) {
+				return c.json({ success: false, configured: true, error: 'File not found' }, 404);
 			}
 
 			const file = storage.file(key);
 			const data = await file.arrayBuffer();
-			const stat = await storage.stat(key);
 
 			return c.body(data, {
 				headers: {
@@ -202,7 +202,7 @@ const router = new Hono<ApiEnv>()
 			// presign() signs locally without calling S3, so a URL for a missing
 			// object would look valid but 404 on open. Check existence first.
 			const storage = createObjectStorageClient();
-			if (!(await objectExists(storage, key))) {
+			if (!(await getObjectStat(storage, key))) {
 				return c.json({ success: false, configured: true, error: 'File not found' }, 404);
 			}
 

--- a/docs/src/api/object-storage/route.ts
+++ b/docs/src/api/object-storage/route.ts
@@ -8,14 +8,23 @@
  * POST /presign/:filename - Generates presigned URL for temporary access
  */
 import type { ApiEnv } from '../context';
-import { s3 } from 'bun';
 import type { S3ClientLike } from '@agentuity/storage';
-import { bucketConfigFromEnv, createS3Client } from '@agentuity/storage';
+import {
+	createObjectStorageClient,
+	createObjectStoragePresignedUrl,
+	isObjectStorageConfigured,
+	objectStorageNotConfiguredMessage,
+} from '../../lib/demo-object-storage';
 import objectstoreAgent from '../../agent/objectstore/agent';
 import { Hono } from 'hono';
 
-function createStorage(): S3ClientLike {
-	return createS3Client(bucketConfigFromEnv());
+const prefix = 'sdk-explorer/';
+
+interface FileInfo {
+	key: string;
+	filename: string;
+	size: number;
+	lastModified?: string;
 }
 
 function isMissingObjectError(error: unknown): boolean {
@@ -37,6 +46,16 @@ async function objectExists(storage: S3ClientLike, key: string): Promise<boolean
 	}
 }
 
+async function listDemoFiles(storage: S3ClientLike): Promise<FileInfo[]> {
+	const objects = await storage.list({ prefix, maxKeys: 100 });
+	return objects.contents.map((obj) => ({
+		key: obj.key,
+		filename: obj.key.replace(prefix, '') || obj.key,
+		size: obj.size,
+		lastModified: obj.lastModified,
+	}));
+}
+
 const router = new Hono<ApiEnv>()
 
 	.get('/', (c) => {
@@ -49,6 +68,17 @@ const router = new Hono<ApiEnv>()
 	})
 
 	.post('/seed', async (c) => {
+		if (!isObjectStorageConfigured()) {
+			return c.json(
+				{
+					success: false,
+					configured: false,
+					message: objectStorageNotConfiguredMessage,
+				},
+				503
+			);
+		}
+
 		const result = await objectstoreAgent.run({ action: 'seed' });
 		return c.json(result);
 	})
@@ -58,7 +88,17 @@ const router = new Hono<ApiEnv>()
 		const key = `sdk-explorer/${filename}`;
 
 		try {
-			const storage = createStorage();
+			if (!isObjectStorageConfigured()) {
+				return c.json(
+					{
+						error: 'Object storage is not configured',
+						message: objectStorageNotConfiguredMessage,
+					},
+					503
+				);
+			}
+
+			const storage = createObjectStorageClient();
 
 			if (!(await objectExists(storage, key))) {
 				return c.json({ error: 'File not found' }, 404);
@@ -89,20 +129,26 @@ const router = new Hono<ApiEnv>()
 
 	.get('/list', async (c) => {
 		try {
-			const storage = createStorage();
-			const prefix = 'sdk-explorer/';
-			const objects = await storage.list({ prefix, maxKeys: 100 });
+			if (!isObjectStorageConfigured()) {
+				return c.json(
+					{
+						success: false,
+						configured: false,
+						count: 0,
+						files: [],
+						error: 'Object storage is not configured',
+						message: objectStorageNotConfiguredMessage,
+					},
+					503
+				);
+			}
 
-			const files =
-				objects.contents.map((obj) => ({
-					key: obj.key,
-					filename: obj.key.replace(prefix, '') || obj.key,
-					size: obj.size,
-					lastModified: obj.lastModified,
-				})) || [];
+			const storage = createObjectStorageClient();
+			const files = await listDemoFiles(storage);
 
 			return c.json({
 				success: true,
+				configured: true,
 				count: files.length,
 				files,
 			});
@@ -137,16 +183,23 @@ const router = new Hono<ApiEnv>()
 		const expiresIn = Math.min(Math.max(rawExpires, 60), 86400);
 
 		try {
-			// `@agentuity/storage` mirrors Bun's object APIs but does not expose
-			// presign yet, so this route keeps Bun's presign helper for the URL.
-			const url = s3.presign(key, {
-				expiresIn,
-				method: 'GET',
-			});
+			if (!isObjectStorageConfigured()) {
+				return c.json(
+					{
+						success: false,
+						configured: false,
+						error: 'Object storage is not configured',
+						message: objectStorageNotConfiguredMessage,
+					},
+					503
+				);
+			}
 
 			return c.json({
 				success: true,
-				url,
+				configured: true,
+				url: createObjectStoragePresignedUrl(key, expiresIn),
+				urlType: 'presigned',
 				filename,
 				expiresIn: `${expiresIn}s`,
 			});

--- a/docs/src/api/sandbox/route.ts
+++ b/docs/src/api/sandbox/route.ts
@@ -254,7 +254,7 @@ const router = new Hono<ApiEnv>().get(
 			scriptFiles = await loadScriptFiles(scriptPath);
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Unknown sandbox setup error';
-			logger?.error('Sandbox setup error', { error: message });
+			logger?.error('Sandbox setup error', { error });
 			await stream.writeSSE({ event: 'error', data: message });
 			return;
 		}

--- a/docs/src/api/sandbox/route.ts
+++ b/docs/src/api/sandbox/route.ts
@@ -258,6 +258,9 @@ const router = new Hono<ApiEnv>().get(
 			await stream.writeSSE({ event: 'error', data: message });
 			return;
 		}
+		// Sandbox env is fixed at creation, so a reused session sandbox can predate
+		// the linked-bucket AWS_* env (e.g. storage linked after the session began).
+		// Always run the object storage script one-shot so it sees current env.
 		const useInteractiveSandbox = scriptName !== 'objectstore';
 
 		// --- Interactive session path ---

--- a/docs/src/api/sandbox/route.ts
+++ b/docs/src/api/sandbox/route.ts
@@ -22,7 +22,9 @@ import {
 	SandboxNotFoundError,
 	SandboxTerminatedError,
 	type ExecutionStatus,
+	type FileToWrite,
 } from '@agentuity/server';
+import { resolve } from 'node:path';
 import { Writable } from 'node:stream';
 import { SCRIPT_NAMES, SCRIPT_DEFAULTS } from './scripts';
 import {
@@ -56,6 +58,18 @@ const SANDBOX_SERVICE_SCOPES = [
 const TERMINAL_STATUSES = new Set<ExecutionStatus>(['completed', 'failed', 'timeout', 'cancelled']);
 
 const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function loadScriptFiles(scriptPath: string): Promise<FileToWrite[]> {
+	const file = Bun.file(resolve(process.cwd(), scriptPath));
+	if (!(await file.exists())) return [];
+
+	return [
+		{
+			path: scriptPath,
+			content: new Uint8Array(await file.arrayBuffer()),
+		},
+	];
+}
 
 interface SandboxExecutionResult {
 	readonly exitCode: number;
@@ -206,11 +220,17 @@ const router = new Hono<ApiEnv>().get(
 		if (process.env.DATABASE_URL) envVars.DATABASE_URL = process.env.DATABASE_URL;
 
 		const storageEnv = {
-			AWS_BUCKET: process.env.AWS_BUCKET,
-			AWS_ENDPOINT: process.env.AWS_ENDPOINT,
-			AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
-			AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
-			AWS_REGION: process.env.AWS_REGION,
+			AWS_BUCKET: process.env.AWS_BUCKET ?? process.env.S3_BUCKET,
+			AWS_ENDPOINT: process.env.AWS_ENDPOINT ?? process.env.S3_ENDPOINT,
+			AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID ?? process.env.S3_ACCESS_KEY_ID,
+			AWS_SECRET_ACCESS_KEY:
+				process.env.AWS_SECRET_ACCESS_KEY ?? process.env.S3_SECRET_ACCESS_KEY,
+			AWS_REGION: process.env.AWS_REGION ?? process.env.S3_REGION,
+			S3_BUCKET: process.env.S3_BUCKET,
+			S3_ENDPOINT: process.env.S3_ENDPOINT,
+			S3_ACCESS_KEY_ID: process.env.S3_ACCESS_KEY_ID,
+			S3_SECRET_ACCESS_KEY: process.env.S3_SECRET_ACCESS_KEY,
+			S3_REGION: process.env.S3_REGION,
 		};
 		for (const [key, value] of Object.entries(storageEnv)) {
 			if (value) envVars[key] = value;
@@ -218,12 +238,14 @@ const router = new Hono<ApiEnv>().get(
 
 		const scriptPath = `dist/run/${scriptName}.js`;
 		const command = ['bun', 'run', scriptPath, JSON.stringify(input)];
+		const scriptFiles = await loadScriptFiles(scriptPath);
+		const useInteractiveSandbox = scriptName !== 'objectstore';
 
 		// --- Interactive session path ---
 		try {
 			const threadId = c.var.thread?.id;
 
-			if (threadId) {
+			if (threadId && useInteractiveSandbox) {
 				const kvResult = await c.var.kv.get<string>(SESSION_BUCKET, threadId);
 
 				let sandboxId: string;
@@ -235,7 +257,7 @@ const router = new Hono<ApiEnv>().get(
 					try {
 						await stream.writeSSE({ event: 'status', data: 'running' });
 						const result = await withHeartbeat(stream, () =>
-							executeOnSandbox(client, sandboxId, command, orgId, stream)
+							executeOnSandbox(client, sandboxId, command, scriptFiles, orgId, stream)
 						);
 						await c.var.kv.set(SESSION_BUCKET, threadId, sandboxId, { ttl: SESSION_TTL });
 						await sendExecutionResult(stream, result);
@@ -274,7 +296,7 @@ const router = new Hono<ApiEnv>().get(
 
 				await stream.writeSSE({ event: 'status', data: 'running' });
 				const result = await withHeartbeat(stream, () =>
-					executeOnSandbox(client, sandboxId, command, orgId, stream)
+					executeOnSandbox(client, sandboxId, command, scriptFiles, orgId, stream)
 				);
 				await sendExecutionResult(stream, result);
 				return;
@@ -316,7 +338,7 @@ const router = new Hono<ApiEnv>().get(
 				sandboxRun(client, {
 					options: {
 						snapshot: SNAPSHOT_ID,
-						command: { exec: command },
+						command: { exec: command, files: scriptFiles },
 						network: { enabled: true },
 						timeout: { execution: SANDBOX_EXEC_TIMEOUT },
 						env: envVars,
@@ -370,12 +392,13 @@ async function executeOnSandbox(
 	client: APIClient,
 	sandboxId: string,
 	command: string[],
+	files: FileToWrite[],
 	orgId: string | undefined,
 	sseStream: SSEStream
 ): Promise<SandboxExecutionResult> {
 	const execution = await sandboxExecute(client, {
 		sandboxId,
-		options: { command, timeout: SANDBOX_EXEC_TIMEOUT },
+		options: { command, files, timeout: SANDBOX_EXEC_TIMEOUT },
 		orgId,
 	});
 

--- a/docs/src/api/sandbox/route.ts
+++ b/docs/src/api/sandbox/route.ts
@@ -12,6 +12,7 @@
  */
 import { sse } from '../http';
 import type { ApiEnv } from '../context';
+import { StructuredError } from '@agentuity/core';
 import {
 	APIClient,
 	sandboxRun,
@@ -56,12 +57,22 @@ const SANDBOX_SERVICE_SCOPES = [
 ];
 // Terminal execution statuses — typed against the SDK enum so drift is caught at compile time
 const TERMINAL_STATUSES = new Set<ExecutionStatus>(['completed', 'failed', 'timeout', 'cancelled']);
+const SandboxScriptFileMissingError = StructuredError('SandboxScriptFileMissingError')<{
+	scriptPath: string;
+	cwd: string;
+}>();
 
 const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 async function loadScriptFiles(scriptPath: string): Promise<FileToWrite[]> {
 	const file = Bun.file(resolve(process.cwd(), scriptPath));
-	if (!(await file.exists())) return [];
+	if (!(await file.exists())) {
+		throw new SandboxScriptFileMissingError({
+			message: `Bundled demo script not found: ${scriptPath}. Run \`bun run build:run\` before using sandbox demos.`,
+			scriptPath,
+			cwd: process.cwd(),
+		});
+	}
 
 	return [
 		{
@@ -238,7 +249,15 @@ const router = new Hono<ApiEnv>().get(
 
 		const scriptPath = `dist/run/${scriptName}.js`;
 		const command = ['bun', 'run', scriptPath, JSON.stringify(input)];
-		const scriptFiles = await loadScriptFiles(scriptPath);
+		let scriptFiles: FileToWrite[];
+		try {
+			scriptFiles = await loadScriptFiles(scriptPath);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : 'Unknown sandbox setup error';
+			logger?.error('Sandbox setup error', { error: message });
+			await stream.writeSSE({ event: 'error', data: message });
+			return;
+		}
 		const useInteractiveSandbox = scriptName !== 'objectstore';
 
 		// --- Interactive session path ---

--- a/docs/src/lib/demo-object-storage.ts
+++ b/docs/src/lib/demo-object-storage.ts
@@ -1,0 +1,55 @@
+import { S3Client } from 'bun';
+import type { S3ClientLike } from '@agentuity/storage';
+import { bucketConfigFromEnv, createS3Client } from '@agentuity/storage';
+import { resolveEndpoint } from '@agentuity/storage/types';
+
+export const objectStorageNotConfiguredMessage =
+	'Object storage is not configured. Link an Agentuity storage bucket or set AWS_* bucket env vars.';
+
+function objectStorageEnv(
+	env: Record<string, string | undefined> = process.env
+): Record<string, string | undefined> {
+	return {
+		AWS_ENDPOINT: env.AWS_ENDPOINT ?? env.S3_ENDPOINT,
+		AWS_BUCKET: env.AWS_BUCKET ?? env.S3_BUCKET,
+		AWS_ACCESS_KEY_ID: env.AWS_ACCESS_KEY_ID ?? env.S3_ACCESS_KEY_ID,
+		AWS_SECRET_ACCESS_KEY: env.AWS_SECRET_ACCESS_KEY ?? env.S3_SECRET_ACCESS_KEY,
+		AWS_REGION: env.AWS_REGION ?? env.S3_REGION,
+	};
+}
+
+export function isObjectStorageConfigured(
+	env: Record<string, string | undefined> = process.env
+): boolean {
+	const storageEnv = objectStorageEnv(env);
+	return Boolean(
+		storageEnv.AWS_ENDPOINT &&
+			storageEnv.AWS_BUCKET &&
+			storageEnv.AWS_ACCESS_KEY_ID &&
+			storageEnv.AWS_SECRET_ACCESS_KEY
+	);
+}
+
+export function isObjectStorageConfigurationError(error: unknown): boolean {
+	return error instanceof Error && error.message.includes('Storage env vars are not set');
+}
+
+export function createObjectStorageClient(): S3ClientLike {
+	return createS3Client(bucketConfigFromEnv(objectStorageEnv()));
+}
+
+export function createObjectStoragePresignedUrl(key: string, expiresIn: number): string {
+	const bucket = bucketConfigFromEnv(objectStorageEnv());
+	const client = new S3Client({
+		endpoint: resolveEndpoint(bucket),
+		accessKeyId: bucket.access_key,
+		secretAccessKey: bucket.secret_key,
+		region: bucket.region || 'auto',
+		virtualHostedStyle: true,
+	});
+
+	return client.presign(key, {
+		expiresIn,
+		method: 'GET',
+	});
+}

--- a/docs/src/lib/demo-object-storage.ts
+++ b/docs/src/lib/demo-object-storage.ts
@@ -6,9 +6,11 @@ import { resolveEndpoint } from '@agentuity/storage/types';
 export const objectStorageNotConfiguredMessage =
 	'Object storage is not configured. Link an Agentuity storage bucket or set AWS_* bucket env vars.';
 
-function objectStorageEnv(
+function objectStorageDemoEnv(
 	env: Record<string, string | undefined> = process.env
 ): Record<string, string | undefined> {
+	// AWS_* is the public contract. S3_* is accepted only so older local
+	// docs environments keep working while the visible demo copy stays canonical.
 	return {
 		AWS_ENDPOINT: env.AWS_ENDPOINT ?? env.S3_ENDPOINT,
 		AWS_BUCKET: env.AWS_BUCKET ?? env.S3_BUCKET,
@@ -21,7 +23,7 @@ function objectStorageEnv(
 export function isObjectStorageConfigured(
 	env: Record<string, string | undefined> = process.env
 ): boolean {
-	const storageEnv = objectStorageEnv(env);
+	const storageEnv = objectStorageDemoEnv(env);
 	return Boolean(
 		storageEnv.AWS_ENDPOINT &&
 			storageEnv.AWS_BUCKET &&
@@ -35,11 +37,11 @@ export function isObjectStorageConfigurationError(error: unknown): boolean {
 }
 
 export function createObjectStorageClient(): S3ClientLike {
-	return createS3Client(bucketConfigFromEnv(objectStorageEnv()));
+	return createS3Client(bucketConfigFromEnv(objectStorageDemoEnv()));
 }
 
 export function createObjectStoragePresignedUrl(key: string, expiresIn: number): string {
-	const bucket = bucketConfigFromEnv(objectStorageEnv());
+	const bucket = bucketConfigFromEnv(objectStorageDemoEnv());
 	const client = new S3Client({
 		endpoint: resolveEndpoint(bucket),
 		accessKeyId: bucket.access_key,

--- a/docs/src/run/durable-stream.ts
+++ b/docs/src/run/durable-stream.ts
@@ -1,8 +1,8 @@
 /**
  * Standalone run script for Durable Streams demo
  *
- * Writes generated text into a durable stream and returns the shareable URL.
- * The stream keeps the completed output available after the request ends.
+ * Writes generated text into a durable stream, verifies it can be read back,
+ * and returns the shareable URL. The stream is left in place so the URL works.
  *
  * Usage: bun run src/run/durable-stream.ts
  */
@@ -34,20 +34,28 @@ try {
 	await stream.write(result.text);
 	await stream.close();
 
+	const info = await ctx.stream.get(stream.id);
+	const downloaded = await new Response(await ctx.stream.download(stream.id)).text();
+	const page = await ctx.stream.list({ namespace: streamName, limit: 10 });
+
 	writeSandboxOutput(
 		[
 			`Stream created: ${streamName}`,
-			`Stream ID: ${stream.id}`,
+			`Stream ID: ${info.id}`,
 			'',
 			'Content written:',
 			result.text,
 			'',
 			`Bytes written: ${stream.bytesWritten}`,
+			`Downloaded bytes: ${downloaded.length}`,
+			`Listed in namespace: ${page.streams.some((item) => item.id === stream.id) ? 'yes' : 'no'}`,
 			'',
 			'Stream closed',
 			'',
 			'Public URL (shareable):',
-			`  ${stream.url}`,
+			`  ${info.url}`,
+			'',
+			'Delete after sharing is no longer needed with ctx.stream.delete(streamId).',
 		].join('\n')
 	);
 } catch (error) {

--- a/docs/src/run/email.ts
+++ b/docs/src/run/email.ts
@@ -50,6 +50,10 @@ try {
 	const input = JSON.parse(process.argv[2] ?? '{"template":"welcome"}');
 	const result = await email.run(input);
 	const outbound = await waitForOutboundStatus(result.id);
+	const [outbox, activity] = await Promise.all([
+		ctx.email.listOutbound(),
+		ctx.email.getActivity({ days: 7 }),
+	]);
 
 	writeSandboxOutput(
 		JSON.stringify(
@@ -58,6 +62,8 @@ try {
 				subject: result.subject,
 				to: result.to,
 				from: result.from,
+				listed: outbox.some((message) => message.id === result.id),
+				activityDays: activity.activity.length,
 			},
 			null,
 			2

--- a/docs/src/run/kv.ts
+++ b/docs/src/run/kv.ts
@@ -29,7 +29,7 @@ try {
 	await ctx.kv.createNamespace(namespace, { defaultTTLSeconds: 300 });
 	namespaceCreated = true;
 
-	ctx.logger.info('Setting key');
+	ctx.logger.info('Setting keys', { namespace, key, summaryKey });
 
 	// TTL keeps demo data from lingering if cleanup fails.
 	await ctx.kv.set(namespace, key, sessionData, { ttl: 300 });
@@ -43,7 +43,7 @@ try {
 		{ ttl: 300 }
 	);
 
-	ctx.logger.info('Getting key');
+	ctx.logger.info('Reading namespace', { namespace, key });
 
 	const result = await ctx.kv.get<typeof sessionData>(namespace, key);
 	const keys = await ctx.kv.getKeys(namespace);

--- a/docs/src/run/kv.ts
+++ b/docs/src/run/kv.ts
@@ -1,19 +1,22 @@
 /**
  * Standalone run script for KV Storage demo
  *
- * Shows the direct service flow: set a value, read it by the same key, then
- * delete the demo record. Unique keys keep concurrent Explorer runs isolated.
+ * Shows the direct service flow: create an isolated namespace, write records,
+ * read/list/search/stat them, then delete the namespace.
  *
  * Usage: bun run src/run/kv.ts '{}'
  */
 import { getDemoContext } from '../api/context';
-import { writeSandboxError, writeSandboxOutput } from '../lib/sandbox-output-writer';
+import { writeSandboxOutput } from '../lib/sandbox-output-writer';
 
 const ctx = getDemoContext();
 
 const runId = Date.now().toString(36);
-const bucket = 'explorer-sandbox';
+const namespace = `explorer-sandbox-${runId}`;
 const key = `${runId}:session-001`;
+const summaryKey = `${runId}:session-001:summary`;
+const output: string[] = [];
+let namespaceCreated = false;
 
 const sessionData = {
 	visitorId: 'visitor-abc123',
@@ -22,28 +25,64 @@ const sessionData = {
 };
 
 try {
+	ctx.logger.info('Creating namespace', { namespace });
+	await ctx.kv.createNamespace(namespace, { defaultTTLSeconds: 300 });
+	namespaceCreated = true;
+
 	ctx.logger.info('Setting key');
 
 	// TTL keeps demo data from lingering if cleanup fails.
-	await ctx.kv.set(bucket, key, sessionData, { ttl: 300 });
+	await ctx.kv.set(namespace, key, sessionData, { ttl: 300 });
+	await ctx.kv.set(
+		namespace,
+		summaryKey,
+		{
+			visitorId: sessionData.visitorId,
+			theme: sessionData.preferences.theme,
+		},
+		{ ttl: 300 }
+	);
 
 	ctx.logger.info('Getting key');
 
-	const result = await ctx.kv.get(bucket, key);
+	const result = await ctx.kv.get<typeof sessionData>(namespace, key);
+	const keys = await ctx.kv.getKeys(namespace);
+	const matches = await ctx.kv.search(namespace, 'session');
+	const stats = await ctx.kv.getStats(namespace);
+	const namespaces = await ctx.kv.getNamespaces();
 
-	await ctx.kv.delete(bucket, key);
-	ctx.logger.info('Deleted key');
+	output.push(`Namespace: "${namespace}"`);
+	output.push(`Set: "${key}"`);
+	output.push(`Set: "${summaryKey}"`);
+	output.push(`Get: ${result.exists ? 'found' : 'not found'}`);
+	output.push(`Keys: ${keys.length}`);
+	output.push(`Search matches: ${matches.size}`);
+	output.push(`Stats count: ${stats.count}`);
+	output.push(`Namespace listed: ${namespaces.includes(namespace) ? 'yes' : 'no'}`);
+} catch (error) {
+	output.push(`Error: ${error instanceof Error ? error.message : String(error)}`);
+	process.exitCode = 1;
+} finally {
+	if (namespaceCreated) {
+		try {
+			await ctx.kv.deleteNamespace(namespace);
+			ctx.logger.info('Deleted namespace', { namespace });
+			output.push(`Deleted namespace: "${namespace}"`);
+		} catch (error) {
+			ctx.logger.warn('Failed to delete KV namespace during cleanup', {
+				error: error instanceof Error ? error.message : String(error),
+				namespace,
+			});
+			output.push(`Cleanup failed: "${namespace}"`);
+			process.exitCode = 1;
+		}
+	}
 
 	writeSandboxOutput(
 		[
-			`Set: "${key}"`,
+			...output,
 			`  visitorId: "${sessionData.visitorId}"`,
 			`  theme: "${sessionData.preferences.theme}"`,
-			`Get: ${result.exists ? 'found' : 'not found'}`,
-			`Deleted: "${key}"`,
 		].join('\n')
 	);
-} catch (error) {
-	writeSandboxError(error);
-	process.exitCode = 1;
 }

--- a/docs/src/run/objectstore.ts
+++ b/docs/src/run/objectstore.ts
@@ -16,7 +16,9 @@ import {
 
 const ctx = getDemoContext();
 
-const key = `sdk-explorer/demo-${Date.now()}.txt`;
+// Stable key: each run overwrites the previous demo file instead of leaving
+// one object per run in the shared explorer bucket (and its UI file list).
+const key = 'sdk-explorer/sandbox-demo.txt';
 const content = `Hello from Object Storage!\nTimestamp: ${new Date().toISOString()}`;
 
 try {

--- a/docs/src/run/objectstore.ts
+++ b/docs/src/run/objectstore.ts
@@ -3,12 +3,16 @@
  *
  * Uses @agentuity/storage so the sandbox matches the public example. The
  * client reads linked bucket credentials from AWS_* environment variables.
+ * Bun's native S3Client is used only for the presigned URL example.
  *
  * Usage: bun run src/run/objectstore.ts '{}'
  */
 import { getDemoContext } from '../api/context';
 import { writeSandboxError, writeSandboxOutput } from '../lib/sandbox-output-writer';
-import { bucketConfigFromEnv, createS3Client } from '@agentuity/storage';
+import {
+	createObjectStorageClient,
+	createObjectStoragePresignedUrl,
+} from '../lib/demo-object-storage';
 
 const ctx = getDemoContext();
 
@@ -16,7 +20,7 @@ const key = `sdk-explorer/demo-${Date.now()}.txt`;
 const content = `Hello from Object Storage!\nTimestamp: ${new Date().toISOString()}`;
 
 try {
-	const storage = createS3Client(bucketConfigFromEnv());
+	const storage = createObjectStorageClient();
 
 	ctx.logger.info('Writing file');
 
@@ -28,9 +32,9 @@ try {
 	const readContent = await file.text();
 	const stat = await storage.stat(key);
 
-	ctx.logger.info('Deleting file');
+	ctx.logger.info('Creating presigned URL');
 
-	await storage.delete(key);
+	const presignedUrl = createObjectStoragePresignedUrl(key, 60 * 15);
 
 	writeSandboxOutput(
 		[
@@ -40,7 +44,9 @@ try {
 			`Read: "${key}"`,
 			`  Content: ${readContent.split('\n')[0]}...`,
 			`  Size: ${stat.size}`,
-			`Deleted: "${key}"`,
+			'Presign: Bun S3Client',
+			`  Presigned URL: ${presignedUrl}`,
+			'Delete the object after the URL no longer needs to work with storage.delete(key).',
 		].join('\n')
 	);
 } catch (error) {

--- a/docs/src/run/schedule.ts
+++ b/docs/src/run/schedule.ts
@@ -1,8 +1,8 @@
 /**
  * Standalone run script for the Schedules demo
  *
- * Creates a real managed schedule, reports the next delivery, then deletes the
- * schedule in cleanup.
+ * Creates a real managed schedule, exercises the schedule client lifecycle,
+ * then deletes the temporary destination and schedule.
  *
  * Usage: bun run src/run/schedule.ts '{"expression":"* * * * *"}'
  */
@@ -32,6 +32,7 @@ function parseInput(): Required<ScheduleInput> {
 
 const schedules = new ScheduleClient();
 let scheduleId: string | undefined;
+let destinationId: string | undefined;
 
 try {
 	const input = parseInput();
@@ -55,16 +56,50 @@ try {
 
 	scheduleId = schedule.id;
 
+	const extraDestination = await schedules.createDestination(schedule.id, {
+		type: 'url',
+		config: {
+			url: input.destinationUrl,
+			method: 'POST',
+			headers: {
+				'x-demo': 'sdk-explorer',
+			},
+		},
+	});
+	destinationId = extraDestination.destination.id;
+
+	const fetched = await schedules.get(schedule.id);
+	const listed = await schedules.list({ limit: 25 });
+	const deliveryHistory = await schedules.listDeliveries(schedule.id, { limit: 10 });
+	const updated = await schedules.update(schedule.id, {
+		description: 'SDK Explorer schedules demo, updated',
+	});
+
 	output.push(`Created schedule: ${schedule.id}`);
 	output.push(`Name: ${schedule.name}`);
-	output.push(`Expression: ${schedule.expression}`);
-	output.push(`Next run: ${schedule.due_date}`);
-	output.push(`Destinations: ${destinations.length}`);
+	output.push(`Expression: ${updated.schedule.expression}`);
+	output.push(`Next run: ${updated.schedule.due_date}`);
+	output.push(`Destinations from create: ${destinations.length}`);
+	output.push(`Destinations after add: ${fetched.destinations.length}`);
+	output.push(
+		`Listed: ${listed.schedules.some((item) => item.id === schedule.id) ? 'yes' : 'no'}`
+	);
+	output.push(`Deliveries: ${deliveryHistory.deliveries.length}`);
 	output.push(`Destination URL: ${input.destinationUrl}`);
 } catch (error) {
 	output.push(`Error: ${error instanceof Error ? error.message : String(error)}`);
 	process.exitCode = 1;
 } finally {
+	if (destinationId) {
+		try {
+			await schedules.deleteDestination(destinationId);
+			output.push(`Deleted destination: ${destinationId}`);
+		} catch {
+			output.push(`Cleanup failed for destination: ${destinationId}`);
+			process.exitCode = 1;
+		}
+	}
+
 	if (scheduleId) {
 		try {
 			await schedules.delete(scheduleId);

--- a/docs/src/run/vector.ts
+++ b/docs/src/run/vector.ts
@@ -1,40 +1,62 @@
 /**
  * Standalone run script for Vector Search demo
  *
- * Shows the direct service flow: upsert text, search by meaning, then delete
- * the demo document. Unique keys keep concurrent Explorer runs isolated.
+ * Shows the direct service flow: upsert text documents, fetch them, search by
+ * meaning, inspect namespace state, then clean up.
  *
  * Usage: bun run src/run/vector.ts '{"query":"comfortable chair"}'
  */
 import { getDemoContext } from '../api/context';
-import { writeSandboxError, writeSandboxOutput } from '../lib/sandbox-output-writer';
+import { writeSandboxOutput } from '../lib/sandbox-output-writer';
 
 const input = JSON.parse(process.argv[2] ?? '{}');
 const query = input.query ?? 'comfortable chair';
 const ctx = getDemoContext();
 
 const runId = Date.now().toString(36);
-const namespace = 'explorer-sandbox';
+const namespace = `explorer-sandbox-${runId}`;
+const output: string[] = [];
+let inserted = false;
 
-const product = {
+const chair = {
 	sku: `${runId}:chair-001`,
 	name: 'ErgoMax Pro Chair',
 	price: 549,
 };
+const desk = {
+	sku: `${runId}:desk-001`,
+	name: 'LiftDesk Air',
+	price: 799,
+};
 
 try {
 	// Document text is embedded by the service so later searches can match by meaning.
-	await ctx.vector.upsert(namespace, {
-		key: product.sku,
-		document: `${product.name}: Premium ergonomic office chair with lumbar support`,
-		metadata: product,
-	});
+	await ctx.vector.upsert(
+		namespace,
+		{
+			key: chair.sku,
+			document: `${chair.name}: Premium ergonomic office chair with lumbar support`,
+			metadata: chair,
+		},
+		{
+			key: desk.sku,
+			document: `${desk.name}: Adjustable standing desk for focused work`,
+			metadata: desk,
+		}
+	);
+	inserted = true;
+
+	const loadedChair = await ctx.vector.get<typeof chair>(namespace, chair.sku);
+	const loadedDocuments = await ctx.vector.getMany(namespace, chair.sku, desk.sku);
 
 	const results = await ctx.vector.search(namespace, {
 		query,
 		limit: 3,
 		similarity: 0.3,
 	});
+	const exists = await ctx.vector.exists(namespace);
+	const stats = await ctx.vector.getStats(namespace);
+	const namespaces = await ctx.vector.getNamespaces();
 
 	for (const result of results) {
 		ctx.logger.info('Match found', {
@@ -44,21 +66,41 @@ try {
 		});
 	}
 
-	await ctx.vector.delete(namespace, product.sku);
-	ctx.logger.info('Cleaned up', { sku: product.sku });
+	const deleted = await ctx.vector.delete(namespace, chair.sku, desk.sku);
+	ctx.logger.info('Cleaned up vector documents', { deleted });
 
-	writeSandboxOutput(
-		[
-			`Upserted: "${product.name}" (${product.sku})`,
-			`Searched: "${query}"`,
-			`Found: ${results.length} match(es)`,
-			...results.map(
-				(r) =>
-					`  - "${r.metadata?.name}" ($${r.metadata?.price}) - ${Math.round(r.similarity * 100)}%`
-			),
-		].join('\n')
+	output.push(`Namespace: "${namespace}"`);
+	output.push(`Upserted: "${chair.name}" (${chair.sku})`);
+	output.push(`Upserted: "${desk.name}" (${desk.sku})`);
+	output.push(`Get chair: ${loadedChair.exists ? 'found' : 'not found'}`);
+	output.push(`Get many: ${loadedDocuments.size}`);
+	output.push(`Searched: "${query}"`);
+	output.push(`Found: ${results.length} match(es)`);
+	output.push(
+		...results.map((r) => `  - "${r.metadata?.name}" - ${Math.round(r.similarity * 100)}%`)
 	);
+	output.push(`Exists before cleanup: ${exists ? 'yes' : 'no'}`);
+	output.push(`Stats count: ${stats.count}`);
+	output.push(`Namespace listed: ${namespaces.includes(namespace) ? 'yes' : 'no'}`);
+	output.push(`Deleted documents: ${deleted}`);
 } catch (error) {
-	writeSandboxError(error);
+	output.push(`Error: ${error instanceof Error ? error.message : String(error)}`);
 	process.exitCode = 1;
+} finally {
+	if (inserted) {
+		try {
+			await ctx.vector.deleteNamespace(namespace);
+			ctx.logger.info('Deleted vector namespace', { namespace });
+			output.push(`Deleted namespace: "${namespace}"`);
+		} catch (error) {
+			ctx.logger.warn('Failed to delete vector namespace during cleanup', {
+				error: error instanceof Error ? error.message : String(error),
+				namespace,
+			});
+			output.push(`Cleanup failed: "${namespace}"`);
+			process.exitCode = 1;
+		}
+	}
+
+	writeSandboxOutput(output.join('\n'));
 }

--- a/docs/src/web/code-examples.ts
+++ b/docs/src/web/code-examples.ts
@@ -88,9 +88,11 @@ let summary: {
   itemCount: number;
   namespaceVisible: boolean;
 };
+let namespaceCreated = false;
 
 try {
   await kv.createNamespace(namespace, { defaultTTLSeconds: 300 });
+  namespaceCreated = true;
   await kv.set(namespace, key, session, { ttl: 300 });
   await kv.set(namespace, key + ":summary", {
     visitorId: session.visitorId,
@@ -111,7 +113,9 @@ try {
     namespaceVisible: namespaces.includes(namespace),
   };
 } finally {
-  await kv.deleteNamespace(namespace);
+  if (namespaceCreated) {
+    await kv.deleteNamespace(namespace);
+  }
 }
 
 export { summary };`,

--- a/docs/src/web/code-examples.ts
+++ b/docs/src/web/code-examples.ts
@@ -3,6 +3,59 @@
  * The live sandbox scripts live in src/run/*.ts. These examples show the
  * framework-first shape readers should copy into their own apps.
  */
+
+/**
+ * Shared by the sse-stream and streaming examples so the two snippets cannot
+ * drift apart. Frame splitting is generic SSE handling; the provider-specific
+ * delta shapes are decoded by the SDK's getAIGatewayStreamDeltaText.
+ */
+const GATEWAY_TEXT_DECODER = `// streamRequest() returns the provider's raw SSE bytes. Split frames on
+// blank lines; the SDK decodes each provider's delta shape to plain text.
+async function* readGatewayText(stream: ReadableStream<Uint8Array>) {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const frames = buffer.split(/\\r?\\n\\r?\\n/);
+      buffer = frames.pop() ?? "";
+
+      for (const frame of frames) {
+        const text = frameText(frame);
+        if (text) yield text;
+      }
+    }
+
+    buffer += decoder.decode();
+    const text = frameText(buffer);
+    if (text) yield text;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function frameText(frame: string): string {
+  const data = frame
+    .split(/\\r?\\n/)
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice(5).trimStart())
+    .join("\\n")
+    .trim();
+
+  if (!data || data === "[DONE]") return "";
+
+  try {
+    return getAIGatewayStreamDeltaText(JSON.parse(data));
+  } catch {
+    return "";
+  }
+}`;
+
 export const CODE_EXAMPLES = {
 	hello: `import { agentuity } from "@agentuity/hono";
 import type { Logger } from "@agentuity/hono";
@@ -83,6 +136,7 @@ const session = {
 
 let summary: {
   found: boolean;
+  theme: string | null;
   keys: string[];
   matches: number;
   itemCount: number;
@@ -100,6 +154,8 @@ try {
   }, { ttl: 300 });
 
   const result = await kv.get<typeof session>(namespace, key);
+  // get() returns a union: narrow on exists before touching data.
+  const theme = result.exists ? result.data.preferences.theme : null;
   const keys = await kv.getKeys(namespace);
   const matches = await kv.search<typeof session>(namespace, "session");
   const stats = await kv.getStats(namespace);
@@ -107,6 +163,7 @@ try {
 
   summary = {
     found: result.exists,
+    theme,
     keys,
     matches: matches.size,
     itemCount: stats.count,
@@ -151,11 +208,14 @@ try {
     }
   );
 
+  // Read back stored documents by key.
   const chair = await vector.get<{ sku: string; name: string; price: number }>(
     namespace,
     sku
   );
   const documents = await vector.getMany(namespace, sku, deskSku);
+
+  // Search by meaning, not keywords: "comfortable chair" matches the ErgoMax.
   const results = await vector.search<{
     sku: string;
     name: string;
@@ -165,6 +225,7 @@ try {
     limit: 3,
     similarity: 0.3,
   });
+  // Inspect namespace state.
   const exists = await vector.exists(namespace);
   const stats = await vector.getStats(namespace);
   const namespaces = await vector.getNamespaces();
@@ -237,10 +298,12 @@ export const report = {
 	'sse-stream': `import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import { AIGatewayClient } from "@agentuity/aigateway";
+import { getAIGatewayStreamDeltaText } from "@agentuity/core/aigateway";
 
 const app = new Hono();
 const gateway = new AIGatewayClient();
-const MODEL = "googleai/gemini-3.5-flash";
+// Default model in the live demo; any gateway model id works here.
+const MODEL = "anthropic/claude-opus-4-8";
 
 app.get("/api/sse-stream", (c) => {
   return streamSSE(c, async (stream) => {
@@ -280,112 +343,19 @@ app.get("/api/sse-stream", (c) => {
   });
 });
 
-async function* readGatewayText(stream: ReadableStream<Uint8Array>) {
-  const reader = stream.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-
-  try {
-    for (;;) {
-      const { value, done } = await reader.read();
-      if (done) break;
-
-      buffer += decoder.decode(value, { stream: true });
-      const frames = buffer.split(/\\r?\\n\\r?\\n/);
-      buffer = frames.pop() ?? "";
-
-      for (const frame of frames) {
-        const text = readFrameText(frame);
-        if (text) yield text;
-      }
-    }
-
-    buffer += decoder.decode();
-    const text = readFrameText(buffer);
-    if (text) yield text;
-  } finally {
-    reader.releaseLock();
-  }
-}
-
-function readFrameText(frame: string): string {
-  const data = frame
-    .split(/\\r?\\n/)
-    .filter((line) => line.startsWith("data:"))
-    .map((line) => line.slice(5).trimStart())
-    .join("\\n")
-    .trim();
-
-  if (!data || data === "[DONE]") return "";
-
-  try {
-    return readDeltaText(JSON.parse(data));
-  } catch {
-    return "";
-  }
-}
-
-function readDeltaText(event: unknown): string {
-  if (!isRecord(event)) return "";
-
-  const choices = event.choices;
-  if (Array.isArray(choices)) {
-    return choices
-      .map((choice) => {
-        if (!isRecord(choice)) return "";
-
-        const delta = choice.delta;
-        if (isRecord(delta) && typeof delta.content === "string") {
-          return delta.content;
-        }
-
-        return typeof choice.text === "string" ? choice.text : "";
-      })
-      .join("");
-  }
-
-  const delta = event.delta;
-  if (typeof delta === "string") return delta;
-  if (isRecord(delta)) {
-    if (typeof delta.text === "string") return delta.text;
-    if (typeof delta.content === "string") return delta.content;
-  }
-
-  const candidates = event.candidates;
-  if (!Array.isArray(candidates)) return "";
-
-  return candidates
-    .map((candidate) => {
-      if (!isRecord(candidate) || !isRecord(candidate.content)) return "";
-      return textFromParts(candidate.content.parts);
-    })
-    .join("");
-}
-
-function textFromParts(parts: unknown): string {
-  if (!Array.isArray(parts)) return "";
-
-  return parts
-    .map((part) => {
-      if (!isRecord(part)) return "";
-      return typeof part.text === "string" ? part.text : "";
-    })
-    .join("");
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
+${GATEWAY_TEXT_DECODER}
 
 export default app;`,
 
 	streaming: `import { Hono } from "hono";
 import { AIGatewayClient } from "@agentuity/aigateway";
+import { getAIGatewayStreamDeltaText } from "@agentuity/core/aigateway";
 
 const app = new Hono();
 const gateway = new AIGatewayClient();
 const encoder = new TextEncoder();
-const MODEL = "googleai/gemini-3.5-flash";
+// Default model in the live demo; any gateway model id works here.
+const MODEL = "anthropic/claude-opus-4-8";
 
 app.post("/api/stream", async (c) => {
   const body: unknown = await c.req.json();
@@ -417,102 +387,9 @@ app.post("/api/stream", async (c) => {
   });
 });
 
-async function* readGatewayText(stream: ReadableStream<Uint8Array>) {
-  const reader = stream.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
+// For named SSE events and an explicit "done" frame, see the SSE Stream demo.
 
-  try {
-    for (;;) {
-      const { value, done } = await reader.read();
-      if (done) break;
-
-      buffer += decoder.decode(value, { stream: true });
-      const frames = buffer.split(/\\r?\\n\\r?\\n/);
-      buffer = frames.pop() ?? "";
-
-      for (const frame of frames) {
-        const text = readFrameText(frame);
-        if (text) yield text;
-      }
-    }
-
-    buffer += decoder.decode();
-    const text = readFrameText(buffer);
-    if (text) yield text;
-  } finally {
-    reader.releaseLock();
-  }
-}
-
-function readFrameText(frame: string): string {
-  const data = frame
-    .split(/\\r?\\n/)
-    .filter((line) => line.startsWith("data:"))
-    .map((line) => line.slice(5).trimStart())
-    .join("\\n")
-    .trim();
-
-  if (!data || data === "[DONE]") return "";
-
-  try {
-    return readDeltaText(JSON.parse(data));
-  } catch {
-    return "";
-  }
-}
-
-function readDeltaText(event: unknown): string {
-  if (!isRecord(event)) return "";
-
-  const choices = event.choices;
-  if (Array.isArray(choices)) {
-    return choices
-      .map((choice) => {
-        if (!isRecord(choice)) return "";
-
-        const delta = choice.delta;
-        if (isRecord(delta) && typeof delta.content === "string") {
-          return delta.content;
-        }
-
-        return typeof choice.text === "string" ? choice.text : "";
-      })
-      .join("");
-  }
-
-  const delta = event.delta;
-  if (typeof delta === "string") return delta;
-  if (isRecord(delta)) {
-    if (typeof delta.text === "string") return delta.text;
-    if (typeof delta.content === "string") return delta.content;
-  }
-
-  const candidates = event.candidates;
-  if (!Array.isArray(candidates)) return "";
-
-  return candidates
-    .map((candidate) => {
-      if (!isRecord(candidate) || !isRecord(candidate.content)) return "";
-      return textFromParts(candidate.content.parts);
-    })
-    .join("");
-}
-
-function textFromParts(parts: unknown): string {
-  if (!Array.isArray(parts)) return "";
-
-  return parts
-    .map((part) => {
-      if (!isRecord(part)) return "";
-      return typeof part.text === "string" ? part.text : "";
-    })
-    .join("");
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
+${GATEWAY_TEXT_DECODER}
 
 export default app;`,
 
@@ -597,6 +474,8 @@ try {
   const deliveryHistory = await schedules.listDeliveries(schedule.id, {
     limit: 10,
   });
+  // update() takes partial fields (name, description, expression); changing
+  // the expression recomputes the next run time.
   const updated = await schedules.update(schedule.id, {
     expression: "0 3 * * *",
   });
@@ -624,6 +503,7 @@ const gateway = new AIGatewayClient();
 const durable = await streams.create("ai-summaries", {
   contentType: "text/plain",
   metadata: { source: "nightly-report" },
+  // Seconds; 30 days is the platform default. Pass null to never expire.
   ttl: 60 * 60 * 24 * 30,
 });
 
@@ -957,11 +837,11 @@ export { published };`,
 const email = new EmailClient();
 
 const outbound = await email.send({
-  from: "hello@your-domain.com",
-  to: ["parteek@example.com"],
-  subject: "Hello from Agentuity",
-  text: "This is the plain-text body.",
-  html: "<p>This is the HTML body.</p>",
+  from: "hello-explorer@agentuity.email",
+  to: ["inbox-explorer@agentuity.email"],
+  subject: "Hello from the Agentuity SDK Explorer",
+  text: "This is a demo email from Agentuity's SDK Explorer.",
+  html: "<p>This is a demo email from Agentuity's SDK Explorer, sent with <code>email.send()</code>.</p>",
 });
 
 const latest = await email.getOutbound(outbound.id);

--- a/docs/src/web/code-examples.ts
+++ b/docs/src/web/code-examples.ts
@@ -185,6 +185,7 @@ export { summary };`,
 import { bucketConfigFromEnv, createS3Client } from "@agentuity/storage";
 import { resolveEndpoint } from "@agentuity/storage/types";
 
+// Reads the linked AWS_* bucket env.
 const bucket = bucketConfigFromEnv();
 const storage = createS3Client(bucket);
 const key = "reports/demo-" + crypto.randomUUID() + ".txt";
@@ -200,7 +201,7 @@ const text = await file.text();
 const stat = await storage.stat(key);
 const listing = await storage.list({ prefix: "reports/", maxKeys: 10 });
 
-// Bun-only option today: use Bun's S3Client for presigned URLs.
+// Bun-only presign option today: S3Client is Bun's client class.
 const bunStorage = new S3Client({
   endpoint: resolveEndpoint(bucket),
   accessKeyId: bucket.access_key,

--- a/docs/src/web/code-examples.ts
+++ b/docs/src/web/code-examples.ts
@@ -183,6 +183,7 @@ const vector = new VectorClient();
 const namespace = "product-search-" + crypto.randomUUID();
 const sku = "chair-" + crypto.randomUUID();
 const deskSku = "desk-" + crypto.randomUUID();
+let namespaceCreated = false;
 
 let summary: {
   chairFound: boolean;
@@ -207,6 +208,7 @@ try {
       metadata: { sku: deskSku, name: "LiftDesk Air", price: 799 },
     }
   );
+  namespaceCreated = true;
 
   // Read back stored documents by key.
   const chair = await vector.get<{ sku: string; name: string; price: number }>(
@@ -241,7 +243,9 @@ try {
 
   await vector.delete(namespace, sku, deskSku);
 } finally {
-  await vector.deleteNamespace(namespace);
+  if (namespaceCreated) {
+    await vector.deleteNamespace(namespace);
+  }
 }
 
 export { summary };`,

--- a/docs/src/web/code-examples.ts
+++ b/docs/src/web/code-examples.ts
@@ -72,7 +72,7 @@ export default app;`,
 	'key-value': `import { KeyValueClient } from "@agentuity/keyvalue";
 
 const kv = new KeyValueClient();
-const namespace = "explorer-sandbox";
+const namespace = "explorer-" + crypto.randomUUID();
 const key = "session-" + crypto.randomUUID();
 
 const session = {
@@ -81,59 +81,116 @@ const session = {
   preferences: { theme: "dark" },
 };
 
-await kv.set(namespace, key, session, { ttl: 300 });
+let summary: {
+  found: boolean;
+  keys: string[];
+  matches: number;
+  itemCount: number;
+  namespaceVisible: boolean;
+};
 
-const result = await kv.get<typeof session>(namespace, key);
-if (result.exists) {
-  // result.data is typed after the discriminated check.
+try {
+  await kv.createNamespace(namespace, { defaultTTLSeconds: 300 });
+  await kv.set(namespace, key, session, { ttl: 300 });
   await kv.set(namespace, key + ":summary", {
-    visitorId: result.data.visitorId,
-    theme: result.data.preferences.theme,
+    visitorId: session.visitorId,
+    theme: session.preferences.theme,
   }, { ttl: 300 });
+
+  const result = await kv.get<typeof session>(namespace, key);
+  const keys = await kv.getKeys(namespace);
+  const matches = await kv.search<typeof session>(namespace, "session");
+  const stats = await kv.getStats(namespace);
+  const namespaces = await kv.getNamespaces();
+
+  summary = {
+    found: result.exists,
+    keys,
+    matches: matches.size,
+    itemCount: stats.count,
+    namespaceVisible: namespaces.includes(namespace),
+  };
+} finally {
+  await kv.deleteNamespace(namespace);
 }
 
-await kv.delete(namespace, key);`,
+export { summary };`,
 
 	'vector-storage': `import { VectorClient } from "@agentuity/vector";
 
 const vector = new VectorClient();
-const namespace = "product-search";
+const namespace = "product-search-" + crypto.randomUUID();
 const sku = "chair-" + crypto.randomUUID();
+const deskSku = "desk-" + crypto.randomUUID();
 
-await vector.upsert(namespace, {
-  key: sku,
-  document: "ErgoMax Pro Chair: ergonomic office chair with lumbar support",
-  metadata: {
-    sku,
-    name: "ErgoMax Pro Chair",
-    price: 549,
-  },
-});
+let summary: {
+  chairFound: boolean;
+  loaded: number;
+  topMatch: string | undefined;
+  exists: boolean;
+  count: number;
+  namespaceVisible: boolean;
+};
 
-const results = await vector.search<{
-  sku: string;
-  name: string;
-  price: number;
-}>(namespace, {
-  query: "comfortable chair",
-  limit: 3,
-  similarity: 0.3,
-});
+try {
+  await vector.upsert(
+    namespace,
+    {
+      key: sku,
+      document: "ErgoMax Pro Chair: ergonomic office chair with lumbar support",
+      metadata: { sku, name: "ErgoMax Pro Chair", price: 549 },
+    },
+    {
+      key: deskSku,
+      document: "LiftDesk Air: adjustable standing desk for focused work",
+      metadata: { sku: deskSku, name: "LiftDesk Air", price: 799 },
+    }
+  );
 
-for (const result of results) {
-  // Similarity scores make ranking visible in your UI or logs.
-  result.metadata?.name;
-  result.similarity;
+  const chair = await vector.get<{ sku: string; name: string; price: number }>(
+    namespace,
+    sku
+  );
+  const documents = await vector.getMany(namespace, sku, deskSku);
+  const results = await vector.search<{
+    sku: string;
+    name: string;
+    price: number;
+  }>(namespace, {
+    query: "comfortable chair",
+    limit: 3,
+    similarity: 0.3,
+  });
+  const exists = await vector.exists(namespace);
+  const stats = await vector.getStats(namespace);
+  const namespaces = await vector.getNamespaces();
+
+  summary = {
+    chairFound: chair.exists,
+    loaded: documents.size,
+    topMatch: results[0]?.metadata?.name,
+    exists,
+    count: stats.count,
+    namespaceVisible: namespaces.includes(namespace),
+  };
+
+  await vector.delete(namespace, sku, deskSku);
+} finally {
+  await vector.deleteNamespace(namespace);
 }
 
-await vector.delete(namespace, sku);`,
+export { summary };`,
 
-	'object-storage': `import { bucketConfigFromEnv, createS3Client } from "@agentuity/storage";
+	'object-storage': `import { S3Client } from "bun";
+import { bucketConfigFromEnv, createS3Client } from "@agentuity/storage";
+import { resolveEndpoint } from "@agentuity/storage/types";
 
-const storage = createS3Client(bucketConfigFromEnv());
+const bucket = bucketConfigFromEnv();
+const storage = createS3Client(bucket);
 const key = "reports/demo-" + crypto.randomUUID() + ".txt";
 const body = "Generated at " + new Date().toISOString();
 
+// Portable SDK path: works in Bun and Node.js.
 await storage.write(key, body, {
   type: "text/plain",
 });
@@ -141,13 +198,35 @@ await storage.write(key, body, {
 const file = storage.file(key);
 const text = await file.text();
 const stat = await storage.stat(key);
+const listing = await storage.list({ prefix: "reports/", maxKeys: 10 });
 
-await storage.delete(key);
+// Bun-only option today: use Bun's S3Client for presigned URLs.
+const bunStorage = new S3Client({
+  endpoint: resolveEndpoint(bucket),
+  accessKeyId: bucket.access_key,
+  secretAccessKey: bucket.secret_key,
+  region: bucket.region ?? "auto",
+  virtualHostedStyle: true,
+});
+
+const downloadUrl = bunStorage.presign(key, {
+  method: "GET",
+  expiresIn: 60 * 15,
+});
+
+// Node.js presign option:
+// Use @aws-sdk/s3-request-presigner with @aws-sdk/client-s3.
+// @agentuity/storage does not expose storage.presign() yet.
+//
+// Delete the object after the share URL no longer needs to work:
+// await storage.delete(key);
 
 export const report = {
   key,
   text,
   bytes: stat.size,
+  filesListed: listing.contents.length,
+  downloadUrl,
 };`,
 
 	'sse-stream': `import { Hono } from "hono";
@@ -473,37 +552,63 @@ export default app;`,
 const schedules = new ScheduleClient();
 const name = "nightly-sync-" + crypto.randomUUID();
 const appUrl = process.env.APP_URL ?? "https://your-app.agentuity.dev";
+let scheduleId: string | undefined;
+let destinationId: string | undefined;
+let summary: {
+  scheduleId: string;
+  destinationCount: number;
+  listed: boolean;
+  deliveries: number;
+  expression: string;
+};
 
-const { schedule, destinations } = await schedules.create({
-  name,
-  description: "Call the sync endpoint every night",
-  expression: "0 2 * * *",
-  destinations: [
-    {
+try {
+  const { schedule, destinations } = await schedules.create({
+    name,
+    description: "Call the sync endpoint every night",
+    expression: "0 2 * * *",
+    destinations: [{
       type: "url",
       config: {
         url: appUrl + "/api/sync",
         method: "POST",
       },
+    }],
+  });
+
+  scheduleId = schedule.id;
+
+  const extraDestination = await schedules.createDestination(schedule.id, {
+    type: "url",
+    config: {
+      url: appUrl + "/api/audit-sync",
+      method: "POST",
     },
-  ],
-});
+  });
+  destinationId = extraDestination.destination.id;
 
-const deliveryHistory = await schedules.listDeliveries(schedule.id, {
-  limit: 10,
-});
+  const fetched = await schedules.get(schedule.id);
+  const page = await schedules.list({ limit: 25 });
+  const deliveryHistory = await schedules.listDeliveries(schedule.id, {
+    limit: 10,
+  });
+  const updated = await schedules.update(schedule.id, {
+    expression: "0 3 * * *",
+  });
 
-await schedules.update(schedule.id, {
-  expression: "0 3 * * *",
-});
+  summary = {
+    scheduleId: fetched.schedule.id,
+    destinationCount: fetched.destinations.length,
+    listed: page.schedules.some((item) => item.id === schedule.id),
+    deliveries: deliveryHistory.deliveries.length,
+    expression: updated.schedule.expression,
+  };
+} finally {
+  if (destinationId) await schedules.deleteDestination(destinationId);
+  if (scheduleId) await schedules.delete(scheduleId);
+}
 
-await schedules.delete(schedule.id);
-
-export const summary = {
-  scheduleId: schedule.id,
-  destinations: destinations.length,
-  deliveries: deliveryHistory.deliveries.length,
-};`,
+export { summary };`,
 
 	'durable-stream': `import { StreamClient } from "@agentuity/stream";
 import { AIGatewayClient } from "@agentuity/aigateway";
@@ -530,10 +635,22 @@ const result = await gateway.completeText({
 await durable.write(result.text);
 await durable.close();
 
+const info = await streams.get(durable.id);
+const body = await new Response(await streams.download(durable.id)).text();
+const page = await streams.list({
+  namespace: "ai-summaries",
+  limit: 10,
+});
+
+// Delete the stream after its public URL no longer needs to work:
+// await streams.delete(durable.id);
+
 export const published = {
-  streamId: durable.id,
-  url: durable.url,
+  streamId: info.id,
+  url: info.url,
   bytesWritten: durable.bytesWritten,
+  downloaded: body,
+  listed: page.streams.some((stream) => stream.id === durable.id),
 };`,
 
 	chat: `import { KeyValueClient } from "@agentuity/keyvalue";
@@ -649,11 +766,12 @@ export { data as judgment };`,
 	'ai-gateway': `import { AIGatewayClient } from "@agentuity/aigateway";
 
 const gateway = new AIGatewayClient();
+const MODEL = "openai/gpt-5.4-mini";
 
 const models = await gateway.listModels();
 
-const completion = await gateway.complete({
-  model: "anthropic/claude-opus-4-8",
+const text = await gateway.completeText({
+  model: MODEL,
   messages: [
     {
       role: "user",
@@ -662,10 +780,35 @@ const completion = await gateway.complete({
   ],
 });
 
+const structured = await gateway.completeStructured<{
+  summary: string;
+  category: "agent" | "workflow" | "other";
+}>({
+  model: MODEL,
+  messages: [
+    {
+      role: "user",
+      content: "Classify this: an AI agent can plan and call tools.",
+    },
+  ],
+  response_schema: {
+    name: "agent_classification",
+    schema: {
+      type: "object",
+      properties: {
+        summary: { type: "string" },
+        category: { type: "string", enum: ["agent", "workflow", "other"] },
+      },
+      required: ["summary", "category"],
+      additionalProperties: false,
+    },
+  },
+});
+
 export const result = {
   providers: Object.keys(models),
-  model: completion.model,
-  firstChoice: completion.choices?.[0],
+  text: text.text,
+  structured: structured.data,
 };`,
 
 	websocket: `import { Hono } from "hono";
@@ -768,31 +911,39 @@ export default {
 
 const queues = new QueueClient();
 const queueName = "orders-" + crypto.randomUUID();
+let published: Awaited<ReturnType<typeof queues.publish>> | undefined;
+let created = false;
 
-await queues.createQueue(queueName, {
-  queueType: "worker",
-  settings: {
-    defaultMaxRetries: 3,
-    defaultVisibilityTimeoutSeconds: 30,
-  },
-});
+try {
+  await queues.createQueue(queueName, {
+    queueType: "worker",
+    settings: {
+      defaultMaxRetries: 3,
+      defaultVisibilityTimeoutSeconds: 30,
+    },
+  });
+  created = true;
 
-const published = await queues.publish(queueName, {
-  task: "process-order",
-  orderId: "order-123",
-  priority: "high",
-}, {
-  sync: true,
-  idempotencyKey: "order-123-v1",
-  metadata: { source: "checkout" },
-});
+  published = await queues.publish(queueName, {
+    task: "process-order",
+    orderId: "order-123",
+    priority: "high",
+  }, {
+    sync: true,
+    idempotencyKey: "order-123-v1",
+    metadata: { source: "checkout" },
+  });
 
-await queues.publish(queueName, {
-  task: "send-receipt",
-  orderId: "order-123",
-});
+  await queues.publish(queueName, {
+    task: "send-receipt",
+    orderId: "order-123",
+  });
+} finally {
+  if (created) await queues.deleteQueue(queueName);
+}
 
-await queues.deleteQueue(queueName);
+// Queue workers receive, ack, nack, and dead-letter messages from the
+// Agentuity runtime route, not from the standalone QueueClient.
 
 export { published };`,
 
@@ -809,10 +960,14 @@ const outbound = await email.send({
 });
 
 const latest = await email.getOutbound(outbound.id);
+const outbox = await email.listOutbound();
+const activity = await email.getActivity({ days: 7 });
 
 export const status = {
   outboundId: outbound.id,
   status: latest?.status ?? outbound.status,
+  listed: outbox.some((message) => message.id === outbound.id),
+  activityDays: activity.activity.length,
 };`,
 
 	database: `import { gte, ilike, lt } from "drizzle-orm";

--- a/docs/src/web/components/ObjectStoreDemo.tsx
+++ b/docs/src/web/components/ObjectStoreDemo.tsx
@@ -56,6 +56,7 @@ export function ObjectStoreDemo() {
 		storage: 'session',
 	});
 	const [copied, setCopied] = useState(false);
+	const [presigningFile, setPresigningFile] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const [loading, setLoading] = useState(false);
 	const [seeding, setSeeding] = useState(false);
@@ -73,17 +74,16 @@ export function ObjectStoreDemo() {
 		try {
 			const response = await fetch('/api/object-storage/list');
 			const result: ListResult = await response.json();
-			if (result.success) {
-				setConfigured(true);
-				applyFiles(result.files);
-				setError(null);
-			} else {
+			if (!response.ok) {
 				if (result.configured === false) {
 					setConfigured(false);
 					applyFiles([]);
 				}
-				setError(result.message || result.error || 'Failed to list files');
+				throw new Error(result.message || result.error || `HTTP ${response.status}`);
 			}
+			setConfigured(true);
+			applyFiles(result.files);
+			setError(null);
 		} catch (err) {
 			setError(err instanceof Error ? err.message : 'Failed to list files');
 		} finally {
@@ -139,6 +139,7 @@ export function ObjectStoreDemo() {
 		async (fileToPresign: string, options: { persist?: boolean } = {}) => {
 			setError(null);
 			setCopied(false);
+			setPresigningFile(fileToPresign);
 			try {
 				const response = await fetch(
 					`/api/object-storage/presign/${encodeURIComponent(fileToPresign)}`,
@@ -168,10 +169,15 @@ export function ObjectStoreDemo() {
 						setLastPresignedFile(result.filename);
 					}
 				} else {
+					// Drop any previous URL card so a failure can't leave a stale link up.
+					setPresignInfo(null);
 					setError(result.message || result.error || 'Presign failed');
 				}
 			} catch (err) {
+				setPresignInfo(null);
 				setError(err instanceof Error ? err.message : 'Presign failed');
+			} finally {
+				setPresigningFile(null);
 			}
 		},
 		[setLastPresignedFile]
@@ -286,8 +292,9 @@ export function ObjectStoreDemo() {
 										variant="ghost"
 										size="xs"
 										onClick={() => handlePresign(file.filename)}
+										disabled={presigningFile !== null}
 									>
-										Presign URL
+										{presigningFile === file.filename ? 'Presigning…' : 'Presign URL'}
 									</Button>
 									<Button variant="ghost" size="xs" asChild>
 										<a

--- a/docs/src/web/components/ObjectStoreDemo.tsx
+++ b/docs/src/web/components/ObjectStoreDemo.tsx
@@ -1,3 +1,4 @@
+import { Check, CopyIcon, ExternalLink } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { usePersistentDemoState } from '../hooks/usePersistentDemoState';
 import { Button, Separator } from './ui';
@@ -11,17 +12,29 @@ interface FileInfo {
 
 interface ListResult {
 	success: boolean;
+	configured?: boolean;
 	count: number;
 	files: FileInfo[];
+	error?: string;
+	message?: string;
+}
+
+interface SeedResult {
+	success: boolean;
+	configured?: boolean;
+	message?: string;
 	error?: string;
 }
 
 interface PresignResult {
 	success: boolean;
-	url: string;
-	filename: string;
-	expiresIn: string;
+	configured?: boolean;
+	url?: string;
+	urlType?: 'presigned';
+	filename?: string;
+	expiresIn?: string;
 	error?: string;
+	message?: string;
 }
 
 interface PresignInfo {
@@ -47,32 +60,36 @@ export function ObjectStoreDemo() {
 	const [loading, setLoading] = useState(false);
 	const [seeding, setSeeding] = useState(false);
 	const [seeded, setSeeded] = useState(false);
+	const [configured, setConfigured] = useState(true);
 	const restoredPresignRef = useRef(false);
 
-	// Stable fetch function
+	const applyFiles = useCallback((nextFiles: FileInfo[]) => {
+		setFiles(nextFiles);
+		setSeeded(nextFiles.some((file) => file.filename === SAMPLE_DOC.name));
+	}, []);
+
 	const fetchFiles = useCallback(async () => {
 		setLoading(true);
 		try {
 			const response = await fetch('/api/object-storage/list');
-			if (!response.ok) {
-				throw new Error(`HTTP ${response.status}`);
-			}
 			const result: ListResult = await response.json();
 			if (result.success) {
-				setFiles(result.files);
-				// Check if sample file exists
-				if (result.files.some((f) => f.filename === 'hello.txt')) {
-					setSeeded(true);
-				}
+				setConfigured(true);
+				applyFiles(result.files);
+				setError(null);
 			} else {
-				setError(result.error || 'Failed to list files');
+				if (result.configured === false) {
+					setConfigured(false);
+					applyFiles([]);
+				}
+				setError(result.message || result.error || 'Failed to list files');
 			}
 		} catch (err) {
 			setError(err instanceof Error ? err.message : 'Failed to list files');
 		} finally {
 			setLoading(false);
 		}
-	}, []);
+	}, [applyFiles]);
 
 	// Fetch on mount
 	useEffect(() => {
@@ -88,17 +105,22 @@ export function ObjectStoreDemo() {
 				method: 'POST',
 			});
 
+			const result: SeedResult = await response.json();
 			if (!response.ok) {
-				throw new Error(`HTTP ${response.status}`);
+				if (result.configured === false) {
+					setConfigured(false);
+				}
+				throw new Error(result.message || result.error || `HTTP ${response.status}`);
 			}
 
-			const result = await response.json();
 			if (result.success) {
+				setConfigured(true);
 				setSeeded(true);
 				await fetchFiles();
 			} else {
 				// If already seeded, still mark as seeded
 				if (result.message?.includes('already')) {
+					setConfigured(true);
 					setSeeded(true);
 					await fetchFiles();
 				} else {
@@ -123,15 +145,22 @@ export function ObjectStoreDemo() {
 					{ method: 'POST' }
 				);
 
-				if (!response.ok) {
-					throw new Error(`HTTP ${response.status}`);
-				}
-
 				const result: PresignResult = await response.json();
 
+				if (!response.ok) {
+					if (result.configured === false) {
+						setConfigured(false);
+					}
+					throw new Error(result.message || result.error || `HTTP ${response.status}`);
+				}
+
 				if (result.success) {
+					if (!result.url || !result.filename || !result.expiresIn) {
+						throw new Error('Presign response was missing URL details');
+					}
+					setConfigured(true);
 					setPresignInfo({
-						url: result.url,
+						url: new URL(result.url, window.location.origin).href,
 						expiresIn: result.expiresIn,
 						filename: result.filename,
 					});
@@ -139,7 +168,7 @@ export function ObjectStoreDemo() {
 						setLastPresignedFile(result.filename);
 					}
 				} else {
-					setError(result.error || 'Presign failed');
+					setError(result.message || result.error || 'Presign failed');
 				}
 			} catch (err) {
 				setError(err instanceof Error ? err.message : 'Presign failed');
@@ -193,7 +222,12 @@ export function ObjectStoreDemo() {
 					>
 						{SAMPLE_DOC.name}
 					</span>
-					<Button variant="success" size="sm" onClick={seedData} disabled={loading || seeded}>
+					<Button
+						variant="success"
+						size="sm"
+						onClick={seedData}
+						disabled={loading || seeded || !configured}
+					>
 						<span className="relative">
 							<span className={seeding || seeded ? 'invisible' : ''}>Load Sample Data</span>
 							{seeding && !seeded && (
@@ -227,7 +261,11 @@ export function ObjectStoreDemo() {
 				<Separator />
 				{files.length === 0 ? (
 					<div className="text-zinc-500 dark:text-zinc-600 text-sm p-8 text-center">
-						No files yet. Click "Load Sample Data" to add a sample file.
+						{!configured
+							? 'No files available until storage is configured.'
+							: loading
+								? 'Loading files...'
+								: 'No files yet. Click "Load Sample Data" to add a sample file.'}
 					</div>
 				) : (
 					<div className="divide-y divide-zinc-200 dark:divide-zinc-900 max-h-64 overflow-auto">
@@ -276,44 +314,30 @@ export function ObjectStoreDemo() {
 								({presignInfo.filename} · expires in {presignInfo.expiresIn})
 							</span>
 						</div>
-						<Button variant="outline" size="xs" onClick={copyToClipboard}>
-							{copied ? (
-								<>
-									<svg
-										aria-hidden="true"
-										className="text-green-600 dark:text-green-400"
-										fill="none"
-										stroke="currentColor"
-										viewBox="0 0 24 24"
-									>
-										<path
-											strokeLinecap="round"
-											strokeLinejoin="round"
-											strokeWidth={2}
-											d="M5 13l4 4L19 7"
+						<div className="flex items-center gap-2">
+							<Button variant="outline" size="xs" asChild>
+								<a href={presignInfo.url} target="_blank" rel="noreferrer">
+									<ExternalLink aria-hidden="true" />
+									<span>Open</span>
+								</a>
+							</Button>
+							<Button variant="outline" size="xs" onClick={copyToClipboard}>
+								{copied ? (
+									<>
+										<Check
+											aria-hidden="true"
+											className="text-green-600 dark:text-green-400"
 										/>
-									</svg>
-									<span className="text-green-600 dark:text-green-400">Copied!</span>
-								</>
-							) : (
-								<>
-									<svg
-										aria-hidden="true"
-										fill="none"
-										stroke="currentColor"
-										viewBox="0 0 24 24"
-									>
-										<path
-											strokeLinecap="round"
-											strokeLinejoin="round"
-											strokeWidth={2}
-											d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
-										/>
-									</svg>
-									<span>Copy</span>
-								</>
-							)}
-						</Button>
+										<span className="text-green-600 dark:text-green-400">Copied!</span>
+									</>
+								) : (
+									<>
+										<CopyIcon aria-hidden="true" />
+										<span>Copy</span>
+									</>
+								)}
+							</Button>
+						</div>
 					</div>
 					<div className="text-zinc-600 dark:text-zinc-400 text-sm font-mono break-all bg-zinc-100 dark:bg-zinc-950 rounded p-3 border border-zinc-300 dark:border-zinc-800">
 						{presignInfo.url}

--- a/docs/src/web/content/services/storage/object.mdx
+++ b/docs/src/web/content/services/storage/object.mdx
@@ -108,18 +108,21 @@ await storage.write('users/user_123/avatar.png', response.body ?? await response
 });
 
 const avatar = storage.file('users/user_123/avatar.png');
-try {
-  const bytes = await avatar.arrayBuffer();
-  const contentType = avatar.type;
-  // bytes is ArrayBuffer; contentType is the stored MIME type
-  void bytes;
-  void contentType;
-} catch (error) {
-  // Object not found or storage service error.
-  throw error;
-}
+
+// arrayBuffer() throws if the object is missing; type is the stored MIME type.
+const bytes = await avatar.arrayBuffer();
+console.log(`avatar: ${bytes.byteLength} bytes (${avatar.type})`);
 
 await storage.delete('users/user_123/avatar.png');
+```
+
+List objects under a prefix to enumerate what you stored:
+
+```typescript
+const result = await storage.list({ prefix: 'users/', maxKeys: 100 });
+for (const object of result.contents) {
+  console.log(object.key, object.size);
+}
 ```
 
 For large files, pass a stream instead of holding the whole payload in memory:

--- a/docs/src/web/content/services/storage/object.mdx
+++ b/docs/src/web/content/services/storage/object.mdx
@@ -275,7 +275,7 @@ The download route returns a short-lived redirect. The file does not flow throug
 
 ## Custom S3 Clients
 
-Use `S3Client` when you need Bun-only helpers, a specific bucket, an external S3-compatible service, or explicit credentials.
+Use `S3Client` when you need Bun-only helpers, a specific bucket, an external S3-compatible service, or explicit credentials. For Agentuity-managed buckets, prefer `bucketConfigFromEnv()` with the linked `AWS_*` values.
 
 ```typescript
 import { S3Client } from 'bun';
@@ -291,17 +291,17 @@ function requireEnv(name: string): string {
 }
 
 const uploads = new S3Client({
-  bucket: requireEnv('S3_BUCKET'),
-  endpoint: requireEnv('S3_ENDPOINT'),
-  accessKeyId: requireEnv('S3_ACCESS_KEY_ID'),
-  secretAccessKey: requireEnv('S3_SECRET_ACCESS_KEY'),
-  region: process.env.S3_REGION ?? 'us-east-1',
+  bucket: requireEnv('UPLOADS_BUCKET'),
+  endpoint: requireEnv('UPLOADS_ENDPOINT'),
+  accessKeyId: requireEnv('UPLOADS_ACCESS_KEY_ID'),
+  secretAccessKey: requireEnv('UPLOADS_SECRET_ACCESS_KEY'),
+  region: process.env.UPLOADS_REGION ?? 'us-east-1',
 });
 
 await uploads.write('healthcheck.txt', 'ok', { type: 'text/plain' });
 ```
 
-For Agentuity-managed buckets, `new S3Client()` can read the linked `AWS_*` values from the environment. For other providers, pass that provider's bucket, endpoint, and credentials explicitly.
+`UPLOADS_*` is app-owned configuration in this example, not an Agentuity-managed credential name. For other providers, pass that provider's bucket, endpoint, and credentials explicitly.
 
 ## Next Steps
 

--- a/docs/src/web/content/services/storage/object.mdx
+++ b/docs/src/web/content/services/storage/object.mdx
@@ -25,8 +25,8 @@ const summary = JSON.parse(await file.text()) as { month: string; total: number 
 
 `storage.file()` creates a lazy file reference. Network work starts when you read, write, check metadata, delete, or stream the file.
 
-<Callout type="info" title="Use the package unless you need Bun-only APIs">
-`@agentuity/storage` uses Bun's S3 client under Bun and the AWS SDK under Node.js. Use Bun's native `S3Client` directly when you need Bun-only helpers such as `presign()`.
+<Callout type="info" title="Use the package unless you need presigned URLs">
+`@agentuity/storage` uses Bun's S3 client under Bun and the AWS SDK under Node.js. Today, use Bun's native `S3Client` directly when you need presigned URLs from a Bun route.
 </Callout>
 
 ## Setup
@@ -174,12 +174,21 @@ Use the explicit `/node` import for Node.js framework routes. In Bun-native rout
 
 ## Presigned URLs
 
-Generate presigned URLs from Bun server code when clients should upload or download directly. Bun's S3 API can read the `AWS_*` values written by `agentuity project add storage`, so a linked Agentuity bucket works without extra mapping.
+Generate presigned URLs from Bun server code when clients should upload or download directly. `@agentuity/storage` does not expose `presign()` yet, so create a Bun `S3Client` with the same bucket config.
 
 ```typescript
 import { S3Client } from 'bun';
+import { bucketConfigFromEnv } from '@agentuity/storage';
+import { resolveEndpoint } from '@agentuity/storage/types';
 
-const s3 = new S3Client();
+const bucket = bucketConfigFromEnv();
+const s3 = new S3Client({
+  endpoint: resolveEndpoint(bucket),
+  accessKeyId: bucket.access_key,
+  secretAccessKey: bucket.secret_key,
+  region: bucket.region ?? 'auto',
+  virtualHostedStyle: true,
+});
 
 const downloadUrl = s3.presign('reports/monthly-summary.json', {
   method: 'GET',
@@ -193,7 +202,7 @@ const uploadUrl = s3.presign('uploads/invoice.pdf', {
 });
 ```
 
-`presign()` is synchronous. It signs a URL from local credentials and does not call S3.
+`presign()` is synchronous. It signs a URL from local credentials and does not call S3. In Node.js routes, use `@aws-sdk/s3-request-presigner` with `@aws-sdk/client-s3`.
 
 For browser uploads, configure CORS on the bucket or the browser will reject the direct `PUT`. Allow the origin that hosts your app, the `PUT` method, and the headers your upload sends, especially `Content-Type`. Keep the presigned route server-side so bucket credentials never leave your app.
 
@@ -203,10 +212,19 @@ Keep browser uploads direct to S3 by returning a short-lived upload URL from you
 
 ```typescript title="src/index.ts"
 import { S3Client } from 'bun';
+import { bucketConfigFromEnv } from '@agentuity/storage';
+import { resolveEndpoint } from '@agentuity/storage/types';
 import { Hono } from 'hono';
 import { z } from 'zod';
 
-const s3 = new S3Client();
+const bucket = bucketConfigFromEnv();
+const s3 = new S3Client({
+  endpoint: resolveEndpoint(bucket),
+  accessKeyId: bucket.access_key,
+  secretAccessKey: bucket.secret_key,
+  region: bucket.region ?? 'auto',
+  virtualHostedStyle: true,
+});
 
 const uploadRequestSchema = z.object({
   filename: z.string(),

--- a/docs/src/web/demo-config.tsx
+++ b/docs/src/web/demo-config.tsx
@@ -193,15 +193,15 @@ export const DEMOS: DemoConfig[] = [
 		id: 'object-storage',
 		title: 'Object Storage',
 		subtitle: 'Agentuity Storage',
-		description: 'Store files with presigned URLs for sharing.',
+		description: 'Store files with the SDK, and generate share URLs from Bun routes.',
 		explanation: (
 			<>
-				Object storage is for files and blobs, not small JSON records. This demo loads a sample
-				text file, lists files in the bucket, and generates a presigned URL for temporary
-				sharing.{' '}
+				Object storage is for files and blobs, not small JSON records. This demo uses
+				<code> @agentuity/storage</code> to load, list, read, and delete files, then uses Bun's
+				native S3 client for temporary share URLs.
 				<span className="bg-cyan-500/10 px-1 rounded">
-					Use it for files such as uploads, reports, images, and generated artifacts
-				</span>{' '}
+					{' Use it for files such as uploads, reports, images, and generated artifacts '}
+				</span>
 				when the data is a file people or systems need to download. For exact-key JSON state,
 				see{' '}
 				<Link

--- a/docs/src/web/demo-config.tsx
+++ b/docs/src/web/demo-config.tsx
@@ -196,9 +196,9 @@ export const DEMOS: DemoConfig[] = [
 		description: 'Store files with the SDK, and generate share URLs from Bun routes.',
 		explanation: (
 			<>
-				Object storage is for files and blobs, not small JSON records. This demo uses
-				<code> @agentuity/storage</code> to load, list, read, and delete files, then uses Bun's
-				native S3 client for temporary share URLs.
+				Object storage is for files and blobs, not small JSON records. This demo reads linked
+				<code> AWS_*</code> bucket env with <code>@agentuity/storage</code>, then uses Bun's{' '}
+				<code>S3Client</code> only for temporary share URLs.
 				<span className="bg-cyan-500/10 px-1 rounded">
 					{' Use it for files such as uploads, reports, images, and generated artifacts '}
 				</span>


### PR DESCRIPTION
## Summary

Repairs the v3 SDK Explorer service demos so sandbox runs, snippets, and object storage UI match current service behavior.

- Sends bundled run scripts into sandbox executions and fails early when missing
- Uses `@agentuity/storage` for storage I/O and Bun `S3Client` for presigned URLs
- Guards `presign` calls against missing objects and clears stale URL cards
- Simplifies Gateway streaming snippets with shared SDK delta decoding
- Restores v2 KV narrowing, email constants, and object storage docs examples

## Why

Object storage `presign` signs locally, so missing keys produced valid-looking URLs that 404 on open. The Explorer snippets also drifted from the live v3 demo behavior and a few v2 teaching points.

## Verification

- `git diff --cached --check`
- `bunx biome check docs/src/agent/objectstore/agent.ts docs/src/web/components/ObjectStoreDemo.tsx`
- `cd docs && bun run typecheck`
- `cd docs && bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Presigned URLs now return richer metadata and use a stable demo object key.
  * Sandboxed demos run with bundled script files; demos use per-run isolated namespaces.
  * UIs show object-storage "configured" state and disable actions when unavailable.

* **Bug Fixes**
  * Consistent 503/configured responses and improved error handling for unconfigured object storage.
  * More robust verification and cleanup across demos (downloads, listings, namespaces, destinations).

* **Documentation**
  * Clarified S3/object-storage guidance and presigning differences for Bun vs Node.js.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
