### PR TITLE
fix(cli): require force for deployment confirmations

### DIFF
--- a/packages/cli/src/cmd/cloud/deployment/remove.ts
+++ b/packages/cli/src/cmd/cloud/deployment/remove.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { createSubcommand } from '../../../types.ts';
 import * as tui from '../../../tui.ts';
 import { projectDeploymentDelete } from '@agentuity/server';
-import { resolveProjectId } from './utils.ts';
+import { requireForceForNonInteractiveDestructiveAction, resolveProjectId } from './utils.ts';
 import { getCommand } from '../../../command-prefix.ts';
 const DeploymentDeleteResponseSchema = z.object({
 	success: z.boolean().describe('Whether the deletion succeeded'),
@@ -47,9 +47,14 @@ export const removeSubcommand = createSubcommand({
 	},
 	async handler(ctx) {
 		const projectId = resolveProjectId(ctx, { projectId: ctx.opts.projectId });
-		const { apiClient, args, opts } = ctx;
+		const { apiClient, args, logger, options, opts } = ctx;
 
 		if (!opts.force) {
+			requireForceForNonInteractiveDestructiveAction(
+				options,
+				logger,
+				`delete deployment ${args.deployment_id}`
+			);
 			const confirmed = await tui.confirm(
 				`Are you sure you want to delete deployment ${args.deployment_id}?`
 			);

--- a/packages/cli/src/cmd/cloud/deployment/rollback.ts
+++ b/packages/cli/src/cmd/cloud/deployment/rollback.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { createSubcommand } from '../../../types.ts';
 import * as tui from '../../../tui.ts';
 import { projectDeploymentRollback, projectDeploymentList } from '@agentuity/server';
-import { resolveProjectId } from './utils.ts';
+import { requireForceForNonInteractiveDestructiveAction, resolveProjectId } from './utils.ts';
 import { getCommand } from '../../../command-prefix.ts';
 const DeploymentRollbackResponseSchema = z.object({
 	success: z.boolean().describe('Whether the rollback succeeded'),
@@ -31,6 +31,10 @@ export const rollbackSubcommand = createSubcommand({
 			command: getCommand('cloud deployment rollback --project-id=proj_abc123xyz'),
 			description: 'Rollback specific project',
 		},
+		{
+			command: getCommand('cloud deployment rollback --force'),
+			description: 'Rollback without confirmation',
+		},
 	],
 	idempotent: false,
 	requires: { auth: true, apiClient: true },
@@ -39,12 +43,13 @@ export const rollbackSubcommand = createSubcommand({
 	schema: {
 		options: z.object({
 			projectId: z.string().optional().describe('filter by project id'),
+			force: z.boolean().default(false).describe('Force rollback without confirmation'),
 		}),
 		response: DeploymentRollbackResponseSchema,
 	},
 	async handler(ctx) {
 		const projectId = resolveProjectId(ctx, { projectId: ctx.opts.projectId });
-		const { apiClient } = ctx;
+		const { apiClient, logger, options, opts } = ctx;
 
 		try {
 			// Fetch deployments to find the previous one
@@ -71,10 +76,17 @@ export const rollbackSubcommand = createSubcommand({
 				tui.fatal('No previous completed deployment found to rollback to.');
 			}
 
-			const confirmed = await tui.confirm(`Rollback to deployment ${targetDeploymentId}?`);
-			if (!confirmed) {
-				tui.info('Operation cancelled');
-				return { success: false, projectId, targetDeploymentId };
+			if (!opts.force) {
+				requireForceForNonInteractiveDestructiveAction(
+					options,
+					logger,
+					`rollback to deployment ${targetDeploymentId}`
+				);
+				const confirmed = await tui.confirm(`Rollback to deployment ${targetDeploymentId}?`);
+				if (!confirmed) {
+					tui.info('Operation cancelled');
+					return { success: false, projectId, targetDeploymentId };
+				}
 			}
 
 			await projectDeploymentRollback(apiClient, projectId, targetDeploymentId!);

--- a/packages/cli/src/cmd/cloud/deployment/undeploy.ts
+++ b/packages/cli/src/cmd/cloud/deployment/undeploy.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { createSubcommand } from '../../../types.ts';
 import * as tui from '../../../tui.ts';
 import { projectDeploymentUndeploy } from '@agentuity/server';
-import { resolveProjectId } from './utils.ts';
+import { requireForceForNonInteractiveDestructiveAction, resolveProjectId } from './utils.ts';
 import { getCommand } from '../../../command-prefix.ts';
 export const undeploySubcommand = createSubcommand({
 	name: 'undeploy',
@@ -34,9 +34,10 @@ export const undeploySubcommand = createSubcommand({
 	},
 	async handler(ctx) {
 		const projectId = resolveProjectId(ctx, { projectId: ctx.opts.projectId });
-		const { apiClient, opts } = ctx;
+		const { apiClient, logger, options, opts } = ctx;
 
 		if (!opts.force) {
+			requireForceForNonInteractiveDestructiveAction(options, logger, 'undeploy the project');
 			const confirmed = await tui.confirm(
 				'Are you sure you want to undeploy? This will stop the active deployment.'
 			);

--- a/packages/cli/src/cmd/cloud/deployment/utils.ts
+++ b/packages/cli/src/cmd/cloud/deployment/utils.ts
@@ -1,5 +1,7 @@
 import { StructuredError } from '@agentuity/core';
-import type { ProjectConfig } from '../../../types.ts';
+import { ErrorCode, getExitCode } from '../../../errors.ts';
+import { canPrompt, createErrorResponse, outputJSON } from '../../../output.ts';
+import type { GlobalOptions, Logger, ProjectConfig } from '../../../types.ts';
 
 const ProjectIDRequiredError = StructuredError(
 	'ProjectIDRequiredError',
@@ -17,4 +19,26 @@ export function resolveProjectId(
 		return ctx.project.projectId;
 	}
 	throw new ProjectIDRequiredError();
+}
+
+export function requireForceForNonInteractiveDestructiveAction(
+	options: GlobalOptions,
+	logger: Logger,
+	action: string
+): void {
+	if (canPrompt(options)) {
+		return;
+	}
+
+	const message = `--force is required to ${action} in non-interactive mode.`;
+	if (options.json) {
+		outputJSON(
+			createErrorResponse(ErrorCode.CONFIG_INVALID, message, {
+				requiredFlag: '--force',
+			})
+		);
+		process.exit(getExitCode(ErrorCode.CONFIG_INVALID));
+	}
+
+	logger.fatal(message, ErrorCode.CONFIG_INVALID);
 }

--- a/packages/cli/src/cmd/cloud/deployment/utils.ts
+++ b/packages/cli/src/cmd/cloud/deployment/utils.ts
@@ -1,6 +1,6 @@
 import { StructuredError } from '@agentuity/core';
 import { ErrorCode, getExitCode } from '../../../errors.ts';
-import { canPrompt, createErrorResponse, outputJSON } from '../../../output.ts';
+import { canPrompt, createErrorResponse, isJSONMode, outputJSON } from '../../../output.ts';
 import type { GlobalOptions, Logger, ProjectConfig } from '../../../types.ts';
 
 const ProjectIDRequiredError = StructuredError(
@@ -31,7 +31,7 @@ export function requireForceForNonInteractiveDestructiveAction(
 	}
 
 	const message = `--force is required to ${action} in non-interactive mode.`;
-	if (options.json) {
+	if (isJSONMode(options) || options.errorFormat === 'json') {
 		outputJSON(
 			createErrorResponse(ErrorCode.CONFIG_INVALID, message, {
 				requiredFlag: '--force',


### PR DESCRIPTION
## Summary
- Requires `--force` before destructive deployment commands can proceed when prompts are unavailable.
- Adds `--force` support to `cloud deployment rollback` for non-interactive workflows.
- Emits a structured JSON error with `requiredFlag: --force` for JSON-mode callers.

Closes #1576

## Test plan
- `bun run build`
- `bun run --filter='@agentuity/cli' typecheck`
- `bun packages/cli/scripts/test-response-schema.ts`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--force` flag to `cloud deployment rollback` to allow non-interactive destructive rollbacks without confirmation.

* **Improvements**
  * Strengthened safety guardrails for destructive deployment commands: in non-interactive mode, destructive actions now require `--force` instead of prompting.
  * Error handling is now consistent for JSON output and non-JSON runs when `--force` is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->