### PR TITLE
fix(cli): add undeploy JSON response schema

### DIFF
--- a/packages/cli/src/cmd/cloud/deployment/undeploy.ts
+++ b/packages/cli/src/cmd/cloud/deployment/undeploy.ts
@@ -4,6 +4,13 @@ import * as tui from '../../../tui.ts';
 import { projectDeploymentUndeploy } from '@agentuity/server';
 import { resolveProjectId } from './utils.ts';
 import { getCommand } from '../../../command-prefix.ts';
+
+const DeploymentUndeployResponseSchema = z.object({
+	success: z.boolean().describe('Whether the undeploy succeeded'),
+	projectId: z.string().describe('Project ID'),
+	message: z.string().describe('Human-readable operation result'),
+});
+
 export const undeploySubcommand = createSubcommand({
 	name: 'undeploy',
 	description: 'Undeploy the latest deployment',
@@ -31,24 +38,32 @@ export const undeploySubcommand = createSubcommand({
 			projectId: z.string().optional().describe('filter by project id'),
 			force: z.boolean().default(false).describe('Force undeploy without confirmation'),
 		}),
+		response: DeploymentUndeployResponseSchema,
 	},
 	async handler(ctx) {
 		const projectId = resolveProjectId(ctx, { projectId: ctx.opts.projectId });
-		const { apiClient, opts } = ctx;
+		const { apiClient, opts, options } = ctx;
 
 		if (!opts.force) {
 			const confirmed = await tui.confirm(
 				'Are you sure you want to undeploy? This will stop the active deployment.'
 			);
 			if (!confirmed) {
-				tui.info('Operation cancelled');
-				return;
+				const message = 'Operation cancelled';
+				if (!options.json) {
+					tui.info(message);
+				}
+				return { success: false, projectId, message };
 			}
 		}
 
 		try {
 			await projectDeploymentUndeploy(apiClient, projectId);
-			tui.success('Undeployed successfully.');
+			const message = 'Undeployed successfully.';
+			if (!options.json) {
+				tui.success(message);
+			}
+			return { success: true, projectId, message };
 		} catch (ex) {
 			tui.fatal(`Failed to undeploy: ${ex}`);
 		}

--- a/packages/cli/src/cmd/cloud/deployment/undeploy.ts
+++ b/packages/cli/src/cmd/cloud/deployment/undeploy.ts
@@ -4,6 +4,7 @@ import * as tui from '../../../tui.ts';
 import { projectDeploymentUndeploy } from '@agentuity/server';
 import { resolveProjectId } from './utils.ts';
 import { getCommand } from '../../../command-prefix.ts';
+import { isJSONMode } from '../../../output.ts';
 
 const DeploymentUndeployResponseSchema = z.object({
 	success: z.boolean().describe('Whether the undeploy succeeded'),
@@ -43,16 +44,22 @@ export const undeploySubcommand = createSubcommand({
 	async handler(ctx) {
 		const projectId = resolveProjectId(ctx, { projectId: ctx.opts.projectId });
 		const { apiClient, opts, options } = ctx;
+		const json = isJSONMode(options);
 
 		if (!opts.force) {
+			if (json) {
+				return {
+					success: false,
+					projectId,
+					message: '--force is required to undeploy in JSON mode.',
+				};
+			}
 			const confirmed = await tui.confirm(
 				'Are you sure you want to undeploy? This will stop the active deployment.'
 			);
 			if (!confirmed) {
 				const message = 'Operation cancelled';
-				if (!options.json) {
-					tui.info(message);
-				}
+				tui.info(message);
 				return { success: false, projectId, message };
 			}
 		}
@@ -60,7 +67,7 @@ export const undeploySubcommand = createSubcommand({
 		try {
 			await projectDeploymentUndeploy(apiClient, projectId);
 			const message = 'Undeployed successfully.';
-			if (!options.json) {
+			if (!json) {
 				tui.success(message);
 			}
 			return { success: true, projectId, message };


### PR DESCRIPTION
## Summary
- Adds a response schema for `agentuity cloud deployment undeploy`.
- Returns structured success/cancelled results and suppresses human status lines in JSON mode.

Closes #1579

## Test plan
- `bun run build`
- `bun run --filter='@agentuity/cli' typecheck`
- `bun packages/cli/scripts/test-response-schema.ts`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `cloud deployment undeploy` command now supports safer operation: when `--force` isn’t provided, it asks for confirmation before proceeding.
  * In JSON mode, undeploy requires `--force`; otherwise it returns a structured failure response instead of prompting.
* **Refactor**
  * Updated undeploy output to consistently return structured `{ success, projectId, message }` results, with human-readable success text shown only in non-JSON mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->