### PR TITLE
Speed up CI builds for snapshot-based Genesis deploys

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentuity/cli",
-	"version": "3.0.9",
+	"version": "3.0.10",
 	"license": "Apache-2.0",
 	"author": "Agentuity employees and contributors",
 	"type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@agentuity/cli",
-	"version": "3.0.10",
+	"version": "3.0.9",
 	"license": "Apache-2.0",
 	"author": "Agentuity employees and contributors",
 	"type": "module",

--- a/packages/cli/src/cmd/build/ci.ts
+++ b/packages/cli/src/cmd/build/ci.ts
@@ -1,7 +1,7 @@
 import { Buffer } from 'node:buffer';
 import { mkdir, mkdtemp, readdir, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import type { Logger } from '@agentuity/core';
 import { ErrorCode } from '../../errors.ts';
 import { pathExists } from '../../node-compat/fs.ts';
@@ -23,6 +23,24 @@ export interface CIBuildOptions {
 	pullRequestUrl?: string;
 	logsUrl?: string;
 	skipDnsValidation?: boolean;
+	skipTypeCheck?: boolean;
+}
+
+export async function hasProjectDependenciesInstalled(projectDir: string): Promise<boolean> {
+	let dir = projectDir;
+	for (;;) {
+		const bunStore = join(dir, 'node_modules', '.bun');
+		const lockfile = join(dir, 'bun.lock');
+		if ((await pathExists(bunStore)) && (await pathExists(lockfile))) {
+			return true;
+		}
+
+		const parent = dirname(dir);
+		if (parent === dir) {
+			return false;
+		}
+		dir = parent;
+	}
 }
 
 async function runCommand(cmd: string[], cwd: string): Promise<number> {
@@ -121,6 +139,7 @@ export function buildDeployArgs(opts: CIBuildOptions): string[] {
 	if (opts.pullRequestUrl) args.push('--pull-request-url', opts.pullRequestUrl);
 	if (opts.logsUrl) args.push('--logs-url', opts.logsUrl);
 	if (opts.skipDnsValidation) args.push('--skip-dns-validation');
+	if (opts.skipTypeCheck) args.push('--skip-type-check');
 
 	return args;
 }
@@ -204,12 +223,16 @@ export async function runCIBuild(opts: CIBuildOptions, _logger: Logger): Promise
 			await writeFile(join(projectDir, '.env'), `AGENTUITY_SDK_KEY=${sdkKey}\n`);
 		}
 
-		tui.info('3️⃣ Installing your project dependencies...');
-		const installExit = await runCommand(['bun', 'install'], projectDir);
-		if (installExit !== 0) {
-			tui.error(`Dependency installation failed (exit ${installExit})`);
-			pendingExitCode = installExit;
-			return;
+		if (await hasProjectDependenciesInstalled(projectDir)) {
+			tui.info('3️⃣ Using existing project dependencies (skipping install)...');
+		} else {
+			tui.info('3️⃣ Installing your project dependencies...');
+			const installExit = await runCommand(['bun', 'install'], projectDir);
+			if (installExit !== 0) {
+				tui.error(`Dependency installation failed (exit ${installExit})`);
+				pendingExitCode = installExit;
+				return;
+			}
 		}
 
 		const packageJsonPath = join(projectDir, 'package.json');

--- a/packages/cli/src/cmd/build/index.ts
+++ b/packages/cli/src/cmd/build/index.ts
@@ -33,7 +33,7 @@ const BuildOptionsSchema = z.intersection(
 			.optional()
 			.describe('file path to save build report JSON with errors, warnings, and diagnostics'),
 		ci: z.boolean().optional().describe('Enable CI build mode'),
-		url: z.string().optional().describe('Source code download URL (required with --ci)'),
+		url: z.string().optional().describe('Source code download URL for CI builds'),
 		directory: z.string().optional().describe('Subdirectory within extracted source'),
 	})
 );
@@ -63,10 +63,6 @@ export const command = createCommand({
 		const { opts, projectDir, project } = ctx;
 
 		if (opts.ci) {
-			if (!opts.url) {
-				tui.fatal('--url is required when using --ci mode', ErrorCode.CONFIG_INVALID);
-			}
-
 			const { runCIBuild } = await import('./ci.ts');
 			await runCIBuild(
 				{
@@ -84,6 +80,7 @@ export const command = createCommand({
 					pullRequestUrl: opts.pullRequestUrl,
 					logsUrl: opts.logsUrl,
 					skipDnsValidation: opts.skipDnsValidation ?? true,
+					skipTypeCheck: opts.skipTypeCheck,
 				},
 				ctx.logger
 			);

--- a/packages/cli/src/cmd/cloud/deploy.ts
+++ b/packages/cli/src/cmd/cloud/deploy.ts
@@ -396,6 +396,7 @@ export const deploySubcommand = createSubcommand({
 				childArgs.push(`--pull-request-number=${opts.pullRequestNumber}`);
 			if (opts.pullRequestUrl) childArgs.push(`--pull-request-url=${opts.pullRequestUrl}`);
 			if (opts.skipDnsValidation) childArgs.push('--skip-dns-validation');
+			if (opts.skipTypeCheck) childArgs.push('--skip-type-check');
 
 			const result = await runForkedDeploy({
 				projectDir,

--- a/packages/cli/src/cmd/cloud/deploy/build.ts
+++ b/packages/cli/src/cmd/cloud/deploy/build.ts
@@ -132,6 +132,7 @@ export function buildBuildStep(params: BuildStepParams): Step {
 					deploymentId: deployment.id,
 					deploymentOptions: deployOptions,
 					deploymentConfig: project.deployment,
+					skipTypeCheck: deployOptions.skipTypeCheck,
 				});
 
 				const { framework, buildResult, packageResult } = pipelineResult;

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -618,6 +618,7 @@ export const DeployOptionsSchema = zod
 			.boolean()
 			.optional()
 			.describe('Skip custom domain DNS validation before deploying'),
+		skipTypeCheck: zod.boolean().optional().describe('Skip TypeScript validation during deploy'),
 	})
 	.merge(GitOptionsSchema);
 

--- a/packages/cli/test/cmd/build/ci.test.ts
+++ b/packages/cli/test/cmd/build/ci.test.ts
@@ -1,14 +1,47 @@
 import { describe, expect, test } from 'bun:test';
 import { Buffer } from 'node:buffer';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { buildDeployArgs, downloadSource, sourceDownloadHeaders } from '../../../src/cmd/build/ci';
+import {
+	buildDeployArgs,
+	downloadSource,
+	hasProjectDependenciesInstalled,
+	sourceDownloadHeaders,
+} from '../../../src/cmd/build/ci';
 
 describe('build ci', () => {
 	test('passes skip DNS validation to nested deploy', () => {
 		const args = buildDeployArgs({ skipDnsValidation: true });
 		expect(args).toContain('--skip-dns-validation');
+	});
+
+	test('passes skip typecheck to nested deploy', () => {
+		const args = buildDeployArgs({ skipTypeCheck: true });
+		expect(args).toContain('--skip-type-check');
+	});
+
+	test('detects existing dependencies from monorepo root', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'agentuity-ci-deps-test-'));
+		try {
+			await mkdir(join(dir, 'node_modules', '.bun'), { recursive: true });
+			await writeFile(join(dir, 'bun.lock'), '');
+			const appDir = join(dir, 'apps', 'web');
+			await mkdir(appDir, { recursive: true });
+
+			expect(await hasProjectDependenciesInstalled(appDir)).toBe(true);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	test('requires install when dependencies are missing', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'agentuity-ci-deps-test-'));
+		try {
+			expect(await hasProjectDependenciesInstalled(dir)).toBe(false);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
 	});
 
 	test('adds GitHub archive token only for GitHub archive hosts', () => {


### PR DESCRIPTION
## Summary
- Wire `--skip-type-check` from `agentuity build --ci` through nested `deploy` and into `runBuildPipeline` (~50–65s/org saved once Genesis uses a CLI with deploy support).
- Skip CI `bun install` when `bun.lock` + `node_modules/.bun` already exist on disk or in a monorepo parent (safe fallback when deps are missing).
- Allow `agentuity build --ci` without `--url` for snapshot/local-source deploys (Genesis sandbox restores source before `deploy.sh` runs).
- Bump `@agentuity/cli` to `3.0.10`.

## Test plan
- [x] `bun test packages/cli/test/cmd/build/ci.test.ts`
- [x] `bun run typecheck` in `packages/cli`
- [ ] Publish `@agentuity/cli@3.0.10`
- [ ] Rebuild sandbox-agentuity image so oneshot sandboxes pick up the new global CLI
- [ ] Merge infra + genesis-mono PRs and validate edge rollout timing

## Stack
- v2 SDK (Genesis nested deploy): https://github.com/agentuity/sdk/pull/1557
- infra: https://github.com/agentuity/infra/pull/682
- genesis-mono: https://github.com/agentuity/genesis-mono/pull/215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `--skip-type-check` flag to skip TypeScript validation during deployment, enabling faster build cycles when type checking is not needed.
  * CLI now automatically detects and reuses existing dependency installations, avoiding redundant installation steps.

* **Chores**
  * Version bumped to 3.0.9 across core packages and plugins; CLI updated to 3.0.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->