### PR TITLE
fix(cli): wire TanStack Start builds to CDN asset URLs

### DIFF
--- a/docs/src/web/content/frameworks/tanstack-start.mdx
+++ b/docs/src/web/content/frameworks/tanstack-start.mdx
@@ -55,6 +55,49 @@ export default defineConfig({
 
 `nitro()` emits the server bundle that your deployed `start` script points at. `agentuity()` supports public local dev and HMR through `agentuity dev --public`; it is a no-op when the Agentuity dev hostname is not present. Agentuity preserves the Nitro output and uses your `start` script when it packages the app.
 
+## CDN static assets
+
+Agentuity uploads hashed browser assets to a CDN at deploy time. TanStack Start must rewrite SSR asset URLs at runtime and emit relative client chunk paths so lazy-loaded routes stay on the CDN during client navigation. See [TanStack Start CDN asset URLs](https://tanstack.com/start/latest/docs/framework/react/guide/cdn-asset-urls).
+
+When you run `agentuity build` or `agentuity deploy` on a TanStack Start project **without** an existing `src/server.ts`, the CLI generates a server entry for the build that wires TanStack `transformAssets` to the platform CDN origin. It also sets Vite `base: ''` in `vite.config.ts` for the duration of the build when `base` is unset or `'/'`.
+
+At runtime the server reads:
+
+| Variable | Purpose |
+| --- | --- |
+| `AGENTUITY_CDN_ORIGIN` | Preferred CDN prefix when the platform injects it |
+| `AGENTUITY_CLOUD_DEPLOYMENT_ID` | Fallback prefix: `https://cdn.agentuity.com/{id}` |
+
+Local `vite dev` and `agentuity dev` leave asset URLs unchanged (no CDN prefix).
+
+### Custom server entry
+
+If you already maintain `src/server.ts`, add CDN wiring yourself:
+
+```ts title="src/server.ts"
+import {
+	createStartHandler,
+	defaultStreamHandler,
+} from '@tanstack/react-start/server';
+import { createServerEntry } from '@tanstack/react-start/server-entry';
+
+const cdnOrigin = process.env.AGENTUITY_CDN_ORIGIN
+	?? (process.env.AGENTUITY_CLOUD_DEPLOYMENT_ID
+		? `https://cdn.agentuity.com/${process.env.AGENTUITY_CLOUD_DEPLOYMENT_ID}`
+		: undefined);
+
+const handler = createStartHandler({
+	handler: defaultStreamHandler,
+	transformAssets: cdnOrigin
+		? { prefix: cdnOrigin, crossOrigin: 'anonymous' }
+		: undefined,
+});
+
+export default createServerEntry({ fetch: handler });
+```
+
+Set Vite `base: ''` in `vite.config.ts` when using the CDN. Remove a generated `src/server.ts` from your repo if you prefer the CLI to create one during `agentuity build` only.
+
 <Callout type="tip" title="Existing app?">
 See [Add Agentuity to an existing app](/get-started/import-existing-app) for validation, import, the `Invalid project folder` deploy case, and first deploy.
 </Callout>
@@ -144,6 +187,8 @@ Configure the variables your deployed app needs. Direct `AIGatewayClient` calls 
 | Variable | Used by |
 | --- | --- |
 | `AGENTUITY_SDK_KEY` | Agentuity service clients and `@agentuity/aigateway` |
+| `AGENTUITY_CLOUD_DEPLOYMENT_ID` | CDN asset prefix fallback in the TanStack server entry |
+| `AGENTUITY_CDN_ORIGIN` | CDN asset prefix when injected by the platform |
 | `DATABASE_URL` | database server routes |
 | `AWS_*` | object storage server routes; see [Object Storage](/services/storage/object) for exact variables |
 
@@ -187,12 +232,14 @@ Do not deploy until `.agentuity/launch.json` points at the server bundle emitted
 | `launch.json` shows static-only server | Verify the build emits a Nitro server bundle under `.output/server/`; check [TanStack Start Hosting](https://tanstack.com/start/latest/docs/framework/react/guide/hosting) for supported adapters |
 | Launch command points at a missing file | Compare the command in `launch.json` against files emitted under `.agentuity` |
 | App detected as `vite` instead of `tanstack-start` | Confirm `@tanstack/react-start` is installed in the app package and rerun `agentuity build` |
+| Static assets load from app origin, not CDN | Run `agentuity build`/`deploy` so CDN wiring runs; add `src/server.ts` with `transformAssets` if you maintain a custom server entry |
 
 ## Framework Docs
 
 - [TanStack Start Getting Started](https://tanstack.com/start/latest/docs/framework/react/getting-started): scaffold with the TanStack CLI
 - [TanStack Start Server Routes](https://tanstack.com/start/latest/docs/framework/react/guide/server-routes): `createFileRoute` server handlers reference
 - [TanStack Start Hosting](https://tanstack.com/start/latest/docs/framework/react/guide/hosting): Nitro and platform-specific deployment adapters
+- [TanStack Start CDN asset URLs](https://tanstack.com/start/latest/docs/framework/react/guide/cdn-asset-urls): `transformAssets` and Vite `base` requirements
 
 ## Next Steps
 

--- a/packages/cli/src/cmd/build/adapters/index.ts
+++ b/packages/cli/src/cmd/build/adapters/index.ts
@@ -9,6 +9,7 @@
 import type { BuildAdapter } from './types.ts';
 import { genericAdapter } from './generic.ts';
 import { nextjsAdapter } from './nextjs.ts';
+import { tanstackStartAdapter } from './tanstack-start.ts';
 
 /**
  * Registry of framework-specific build adapters.
@@ -16,14 +17,15 @@ import { nextjsAdapter } from './nextjs.ts';
  */
 const adapters: Record<string, BuildAdapter> = {
 	nextjs: nextjsAdapter,
+	'tanstack-start': tanstackStartAdapter,
 };
 
 /**
  * Get the build adapter for a detected framework.
  * Falls back to the generic adapter if no specific one exists.
  */
-export function getAdapter(frameworkName: string): BuildAdapter {
-	return adapters[frameworkName] ?? genericAdapter;
+export function getAdapter(frameworkSlug: string): BuildAdapter {
+	return adapters[frameworkSlug] ?? genericAdapter;
 }
 
 // Re-export types

--- a/packages/cli/src/cmd/build/adapters/tanstack-start.ts
+++ b/packages/cli/src/cmd/build/adapters/tanstack-start.ts
@@ -1,0 +1,28 @@
+/**
+ * TanStack Start build adapter.
+ *
+ * Runs the generic build pipeline after applying CDN wiring (server entry +
+ * Vite base) required for Agentuity static asset delivery.
+ */
+
+import type { BuildAdapter, BuildAdapterOptions, BuildResult } from './types.ts';
+import { genericAdapter } from './generic.ts';
+import { prepareTanStackCdnBuild } from './tanstack-start/cdn-build.ts';
+
+export const tanstackStartAdapter: BuildAdapter = {
+	name: 'tanstack-start',
+
+	async build(options: BuildAdapterOptions): Promise<BuildResult> {
+		const preparation = prepareTanStackCdnBuild(options.projectDir, options.logger);
+
+		try {
+			const result = await genericAdapter.build(options);
+			return {
+				...result,
+				logs: [...preparation.logs, ...result.logs],
+			};
+		} finally {
+			preparation.cleanup();
+		}
+	},
+};

--- a/packages/cli/src/cmd/build/adapters/tanstack-start/cdn-build.ts
+++ b/packages/cli/src/cmd/build/adapters/tanstack-start/cdn-build.ts
@@ -1,0 +1,162 @@
+/**
+ * TanStack Start CDN build preparation.
+ *
+ * Before `vite build`, ensures:
+ * 1. A server entry exists with TanStack `transformAssets` wired to Agentuity CDN env
+ * 2. Vite `base` is empty so client-side lazy chunks resolve against the CDN entry
+ *
+ * Changes are applied to the project tree for the duration of the build and reverted
+ * afterward when we generated or patched files (same pattern as buildFileReplacements).
+ */
+
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SERVER_CANDIDATES = ['src/server.ts', 'app/server.ts'] as const;
+
+const VITE_CONFIG_NAMES = [
+	'vite.config.ts',
+	'vite.config.mts',
+	'vite.config.js',
+	'vite.config.mjs',
+] as const;
+
+/** Default TanStack Start server entry when the scaffold omitted one. */
+export const GENERATED_TANSTACK_SERVER_TS = `/**
+ * Agentuity CDN wiring for TanStack Start (generated during agentuity build).
+ * @see https://tanstack.com/start/latest/docs/framework/react/guide/cdn-asset-urls
+ */
+import {
+	createStartHandler,
+	defaultStreamHandler,
+} from '@tanstack/react-start/server';
+import { createServerEntry } from '@tanstack/react-start/server-entry';
+
+function resolveCdnOrigin(): string | undefined {
+	const explicit = process.env.AGENTUITY_CDN_ORIGIN?.replace(/\\/+$/, '');
+	if (explicit) return explicit;
+	const deploymentId = process.env.AGENTUITY_CLOUD_DEPLOYMENT_ID;
+	return deploymentId ? \`https://cdn.agentuity.com/\${deploymentId}\` : undefined;
+}
+
+const cdnOrigin = resolveCdnOrigin();
+
+const handler = createStartHandler({
+	handler: defaultStreamHandler,
+	transformAssets: cdnOrigin
+		? { prefix: cdnOrigin, crossOrigin: 'anonymous' }
+		: undefined,
+});
+
+export default createServerEntry({ fetch: handler });
+`;
+
+export interface TanStackCdnBuildPreparation {
+	cleanup: () => void;
+	logs: string[];
+}
+
+export function findTanStackServerEntry(projectDir: string): string | null {
+	for (const rel of SERVER_CANDIDATES) {
+		const path = join(projectDir, rel);
+		if (existsSync(path)) return rel;
+	}
+	return null;
+}
+
+export function findViteConfigPath(projectDir: string): string | null {
+	for (const name of VITE_CONFIG_NAMES) {
+		const path = join(projectDir, name);
+		if (existsSync(path)) return name;
+	}
+	return null;
+}
+
+function hasTransformAssets(source: string): boolean {
+	return /\btransformAssets\b/.test(source);
+}
+
+/** Inject `base: ''` when unset, or replace `base: '/'` for CDN-relative chunks. */
+export function patchViteConfigBase(source: string): { content: string; changed: boolean } {
+	if (/\bbase\s*:\s*['"]{2}/.test(source) || /\bbase\s*:\s*''/.test(source)) {
+		return { content: source, changed: false };
+	}
+
+	if (/\bbase\s*:\s*['"]\/['"]/.test(source)) {
+		return {
+			content: source.replace(/\bbase\s*:\s*['"]\/['"]/, "base: ''"),
+			changed: true,
+		};
+	}
+
+	if (/\bbase\s*:/.test(source)) {
+		return { content: source, changed: false };
+	}
+
+	const defineConfigMatch = source.match(/(export\s+default\s+defineConfig\s*\(\s*\{)/);
+	if (!defineConfigMatch) {
+		return { content: source, changed: false };
+	}
+
+	return {
+		content: source.replace(defineConfigMatch[0], `${defineConfigMatch[0]}\n\tbase: '',`),
+		changed: true,
+	};
+}
+
+export function prepareTanStackCdnBuild(
+	projectDir: string,
+	logger: { debug: (...args: unknown[]) => void }
+): TanStackCdnBuildPreparation {
+	const cleanups: Array<() => void> = [];
+	const logs: string[] = [];
+
+	const existingServer = findTanStackServerEntry(projectDir);
+	if (existingServer) {
+		const serverPath = join(projectDir, existingServer);
+		const original = readFileSync(serverPath, 'utf-8');
+		if (hasTransformAssets(original)) {
+			logger.debug('TanStack server entry already configures transformAssets; skipping');
+		} else {
+			logger.debug(
+				'TanStack server entry exists without transformAssets; add CDN wiring manually or remove src/server.ts to let agentuity build generate one'
+			);
+		}
+	} else {
+		const serverRel = SERVER_CANDIDATES[0];
+		const serverPath = join(projectDir, serverRel);
+		mkdirSync(join(projectDir, 'src'), { recursive: true });
+		writeFileSync(serverPath, GENERATED_TANSTACK_SERVER_TS, 'utf-8');
+		cleanups.push(() => {
+			if (existsSync(serverPath)) {
+				try {
+					unlinkSync(serverPath);
+				} catch {
+					// ignore
+				}
+			}
+		});
+		logs.push(`✓ Generated ${serverRel} with Agentuity CDN asset transform`);
+	}
+
+	const viteConfigRel = findViteConfigPath(projectDir);
+	if (viteConfigRel) {
+		const vitePath = join(projectDir, viteConfigRel);
+		const original = readFileSync(vitePath, 'utf-8');
+		const patched = patchViteConfigBase(original);
+		if (patched.changed) {
+			writeFileSync(vitePath, patched.content, 'utf-8');
+			cleanups.push(() => writeFileSync(vitePath, original));
+			logs.push(`✓ Set Vite base: '' for CDN client chunk resolution`);
+		}
+	} else {
+		logger.debug('No vite.config found; skipped Vite base patch');
+	}
+
+	return {
+		logs,
+		cleanup: () => {
+			for (const cleanup of cleanups.reverse()) cleanup();
+		},
+	};
+}

--- a/packages/cli/test/cmd/build/adapters/registry.test.ts
+++ b/packages/cli/test/cmd/build/adapters/registry.test.ts
@@ -12,6 +12,11 @@ describe('Adapter Registry', () => {
 		expect(adapter.name).toBe('nextjs');
 	});
 
+	test('returns tanstack-start adapter for tanstack-start framework', () => {
+		const adapter = getAdapter('tanstack-start');
+		expect(adapter.name).toBe('tanstack-start');
+	});
+
 	test('returns generic adapter for vite (no specific adapter)', () => {
 		const adapter = getAdapter('vite');
 		expect(adapter.name).toBe('generic');

--- a/packages/cli/test/cmd/build/adapters/tanstack-start.test.ts
+++ b/packages/cli/test/cmd/build/adapters/tanstack-start.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+	findTanStackServerEntry,
+	GENERATED_TANSTACK_SERVER_TS,
+	patchViteConfigBase,
+	prepareTanStackCdnBuild,
+} from '../../../../src/cmd/build/adapters/tanstack-start/cdn-build.ts';
+
+describe('TanStack Start CDN build prep', () => {
+	let testDir: string;
+
+	afterEach(() => {
+		if (testDir && existsSync(testDir)) {
+			rmSync(testDir, { recursive: true, force: true });
+		}
+	});
+
+	test('patchViteConfigBase injects base when missing', () => {
+		const source = `import { defineConfig } from 'vite';\nexport default defineConfig({\n\tplugins: [],\n});\n`;
+		const { content, changed } = patchViteConfigBase(source);
+		expect(changed).toBe(true);
+		expect(content).toContain("base: ''");
+	});
+
+	test('patchViteConfigBase replaces base slash with empty string', () => {
+		const source = `export default defineConfig({ base: '/', plugins: [] });`;
+		const { content, changed } = patchViteConfigBase(source);
+		expect(changed).toBe(true);
+		expect(content).toContain("base: ''");
+		expect(content).not.toContain("base: '/'");
+	});
+
+	test('patchViteConfigBase leaves custom base unchanged', () => {
+		const source = `export default defineConfig({ base: '/app/', plugins: [] });`;
+		const { changed } = patchViteConfigBase(source);
+		expect(changed).toBe(false);
+	});
+
+	test('prepareTanStackCdnBuild generates server.ts and patches vite config', () => {
+		testDir = join(import.meta.dir, `.tmp-tanstack-cdn-${Date.now()}`);
+		mkdirSync(join(testDir, 'src'), { recursive: true });
+		writeFileSync(
+			join(testDir, 'vite.config.ts'),
+			`export default defineConfig({ plugins: [] });`,
+			'utf-8'
+		);
+
+		const prep = prepareTanStackCdnBuild(testDir, { debug: () => {} });
+		expect(prep.logs.some((line) => line.includes('Generated src/server.ts'))).toBe(true);
+		expect(prep.logs.some((line) => line.includes("Vite base: ''"))).toBe(true);
+
+		expect(findTanStackServerEntry(testDir)).toBe('src/server.ts');
+		expect(readFileSync(join(testDir, 'src/server.ts'), 'utf-8')).toBe(
+			GENERATED_TANSTACK_SERVER_TS
+		);
+		expect(readFileSync(join(testDir, 'vite.config.ts'), 'utf-8')).toContain("base: ''");
+
+		prep.cleanup();
+
+		expect(existsSync(join(testDir, 'src/server.ts'))).toBe(false);
+		expect(readFileSync(join(testDir, 'vite.config.ts'), 'utf-8')).not.toContain("base: ''");
+	});
+
+	test('prepareTanStackCdnBuild skips server generation when transformAssets exists', () => {
+		testDir = join(import.meta.dir, `.tmp-tanstack-cdn-existing-${Date.now()}`);
+		mkdirSync(join(testDir, 'src'), { recursive: true });
+		writeFileSync(
+			join(testDir, 'src/server.ts'),
+			'export default createServerEntry({ transformAssets: "https://cdn.example.com" });',
+			'utf-8'
+		);
+
+		const prep = prepareTanStackCdnBuild(testDir, { debug: () => {} });
+		expect(prep.logs.some((line) => line.includes('Generated'))).toBe(false);
+		prep.cleanup();
+	});
+});

--- a/packages/core/src/env.d.ts
+++ b/packages/core/src/env.d.ts
@@ -152,6 +152,12 @@ declare global {
 			AGENTUITY_CLOUD_DEPLOYMENT_ID?: string;
 
 			/**
+			 * CDN origin for static assets (platform-injected in production).
+			 * Example: https://cdn.agentuity.com/deploy_abc123
+			 */
+			AGENTUITY_CDN_ORIGIN?: string;
+
+			/**
 			 * Cloud domains configuration.
 			 * JSON array of domain strings.
 			 */


### PR DESCRIPTION
## Summary
- Add a TanStack Start build adapter that applies CDN wiring during `agentuity build`/`deploy` without requiring users to hand-edit `src/server.ts`.
- Temporarily generate a server entry with TanStack `transformAssets` and set Vite `base: ''` for the build when not already configured.
- Document CDN behavior and env vars (`AGENTUITY_CDN_ORIGIN`, `AGENTUITY_CLOUD_DEPLOYMENT_ID`) in the TanStack Start framework guide.

Fixes #1570

## Test plan
- [ ] `bun test packages/cli/test/cmd/build/adapters/tanstack-start.test.ts`
- [ ] `bun test packages/cli/test/cmd/build/adapters/registry.test.ts`
- [ ] Deploy a TanStack Start app and confirm SSR HTML references CDN asset URLs
- [ ] Confirm client-side navigation still loads lazy chunks from the CDN


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TanStack Start framework support with automatic CDN static asset URL rewriting during builds.
  * Introduced new environment variables for CDN origin and deployment configuration.

* **Documentation**
  * Added comprehensive guide for configuring TanStack Start CDN static assets, including custom server entry examples and troubleshooting.

* **Tests**
  * Added test coverage for TanStack Start build adapter and CDN build preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->