### PR TITLE
Genesis managed rollout: deploy --metadata passthrough

### DIFF
--- a/packages/cli/src/cmd/cloud/deploy.ts
+++ b/packages/cli/src/cmd/cloud/deploy.ts
@@ -167,6 +167,7 @@ const DeployResponseSchema = z.object({
 	success: z.boolean().describe('Whether deployment succeeded'),
 	deploymentId: z.string().describe('Deployment ID'),
 	projectId: z.string().describe('Project ID'),
+	rolloutId: z.string().optional().describe('Genesis managed rollout id when fan-out was triggered'),
 	logs: z.array(z.string()).optional().describe('The deployment startup logs'),
 	urls: z
 		.object({
@@ -397,6 +398,7 @@ export const deploySubcommand = createSubcommand({
 			if (opts.pullRequestUrl) childArgs.push(`--pull-request-url=${opts.pullRequestUrl}`);
 			if (opts.skipDnsValidation) childArgs.push('--skip-dns-validation');
 			if (opts.skipTypeCheck) childArgs.push('--skip-type-check');
+			if (opts.metadata) childArgs.push(`--metadata=${opts.metadata}`);
 
 			const result = await runForkedDeploy({
 				projectDir,
@@ -830,6 +832,7 @@ export const deploySubcommand = createSubcommand({
 				success: true,
 				deploymentId: deployment.id,
 				projectId: project.projectId,
+				rolloutId: complete?.rolloutId,
 				logs,
 				urls: complete?.publicUrls
 					? {

--- a/packages/cli/src/cmd/cloud/deploy.ts
+++ b/packages/cli/src/cmd/cloud/deploy.ts
@@ -167,7 +167,10 @@ const DeployResponseSchema = z.object({
 	success: z.boolean().describe('Whether deployment succeeded'),
 	deploymentId: z.string().describe('Deployment ID'),
 	projectId: z.string().describe('Project ID'),
-	rolloutId: z.string().optional().describe('Genesis managed rollout id when fan-out was triggered'),
+	rolloutId: z
+		.string()
+		.optional()
+		.describe('Genesis managed rollout id when fan-out was triggered'),
 	logs: z.array(z.string()).optional().describe('The deployment startup logs'),
 	urls: z
 		.object({

--- a/packages/cli/src/cmd/cloud/deploy/build.ts
+++ b/packages/cli/src/cmd/cloud/deploy/build.ts
@@ -185,7 +185,10 @@ export function buildBuildStep(params: BuildStepParams): Step {
 					if (registeredProjectName) {
 						build.project.name = registeredProjectName;
 					}
-					build = mergeDeployRolloutMetadata(build, resolveDeployRolloutMetadata(deployOptions));
+					build = mergeDeployRolloutMetadata(
+						build,
+						resolveDeployRolloutMetadata(deployOptions)
+					);
 				} else {
 					build = await generateDeployMetadata({
 						buildResult,

--- a/packages/cli/src/cmd/cloud/deploy/build.ts
+++ b/packages/cli/src/cmd/cloud/deploy/build.ts
@@ -40,6 +40,10 @@ import { getCachedProject } from '../../../cache/index.ts';
 import { loadBuildMetadata } from '../../../config.ts';
 import { generateDeployMetadata } from '../../../deploy-metadata.ts';
 import {
+	mergeDeployRolloutMetadata,
+	resolveDeployRolloutMetadata,
+} from '../../../deploy-rollout-metadata.ts';
+import {
 	type Step,
 	type StepContext,
 	type StepOutcome,
@@ -181,6 +185,7 @@ export function buildBuildStep(params: BuildStepParams): Step {
 					if (registeredProjectName) {
 						build.project.name = registeredProjectName;
 					}
+					build = mergeDeployRolloutMetadata(build, resolveDeployRolloutMetadata(deployOptions));
 				} else {
 					build = await generateDeployMetadata({
 						buildResult,
@@ -198,6 +203,7 @@ export function buildBuildStep(params: BuildStepParams): Step {
 				}
 
 				logger.debug('Launch metadata: %s', JSON.stringify(build.launch, null, 2));
+				build = mergeDeployRolloutMetadata(build, resolveDeployRolloutMetadata(deployOptions));
 				state.build = build;
 
 				// 6. Send metadata to the server, get back upload URLs.

--- a/packages/cli/src/deploy-rollout-metadata.ts
+++ b/packages/cli/src/deploy-rollout-metadata.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+
+export const DeployRolloutMetadataSchema = z
+	.object({
+		source: z.enum(['managed']).optional(),
+		channel: z.enum(['edge', 'stable', 'commit']).optional(),
+		rollout_org_ids: z.array(z.string().min(1)).optional(),
+	})
+	.strict();
+
+export type DeployRolloutMetadata = z.infer<typeof DeployRolloutMetadataSchema>;
+
+export function parseDeployRolloutMetadata(raw: string | undefined): DeployRolloutMetadata | undefined {
+	const value = raw?.trim();
+	if (!value) {
+		return undefined;
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(value);
+	} catch (error) {
+		throw new Error(
+			`Invalid deploy metadata JSON: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	const result = DeployRolloutMetadataSchema.safeParse(parsed);
+	if (!result.success) {
+		const details = result.error.issues.map((issue) => issue.message).join(', ');
+		throw new Error(`Invalid deploy metadata: ${details}`);
+	}
+	if (!result.data.source && !result.data.channel && !result.data.rollout_org_ids?.length) {
+		return undefined;
+	}
+	return result.data;
+}
+
+export function resolveDeployRolloutMetadata(options?: {
+	metadata?: string;
+}): DeployRolloutMetadata | undefined {
+	return parseDeployRolloutMetadata(options?.metadata ?? process.env.AGENTUITY_DEPLOY_METADATA);
+}
+
+export function mergeDeployRolloutMetadata<T extends { deployment?: Record<string, unknown> }>(
+	build: T,
+	rolloutMetadata: DeployRolloutMetadata | undefined,
+): T {
+	if (!rolloutMetadata || !build.deployment) {
+		return build;
+	}
+	const deployment = { ...build.deployment };
+	if (rolloutMetadata.source) {
+		deployment.source = rolloutMetadata.source;
+	}
+	if (rolloutMetadata.channel) {
+		deployment.channel = rolloutMetadata.channel;
+	}
+	if (rolloutMetadata.rollout_org_ids?.length) {
+		deployment.rollout_org_ids = rolloutMetadata.rollout_org_ids;
+	}
+	return {
+		...build,
+		deployment,
+	};
+}

--- a/packages/cli/src/deploy-rollout-metadata.ts
+++ b/packages/cli/src/deploy-rollout-metadata.ts
@@ -11,7 +11,7 @@ export const DeployRolloutMetadataSchema = z
 export type DeployRolloutMetadata = z.infer<typeof DeployRolloutMetadataSchema>;
 
 export function parseDeployRolloutMetadata(
-	raw: string | undefined,
+	raw: string | undefined
 ): DeployRolloutMetadata | undefined {
 	const value = raw?.trim();
 	if (!value) {

--- a/packages/cli/src/deploy-rollout-metadata.ts
+++ b/packages/cli/src/deploy-rollout-metadata.ts
@@ -10,7 +10,9 @@ export const DeployRolloutMetadataSchema = z
 
 export type DeployRolloutMetadata = z.infer<typeof DeployRolloutMetadataSchema>;
 
-export function parseDeployRolloutMetadata(raw: string | undefined): DeployRolloutMetadata | undefined {
+export function parseDeployRolloutMetadata(
+	raw: string | undefined,
+): DeployRolloutMetadata | undefined {
 	const value = raw?.trim();
 	if (!value) {
 		return undefined;
@@ -20,7 +22,7 @@ export function parseDeployRolloutMetadata(raw: string | undefined): DeployRollo
 		parsed = JSON.parse(value);
 	} catch (error) {
 		throw new Error(
-			`Invalid deploy metadata JSON: ${error instanceof Error ? error.message : String(error)}`,
+			`Invalid deploy metadata JSON: ${error instanceof Error ? error.message : String(error)}`
 		);
 	}
 	const result = DeployRolloutMetadataSchema.safeParse(parsed);
@@ -42,7 +44,7 @@ export function resolveDeployRolloutMetadata(options?: {
 
 export function mergeDeployRolloutMetadata<T extends { deployment?: Record<string, unknown> }>(
 	build: T,
-	rolloutMetadata: DeployRolloutMetadata | undefined,
+	rolloutMetadata: DeployRolloutMetadata | undefined
 ): T {
 	if (!rolloutMetadata || !build.deployment) {
 		return build;

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -619,6 +619,12 @@ export const DeployOptionsSchema = zod
 			.optional()
 			.describe('Skip custom domain DNS validation before deploying'),
 		skipTypeCheck: zod.boolean().optional().describe('Skip TypeScript validation during deploy'),
+		metadata: zod
+			.string()
+			.optional()
+			.describe(
+				'JSON deployment metadata merged onto the deployment record (e.g. Genesis managed rollout intent)'
+			),
 	})
 	.merge(GitOptionsSchema);
 

--- a/packages/core/src/env.d.ts
+++ b/packages/core/src/env.d.ts
@@ -172,6 +172,9 @@ declare global {
 			/** Deployment name/identifier */
 			AGENTUITY_DEPLOYMENT?: string;
 
+			/** JSON metadata merged onto the deployment record during deploy (Genesis managed rollouts) */
+			AGENTUITY_DEPLOY_METADATA?: string;
+
 			// ============================================================================
 			// Database
 			// ============================================================================

--- a/packages/server/src/api/project/deploy.ts
+++ b/packages/server/src/api/project/deploy.ts
@@ -212,6 +212,9 @@ export const BuildMetadataSchema = z.object({
 				arch: z.string().describe('the machine architecture'),
 				platform: z.string().describe('the machine os platform'),
 			}),
+			source: z.enum(['github', 'cli', 'managed']).optional(),
+			channel: z.enum(['edge', 'stable', 'commit']).optional(),
+			rollout_org_ids: z.array(z.string()).optional(),
 		})
 	),
 	launch: LaunchMetadataSchema.optional().describe(
@@ -307,6 +310,10 @@ export async function projectDeploymentUpdate(
 
 export const DeploymentCompleteSchema = z.object({
 	streamId: z.string().optional().describe('the stream id for warmup logs'),
+	rolloutId: z
+		.string()
+		.optional()
+		.describe('Genesis managed rollout id when source deploy triggered fan-out'),
 	publicUrls: z
 		.object({
 			latest: z.string().url().describe('the public url for the latest deployment'),


### PR DESCRIPTION
## Summary
- `--metadata` / `AGENTUITY_DEPLOY_METADATA` on `agentuity deploy` merges Genesis rollout intent onto the deployment record
- Fields: `source: managed`, `channel` (`edge`|`stable`|`commit`), optional `rollout_org_ids`
- Surfaces `rolloutId` from deploy complete when app fan-out runs

Replaces closed #1572 (source_blob_id stdout emission).

## Merge order
Before agentuity/infra#737 and agentuity/app#1349

## Test plan
- [ ] Deploy with `--metadata '{"source":"managed","channel":"edge"}'` merges fields into build metadata
- [ ] Complete response includes rolloutId when app hook is live