### PR TITLE
Make docs sync tolerate deployment rollouts

### DIFF
--- a/.github/workflows/sync-docs-full.yml
+++ b/.github/workflows/sync-docs-full.yml
@@ -31,6 +31,11 @@ jobs:
               DOCS_WEBHOOK_URL: ${{ secrets.DOCS_WEBHOOK_URL }}
               DOCS_SYNC_COMMIT: ${{ github.sha }}
               BATCH_SIZE: 5
+              # Full sync can hit the same transient webhook outage window
+              # as incremental sync, so use the shared retry budget.
+              MAX_RETRIES: 10
+              RETRY_DELAY: 5
+              MAX_RETRY_DELAY: 60
            run: |
               set -euo pipefail
               cat all-files.txt | \

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -72,6 +72,12 @@ jobs:
               DOCS_WEBHOOK_URL: ${{ secrets.DOCS_WEBHOOK_URL }}
               DOCS_SYNC_COMMIT: ${{ steps.commits.outputs.after_commit }}
               BATCH_SIZE: 5
+              # The merge that triggers this sync also redeploys the docs app that
+              # receives it; retry past the rollout window (observed ~5 minutes)
+              # instead of giving up within seconds.
+              MAX_RETRIES: 10
+              RETRY_DELAY: 5
+              MAX_RETRY_DELAY: 60
            run: |
               set -euo pipefail
               cat changed-files.txt | \

--- a/docs/bin/send-webhook.sh
+++ b/docs/bin/send-webhook.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 # send-webhook.sh <webhook_url> [auth_token]
 # Reads JSON payload from stdin, sends to webhook with retries and exponential backoff.
+#
+# Environment:
+#   MAX_RETRIES     - positive attempts before giving up (default: 3)
+#   RETRY_DELAY     - initial backoff in seconds, doubles per attempt (default: 2)
+#   MAX_RETRY_DELAY - backoff ceiling in seconds (default: 60)
 
 usage() {
     echo "Usage: $0 <webhook_url> [auth_token]" >&2
@@ -16,8 +21,23 @@ fi
 
 WEBHOOK_URL="$1"
 AUTH_TOKEN="${2:-}"
-MAX_RETRIES=3
-RETRY_DELAY=2
+MAX_RETRIES="${MAX_RETRIES:-3}"
+RETRY_DELAY="${RETRY_DELAY:-2}"
+MAX_RETRY_DELAY="${MAX_RETRY_DELAY:-60}"
+
+# Invalid values would silently disable the retry loop or backoff cap; fail
+# loudly instead, like BATCH_SIZE validation in send-batched.sh.
+if ! [[ "$MAX_RETRIES" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Error: MAX_RETRIES must be a positive integer, got '$MAX_RETRIES'" >&2
+    exit 1
+fi
+
+for var in RETRY_DELAY MAX_RETRY_DELAY; do
+    if ! [[ "${!var}" =~ ^[0-9]+$ ]]; then
+        echo "Error: $var must be a non-negative integer, got '${!var}'" >&2
+        exit 1
+    fi
+done
 
 echo "Sending webhook to $WEBHOOK_URL" >&2
 
@@ -78,10 +98,25 @@ for attempt in $(seq 1 $MAX_RETRIES); do
 
         echo "Attempt $attempt failed: $response" >&2
 
+        # curl --fail reports HTTP errors as 'curl: (22) ... returned error: NNN'.
+        # A 4xx (other than 408/429) is deterministic, so retrying it only burns
+        # the retry window without ever succeeding.
+        status=$(printf '%s\n' "$response" | grep -oE 'returned error: [0-9]{3}' | grep -oE '[0-9]{3}' | tail -n 1 || true)
+        case "$status" in
+            408 | 429) ;;
+            4??)
+                echo "Error: HTTP $status is not retryable, giving up" >&2
+                exit 1
+                ;;
+        esac
+
         if [ $attempt -lt $MAX_RETRIES ]; then
             echo "Retrying in ${RETRY_DELAY}s..." >&2
             sleep $RETRY_DELAY
             RETRY_DELAY=$((RETRY_DELAY * 2))
+            if [ "$RETRY_DELAY" -gt "$MAX_RETRY_DELAY" ]; then
+                RETRY_DELAY=$MAX_RETRY_DELAY
+            fi
         fi
     fi
 done

--- a/docs/bin/test/send-webhook.test.ts
+++ b/docs/bin/test/send-webhook.test.ts
@@ -1,0 +1,159 @@
+import { expect, test } from 'bun:test';
+import { join } from 'node:path';
+
+const SCRIPT = join(import.meta.dir, '..', 'send-webhook.sh');
+const OK_BODY = JSON.stringify({
+	status: 'ok',
+	stats: { processed: 1, deleted: 0, errors: 0, errorFiles: [] },
+});
+
+interface FakeReceiver {
+	url: string;
+	requestCount: () => number;
+	stop: () => void;
+}
+
+// Responds with the queued statuses in order, repeating the last one once the
+// queue is exhausted. A 200 returns the canonical sync response body.
+function startReceiver(statuses: number[]): FakeReceiver {
+	let count = 0;
+	const server = Bun.serve({
+		port: 0,
+		fetch() {
+			const status = statuses[Math.min(count, statuses.length - 1)] ?? 500;
+			count++;
+			if (status === 200) {
+				return new Response(OK_BODY, {
+					status,
+					headers: { 'Content-Type': 'application/json' },
+				});
+			}
+			return new Response('receiver unavailable', { status });
+		},
+	});
+	return {
+		url: `http://127.0.0.1:${server.port}`,
+		requestCount: () => count,
+		stop: () => server.stop(true),
+	};
+}
+
+async function runSendWebhook(
+	url: string,
+	env: Record<string, string> = {}
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+	const proc = Bun.spawn(['bash', SCRIPT, url, 'Bearer test-token'], {
+		env: { ...process.env, ...env },
+		stdin: new TextEncoder().encode('{"repo":"agentuity/sdk","changed":[]}'),
+		stdout: 'pipe',
+		stderr: 'pipe',
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+	return { stdout, stderr, exitCode };
+}
+
+test('forwards the payload and prints only the receiver JSON response on stdout', async () => {
+	const receiver = startReceiver([200]);
+	try {
+		const result = await runSendWebhook(receiver.url);
+		expect(result.exitCode).toBe(0);
+		// send-batched.sh parses stdout with jq, so it must stay pure JSON.
+		expect(result.stdout.trim()).toBe(OK_BODY);
+		expect(receiver.requestCount()).toBe(1);
+	} finally {
+		receiver.stop();
+	}
+});
+
+test('rejects non-numeric retry env instead of silently disabling the backoff cap', async () => {
+	const receiver = startReceiver([500, 500, 200]);
+	try {
+		const result = await runSendWebhook(receiver.url, {
+			MAX_RETRIES: '3',
+			RETRY_DELAY: '0',
+			MAX_RETRY_DELAY: 'banana',
+		});
+		expect(result.exitCode).not.toBe(0);
+		expect(receiver.requestCount()).toBe(0);
+		expect(result.stderr).toContain('MAX_RETRY_DELAY');
+	} finally {
+		receiver.stop();
+	}
+});
+
+test('rejects zero retries instead of skipping every request', async () => {
+	const receiver = startReceiver([200]);
+	try {
+		const result = await runSendWebhook(receiver.url, {
+			MAX_RETRIES: '0',
+			RETRY_DELAY: '0',
+		});
+		expect(result.exitCode).not.toBe(0);
+		expect(receiver.requestCount()).toBe(0);
+		expect(result.stderr).toContain('MAX_RETRIES');
+	} finally {
+		receiver.stop();
+	}
+});
+
+test('gives up immediately on a non-retryable 4xx instead of burning the retry budget', async () => {
+	const receiver = startReceiver([400]);
+	try {
+		const result = await runSendWebhook(receiver.url, {
+			MAX_RETRIES: '10',
+			RETRY_DELAY: '0',
+		});
+		expect(result.exitCode).not.toBe(0);
+		expect(receiver.requestCount()).toBe(1);
+	} finally {
+		receiver.stop();
+	}
+});
+
+test(
+	'caps exponential backoff at MAX_RETRY_DELAY',
+	async () => {
+		const receiver = startReceiver([500]);
+		try {
+			const result = await runSendWebhook(receiver.url, {
+				MAX_RETRIES: '4',
+				RETRY_DELAY: '1',
+				MAX_RETRY_DELAY: '2',
+			});
+			expect(result.exitCode).not.toBe(0);
+			expect(receiver.requestCount()).toBe(4);
+			// Uncapped doubling would announce 1s, 2s, 4s; the cap holds it at 2s.
+			expect(result.stderr).toContain('Retrying in 1s');
+			expect(result.stderr.match(/Retrying in 2s/g)?.length).toBe(2);
+			expect(result.stderr).not.toContain('Retrying in 4s');
+		} finally {
+			receiver.stop();
+		}
+	},
+	{ timeout: 20000 }
+);
+
+test(
+	'honors MAX_RETRIES and RETRY_DELAY env so sync survives a receiver outage longer than the default window',
+	async () => {
+		// Incident shape: receiver 500s while its own deployment rolls out, then
+		// recovers. Four 500s exceeds the default 3-attempt budget.
+		const receiver = startReceiver([500, 500, 500, 500, 200]);
+		try {
+			const result = await runSendWebhook(receiver.url, {
+				MAX_RETRIES: '6',
+				RETRY_DELAY: '0',
+			});
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout.trim()).toBe(OK_BODY);
+			expect(receiver.requestCount()).toBe(5);
+		} finally {
+			receiver.stop();
+		}
+	},
+	{ timeout: 20000 }
+);

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,6 +16,7 @@
 		"start": "bun dist/server.js",
 		"deploy": "agentuity deploy --dir .",
 		"typecheck": "bunx tsc --noEmit",
+		"test": "bun test",
 		"generate:schema": "bun run scripts/generate-agentuity-schema.ts",
 		"build:run": "bun run scripts/bundle-run-scripts.ts",
 		"generate:scripts": "bun run scripts/generate-sandbox-scripts.ts",

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -29,6 +29,7 @@
 		"src/**/*",
 		"app.ts",
 		"server.ts",
+		"bin/test/**/*",
 		"scripts/dev.ts",
 		"scripts/prepare-start-output.ts"
 	],

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"build:apps": "bun run --filter='./tests/frameworks/*' build && bun run --filter='./tests/integration/*' build && bun run --filter='./tests/services/*' build",
 		"build:all": "bun run build && bun run build:apps",
 		"test": "bun test:packages && cd packages/cli && bun run test && cd ../.. && bun test:pkginstall && bun test:create",
-		"test:packages": "cd packages/core && bun test && cd ../schema && bun test && cd ../server && bun test && cd ../postgres && bun test && cd ../drizzle && bun test && cd ../opencode && bun test && cd ../hono && bun test && cd ../analytics && bun test",
+		"test:packages": "cd packages/core && bun test && cd ../schema && bun test && cd ../server && bun test && cd ../postgres && bun test && cd ../drizzle && bun test && cd ../opencode && bun test && cd ../hono && bun test && cd ../analytics && bun test && cd ../../docs && bun test",
 		"test:unit": "bun run test:packages && cd packages/cli && bun run test",
 		"test:dev": "bash scripts/test-dev.sh",
 		"test:frameworks": "bash scripts/test-framework-demos.sh",


### PR DESCRIPTION
## Summary

> Makes docs vector sync tolerate transient webhook failures during docs app rollouts before failing the workflow.

- Adds configurable `MAX_RETRIES`, `RETRY_DELAY`, and `MAX_RETRY_DELAY` handling to `send-webhook.sh`
- Keeps deterministic `4xx` responses non-retryable while still retrying `408`, `429`, and `5xx`
- Uses the longer retry window from both incremental and full docs sync workflows
- Runs webhook retry tests from both `docs` and root `test:packages`

## Why

Follow-up to agentuity/sdk#1555. The merge-triggered `Sync Docs to Vector Store` workflow hit a transient `500` from the docs webhook while the docs deployment was still rolling out. Rerunning the same workflow after the deployment settled succeeded:
https://github.com/agentuity/sdk/actions/runs/27367700561

## Implementation

- `send-webhook.sh` now reads retry settings from env with defaults matching the previous behavior
- `MAX_RETRIES` must be positive, while `RETRY_DELAY` and `MAX_RETRY_DELAY` remain non-negative so tests can use zero-second sleeps
- Retry handling exits immediately for deterministic `4xx` responses, except `408` and `429`
- Backoff still doubles between attempts, but is capped by `MAX_RETRY_DELAY`
- Both docs sync workflows set `MAX_RETRIES=10`, `RETRY_DELAY=5`, and `MAX_RETRY_DELAY=60`
- The new tests use a local Bun receiver to cover stdout purity, invalid env, non-retryable `4xx`, capped backoff, and transient `500` recovery

## Verification

- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' .github/workflows/sync-docs.yml .github/workflows/sync-docs-full.yml`
- `bunx biome check .github/workflows/sync-docs.yml .github/workflows/sync-docs-full.yml docs/bin/send-webhook.sh docs/bin/test/send-webhook.test.ts docs/package.json docs/tsconfig.json package.json`
- `bash -n docs/bin/send-webhook.sh docs/bin/send-batched.sh docs/bin/build-payload.sh docs/bin/collect-changed-files.sh`
- `cd docs && bun test`
- `cd docs && bun run typecheck`
- `bun run test:packages`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation sync reliability with enhanced retry logic and exponential backoff for transient webhook failures
  * Added intelligent error handling to prevent retries on non-retryable errors

* **Chores**
  * Updated documentation sync workflows with configurable retry parameters for better outage resilience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
