### PR TITLE
Restore sandbox package behavior

### DIFF
--- a/docs/src/api/sandbox/route.ts
+++ b/docs/src/api/sandbox/route.ts
@@ -18,6 +18,7 @@ import {
 	sandboxRun,
 	sandboxCreate,
 	sandboxExecute,
+	sandboxWriteFiles,
 	executionGet,
 	getServiceUrls,
 	SandboxNotFoundError,
@@ -450,9 +451,15 @@ async function executeOnSandbox(
 	orgId: string | undefined,
 	sseStream: SSEStream
 ): Promise<SandboxExecutionResult> {
+	await sandboxWriteFiles(client, {
+		sandboxId,
+		files,
+		orgId,
+	});
+
 	const execution = await sandboxExecute(client, {
 		sandboxId,
-		options: { command, files, timeout: SANDBOX_EXEC_TIMEOUT },
+		options: { command, timeout: SANDBOX_EXEC_TIMEOUT },
 		orgId,
 	});
 

--- a/docs/src/api/test/sandbox-route.test.ts
+++ b/docs/src/api/test/sandbox-route.test.ts
@@ -35,9 +35,15 @@ interface SandboxExecuteParams {
 	};
 }
 
+interface SandboxWriteFilesParams {
+	readonly sandboxId: string;
+	readonly files: readonly unknown[];
+}
+
 const sandboxRunCalls: SandboxRunParams[] = [];
 const sandboxCreateCalls: SandboxCreateParams[] = [];
 const sandboxExecuteCalls: SandboxExecuteParams[] = [];
+const sandboxWriteFilesCalls: SandboxWriteFilesParams[] = [];
 const createdScriptPaths: string[] = [];
 const storageEnvNames = [
 	'AWS_BUCKET',
@@ -81,6 +87,11 @@ const sandboxExecuteMock = mock(async (_client: unknown, params: SandboxExecuteP
 	return { executionId: 'execution_1' };
 });
 
+const sandboxWriteFilesMock = mock(async (_client: unknown, params: SandboxWriteFilesParams) => {
+	sandboxWriteFilesCalls.push(params);
+	return { filesWritten: params.files.length };
+});
+
 const executionGetMock = mock(async () => ({
 	status: 'completed',
 	exitCode: 0,
@@ -98,6 +109,7 @@ mock.module('@agentuity/server', () => ({
 	getServiceUrls: () => ({ sandbox: 'https://sandbox.test' }),
 	sandboxCreate: sandboxCreateMock,
 	sandboxExecute: sandboxExecuteMock,
+	sandboxWriteFiles: sandboxWriteFilesMock,
 	sandboxRun: sandboxRunMock,
 }));
 
@@ -225,6 +237,7 @@ test('sandbox route completes one-shot execution without storage credentials for
 test('sandbox route completes interactive execution without storage credentials for non-storage scripts', async () => {
 	sandboxCreateCalls.length = 0;
 	sandboxExecuteCalls.length = 0;
+	sandboxWriteFilesCalls.length = 0;
 
 	const response = await createApp({ interactive: true }).fetch(
 		new Request('http://docs.test/api/sandbox/run?script=hello')
@@ -235,9 +248,11 @@ test('sandbox route completes interactive execution without storage credentials 
 	expect(body).toContain('event: status');
 	expect(body).toContain('event: done');
 	expect(sandboxCreateCalls).toHaveLength(1);
+	expect(sandboxWriteFilesCalls).toHaveLength(1);
 	expect(sandboxExecuteCalls).toHaveLength(1);
 	expect(storageEnvKeys(sandboxCreateCalls[0]?.options.env)).toEqual([]);
-	expect(sandboxExecuteCalls[0]?.options.files).toHaveLength(1);
+	expect(sandboxWriteFilesCalls[0]?.files).toHaveLength(1);
+	expect(sandboxExecuteCalls[0]?.options.files).toBeUndefined();
 });
 
 test('sandbox route passes object storage credentials as S3 env only', async () => {

--- a/packages/core/src/services/sandbox/execute.ts
+++ b/packages/core/src/services/sandbox/execute.ts
@@ -1,10 +1,8 @@
-import type { ExecuteOptions, Execution, ExecutionStatus, FileToWrite } from './types.ts';
+import type { ExecuteOptions, Execution, ExecutionStatus } from './types.ts';
 import { z } from 'zod';
 import type { APIClient } from '../api.ts';
 import { SandboxBusyError, SandboxNotFoundError, throwSandboxError } from './util.ts';
-import { sandboxRmFile, sandboxWriteFiles } from './files.ts';
-
-const EXECUTE_FILE_ROLLBACK_TIMEOUT_MS = 5_000;
+import { base64Encode } from './base64.ts';
 
 export const ExecuteRequestSchema = z
 	.object({
@@ -70,47 +68,6 @@ export const SandboxExecuteParamsSchema = z.object({
 
 export type SandboxExecuteParams = z.infer<typeof SandboxExecuteParamsSchema>;
 
-function createRollbackSignal(): { readonly signal: AbortSignal; readonly cleanup: () => void } {
-	if (typeof AbortSignal.timeout === 'function') {
-		return { signal: AbortSignal.timeout(EXECUTE_FILE_ROLLBACK_TIMEOUT_MS), cleanup() {} };
-	}
-
-	const controller = new AbortController();
-	const timer = setTimeout(() => controller.abort(), EXECUTE_FILE_ROLLBACK_TIMEOUT_MS);
-	return {
-		signal: controller.signal,
-		cleanup() {
-			clearTimeout(timer);
-		},
-	};
-}
-
-async function cleanupStagedExecuteFiles(
-	client: APIClient,
-	params: {
-		readonly sandboxId: string;
-		readonly files: readonly FileToWrite[];
-		readonly orgId: string | undefined;
-	}
-): Promise<void> {
-	const { sandboxId, files, orgId } = params;
-	const rollback = createRollbackSignal();
-	try {
-		await Promise.allSettled(
-			files.map((file) =>
-				sandboxRmFile(client, {
-					sandboxId,
-					path: file.path,
-					orgId,
-					signal: rollback.signal,
-				})
-			)
-		);
-	} finally {
-		rollback.cleanup();
-	}
-}
-
 /**
  * Executes a command in an existing sandbox.
  *
@@ -127,16 +84,12 @@ export async function sandboxExecute(
 	const body: z.infer<typeof ExecuteRequestSchema> = {
 		command: options.command,
 	};
-	let stagedFiles: readonly FileToWrite[] | undefined;
 
 	if (options.files && options.files.length > 0) {
-		await sandboxWriteFiles(client, {
-			sandboxId,
-			files: options.files,
-			orgId,
-			signal: signal ?? options.signal,
-		});
-		stagedFiles = options.files;
+		body.files = options.files.map((f) => ({
+			path: f.path,
+			content: base64Encode(f.content),
+		}));
 	}
 	if (options.timeout) {
 		body.timeout = options.timeout;
@@ -162,9 +115,6 @@ export async function sandboxExecute(
 			signal ?? options.signal
 		);
 	} catch (error: unknown) {
-		if (stagedFiles) {
-			await cleanupStagedExecuteFiles(client, { sandboxId, files: stagedFiles, orgId });
-		}
 		if (
 			error &&
 			typeof error === 'object' &&
@@ -213,8 +163,5 @@ export async function sandboxExecute(
 		};
 	}
 
-	if (stagedFiles) {
-		await cleanupStagedExecuteFiles(client, { sandboxId, files: stagedFiles, orgId });
-	}
 	throwSandboxError(resp, { sandboxId });
 }

--- a/packages/core/src/services/sandbox/run.ts
+++ b/packages/core/src/services/sandbox/run.ts
@@ -253,14 +253,10 @@ export async function sandboxRun(
 			);
 
 			try {
-				// Resolve execution/status first so a failed create is not hidden by
-				// Pulse streams that stay open until the client deadline.
-				const execution = await completionPromise;
+				// Resolve execution/status first so a hung Pulse reader cannot block the
+				// whole run until the client deadline. Output stream fetches still run in parallel.
+				const [execution] = await Promise.all([completionPromise, streamsPromise]);
 				finalExecution = execution;
-				if (execution.status !== 'completed') {
-					abortController.abort();
-				}
-				await streamsPromise;
 				abortController.abort();
 			} catch (error) {
 				throw mapRunAbortError(
@@ -515,7 +511,6 @@ async function waitForRunCompletion(
 		const result = await Promise.race([executionPromise, statusPromise]);
 		return result;
 	} finally {
-		completionAbortController.abort();
 		if (onAbort && signal) {
 			signal.removeEventListener('abort', onAbort);
 		}

--- a/packages/server/test/sandbox-client.test.ts
+++ b/packages/server/test/sandbox-client.test.ts
@@ -258,24 +258,12 @@ describe('SandboxClient', () => {
 			expect(result.exitCode).toBe(0);
 		});
 
-		test('execute with files should stage files before executing command', async () => {
-			let executeRequestBody: Record<string, unknown> | null = null;
-			let writeFilesRequestBody: Record<string, unknown> | null = null;
+		test('execute with files should send files as map in request body', async () => {
+			let requestBody: Record<string, unknown> | null = null;
 
 			mockFetch(async (url, opts) => {
-				if (opts?.method === 'POST' && url.includes('/fs/sandbox-123')) {
-					writeFilesRequestBody = JSON.parse(opts.body as string);
-					return new Response(
-						JSON.stringify({
-							success: true,
-							data: { filesWritten: 2 },
-						}),
-						{ status: 200, headers: { 'content-type': 'application/json' } }
-					);
-				}
-
 				if (opts?.method === 'POST' && url.includes('/execute')) {
-					executeRequestBody = JSON.parse(opts.body as string);
+					requestBody = JSON.parse(opts.body as string);
 					return new Response(
 						JSON.stringify({
 							success: true,
@@ -327,76 +315,12 @@ describe('SandboxClient', () => {
 				],
 			});
 
-			expect(writeFilesRequestBody).not.toBeNull();
-			expect(writeFilesRequestBody!.files).toEqual([
+			expect(requestBody).not.toBeNull();
+			expect(requestBody!.command).toEqual(['bun', 'run', 'script.ts']);
+			expect(requestBody!.files).toEqual([
 				{ path: 'script.ts', content: Buffer.from('console.log("hello")').toString('base64') },
 				{ path: 'data.json', content: Buffer.from('{"key": "value"}').toString('base64') },
 			]);
-			expect(executeRequestBody).not.toBeNull();
-			expect(executeRequestBody!.command).toEqual(['bun', 'run', 'script.ts']);
-			expect(executeRequestBody!.files).toBeUndefined();
-		});
-
-		test('execute with files should remove staged files when execute is rejected', async () => {
-			const removedPaths: string[] = [];
-
-			mockFetch(async (url, opts) => {
-				if (opts?.method === 'POST' && url.includes('/fs/rm/sandbox-123')) {
-					const body = JSON.parse(opts.body as string) as { path: string };
-					removedPaths.push(body.path);
-					return new Response(JSON.stringify({ success: true, found: true }), {
-						status: 200,
-						headers: { 'content-type': 'application/json' },
-					});
-				}
-
-				if (opts?.method === 'POST' && url.includes('/fs/sandbox-123')) {
-					return new Response(
-						JSON.stringify({
-							success: true,
-							data: { filesWritten: 2 },
-						}),
-						{ status: 200, headers: { 'content-type': 'application/json' } }
-					);
-				}
-
-				if (opts?.method === 'POST' && url.includes('/execute')) {
-					return new Response(
-						JSON.stringify({
-							success: false,
-							message: 'sandbox is busy',
-						}),
-						{ status: 200, headers: { 'content-type': 'application/json' } }
-					);
-				}
-
-				if (opts?.method === 'POST' && url.includes('/sandbox')) {
-					return new Response(
-						JSON.stringify({
-							success: true,
-							data: { sandboxId: 'sandbox-123', status: 'idle' },
-						}),
-						{ status: 200, headers: { 'content-type': 'application/json' } }
-					);
-				}
-
-				return new Response(null, { status: 404 });
-			});
-
-			const client = new SandboxClient({ logger: createMockLogger() });
-			const sandbox = await client.create();
-
-			await expect(
-				sandbox.execute({
-					command: ['bun', 'run', 'script.ts'],
-					files: [
-						{ path: 'script.ts', content: Buffer.from('console.log("hello")') },
-						{ path: 'data.json', content: Buffer.from('{"key": "value"}') },
-					],
-				})
-			).rejects.toThrow('sandbox is busy');
-
-			expect(removedPaths.sort()).toEqual(['data.json', 'script.ts']);
 		});
 
 		test('execute with empty files array should not include files in request', async () => {
@@ -1071,151 +995,6 @@ describe('SandboxClient', () => {
 
 			expect(result.sandboxId).toBe('sandbox-fail-test');
 			expect(result.exitCode).toBe(1);
-		});
-
-		test('should return failed execution result without waiting for hung output streams', async () => {
-			let executionPolls = 0;
-
-			mockFetch(async (url, opts) => {
-				if (opts?.method === 'POST' && url.includes('/sandbox')) {
-					return new Response(
-						JSON.stringify({
-							success: true,
-							data: {
-								sandboxId: 'sandbox-failed-stream',
-								executionId: 'exec-failed-stream',
-								status: 'running',
-								stdoutStreamUrl: 'https://stream.example.com/combined/failed-stream',
-								stderrStreamUrl: 'https://stream.example.com/combined/failed-stream',
-							},
-						}),
-						{ status: 200, headers: { 'content-type': 'application/json' } }
-					);
-				}
-
-				if (url.includes('stream.example.com/combined/failed-stream')) {
-					return new Response(
-						new ReadableStream({
-							start(controller) {
-								controller.enqueue(new TextEncoder().encode('booting...\n'));
-								opts?.signal?.addEventListener('abort', () => controller.close(), {
-									once: true,
-								});
-							},
-						}),
-						{ status: 200 }
-					);
-				}
-
-				if (url.includes('/execution/exec-failed-stream')) {
-					executionPolls++;
-					return new Response(
-						JSON.stringify({
-							success: true,
-							data: {
-								executionId: 'exec-failed-stream',
-								sandboxId: 'sandbox-failed-stream',
-								status: 'failed',
-								error: 'error creating sandbox',
-							},
-						}),
-						{ status: 200, headers: { 'content-type': 'application/json' } }
-					);
-				}
-
-				return new Response(null, { status: 404 });
-			});
-
-			const client = new SandboxClient({ logger: createMockLogger() });
-			const abortController = new AbortController();
-			const timeout = setTimeout(() => abortController.abort(), 100);
-
-			try {
-				const result = await client.run(
-					{ command: { exec: ['false'] } },
-					{ signal: abortController.signal }
-				);
-
-				expect(result.sandboxId).toBe('sandbox-failed-stream');
-				expect(result.exitCode).toBe(1);
-				expect(executionPolls).toBe(1);
-			} finally {
-				clearTimeout(timeout);
-			}
-		});
-
-		test('should abort status completion waiter after execution completion wins', async () => {
-			let resolveStatusStarted: (() => void) | undefined;
-			const statusStarted = new Promise<void>((resolve) => {
-				resolveStatusStarted = resolve;
-			});
-			let statusWaitAborted = false;
-
-			mockFetch(async (url, opts) => {
-				if (opts?.method === 'POST' && url.includes('/sandbox')) {
-					return new Response(
-						JSON.stringify({
-							success: true,
-							data: {
-								sandboxId: 'sandbox-race-test',
-								executionId: 'exec-race-test',
-								status: 'running',
-							},
-						}),
-						{ status: 200, headers: { 'content-type': 'application/json' } }
-					);
-				}
-
-				if (url.includes('/sandbox/status/sandbox-race-test')) {
-					resolveStatusStarted?.();
-					return new Promise<Response>((resolve) => {
-						opts?.signal?.addEventListener(
-							'abort',
-							() => {
-								statusWaitAborted = true;
-								resolve(
-									new Response(
-										JSON.stringify({
-											success: true,
-											data: {
-												sandboxId: 'sandbox-race-test',
-												status: 'running',
-											},
-										}),
-										{ status: 200, headers: { 'content-type': 'application/json' } }
-									)
-								);
-							},
-							{ once: true }
-						);
-					});
-				}
-
-				if (url.includes('/execution/exec-race-test')) {
-					await statusStarted;
-					return new Response(
-						JSON.stringify({
-							success: true,
-							data: {
-								executionId: 'exec-race-test',
-								sandboxId: 'sandbox-race-test',
-								status: 'completed',
-								exitCode: 0,
-							},
-						}),
-						{ status: 200, headers: { 'content-type': 'application/json' } }
-					);
-				}
-
-				return new Response(null, { status: 404 });
-			});
-
-			const client = new SandboxClient({ logger: createMockLogger() });
-			const result = await client.run({ command: { exec: ['true'] } });
-
-			expect(result.sandboxId).toBe('sandbox-race-test');
-			expect(result.exitCode).toBe(0);
-			expect(statusWaitAborted).toBe(true);
 		});
 
 		test('should return captured stdout in result', async () => {


### PR DESCRIPTION
## Summary

Restores the sandbox package files changed by #1559 and keeps the SDK Explorer fix scoped to the docs app.

- Restores `packages/core/src/services/sandbox/execute.ts` to pre-merge behavior
- Restores `packages/core/src/services/sandbox/run.ts` to pre-merge behavior
- Restores `packages/server/test/sandbox-client.test.ts` to pre-merge behavior
- Writes Explorer script files from `docs/src/api/sandbox/route.ts` before calling `sandboxExecute()`
- Updates the docs route test so `sandboxExecute()` is called without inline `files`

## Why

#1559 fixed the Explorer hang, but it also changed package-level sandbox behavior. That was too broad for a docs Explorer bug.

The safer correction is to keep package APIs and behavior unchanged, then make the Explorer route do its own staging:

```ts
await sandboxWriteFiles(client, {
  sandboxId,
  files,
  orgId,
});

const execution = await sandboxExecute(client, {
  sandboxId,
  options: { command, timeout: SANDBOX_EXEC_TIMEOUT },
  orgId,
});
```

That keeps the workaround at the call site that needs it.

## Verification

- `git diff --check`
- `bun test src/api/test/sandbox-route.test.ts`
- `bunx biome check docs/src/api/sandbox/route.ts docs/src/api/test/sandbox-route.test.ts packages/core/src/services/sandbox/execute.ts packages/core/src/services/sandbox/run.ts packages/server/test/sandbox-client.test.ts`
- `cd docs && bun run typecheck`
- `cd packages/core && bun run typecheck`
- `cd packages/server && bun run typecheck`
- Verified package files match the pre-#1559 merge commit byte-for-byte


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized sandbox file upload and execution handling to process file uploads and output streaming concurrently, reducing execution latency.
  * Improved test coverage for file upload scenarios in sandbox execution workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->