### PR TITLE
Emit source_blob_id from CI deploy

### DIFF
--- a/packages/cli/src/cmd/cloud/deploy.ts
+++ b/packages/cli/src/cmd/cloud/deploy.ts
@@ -808,6 +808,8 @@ export const deploySubcommand = createSubcommand({
 			if (deployResultFile) {
 				try {
 					const resultData = {
+						source_blob_id: deployment.id,
+						source_deployment_id: deployment.id,
 						urls: complete?.publicUrls
 							? {
 									deployment:
@@ -826,9 +828,22 @@ export const deploySubcommand = createSubcommand({
 				}
 			}
 
+			if (process.env.CI === 'true') {
+				console.log(
+					JSON.stringify({
+						source_blob_id: deployment.id,
+						source_deployment_id: deployment.id,
+						deployment_id: deployment.id,
+						project_id: project.projectId,
+					})
+				);
+			}
+
 			return {
 				success: true,
 				deploymentId: deployment.id,
+				sourceBlobId: deployment.id,
+				sourceDeploymentId: deployment.id,
 				projectId: project.projectId,
 				logs,
 				urls: complete?.publicUrls


### PR DESCRIPTION
## Summary
- Emits `source_blob_id` / `source_deployment_id` in `AGENTUITY_DEPLOY_RESULT_FILE` JSON
- Prints structured JSON to stdout when `CI=true` for genesis-mono / rollout scripts to parse

## Depends on
- https://github.com/agentuity/infra/pull/737
- https://github.com/agentuity/genesis-mono/pull/NEW

## Test plan
- [ ] `agentuity deploy` in CI prints JSON line with `source_blob_id`
- [ ] `tools/genesis/deploy.ts` parse path works without log-regex fallback


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cloud deploy now outputs additional deployment tracking information, including source blob ID and source deployment ID, to better identify and trace deployment sources and relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->