### PR TITLE
fix(storage): stop corrupting streamed uploads under Bun

### DIFF
--- a/packages/storage/src/bun.ts
+++ b/packages/storage/src/bun.ts
@@ -29,6 +29,32 @@ export type { BucketConfig, S3ClientLike } from './types.ts';
 export { bucketConfigFromEnv } from './types.ts';
 
 /**
+ * Normalize a write body into a shape `Bun.S3Client.write` stores
+ * losslessly.
+ *
+ * Bun 1.3.x's `S3Client.write` does not consume a Web `ReadableStream`:
+ * it string-coerces it to the 23-byte literal `"[object ReadableStream]"`
+ * and stores that instead of the stream's bytes. Buffer a stream to bytes
+ * first (a `Uint8Array` round-trips correctly); every other accepted
+ * shape (string/Uint8Array/ArrayBuffer/Blob) is already stored losslessly
+ * and passes through untouched.
+ *
+ * Exported for regression testing: Bun's built-in `bun` module can't be
+ * overridden via `mock.module`, so the buffering is verified here rather
+ * than through a mocked `write`.
+ */
+export async function normalizeWriteBody(
+	body: S3Body
+): Promise<Exclude<S3Body, ReadableStream<Uint8Array>>> {
+	if (body instanceof ReadableStream) {
+		// Buffer the stream to bytes; a Uint8Array round-trips correctly
+		// where a raw Web stream is silently corrupted.
+		return new Uint8Array(await new Response(body).arrayBuffer());
+	}
+	return body;
+}
+
+/**
  * Create an S3 client backed by `Bun.S3Client`.
  *
  * Endpoints are bucket-scoped (virtual-hosted-style), so we do not pass
@@ -106,10 +132,10 @@ export function createS3Client(bucket: BucketConfig): S3ClientLike {
 		},
 
 		async write(key: string, body: S3Body, opts?: S3WriteOptions): Promise<number> {
-			// `Bun.S3Client.write` accepts string, Uint8Array, ArrayBuffer,
-			// Blob, ReadableStream, or Response. We accept the same shapes
-			// minus Response (callers should pass the underlying stream).
-			return client.write(key, body as any, opts);
+			// `Bun.S3Client.write` cannot consume a Web `ReadableStream` (it
+			// string-coerces it to "[object ReadableStream]"), so normalize
+			// the body to a shape Bun stores losslessly before writing.
+			return client.write(key, await normalizeWriteBody(body), opts);
 		},
 
 		async delete(key: string): Promise<void> {

--- a/packages/storage/test/bun.test.ts
+++ b/packages/storage/test/bun.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import { normalizeWriteBody } from '../src/bun.ts';
+
+/**
+ * Regression coverage for the Bun upload corruption.
+ *
+ * On Bun 1.3.x, `Bun.S3Client.write` does not consume a Web
+ * `ReadableStream` body: it string-coerces it to the 23-byte literal
+ * `"[object ReadableStream]"` and stores that instead of the file's
+ * bytes (verified on Bun 1.3.14). `normalizeWriteBody` is the guard — it
+ * must buffer a stream to its exact bytes before the client ever sees it.
+ *
+ * The helper is tested directly rather than through
+ * `createS3Client().write()` because Bun's built-in `bun` module — where
+ * `S3Client` comes from — cannot be overridden via `mock.module`, so a
+ * full-path unit test would require a live S3 endpoint.
+ */
+
+function streamOf(bytes: Uint8Array): ReadableStream<Uint8Array> {
+	return new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(bytes);
+			controller.close();
+		},
+	});
+}
+
+describe('normalizeWriteBody (Bun upload body guard)', () => {
+	test('buffers a Web ReadableStream to its exact bytes', async () => {
+		// Payload length is deliberately != 23 so a "[object ReadableStream]"
+		// corruption would be unmistakable.
+		const payload = new TextEncoder().encode('bun-stream-payload-ABCDEFGHIJKLMNOP-0123456789\n');
+
+		const out = await normalizeWriteBody(streamOf(payload));
+
+		// Must be materialized bytes, never a stream (which Bun coerces to
+		// the 23-byte "[object ReadableStream]").
+		expect(out).toBeInstanceOf(Uint8Array);
+		expect(out instanceof ReadableStream).toBe(false);
+		const bytes = out as Uint8Array;
+		expect(bytes.byteLength).toBe(payload.byteLength);
+		expect(bytes).toEqual(payload);
+	});
+
+	test('passes non-stream bodies through unchanged', async () => {
+		// string / Uint8Array / Blob are stored losslessly by Bun, so the
+		// guard must not touch them.
+		const text = 'plain-text-body';
+		expect(await normalizeWriteBody(text)).toBe(text);
+
+		const u8 = new TextEncoder().encode('uint8-body');
+		expect(await normalizeWriteBody(u8)).toBe(u8);
+
+		const blob = new Blob(['blob-body']);
+		expect(await normalizeWriteBody(blob)).toBe(blob);
+	});
+});

--- a/packages/storage/test/node.test.ts
+++ b/packages/storage/test/node.test.ts
@@ -1,15 +1,19 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { Buffer } from 'node:buffer';
 import { createS3Client } from '../src/node.ts';
 import { bucketConfigFromEnv } from '../src/types.ts';
 
 interface CapturedState {
 	readonly clientConfigs: unknown[];
 	readonly commands: S3Command[];
+	/** Bytes drained from each upload command's `Body`, in call order. */
+	readonly uploadedBodies: Uint8Array[];
 }
 
 const captured: CapturedState = {
 	clientConfigs: [],
 	commands: [],
+	uploadedBodies: [],
 };
 
 class S3Command {
@@ -20,6 +24,22 @@ class S3Command {
 	}
 }
 
+/**
+ * Drain a mocked upload `Body` into bytes, mirroring what the real S3
+ * SDK reads off the wire. Handles fixed bodies and the Node `Readable`
+ * that `node.ts` produces for streaming uploads.
+ */
+async function drainBody(body: unknown): Promise<Uint8Array> {
+	if (body == null) return new Uint8Array();
+	if (typeof body === 'string') return new Uint8Array(Buffer.from(body, 'utf-8'));
+	if (body instanceof Uint8Array) return new Uint8Array(body);
+	const chunks: Buffer[] = [];
+	for await (const chunk of body as AsyncIterable<Buffer>) {
+		chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+	}
+	return new Uint8Array(Buffer.concat(chunks));
+}
+
 mock.module('@aws-sdk/client-s3', () => {
 	class S3Client {
 		constructor(config: unknown) {
@@ -28,6 +48,10 @@ mock.module('@aws-sdk/client-s3', () => {
 
 		async send(command: S3Command): Promise<Record<string, unknown>> {
 			captured.commands.push(command);
+			const input = command.input as { Body?: unknown } | null;
+			if (input && 'Body' in input && input.Body != null) {
+				captured.uploadedBodies.push(await drainBody(input.Body));
+			}
 			return { Contents: [], IsTruncated: false };
 		}
 	}
@@ -133,5 +157,40 @@ describe('Node S3 client endpoint resolution', () => {
 				secret_key: 'secret',
 			})
 		).toThrow('BucketConfig accepts either `endpoint` or `host`+`bucket`, not both.');
+	});
+});
+
+describe('Node S3 client upload body handling', () => {
+	beforeEach(() => {
+		captured.clientConfigs.length = 0;
+		captured.commands.length = 0;
+		captured.uploadedBodies.length = 0;
+	});
+
+	test('streams a Web ReadableStream body as exact bytes (parity with the Bun fix)', async () => {
+		const storage = createS3Client({
+			endpoint: 'https://example-bucket.storage.example.test',
+			access_key: 'access',
+			secret_key: 'secret',
+		});
+		// Length deliberately != 23 so a "[object ReadableStream]" corruption
+		// would be unmistakable.
+		const payload = new TextEncoder().encode('node-stream-payload-ABCDEFGHIJKLMNOP-0123456789\n');
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(payload);
+				controller.close();
+			},
+		});
+
+		const wrote = await storage.write('obj.txt', stream, { type: 'text/plain' });
+
+		// node.ts streams via a counting passthrough: both the returned byte
+		// count and the bytes that reach PutObjectCommand.Body must equal the
+		// payload — never the 23-byte string Bun would have stored.
+		expect(wrote).toBe(payload.byteLength);
+		expect(captured.uploadedBodies).toHaveLength(1);
+		const sent = captured.uploadedBodies[0];
+		expect(sent).toEqual(payload);
 	});
 });


### PR DESCRIPTION
## Summary

> Uploads that pass a Web `ReadableStream` body no longer store the string `[object ReadableStream]` instead of the file's bytes.

- `bun.ts` `write()` buffers a Web `ReadableStream` to a `Uint8Array` before calling `Bun.S3Client.write`
- All other body shapes (`string`, `Uint8Array`, `ArrayBuffer`, `Blob`) pass through untouched
- Adds a Bun regression test and a Node streaming-parity guard

## Why

On Bun 1.3.x, `Bun.S3Client.write` does not consume a Web `ReadableStream`. It string-coerces the stream to the 23-byte literal `[object ReadableStream]` and stores that. Downloads then faithfully return the corrupted 23 bytes, so the failure looked like a read-path problem but is an upload bug owned by the SDK. The old `body as any` cast hid the type mismatch.

This is the shared storage client, so the defect hits any Bun caller that streams, not just the CLI.

## Implementation

```ts
// packages/storage/src/bun.ts
export async function normalizeWriteBody(
  body: S3Body
): Promise<Exclude<S3Body, ReadableStream<Uint8Array>>> {
  if (body instanceof ReadableStream) {
    // Bun coerces a raw Web stream to "[object ReadableStream]";
    // a Uint8Array round-trips correctly.
    return new Uint8Array(await new Response(body).arrayBuffer());
  }
  return body;
}

// write() normalizes before handing the body to Bun:
return client.write(key, await normalizeWriteBody(body), opts);
```

The Node backend already streamed correctly through a counting passthrough, so it needed no fix, only a guard test.

## Tests

Test-first: a Bun test reproduced the corruption (a streamed body came back as a `ReadableStream` instead of bytes), then the buffering fix turned it green. A second test locks in that non-stream bodies pass through untouched.

- `test/bun.test.ts` (new): `normalizeWriteBody` buffers a stream to its exact bytes and leaves `string`/`Uint8Array`/`Blob` as-is.
- `test/node.test.ts` (+1): a streamed body reaches `PutObjectCommand.Body` as the real bytes, with the correct byte count.

Bun's built-in `bun` module cannot be overridden by `mock.module`, so the Bun test covers `normalizeWriteBody` directly. The Node test drives the full `write()` path with a mocked SDK.

## Verification

- `bun test packages/storage/` -> 10 pass, 0 fail
- `bunx tsc --noEmit -p packages/storage/tsconfig.json` -> clean
- `bunx tsc --noEmit -p packages/storage/tsconfig.test.json` -> clean
- `bunx tsc --build --force` -> clean
- `bunx biome check` on the changed files -> 0 errors, 0 warnings

Not run: end-to-end upload against a live bucket. The buffered `Uint8Array` shape was already confirmed to round-trip on a real bucket during diagnosis.

## Scope and rollout

- A CLI version bump alone does not fix this. Publish `@agentuity/storage` first, then cut a CLI release that picks up the patched dependency.
- The Infra E2E checks `cloud_03` and `s3_01` are correctly red today and should go green once the patched storage ships in the CLI. Do not relax them.

## Reviewer notes

- Only Web `ReadableStream` is buffered. Node `Readable` is not part of the `S3Body` contract, so it is out of scope.
- `normalizeWriteBody` is exported for the regression test; it is reachable on the `@agentuity/storage/bun` subpath but not the default entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where stream-based uploads were being corrupted during storage operations in Bun environments.

* **Tests**
  * Added regression test coverage to ensure stream uploads and various input types are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->