### PR TITLE
fix(postgres): close leaked pools during Bun hot reload

### DIFF
--- a/packages/postgres/src/hot-reload.ts
+++ b/packages/postgres/src/hot-reload.ts
@@ -1,0 +1,112 @@
+import type { PoolConfig } from './types.ts';
+
+const SHARED_POOL_CACHE_KEY = Symbol.for('@agentuity/postgres:shared-pools');
+
+let hotReloadEnabledOverride: boolean | undefined;
+
+interface HotReloadConnection {
+	readonly shuttingDown: boolean;
+	readonly ended?: boolean;
+	close(): Promise<void>;
+}
+
+/**
+ * Whether Bun hot module replacement is active.
+ * Undefined in production; Bun dead-code-eliminates callers when false.
+ */
+export function isHotReloadEnabled(): boolean {
+	if (hotReloadEnabledOverride !== undefined) {
+		return hotReloadEnabledOverride;
+	}
+	return typeof import.meta !== 'undefined' && import.meta.hot !== undefined;
+}
+
+/** @internal Test-only override for hot reload detection. */
+export function __setHotReloadEnabledForTests(value: boolean | undefined): void {
+	hotReloadEnabledOverride = value;
+}
+
+function getSharedPoolCache(): Map<string, HotReloadConnection> {
+	const global = globalThis as Record<symbol, Map<string, HotReloadConnection>>;
+	if (!global[SHARED_POOL_CACHE_KEY]) {
+		global[SHARED_POOL_CACHE_KEY] = new Map();
+	}
+	return global[SHARED_POOL_CACHE_KEY];
+}
+
+function normalizePoolConfig(config?: string | PoolConfig): PoolConfig {
+	if (typeof config === 'string') {
+		return { connectionString: config };
+	}
+	return {
+		...config,
+		connectionString: config?.connectionString ?? process.env.DATABASE_URL,
+	};
+}
+
+/**
+ * Stable cache key for pools that target the same backend with the same sizing.
+ */
+export function computePoolHotReloadKey(config?: string | PoolConfig): string {
+	const normalized = normalizePoolConfig(config);
+	const connectionString = normalized.connectionString ?? '';
+	const max = normalized.max ?? 10;
+	const maxLifetimeSeconds = normalized.maxLifetimeSeconds ?? '';
+	const connectionTimeoutMillis = normalized.connectionTimeoutMillis ?? '';
+	return `${connectionString}\0${max}\0${maxLifetimeSeconds}\0${connectionTimeoutMillis}`;
+}
+
+function isConnectionEnded(connection: HotReloadConnection): boolean {
+	return connection.ended === true || connection.shuttingDown;
+}
+
+/**
+ * Close a superseded pool/client during hot reload and track the replacement.
+ * @internal
+ */
+export function supersedeHotReloadConnection(
+	connection: HotReloadConnection,
+	hotReloadKey: string
+): void {
+	const cache = getSharedPoolCache();
+	const existing = cache.get(hotReloadKey);
+	if (existing && existing !== connection && !isConnectionEnded(existing)) {
+		void existing.close().catch(() => {});
+	}
+	cache.set(hotReloadKey, connection);
+}
+
+/**
+ * Remove a closed connection from the shared hot-reload cache.
+ * @internal
+ */
+export function removeHotReloadCachedConnection(connection: HotReloadConnection): void {
+	const cache = getSharedPoolCache();
+	for (const [key, cached] of cache.entries()) {
+		if (cached === connection) {
+			cache.delete(key);
+		}
+	}
+}
+
+/** Clear all shared hot-reload pool references. */
+export function clearSharedHotReloadCache(): void {
+	getSharedPoolCache().clear();
+}
+
+/** @internal Clear shared pool cache between tests. */
+export function __clearHotReloadCacheForTests(): void {
+	clearSharedHotReloadCache();
+}
+
+/**
+ * Returns a shared pool cached from a prior hot reload, if still open.
+ * @internal
+ */
+export function getSharedHotReloadPool(hotReloadKey: string): HotReloadConnection | undefined {
+	const cached = getSharedPoolCache().get(hotReloadKey);
+	if (cached && !isConnectionEnded(cached)) {
+		return cached;
+	}
+	return undefined;
+}

--- a/packages/postgres/src/index.ts
+++ b/packages/postgres/src/index.ts
@@ -73,6 +73,7 @@ export type {
 	PoolConfig,
 	PoolStats,
 	PoolSSLConfig,
+	CreatePoolOptions,
 } from './types.ts';
 
 // Errors

--- a/packages/postgres/src/pool.ts
+++ b/packages/postgres/src/pool.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events';
 import pg from 'pg';
-import type { PoolConfig, PoolStats } from './types.ts';
+import type { PoolConfig, PoolStats, CreatePoolOptions } from './types.ts';
 import {
 	ConnectionClosedError,
 	PostgresError,
@@ -10,6 +10,11 @@ import {
 } from './errors.ts';
 import { computeBackoff, sleep, mergeReconnectConfig } from './reconnect.ts';
 import { registerClient, unregisterClient, type Registrable } from './registry.ts';
+import {
+	computePoolHotReloadKey,
+	getSharedHotReloadPool,
+	isHotReloadEnabled,
+} from './hot-reload.ts';
 
 /**
  * A resilient PostgreSQL connection pool with automatic reconnection.
@@ -82,7 +87,7 @@ export class PostgresPool extends EventEmitter implements Registrable {
 		this._registerShutdownHandlers();
 
 		// Register this pool in the global registry for coordinated shutdown
-		registerClient(this);
+		registerClient(this, { hotReloadKey: computePoolHotReloadKey(this._config) });
 
 		// If preconnect is enabled, establish connection immediately
 		if (this._config.preconnect) {
@@ -769,12 +774,24 @@ export class PostgresPool extends EventEmitter implements Registrable {
 
 /**
  * Creates a new PostgresPool.
- * This is an alias for `new PostgresPool(config)` for convenience.
  *
  * @param config - Connection configuration
- * @returns A new PostgresPool instance
+ * @param options - Pool creation options. Set `shared: true` during Bun hot reload
+ *                  development to reuse one pool across module re-evaluations.
+ * @returns A PostgresPool instance
  */
-export function createPool(config?: string | PoolConfig): PostgresPool {
+export function createPool(
+	config?: string | PoolConfig,
+	options?: CreatePoolOptions
+): PostgresPool {
+	if (options?.shared && isHotReloadEnabled()) {
+		const key = computePoolHotReloadKey(config);
+		const cached = getSharedHotReloadPool(key);
+		if (cached) {
+			return cached as PostgresPool;
+		}
+	}
+
 	return new PostgresPool(config);
 }
 

--- a/packages/postgres/src/registry.ts
+++ b/packages/postgres/src/registry.ts
@@ -9,7 +9,18 @@
  *
  * Automatically registers process shutdown hooks (beforeExit, SIGTERM, SIGINT)
  * so all postgres clients/pools are closed during graceful shutdown.
+ *
+ * During Bun hot reload (`import.meta.hot`), registering a pool with the same
+ * hot-reload key closes the superseded pool so module re-evaluation does not
+ * leak connections.
  */
+
+import {
+	isHotReloadEnabled,
+	removeHotReloadCachedConnection,
+	supersedeHotReloadConnection,
+	clearSharedHotReloadCache,
+} from './hot-reload.ts';
 
 /**
  * Common interface for registrable PostgreSQL connections.
@@ -30,6 +41,14 @@ export interface Registrable {
 	 * Close the connection.
 	 */
 	close(): Promise<void>;
+}
+
+export interface RegisterClientOptions {
+	/**
+	 * Stable key for Bun hot reload deduplication. When a new connection
+	 * registers with the same key, the previous one is closed.
+	 */
+	hotReloadKey?: string;
 }
 
 /**
@@ -60,7 +79,10 @@ function getRegistry(): Set<Registrable> {
  * @param connection - The client or pool to register
  * @internal
  */
-export function registerClient(connection: Registrable): void {
+export function registerClient(connection: Registrable, options?: RegisterClientOptions): void {
+	if (options?.hotReloadKey && isHotReloadEnabled()) {
+		supersedeHotReloadConnection(connection, options.hotReloadKey);
+	}
 	getRegistry().add(connection);
 }
 
@@ -73,6 +95,9 @@ export function registerClient(connection: Registrable): void {
  */
 export function unregisterClient(connection: Registrable): void {
 	getRegistry().delete(connection);
+	if (isHotReloadEnabled()) {
+		removeHotReloadCachedConnection(connection);
+	}
 }
 
 /**
@@ -157,6 +182,7 @@ export async function shutdownAll(timeoutMs?: number): Promise<void> {
 
 	// Clear the registry
 	registry.clear();
+	clearSharedHotReloadCache();
 }
 
 /**

--- a/packages/postgres/src/types.ts
+++ b/packages/postgres/src/types.ts
@@ -407,6 +407,19 @@ export interface PoolConfig extends pg.PoolConfig {
 }
 
 /**
+ * Options for {@link createPool}.
+ */
+export interface CreatePoolOptions {
+	/**
+	 * Reuse one pool per connection profile across Bun hot reloads.
+	 * Avoids reconnect churn during local development.
+	 *
+	 * @default false
+	 */
+	shared?: boolean;
+}
+
+/**
  * Statistics about the pool state and reconnection history.
  */
 export interface PoolStats {

--- a/packages/postgres/test/hot-reload.test.ts
+++ b/packages/postgres/test/hot-reload.test.ts
@@ -1,0 +1,125 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import {
+	__clearHotReloadCacheForTests,
+	__setHotReloadEnabledForTests,
+	computePoolHotReloadKey,
+	getSharedHotReloadPool,
+	supersedeHotReloadConnection,
+} from '../src/hot-reload';
+import { getClientCount, registerClient, shutdownAll, unregisterClient } from '../src/registry';
+
+const REGISTRY_KEY = Symbol.for('@agentuity/postgres:registry');
+
+function clearRegistry() {
+	const global = globalThis as Record<symbol, Set<unknown>>;
+	if (global[REGISTRY_KEY]) {
+		global[REGISTRY_KEY].clear();
+	}
+}
+
+function createMockPool(options: { ended?: boolean; shuttingDown?: boolean } = {}) {
+	return {
+		shutdown: mock(() => {}),
+		close: mock(() => Promise.resolve()),
+		ended: options.ended ?? false,
+		shuttingDown: options.shuttingDown ?? false,
+	};
+}
+
+describe('hot-reload', () => {
+	beforeEach(() => {
+		__setHotReloadEnabledForTests(undefined);
+		__clearHotReloadCacheForTests();
+		clearRegistry();
+	});
+
+	describe('computePoolHotReloadKey', () => {
+		test('uses connection string and pool sizing', () => {
+			const key = computePoolHotReloadKey({
+				connectionString: 'postgres://example/db',
+				max: 5,
+				maxLifetimeSeconds: 240,
+				connectionTimeoutMillis: 5000,
+			});
+			expect(key).toContain('postgres://example/db');
+			expect(key).toContain('5');
+			expect(key).toContain('240');
+			expect(key).toContain('5000');
+		});
+
+		test('normalizes string config', () => {
+			expect(computePoolHotReloadKey('postgres://example/db')).toContain(
+				'postgres://example/db'
+			);
+		});
+	});
+
+	describe('registerClient hot reload supersession', () => {
+		test('closes superseded pool with the same hot-reload key', () => {
+			__setHotReloadEnabledForTests(true);
+			const key = computePoolHotReloadKey({ connectionString: 'postgres://example/db', max: 3 });
+			const first = createMockPool();
+			const second = createMockPool();
+
+			registerClient(first, { hotReloadKey: key });
+			registerClient(second, { hotReloadKey: key });
+
+			expect(first.close).toHaveBeenCalledTimes(1);
+			expect(getClientCount()).toBe(2);
+			expect(getSharedHotReloadPool(key)).toBe(second);
+		});
+
+		test('does not close pools when hot reload is disabled', () => {
+			__setHotReloadEnabledForTests(false);
+			const key = computePoolHotReloadKey({ connectionString: 'postgres://example/db', max: 3 });
+			const first = createMockPool();
+			const second = createMockPool();
+
+			registerClient(first, { hotReloadKey: key });
+			registerClient(second, { hotReloadKey: key });
+
+			expect(first.close).not.toHaveBeenCalled();
+		});
+
+		test('unregister removes cached shared pool reference', () => {
+			__setHotReloadEnabledForTests(true);
+			const key = computePoolHotReloadKey({ connectionString: 'postgres://example/db', max: 3 });
+			const pool = createMockPool();
+
+			registerClient(pool, { hotReloadKey: key });
+			expect(getSharedHotReloadPool(key)).toBe(pool);
+
+			unregisterClient(pool);
+			expect(getSharedHotReloadPool(key)).toBeUndefined();
+		});
+	});
+
+	describe('getSharedHotReloadPool', () => {
+		test('returns cached pool while open', () => {
+			const key = 'test-key';
+			const pool = createMockPool();
+			supersedeHotReloadConnection(pool, key);
+			expect(getSharedHotReloadPool(key)).toBe(pool);
+		});
+
+		test('ignores ended pools', () => {
+			const key = 'test-key';
+			const pool = createMockPool({ ended: true });
+			supersedeHotReloadConnection(pool, key);
+			expect(getSharedHotReloadPool(key)).toBeUndefined();
+		});
+	});
+
+	describe('shutdownAll', () => {
+		test('still clears registry after hot reload registrations', async () => {
+			__setHotReloadEnabledForTests(true);
+			const key = computePoolHotReloadKey({ connectionString: 'postgres://example/db', max: 3 });
+			const pool = createMockPool();
+			registerClient(pool, { hotReloadKey: key });
+
+			await shutdownAll();
+			expect(getClientCount()).toBe(0);
+			expect(getSharedHotReloadPool(key)).toBeUndefined();
+		});
+	});
+});

--- a/packages/postgres/test/hot-reload.test.ts
+++ b/packages/postgres/test/hot-reload.test.ts
@@ -1,4 +1,5 @@
-import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { createMockPostgresPool } from '@agentuity/test-utils';
 import {
 	__clearHotReloadCacheForTests,
 	__setHotReloadEnabledForTests,
@@ -17,15 +18,6 @@ function clearRegistry() {
 	}
 }
 
-function createMockPool(options: { ended?: boolean; shuttingDown?: boolean } = {}) {
-	return {
-		shutdown: mock(() => {}),
-		close: mock(() => Promise.resolve()),
-		ended: options.ended ?? false,
-		shuttingDown: options.shuttingDown ?? false,
-	};
-}
-
 describe('hot-reload', () => {
 	beforeEach(() => {
 		__setHotReloadEnabledForTests(undefined);
@@ -41,15 +33,12 @@ describe('hot-reload', () => {
 				maxLifetimeSeconds: 240,
 				connectionTimeoutMillis: 5000,
 			});
-			expect(key).toContain('postgres://example/db');
-			expect(key).toContain('5');
-			expect(key).toContain('240');
-			expect(key).toContain('5000');
+			expect(key).toBe('postgres://example/db\x005\x00240\x005000');
 		});
 
 		test('normalizes string config', () => {
-			expect(computePoolHotReloadKey('postgres://example/db')).toContain(
-				'postgres://example/db'
+			expect(computePoolHotReloadKey('postgres://example/db')).toBe(
+				'postgres://example/db\x0010\x00\x00'
 			);
 		});
 	});
@@ -58,8 +47,8 @@ describe('hot-reload', () => {
 		test('closes superseded pool with the same hot-reload key', () => {
 			__setHotReloadEnabledForTests(true);
 			const key = computePoolHotReloadKey({ connectionString: 'postgres://example/db', max: 3 });
-			const first = createMockPool();
-			const second = createMockPool();
+			const first = createMockPostgresPool();
+			const second = createMockPostgresPool();
 
 			registerClient(first, { hotReloadKey: key });
 			registerClient(second, { hotReloadKey: key });
@@ -72,8 +61,8 @@ describe('hot-reload', () => {
 		test('does not close pools when hot reload is disabled', () => {
 			__setHotReloadEnabledForTests(false);
 			const key = computePoolHotReloadKey({ connectionString: 'postgres://example/db', max: 3 });
-			const first = createMockPool();
-			const second = createMockPool();
+			const first = createMockPostgresPool();
+			const second = createMockPostgresPool();
 
 			registerClient(first, { hotReloadKey: key });
 			registerClient(second, { hotReloadKey: key });
@@ -84,7 +73,7 @@ describe('hot-reload', () => {
 		test('unregister removes cached shared pool reference', () => {
 			__setHotReloadEnabledForTests(true);
 			const key = computePoolHotReloadKey({ connectionString: 'postgres://example/db', max: 3 });
-			const pool = createMockPool();
+			const pool = createMockPostgresPool();
 
 			registerClient(pool, { hotReloadKey: key });
 			expect(getSharedHotReloadPool(key)).toBe(pool);
@@ -97,14 +86,14 @@ describe('hot-reload', () => {
 	describe('getSharedHotReloadPool', () => {
 		test('returns cached pool while open', () => {
 			const key = 'test-key';
-			const pool = createMockPool();
+			const pool = createMockPostgresPool();
 			supersedeHotReloadConnection(pool, key);
 			expect(getSharedHotReloadPool(key)).toBe(pool);
 		});
 
 		test('ignores ended pools', () => {
 			const key = 'test-key';
-			const pool = createMockPool({ ended: true });
+			const pool = createMockPostgresPool({ ended: true });
 			supersedeHotReloadConnection(pool, key);
 			expect(getSharedHotReloadPool(key)).toBeUndefined();
 		});
@@ -114,7 +103,7 @@ describe('hot-reload', () => {
 		test('still clears registry after hot reload registrations', async () => {
 			__setHotReloadEnabledForTests(true);
 			const key = computePoolHotReloadKey({ connectionString: 'postgres://example/db', max: 3 });
-			const pool = createMockPool();
+			const pool = createMockPostgresPool();
 			registerClient(pool, { hotReloadKey: key });
 
 			await shutdownAll();

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -13,3 +13,8 @@ export {
 	type MockAdapterResponse,
 	type MockAdapterConfig,
 } from './mock-adapter';
+export {
+	createMockPostgresPool,
+	type MockPostgresPool,
+	type MockPostgresPoolOptions,
+} from './mock-postgres-pool';

--- a/packages/test-utils/src/mock-postgres-pool.ts
+++ b/packages/test-utils/src/mock-postgres-pool.ts
@@ -1,0 +1,25 @@
+import { mock } from 'bun:test';
+
+export interface MockPostgresPoolOptions {
+	ended?: boolean;
+	shuttingDown?: boolean;
+}
+
+export interface MockPostgresPool {
+	readonly shuttingDown: boolean;
+	readonly ended?: boolean;
+	shutdown: ReturnType<typeof mock>;
+	close: ReturnType<typeof mock>;
+}
+
+/**
+ * Create a mock postgres pool/connection for registry and hot-reload tests.
+ */
+export function createMockPostgresPool(options: MockPostgresPoolOptions = {}): MockPostgresPool {
+	return {
+		shutdown: mock(() => {}),
+		close: mock(() => Promise.resolve()),
+		ended: options.ended ?? false,
+		shuttingDown: options.shuttingDown ?? false,
+	};
+}


### PR DESCRIPTION
## Summary
- Close superseded `PostgresPool` instances when the same hot-reload key registers again during Bun `--hot` module re-evaluation, preventing connection leaks to shared ion Postgres proxies.
- Add `createPool(config, { shared: true })` to reuse one pool across hot reloads in local development and avoid reconnect churn on every save.
- Clear the shared hot-reload cache during `shutdownAll()` so graceful shutdown stays consistent.

## Motivation
Local Genesis dev against `genesis_localdev` on ion US Central was leaking pools on every backend hot reload (`new PostgresPool()` in module scope). This contributed to ion postgres proxy pool acquire timeouts during a recent USC incident.

## Test plan
- [x] `cd packages/postgres && bun test`
- [x] `cd packages/postgres && bun run typecheck`
- [ ] Verify locally with `bun --hot` dev: `getClientCount()` stays flat across saves when using `createPool(..., { shared: true })`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added hot-reload–aware pooling so shared PostgreSQL pools can be reused across development refreshes via a new `shared` option.
  * Improved hot-reload deduplication to supersede prior cached connections for the same pool profile when registering new ones.

* **Bug Fixes**
  * Ensured hot-reload shared state is cleared during full shutdown/cleanup.

* **Documentation**
  * Exposed the `CreatePoolOptions` type publicly.

* **Tests**
  * Added coverage for hot-reload keying, cache reuse, and cleanup behavior.

* **Chores**
  * Extended test utilities with a mock Postgres pool helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->