### PR TITLE
Genesis managed rollout: deploy --metadata passthrough (v2)

### DIFF
--- a/packages/cli/src/cmd/cloud/deploy.ts
+++ b/packages/cli/src/cmd/cloud/deploy.ts
@@ -47,6 +47,10 @@ import {
 import { encryptFIPSKEMDEMStream } from '../../crypto/box';
 import * as domain from '../../domain';
 import {
+	mergeDeployRolloutMetadata,
+	resolveDeployRolloutMetadata,
+} from '../../deploy-rollout-metadata';
+import {
 	filterAgentuitySdkKeys,
 	findExistingEnvFile,
 	readEnvFile,
@@ -83,6 +87,10 @@ const DeployResponseSchema = z.object({
 	success: z.boolean().describe('Whether deployment succeeded'),
 	deploymentId: z.string().describe('Deployment ID'),
 	projectId: z.string().describe('Project ID'),
+	rolloutId: z
+		.string()
+		.optional()
+		.describe('Genesis managed rollout id when fan-out was triggered'),
 	logs: z.array(z.string()).optional().describe('The deployment startup logs'),
 	urls: z
 		.object({
@@ -403,6 +411,7 @@ export const deploySubcommand = createSubcommand({
 			if (opts.pullRequestUrl) childArgs.push(`--pull-request-url=${opts.pullRequestUrl}`);
 			if (opts.skipDnsValidation) childArgs.push('--skip-dns-validation');
 			if (opts.skipTypeCheck) childArgs.push('--skip-type-check');
+			if (opts.metadata) childArgs.push(`--metadata=${opts.metadata}`);
 
 			const result = await runForkedDeploy({
 				projectDir,
@@ -686,6 +695,10 @@ export const deploySubcommand = createSubcommand({
 								});
 								capturedOutput = [...capturedOutput, ...bundleResult.output];
 								build = await loadBuildMetadata(join(projectDir, '.agentuity'));
+								build = mergeDeployRolloutMetadata(
+									build,
+									resolveDeployRolloutMetadata(opts)
+								);
 								instructions = await projectDeploymentUpdate(
 									apiClient,
 									deployment.id,
@@ -1369,6 +1382,7 @@ export const deploySubcommand = createSubcommand({
 				success: true,
 				deploymentId: deployment.id,
 				projectId: project.projectId,
+				rolloutId: complete?.rolloutId,
 				logs,
 				urls: complete?.publicUrls
 					? {

--- a/packages/cli/src/deploy-rollout-metadata.ts
+++ b/packages/cli/src/deploy-rollout-metadata.ts
@@ -1,0 +1,66 @@
+import { z } from 'zod';
+
+export const DeployRolloutMetadataSchema = z
+	.object({
+		source: z.enum(['managed']).optional(),
+		channel: z.enum(['edge', 'stable', 'commit']).optional(),
+		rollout_org_ids: z.array(z.string().min(1)).optional(),
+	})
+	.strict();
+
+export type DeployRolloutMetadata = z.infer<typeof DeployRolloutMetadataSchema>;
+
+export function parseDeployRolloutMetadata(
+	raw: string | undefined
+): DeployRolloutMetadata | undefined {
+	const value = raw?.trim();
+	if (!value) {
+		return undefined;
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(value);
+	} catch (error) {
+		throw new Error(
+			`Invalid deploy metadata JSON: ${error instanceof Error ? error.message : String(error)}`
+		);
+	}
+	const result = DeployRolloutMetadataSchema.safeParse(parsed);
+	if (!result.success) {
+		const details = result.error.issues.map((issue) => issue.message).join(', ');
+		throw new Error(`Invalid deploy metadata: ${details}`);
+	}
+	if (!result.data.source && !result.data.channel && !result.data.rollout_org_ids?.length) {
+		return undefined;
+	}
+	return result.data;
+}
+
+export function resolveDeployRolloutMetadata(options?: {
+	metadata?: string;
+}): DeployRolloutMetadata | undefined {
+	return parseDeployRolloutMetadata(options?.metadata ?? process.env.AGENTUITY_DEPLOY_METADATA);
+}
+
+export function mergeDeployRolloutMetadata<T extends { deployment?: Record<string, unknown> }>(
+	build: T,
+	rolloutMetadata: DeployRolloutMetadata | undefined
+): T {
+	if (!rolloutMetadata || !build.deployment) {
+		return build;
+	}
+	const deployment = { ...build.deployment };
+	if (rolloutMetadata.source) {
+		deployment.source = rolloutMetadata.source;
+	}
+	if (rolloutMetadata.channel) {
+		deployment.channel = rolloutMetadata.channel;
+	}
+	if (rolloutMetadata.rollout_org_ids?.length) {
+		deployment.rollout_org_ids = rolloutMetadata.rollout_org_ids;
+	}
+	return {
+		...build,
+		deployment,
+	};
+}

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -827,6 +827,12 @@ export const DeployOptionsSchema = zod
 			.optional()
 			.describe('Skip custom domain DNS validation before deploying'),
 		skipTypeCheck: zod.boolean().optional().describe('Skip TypeScript validation during deploy'),
+		metadata: zod
+			.string()
+			.optional()
+			.describe(
+				'JSON deployment metadata merged onto the deployment record (e.g. Genesis managed rollout intent)'
+			),
 	})
 	.merge(GitOptionsSchema);
 

--- a/packages/core/src/env.d.ts
+++ b/packages/core/src/env.d.ts
@@ -190,6 +190,9 @@ declare global {
 			/** Deployment name/identifier */
 			AGENTUITY_DEPLOYMENT?: string;
 
+			/** JSON metadata merged onto the deployment record during deploy (Genesis managed rollouts) */
+			AGENTUITY_DEPLOY_METADATA?: string;
+
 			// ============================================================================
 			// Database
 			// ============================================================================

--- a/packages/core/src/services/project/deploy.ts
+++ b/packages/core/src/services/project/deploy.ts
@@ -174,6 +174,9 @@ export const BuildMetadataSchema = z.object({
 				arch: z.string().describe('the machine architecture'),
 				platform: z.string().describe('the machine os platform'),
 			}),
+			source: z.enum(['github', 'cli', 'managed']).optional(),
+			channel: z.enum(['edge', 'stable', 'commit']).optional(),
+			rollout_org_ids: z.array(z.string()).optional(),
 		})
 	),
 });
@@ -266,6 +269,10 @@ export async function projectDeploymentUpdate(
 
 export const DeploymentCompleteSchema = z.object({
 	streamId: z.string().optional().describe('the stream id for warmup logs'),
+	rolloutId: z
+		.string()
+		.optional()
+		.describe('Genesis managed rollout id when source deploy triggered fan-out'),
 	publicUrls: z
 		.object({
 			latest: z.string().url().describe('the public url for the latest deployment'),


### PR DESCRIPTION
## Summary
- Port of #1573 onto `v2`: `--metadata` / `AGENTUITY_DEPLOY_METADATA` merges Genesis managed rollout fields (`source`, `channel`, `rollout_org_ids`) onto the deployment upload payload.
- Deploy complete response includes optional `rolloutId` when app fan-out succeeds.
- v2-specific wiring: metadata merge runs inline in `deploy.ts` after `loadBuildMetadata` (no separate `deploy/build.ts` on v2).

## Test plan
- [ ] `bunx biome ci .`
- [ ] `AGENTUITY_DEPLOY_METADATA='{"source":"managed","channel":"edge"}' agentuity cloud deploy ...` persists metadata on upload
- [ ] Complete response surfaces `rolloutId` when present

## Related
- Main-line equivalent: #1573

Made with [Cursor](https://cursor.com)