### PR TITLE
fix(cli): dereference monorepo symlinks with recursive cpSync (#1564)

### DIFF
--- a/packages/cli/src/cmd/build/adapters/generic.ts
+++ b/packages/cli/src/cmd/build/adapters/generic.ts
@@ -350,7 +350,7 @@ export function copyMonorepoTree(
 				// Resolve symlinks during copy. `node_modules` symlinks have
 				// already been skipped above; everything else is either a
 				// genuine source link or a regular file pretending to be one.
-				cpSync(srcChild, dstChild, { dereference: true });
+				cpSync(srcChild, dstChild, { dereference: true, recursive: true });
 			} else {
 				cpSync(srcChild, dstChild);
 			}

--- a/packages/cli/test/cmd/build/staging-cleanliness.test.ts
+++ b/packages/cli/test/cmd/build/staging-cleanliness.test.ts
@@ -128,6 +128,18 @@ describe('copyMonorepoTree', () => {
 		expect(existsSync(join(dst, 'apps/web/dist/chunk-abc.js'))).toBe(true);
 	});
 
+	test('dereferences relative symlinks at repo root (Node ERR_FS_EISDIR without recursive)', () => {
+		write(join(root, 'real.txt'), 'hello from symlink');
+		symlinkSync('real.txt', join(root, 'link.txt'));
+		write(join(root, 'package.json'), '{"workspaces":["apps/*"]}');
+
+		copyMonorepoTree(ctx(), dst, noopLogger);
+
+		const dstPath = join(dst, 'link.txt');
+		expect(existsSync(dstPath)).toBe(true);
+		expect(Bun.file(dstPath).text()).resolves.toBe('hello from symlink');
+	});
+
 	test('dereferences symlinks (so workspace-link targets ship as files)', () => {
 		// `packages/shared/src/index.ts` is the real file; `apps/web/src/shared.ts`
 		// is a symlink to it. We expect the symlink to be resolved to a


### PR DESCRIPTION
## Summary
- Fix `agentuity build` / `deploy` crashing when a Bun-workspace monorepo contains symlinks outside `node_modules`
- Add `recursive: true` to symlink dereference in `copyMonorepoTree` to work around Node `ERR_FS_EISDIR`
- Add a regression test for relative symlinks at the repo root (the #1564 repro case)

Fixes #1564

## Test plan
- [x] `bun test packages/cli/test/cmd/build/staging-cleanliness.test.ts`
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved symlink handling during the build process to correctly expand and dereference directory symlinks.

* **Tests**
  * Added test coverage for symlink dereferencing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->