### PR TITLE
fix(cli): expose profile workflows

### DIFF
--- a/packages/cli/src/cmd/profile/index.ts
+++ b/packages/cli/src/cmd/profile/index.ts
@@ -9,14 +9,17 @@ import { getCommand } from '../../command-prefix.ts';
 
 export const command = createCommand({
 	name: 'profile',
-	description: 'Manage configuration profiles',
+	description: 'Manage configuration profiles for --profile and AGENTUITY_PROFILE',
 	tags: ['read-only', 'fast'],
-	hidden: true,
 	examples: [
 		{ command: getCommand('profile list'), description: 'List all profiles' },
 		{
 			command: getCommand('profile use production'),
 			description: 'Switch to production profile',
+		},
+		{
+			command: getCommand('--profile staging auth whoami'),
+			description: 'Run a command with a specific profile',
 		},
 	],
 	subcommands: [

--- a/packages/cli/src/cmd/profile/use.ts
+++ b/packages/cli/src/cmd/profile/use.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { fetchProfiles, saveProfile } from '../../config.ts';
 import * as tui from '../../tui.ts';
 import { getCommand } from '../../command-prefix.ts';
+import { isJSONMode } from '../../output.ts';
 
 const ProfileUseResponseSchema = z.object({
 	success: z.boolean().describe('Whether the profile switch succeeded'),
@@ -39,6 +40,7 @@ export const useCommand = createSubcommand({
 
 	async handler(ctx) {
 		const { args, options } = ctx;
+		const json = isJSONMode(options);
 		let { name } = args;
 
 		const profiles = await fetchProfiles();
@@ -54,7 +56,7 @@ export const useCommand = createSubcommand({
 		}
 
 		await saveProfile(profile!.filename);
-		if (!options.json) {
+		if (!json) {
 			tui.success(`Switched to profile "${name}"`);
 		}
 

--- a/packages/cli/src/cmd/profile/use.ts
+++ b/packages/cli/src/cmd/profile/use.ts
@@ -4,6 +4,12 @@ import { fetchProfiles, saveProfile } from '../../config.ts';
 import * as tui from '../../tui.ts';
 import { getCommand } from '../../command-prefix.ts';
 
+const ProfileUseResponseSchema = z.object({
+	success: z.boolean().describe('Whether the profile switch succeeded'),
+	name: z.string().describe('Profile name'),
+	path: z.string().describe('Profile file path'),
+});
+
 export const useCommand = createSubcommand({
 	name: 'use',
 	description: 'Switch to a different configuration profile',
@@ -28,10 +34,11 @@ export const useCommand = createSubcommand({
 		args: z.object({
 			name: z.string().optional().describe('The name of the profile to use'),
 		}),
+		response: ProfileUseResponseSchema,
 	},
 
 	async handler(ctx) {
-		const { args } = ctx;
+		const { args, options } = ctx;
 		let { name } = args;
 
 		const profiles = await fetchProfiles();
@@ -47,6 +54,14 @@ export const useCommand = createSubcommand({
 		}
 
 		await saveProfile(profile!.filename);
-		tui.success(`Switched to profile "${name}"`);
+		if (!options.json) {
+			tui.success(`Switched to profile "${name}"`);
+		}
+
+		return {
+			success: true,
+			name,
+			path: profile!.filename,
+		};
 	},
 });


### PR DESCRIPTION
## Summary
- Exposes `agentuity profile` in normal command help so profile workflows are discoverable to agents and humans.
- Adds structured response data for `profile use` / `profile switch` in JSON mode.

Closes #1580

## Test plan
- `bun run build`
- `bun run --filter='@agentuity/cli' typecheck`
- `bun packages/cli/scripts/test-response-schema.ts`
- `bun packages/cli/src/main.ts --help | rg '^\\s+profile\\b|Manage configuration profiles'`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `profile use` now returns a structured, machine-readable response (including `success`, profile `name`, and `path`) and suppresses the interactive success message when JSON output is enabled.

* **Documentation**
  * The `profile` CLI command is now shown in help output with clearer descriptions referencing `--profile` and `AGENTUITY_PROFILE`, plus an added example demonstrating `--profile` usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->